### PR TITLE
docs: improve developer documentation and system architecture

### DIFF
--- a/helm_manager/README.md
+++ b/helm_manager/README.md
@@ -1,14 +1,40 @@
 # Helm Manager
 
-The helm_manager is a Project11 package that helps manage the flow of control commands. It responds to changes in piloting mode to determine which helm or command velocity source to direct to the underlying node controlling the hardware. It also sends a heartbeat message indicating the current piloting mode and status information from the helm node.
+The `helm_manager` is a core component of the UNH Marine Autonomy framework (formerly Project11). It acts as a control arbitrator, ensuring that only one source of guidance (e.g., manual joystick or autonomous mission planner) is actively controlling the vehicle hardware at any given time.
 
-## Piloting modes
+## Overview
+The node is implemented as a **ROS 2 Lifecycle Node**, allowing for controlled transitions between unconfigured, inactive, and active states. It manages multiple "Piloting Modes" and handles switching between them based on operator input.
 
-active vs standby
+### Key Features
+- **Arbitration**: Swallows control messages from inactive modes and passes through messages from the active mode.
+- **Type Conversion**: Automatically converts between `marine_interfaces/msg/Helm` and `geometry_msgs/msg/TwistStamped`.
+- **Safety**: Defaults to "standby" mode where no output is generated.
+- **Status Aggregation**: Combines internal state with feedback from low-level helm nodes into a system-wide heartbeat.
 
-## Control message types and conversion
+## Piloting Modes
 
-Helm and TwistStamped
+| Mode | Input Topics | Description |
+| :--- | :--- | :--- |
+| **standby** | N/A | Default mode. Output is disabled. |
+| **manual** | `manual/helm`, `manual/cmd_vel` | Passes through commands from teleoperation/joystick nodes. |
+| **autonomous** | `autonomous/helm`, `autonomous/cmd_vel` | Passes through commands from the Navigation Stack or Mission Manager. |
 
-## 
+## Topics
+
+### Subscribed
+- `piloting_mode` (`std_msgs/msg/String`): The command to switch the active mode.
+- `status/helm` (`marine_interfaces/msg/Heartbeat`): Status feedback from the low-level hardware-specific helm node.
+- `manual/helm`, `manual/cmd_vel`: Inputs for manual control.
+- `autonomous/helm`, `autonomous/cmd_vel`: Inputs for autonomous control.
+
+### Published
+- `out/helm` (`marine_interfaces/msg/Helm`): Arbitrated output (if `output_type` is `helm` or `dual`).
+- `out/cmd_vel` (`geometry_msgs/msg/TwistStamped`): Arbitrated output (if `output_type` is `twist` or `dual`).
+- `heartbeat` (`marine_interfaces/msg/Heartbeat`): System status including current mode and low-level diagnostics.
+
+## Parameters
+
+- `output_type` (`string`, default: `"helm"`): One of `"helm"`, `"twist"`, or `"dual"`. Determines which output topic is used.
+- `max_speed` (`double`, default: `1.0`): Used for scaling when converting between `Helm` throttle and `Twist` linear velocity.
+- `max_yaw_speed` (`double`, default: `1.0`): Used for scaling when converting between `Helm` rudder and `Twist` angular velocity.
 

--- a/marine_autonomy/README.md
+++ b/marine_autonomy/README.md
@@ -58,41 +58,39 @@ Two windows should appear, CAMP and RViz. RViz can seem to freeze when loading t
 
 In the CAMP window, zoom out with the mouse wheel to find the boat. Right click on a target area and select "Hover here" to have the boat go into autonomous mode, transit to the location, and hover in place once it gets there.
     
-## Major components and concepts
+## Major Components & Concepts
 
-A typical setup has a ROS nodes running on the robot with some key nodes including the `mission_manager`, the `helm_manager` and the `udp_bridge`. The operator station also runs  a `udp_bridge` node as well as `camp`, the CCOM Autonomous Mission Planner which provide a planning and monitoring interface.
+The framework is a modular ecosystem of ROS 2 nodes. For a detailed deep-dive into data flows, piloting modes, and hardware abstraction, see the **[System Architecture Documentation](./docs/system_architecture.md)**.
 
