### PR TITLE
chore: Track self in core.repos [TASK-022]

### DIFF
--- a/config/repos/core.repos
+++ b/config/repos/core.repos
@@ -15,3 +15,7 @@ repositories:
     type: git
     url: git@github.com:rolker/s57_tools.git
     version: jazzy
+  unh_marine_autonomy:
+    type: git
+    url: git@github.com:rolker/unh_marine_autonomy.git
+    version: jazzy


### PR DESCRIPTION
## Description
Adds `unh_marine_autonomy` (this repository) to `config/repos/core.repos` so that it is properly tracked by the workspace status scripts.

## Rationale
The upcoming status report update flags any local repository not in a `.repos` file as "Untracked". Since this repository contains the core configuration, it should be self-referential to avoid false positives.

## Verification
- Verified that `status_report.sh` (from PR #29 in root workspace) correctly identifies this repo as tracked when this change is applied.