### PR TITLE
chore: Track remaining legacy repositories [TASK-022]

### DIFF
--- a/config/repos/platforms.repos
+++ b/config/repos/platforms.repos
@@ -11,3 +11,11 @@ repositories:
     type: git
     url: git@github.com:rolker/mru_transform.git
     version: jazzy
+  seafloor_echoboat_project11:
+    type: git
+    url: git@github.com:rolker/seafloor_echoboat_project11.git
+    version: jazzy
+  unh_echoboats_project11:
+    type: git
+    url: git@github.com:rolker/unh_echoboats_project11.git
+    version: jazzy


### PR DESCRIPTION
## Description
Updates `.repos` files to track repositories that were previously untracked in the workspace.

## Changes
- **`platforms.repos`**: Added `seafloor_echoboat_project11` and `unh_echoboats_project11`.
- **`simulation.repos`**: Renamed key `project11_simulation` to `unh_marine_simulation` and updated URL to match the renamed GitHub repository.

## Verification
- Verified URLs match the current remotes of the local clones.
- Checked other `.repos` files for similar discrepancies (found none).