-### Operator user interface - CAMP
+### Operator Interface (CAMP)
+The **CCOM Autonomous Mission Planner (CAMP)** is the primary UI. It allows operators to:
+- Visualize vehicle position on georeferenced charts.
+- Plan and transmit complex survey missions.
+- Monitor real-time status and command mode changes.
 
-The [CCOM Autonomous Mission Planner](../../../camp), also known as CAMP, displays the vehicle's position on background georeferenced charts and maps. It also allows the planning of missions to be sent to the vehicle and to manage the vehicle's piloting mode.
+### Mission Management
+The `mission_manager` receives JSON plans from CAMP and translates them into discrete navigation tasks (e.g., "Follow this path", "Hover here"). It manages the high-level mission state machine.
 
-![Camp](doc/CAMP_3Click_Survey_Pattern.gif)
+### Control Arbitration (Helm Manager)
+The `helm_manager` is the safety-critical arbitrator. it switches between **Standby**, **Manual**, and **Autonomous** modes, ensuring only one source of control is ever active on the hardware.
 
-### UDP Bridge - udp_bridge
+### Reliable Communications (UDP & Command Bridge)
+To support operations over low-bandwidth or unreliable wireless links, we use:
+- **`udp_bridge`**: Optimized message transport.
+- **`command_bridge`**: A transaction layer ensuring high-level commands (like "Start") are successfully delivered even if the link drops momentarily.
 
-The [UDP Bridge](../../../udp_bridge) sends select ROS topics between ROS cores. It allows control and monitoring over wireless unreliable networks.
+### Hardware Agnosticism
+The framework uses a **Low-Level Helm** pattern. Core nodes output generic control messages, which are then translated by a vehicle-specific node (e.g., `ben_helm`) into hardware commands. This allows the same framework to drive diverse vessels with minimal changes.
 
-### Mission Manager - mission_manager
+## Piloting Modes
 
-The [Mission Manager](../../../mission_manager) receives missions from CAMP and executes them. It also handles requests such as hover.
+The system operates in three states, managed by the `helm_manager`:
+1. **Standby**: No control output; safest state.
+2. **Manual**: Passthrough for joystick or teleoperation commands.
+3. **Autonomous**: Passthrough for Mission Manager and Navigation Stack outputs.
 
-### Helm Manager - helm_manager
+---
 
-The [Helm Manager](../../../helm_manager) controls which commands get sent to the underlying hardware. It reacts to changes in piloting mode by sending messages to the piloting mode enable topics and only allowing incoming control messages from the current piloting mode to be sent to the hardware interface.
+## Detailed Navigation Stack
 
-### Piloting modes
-
-Project11 operates in 3 major piloting modes: "manual", "autonomous" and "standby". 
-
-In "manual" mode, the vehicle responds to commands sent from a device such as a joystick or a gamepad. The commands are converted to "helm" messages by the `joy_to_helm` node and are sent from the operator station to the vehicle via the `udp_bridge`.
-
-In "autonomous" mode, the `mission_manager` sends mission items to the navigation stack and responds to override commands such as the hover command that can allow the vehicle to station keep for a while, then resume the mission when the hover is canceled.
-
-The "standby" mode is used to when no control commands are to be sent by Project11.
-
-
-
-### Navigation Stack
-
-The `mission_manager` receives and executes the higher level missions. Depending on the task, track lines may be sent to the `path_follower` or another node will receive a higher level directive, such as "survey this area", and generate and send out track lines or other navigation segments to lower level planners or controllers.
-Eventually, a "helm" or "cmd_velocity" message gets sent to the autonomous/helm or autonomous/cmd_vel topic reaching the `helm_manager`. 
+The `mission_manager` interacts with a Behavior Tree-based navigation stack. High-level directives like "Survey this area" are decomposed into track lines which are then sent to path followers. Eventually, these result in `Helm` or `Twist` messages reaching the `helm_manager`.

--- a/marine_autonomy/README.md
+++ b/marine_autonomy/README.md
@@ -72,7 +72,7 @@ The **CCOM Autonomous Mission Planner (CAMP)** is the primary UI. It allows oper
 The `mission_manager` receives JSON plans from CAMP and translates them into discrete navigation tasks (e.g., "Follow this path", "Hover here"). It manages the high-level mission state machine.
 
 ### Control Arbitration (Helm Manager)
