### PR TITLE
refactor: Consolidate repositories and remove deprecated project11 msgs

### DIFF
--- a/config/repos/core.repos
+++ b/config/repos/core.repos
@@ -1,35 +1,11 @@
 repositories:
-  project11:
-    type: git
-    url: git@github.com:rolker/project11.git
-    version: jazzy
-  project11_msgs:
-    type: git
-    url: git@github.com:rolker/project11_msgs.git
-    version: jazzy
   marine_ais:
     type: git
     url: git@github.com:rolker/marine_ais.git
     version: jazzy
-  project11_nav_msgs:
-    type: git
-    url: git@github.com:rolker/project11_nav_msgs.git
-    version: jazzy
   udp_bridge:
     type: git
     url: git@github.com:rolker/udp_bridge.git
-    version: jazzy
-  command_bridge:
-    type: git
-    url: git@github.com:rolker/command_bridge.git
-    version: jazzy
-  helm_manager:
-    type: git
-    url: git@github.com:rolker/helm_manager.git
-    version: jazzy
-  mission_manager:
-    type: git
-    url: git@github.com:rolker/mission_manager.git
     version: jazzy
   unh_marine_navigation:
     type: git

--- a/config/repos/ui.repos
+++ b/config/repos/ui.repos
@@ -15,7 +15,3 @@ repositories:
     type: git
     url: git@github.com:rolker/rviz_sonar_image.git
     version: jazzy
-  joy_to_helm:
-    type: git
-    url: git@github.com:rolker/joy_to_helm.git
-    version: jazzy


### PR DESCRIPTION
## Description
This PR cleans up the repository configuration files to reflect the recent rebranding and consolidation. 

### Changes
- **Consolidated Repositories Removed**:
    - `command_bridge`
    - `helm_manager`
    - `mission_manager`
    - `joy_to_helm`
    - `project11` (Legacy)
- **Deprecated Repositories Removed**:
    - `project11_msgs`
    - `project11_nav_msgs`

These packages are now part of the `unh_marine_autonomy` monorepo or are no longer used.

### Verification
- Verified removal of redundant entries from `core.repos` and `ui.repos`.
- Confirmed that consolidated packages exist within this repository.
