### PR TITLE
Refactor: Define workspace layer order

### DIFF
--- a/config/layers.txt
+++ b/config/layers.txt
@@ -1,0 +1,6 @@
+underlay
+core
+platforms
+sensors
+simulation
+ui

--- a/config/repos/core.repos
+++ b/config/repos/core.repos
@@ -1,0 +1,41 @@
+repositories:
+  project11:
+    type: git
+    url: git@github.com:rolker/project11.git
+    version: jazzy
+  project11_msgs:
+    type: git
+    url: git@github.com:rolker/project11_msgs.git
+    version: jazzy
+  marine_ais:
+    type: git
+    url: git@github.com:rolker/marine_ais.git
+    version: jazzy
+  project11_nav_msgs:
+    type: git
+    url: git@github.com:rolker/project11_nav_msgs.git
+    version: jazzy
+  udp_bridge:
+    type: git
+    url: git@github.com:rolker/udp_bridge.git
+    version: jazzy
+  command_bridge:
+    type: git
+    url: git@github.com:rolker/command_bridge.git
+    version: jazzy
+  helm_manager:
+    type: git
+    url: git@github.com:rolker/helm_manager.git
+    version: jazzy
+  mission_manager:
+    type: git
+    url: git@github.com:rolker/mission_manager.git
+    version: jazzy
+  unh_marine_navigation:
+    type: git
+    url: git@github.com:rolker/unh_marine_navigation.git
+    version: jazzy
+  s57_tools:
+    type: git
+    url: git@github.com:rolker/s57_tools.git
+    version: jazzy

--- a/config/repos/platforms.repos
+++ b/config/repos/platforms.repos
@@ -1,0 +1,13 @@
+repositories:
+  ben_project11:
+    type: git
+    url: git@github.com:rolker/ben_project11.git
+    version: jazzy
+  ben_description:
+    type: git
+    url: git@github.com:rolker/ben_description.git
+    version: jazzy
+  mru_transform:
+    type: git
+    url: git@github.com:rolker/mru_transform.git
+    version: jazzy

--- a/config/repos/sensors.repos
+++ b/config/repos/sensors.repos
@@ -1,0 +1,13 @@
+repositories:
+  unh_marine_radar:
+    type: git
+    url: git@github.com:rolker/unh_marine_radar.git
+    version: jazzy
+  cube_bathymetry:
+    type: git
+    url: git@github.com:rolker/cube_bathymetry.git
+    version: jazzy
+  unh_marine_perception:
+    type: git
+    url: git@github.com:rolker/unh_marine_perception.git
+    version: jazzy

--- a/config/repos/simulation.repos
+++ b/config/repos/simulation.repos
@@ -1,0 +1,5 @@
+repositories:
+  project11_simulation:
+    type: git
+    url: git@github.com:rolker/project11_simulation.git
+    version: jazzy

--- a/config/repos/ui.repos
+++ b/config/repos/ui.repos
@@ -1,0 +1,21 @@
+repositories:
+  camp:
+    type: git
+    url: git@github.com:rolker/camp.git
+    version: jazzy
+  rqt_marine_radar:
+    type: git
+    url: git@github.com:rolker/rqt_marine_radar.git
+    version: jazzy
+  rqt_udp_bridge:
+    type: git
+    url: git@github.com:rolker/rqt_udp_bridge.git
+    version: jazzy
+  rviz_sonar_image:
+    type: git
+    url: git@github.com:rolker/rviz_sonar_image.git
+    version: jazzy
+  joy_to_helm:
+    type: git
+    url: git@github.com:rolker/joy_to_helm.git
+    version: jazzy

--- a/config/repos/underlay.repos
+++ b/config/repos/underlay.repos
@@ -1,0 +1,13 @@
+repositories:
+  ros2launch_gui:
+    type: git
+    url: git@github.com:rolker/ros2launch_gui.git
+    version: jazzy
+  geographic_info:
+    type: git
+    url: https://github.com/ros-geographic-info/geographic_info.git
+    version: ros2
+  audio_common:
+    type: git
+    url: git@github.com:rolker/audio_common.git
+    version: port_sound_play_h_to_ros2


### PR DESCRIPTION
## Add Layer Build Order Configuration

This PR adds `config/layers.txt` which defines the build and source order for the workspace layers.

### Context
This moves the "business logic" of the ROS project out of the Agent Framework scripts (which were hardcoded), allowing this repo to define its own structure.

### Usage
The root workspace scripts (`env.sh`) will read this file to determine priority.