-The `helm_manager` is the safety-critical arbitrator. it switches between **Standby**, **Manual**, and **Autonomous** modes, ensuring only one source of control is ever active on the hardware.
+The `helm_manager` is the safety-critical arbitrator. It switches between **Standby**, **Manual**, and **Autonomous** modes, ensuring only one source of control is ever active on the hardware.
 
 ### Reliable Communications (UDP & Command Bridge)
 To support operations over low-bandwidth or unreliable wireless links, we use:

--- a/marine_autonomy/docs/system_architecture.md
+++ b/marine_autonomy/docs/system_architecture.md
@@ -1,57 +1,79 @@
 # UNH Marine Autonomy System Architecture
 
 ## Overview
-The **UNH Marine Autonomy** system is a modular framework for Autonomous Surface Vehicle (ASV) control and multi-vehicle mission planning and execution. It was originally known as "Project11".
+The **UNH Marine Autonomy** system (aka **Project11**) is a modular framework for Autonomous Surface Vehicle (ASV) control and multi-vehicle mission planning and execution. It prioritizes reliability over unreliable networks and abstracts hardware specifics to support heterogeneous fleets.
 
-## Core Components
-The system is composed of several independent ROS 2 nodes that work together to provide autonomy capabilities.
+## Core Concepts
 
-| Component | Description |
-| :--- | :--- |
-| **Mission Planner (CAMP)** | Desktop Operator UI for defining missions, monitoring status, and visualizing data. |
-| **Mission Manager** | On-vehicle executive node. Receives missions and orchestrates execution by issuing tasks. |
-| **Navigation Stack** | A Behavior Tree (BT) based system that receives tasks (e.g., "Survey Area") and generates low-level navigation commands. |
-| **Helm Manager** | Control arbitration node. Switches between Manual (Joystick) and Autonomous modes. Ensures only one controller drives the hardware. |
-| **UDP Bridge** | Robust, low-bandwidth communications link between the vehicle and the operator station. |
+### 1. Reliable Command Bridging (`udp_bridge` & `command_bridge`)
+In marine environments, telemetry links (Radio, Cellular, Satellite) are often intermittent. To ensure commands (like "Hover" or "Start Mission") are received, we use a "Send-Until-Acknowledged" pattern.
+- **`udp_bridge`**: Handles the low-level transport of ROS messages over UDP, optimized for bandwidth.
+- **`command_bridge`**: Sits on top of the bridge. It queues commands with a timestamp and republishes them until the remote side sends a matching acknowledgment.
 
-## Data Flow
-The high-level data flow from operator to hardware is:
+### 2. Hardware Agnosticism (Low-Level Helm Nodes)
+To keep the core framework agnostic of specific vehicle hardware (different thruster configurations, steering types, etc.), we use **Low-Level Helm Nodes**.
+- **Core Framework**: Outputs generic `Helm` or `Twist` messages.
+- **Platform-Specific Node**: (e.g., `ben_helm`, `dory_helm`) Subscribes to these generic commands and translates them into specific thruster setpoints or serial commands for that vehicle.
+- **Benefit**: Changing vehicles only requires swapping one low-level node.
+
+## Data Flows
+
+### 1. Mission Planning & Execution Flow
+How a mission goes from the operator's clicks to the vehicle's movement:
 
 ```mermaid
-graph LR
-    User[Operator UI] -- Mission Msg --> MM[Mission Manager]
-    MM -- Task List --> Nav[Navigation Stack]
-    Nav -- Nav Command --> Helm[Helm Manager]
-    Joystick -- Joy Command --> Helm
-    Helm -- Thruster Cmd --> Hardware[Vehicle Hardware]
+sequenceDiagram
+    participant UI as CAMP (Operator UI)
+    participant CB_S as Command Bridge (Shore)
+    participant UDP as UDP Bridge (Link)
+    participant CB_R as Command Bridge (Robot)
+    participant MM as Mission Manager
+    participant Nav as Navigation Stack
+    participant HM as Helm Manager
+    participant LL as Low-Level Helm
+    participant HW as Hardware
+
+    UI->>CB_S: "Execute Survey Plan"
+    CB_S->>UDP: Bridge (project11/command)
+    UDP->>CB_R: Receive Command
+    CB_R->>CB_S: Acknowledge (project11/response)
+    CB_R->>MM: Request Mission Execution
+    MM->>Nav: Send Task List (project11_nav_msgs/TaskInformation)
+    Nav->>HM: Output Helm/Twist (autonomous/helm)
+    HM->>LL: Passthrough (active/helm)
+    LL->>HW: Hardware Specific Commands
 ```
 
-## Repository Structure (Planned)
+### 2. Status Feedback Flow
+How the operator knows what the robot is doing:
 
-### 1. `unh_marine_autonomy`
-The central monorepo for core robot capabilities.
-*   `marine_autonomy`: Core launch files and system configuration.
-*   `marine_interfaces`: Standard message definitions.
-*   `mission_manager`: Autonomy executive.
-*   `helm_manager`: Control arbitrator.
-*   `command_bridge`: Shore-side communications.
-*   `joy_to_helm`: Joystick Adapter.
+```mermaid
+graph RL
+    HW[Hardware] --> LL[Low-Level Helm]
+    LL -- Status --> HM[Helm Manager]
+    HM -- Heartbeat --> UDP[UDP Bridge]
+    UDP -- Telemetry --> UI[CAMP UI]
+    MM[Mission Manager] -- "state: executing" --> UDP
+```
 
-### 2. `unh_marine_navigation`
-The Guidance, Navigation, and Control connection.
-*   `marine_nav_behaviors`: Path following and specific behaviors.
-*   `marine_nav_interfaces`: Internal navigation messages.
+## Piloting Modes & Arbitration
+The **`helm_manager`** is the "brain" that decides who is currently driving the vehicle. It arbitrates between three primary modes:
 
-### 3. `camp` & `s57_tools`
-*   `camp`: The operator interface (Qt Application).
-*   `s57_tools`: Tools for handling Chart data (S-57/S-63).
+| Mode | Trigger | Description |
+| :--- | :--- | :--- |
+| **Standby** | Default / "Stop" | No control signals are sent to the hardware. Safest state. |
+| **Manual** | Joystick Input | Commands from a local or remote joystick (`joy_to_helm`) are passed through. |
+| **Autonomous** | Mission Start | Signals from the `mission_manager` and Navigation Stack are passed through. |
 
-### 4. Hardware Interfaces
-*   `udp_bridge`: Communications link.
-*   `marine_ais`: AIS data handling.
+The `helm_manager` ensures that if the user grabs a joystick, the system can quickly switch to Manual, or if a mission is aborted, it returns to Standby.
 
-## Robot Configuration
-Each specific robot (e.g., "Ben") has its own configuration package (e.g., `ben_marine`) containing:
-*   URDF / Mesh descriptions.
-*   Specific launch files (sensor drivers, hardware interface selection).
-*   Parameter configurations.
+## Component Map
+
+| Component | Role |
+| :--- | :--- |
+| **CAMP** | Planning interface & Situational Awareness. |
+| **Mission Manager** | High-level executive; converts plans to discrete navigation tasks. |
+| **Navigation Stack** | Path planners and followers; handles the "physics" of getting there. |
+| **Helm Manager** | Safety-critical arbitrator of control sources. |
+| **Command Bridge** | Reliable transaction layer for critical commands. |
+| **UDP Bridge** | Efficient data transport for remote operations. |

--- a/marine_autonomy/docs/system_architecture.md
+++ b/marine_autonomy/docs/system_architecture.md
@@ -40,7 +40,7 @@ sequenceDiagram
     CB_R->>MM: Request Mission Execution
     MM->>Nav: Send Task List (project11_nav_msgs/TaskInformation)
     Nav->>HM: Output Helm/Twist (autonomous/helm)
-    HM->>LL: Passthrough (active/helm)
+    HM->>LL: Passthrough (out/helm)
     LL->>HW: Hardware Specific Commands
 ```
 


### PR DESCRIPTION
This PR improves the developer and advanced user documentation for the Project11 / UNH Marine Autonomy framework.

### Changes:
- **`marine_autonomy/docs/system_architecture.md`**: Added detailed data flow diagrams (mermaid), explained the "Low-Level Helm" hardware abstraction pattern, and detailed reliability concepts (`udp_bridge`/`command_bridge`).
- **`helm_manager/README.md`**: Fleshed out with technical details including piloting modes (Standby, Manual, Autonomous), Lifecycle node behavior, and ROS 2 topics/parameters.
- **`marine_autonomy/README.md`**: Updated to better guide users toward architectural documentation and clarified the Project11 naming alias.

These changes provide deeper insights for debugging and adding features to the framework.