### PR TITLE
fix: migrate project11/project11_msgs references to marine namespaces

### DIFF
--- a/command_bridge/command_bridge/command_bridge_receiver.py
+++ b/command_bridge/command_bridge/command_bridge_receiver.py
@@ -23,17 +23,17 @@ class CommandBridgeReceiver(Node):
     def __init__(self):
         super().__init__('command_bridge_receiver')
         self.response_pub = self.create_publisher(
-            String, 'project11/response', 10)
+            String, 'marine/response', 10)
         self.mission_plan_pub = self.create_publisher(
-            String, 'project11/mission_plan', 10)
+            String, 'marine/mission_plan', 10)
         self.piloting_mode_pub = self.create_publisher(
             String, 'piloting_mode', 10)
         self.mm_comand_pub = self.create_publisher(
-            String, 'project11/mission_manager/command', 10)
+            String, 'marine/mission_manager/command', 10)
         self.last_messages_received = {}
         self.emControl = None
         self.command_sub = self.create_subscription(
-            String, 'project11/command', self.command_callback, 10)
+            String, 'marine/command', self.command_callback, 10)
 
     def send_ack(self, cmd, ts):
         """Send an acknowledgment back to the sender.

--- a/command_bridge/command_bridge/command_bridge_sender.py
+++ b/command_bridge/command_bridge/command_bridge_sender.py
@@ -21,12 +21,12 @@ class CommandBridgeSender(Node):
         self.send_queue = {}
         self.lock = Lock()
         self.command_pub = self.create_publisher(
-            String, 'project11/command', 10)
+            String, 'marine/command', 10)
         self.send_command_sub = self.create_subscription(
-            String, 'project11/send_command',
+            String, 'marine/send_command',
             self.send_command_callback, 10)
         self.response_sub = self.create_subscription(
-            String, 'project11/response', self.response_callback, 10)
+            String, 'marine/response', self.response_callback, 10)
         self.timer = self.create_timer(1.0, self.update)
 
     def send_command_callback(self, msg):

--- a/command_bridge/setup.py
+++ b/command_bridge/setup.py
@@ -15,7 +15,7 @@ setup(
     zip_safe=True,
     maintainer='Roland Arsenault',
     maintainer_email='roland@ccom.unh.edu',
-    description='Command bridge for project11',
+    description='Command bridge for marine autonomy',
     license='BSD-2-Clause',
     entry_points={
         'console_scripts': [

--- a/joy_to_helm/joy_to_helm/joy_to_helm.py
+++ b/joy_to_helm/joy_to_helm/joy_to_helm.py
@@ -11,9 +11,9 @@ from rclpy.lifecycle import State
 from rclpy.lifecycle import TransitionCallbackReturn
 
 from sensor_msgs.msg import Joy
-from project11_msgs.msg import Helm
-from project11_msgs.msg import DifferentialDrive
-from project11_msgs.msg import Heartbeat
+from marine_interfaces.msg import Helm
+from marine_interfaces.msg import DifferentialDrive
+from marine_interfaces.msg import Heartbeat
 from std_msgs.msg import String
 
 
@@ -49,11 +49,11 @@ class JoyToHelm(Node):
 
         self.dd_publisher = self.create_lifecycle_publisher(DifferentialDrive, 'differential_drive', 10)
 
-        self.piloting_mode_publisher = self.create_publisher(String, 'project11/send_command', 10)
+        self.piloting_mode_publisher = self.create_publisher(String, 'marine/send_command', 10)
 
         self.joy_subscriber = self.create_subscription(Joy, 'joy', self.joystickCallback, 10)
 
-        self.heartbeat_subscriber = self.create_subscription(Heartbeat, 'project11/heartbeat', self.heartbeatCallback, 10)
+        self.heartbeat_subscriber = self.create_subscription(Heartbeat, 'marine/heartbeat', self.heartbeatCallback, 10)
         return TransitionCallbackReturn.SUCCESS
 
     def on_activate(self, state: State) -> TransitionCallbackReturn:

--- a/marine_autonomy/launch/robot_core_launch.py
+++ b/marine_autonomy/launch/robot_core_launch.py
@@ -61,7 +61,7 @@ def generate_launch_description():
                 name='command_bridge_receiver',
                 emulate_tty=True,
             ),
-            # helm_manager is the low level heart of project11. It manages which control messages get sent to the robot based on piloting mode and reports the piloting mode and other status as a heartbeat message.
+            # helm_manager is the low level heart of marine_autonomy. It manages which control messages get sent to the robot based on piloting mode and reports the piloting mode and other status as a heartbeat message.
             GroupAction(
                 actions=[
                     SetRemap(src='out/helm', dst='marine/control/helm'),
@@ -89,10 +89,10 @@ def generate_launch_description():
                     'map_frame': map_frame
                 }.items()
             ),
-            # project11_navigation is the plugin based navigation stack that uses a list of tasks to plan trajectories and generate commands to drive the robot.
+            # marine_navigation is the plugin based navigation stack that uses a list of tasks to plan trajectories and generate commands to drive the robot.
             # IncludeLaunchDescription(
             #     PythonLaunchDescriptionSource(
-            #         PathJoinSubstitution([FindPackageShare('project11_navigation'), 'launch', 'navigator_launch.py'])
+            #         PathJoinSubstitution([FindPackageShare('marine_navigation'), 'launch', 'navigator_launch.py'])
             #     ),
             #     launch_arguments={
             #         'map_frame': map_frame

--- a/marine_autonomy/marine_autonomy/nav.py
+++ b/marine_autonomy/marine_autonomy/nav.py
@@ -29,7 +29,7 @@ import copy
 def distanceBearingDegrees(start_lat, start_lon, dest_lat, dest_lon):
     """ Returns distance and bearing of a geodesic line.
 
-    Uses project11.geodesic library to determine bearing (degrees, NED)
+    Uses marine_autonomy.geodesic library to determine bearing (degrees, NED)
     from start lat/lon to destination lat/lon.
 
     TODO: Write Args documentation.
@@ -269,7 +269,7 @@ class RobotNavigation(EarthTransforms):
         1. Use the frame_id value in the odometry message to lookup the 
         tf transfrom from the "earth" frame to the frame_id.  
         2. Transform odometry.pose to ECEF frame
-        2. The wgs84.py module from project11 is used to transfrom 
+        2. The wgs84.py module from marine_autonomy is used to transfrom
         ECEF -> lat/lon
 
         Returns:
@@ -294,7 +294,7 @@ class RobotNavigation(EarthTransforms):
         """Uses current odometry message to return heading in degrees NED.
 
         TODO: This should not be a method of the object.  Should be a general
-              purpose function, probably in project11 module.  
+              purpose function, probably in marine_autonomy module.
               Not specific to this program.
 
         Returns:
@@ -328,6 +328,6 @@ class RobotNavigation(EarthTransforms):
         current_lon_rad = p_rad[1]
         target_lat_rad = math.radians(lat)
         target_lon_rad = math.radians(lon)
-        azimuth, distance = project11.geodesic.inverse(current_lon_rad, current_lat_rad, target_lon_rad, target_lat_rad)
+        azimuth, distance = marine_autonomy.geodesic.inverse(current_lon_rad, current_lat_rad, target_lon_rad, target_lat_rad)
         return distance, math.degrees(azimuth)
 

--- a/marine_autonomy/scripts/platform_send.py
+++ b/marine_autonomy/scripts/platform_send.py
@@ -12,9 +12,9 @@ from rclpy.lifecycle import State
 from rclpy.lifecycle import TransitionCallbackReturn
 from rclpy.timer import Timer
 
-from project11_msgs.msg import NavSource
-from project11_msgs.msg import Platform
-from project11_msgs.msg import PlatformList
+from marine_interfaces.msg import NavSource
+from marine_interfaces.msg import Platform
+from marine_interfaces.msg import PlatformList
 
 class PlatformPublisher(Node):
     def __init__(self, node_name, **kwargs):
@@ -86,7 +86,7 @@ class PlatformPublisher(Node):
             self.declare_parameter('nav.source_names', ['',])
             self.update_nav_source_parameters()
 
-            self._platform_publisher = self.create_lifecycle_publisher(PlatformList, "/project11/platforms", 5)
+            self._platform_publisher = self.create_lifecycle_publisher(PlatformList, "/marine/platforms", 5)
 
             self._timer = self.create_timer(1.0, self.publish)
         except Exception as e:

--- a/mission_manager/mission_manager/mission_manager/camp_interface.py
+++ b/mission_manager/mission_manager/mission_manager/camp_interface.py
@@ -9,8 +9,8 @@ from typing import Optional
 import yaml
 from geometry_msgs.msg import PoseStamped, Quaternion
 from marine_nav_interfaces.msg import TaskInformation
-from project11 import nav
-from project11_msgs.msg import BehaviorInformation, Heartbeat, KeyValue
+from marine_autonomy import nav
+from marine_interfaces.msg import BehaviorInformation, Heartbeat, KeyValue
 from rclpy.lifecycle import Node, Publisher
 from rclpy.subscription import Subscription
 from std_msgs.msg import String
@@ -82,13 +82,13 @@ class CampInterface:
     def on_configure(self):
         """Configure CAMP interface."""
         self.command_subscriber = self.mission_manager.create_subscription(
-            String, 'project11/mission_manager/command',
+            String, 'marine/mission_manager/command',
             self.commandCallback, 1)
 
         self.status_publisher = (
             self.mission_manager.create_lifecycle_publisher(
                 Heartbeat,
-                'project11/status/mission_manager',
+                'marine/status/mission_manager',
                 10
             )
         )

--- a/mission_manager/mission_manager/mission_manager/mission_manager.py
+++ b/mission_manager/mission_manager/mission_manager/mission_manager.py
@@ -8,7 +8,7 @@ from marine_nav_interfaces.action import RunTasks
 from marine_nav_interfaces.msg import TaskFeedback, TaskInformation
 from marine_nav_tasks import TaskList
 from mission_manager_interfaces.srv import TaskManagerCmd
-from project11_msgs.msg import BehaviorInformation
+from marine_interfaces.msg import BehaviorInformation
 from rclpy.action import ActionClient
 from rclpy.action.client import ClientGoalHandle
 from rclpy.executors import ExternalShutdownException, SingleThreadedExecutor

--- a/mission_manager/mission_manager/mission_manager/track_patterns.py
+++ b/mission_manager/mission_manager/mission_manager/track_patterns.py
@@ -8,7 +8,7 @@ Copyright 2023
 This module contains routines that create canned track patterns, which can be
 used as building blocks to create larger missions or to dynamically respond to
 changing situations quickly. Track patterns are returned as a list of
-project11_nav_msgs/TaskInformation messages which can be passed on directly to
+marine_interfaces/TaskInformation messages which can be passed on directly to
 the MissionManager node, which in turn, will then update the Navigator node
 for execution. (See the mission_manager service for updating the task queue.)
 

--- a/mission_manager/mission_manager/setup.py
+++ b/mission_manager/mission_manager/setup.py
@@ -22,7 +22,7 @@ setup(
     zip_safe=True,
     maintainer='Roland Arsenault',
     maintainer_email='roland@ccom.unh.edu',
-    description='Mission manager for project11',
+    description='Mission manager for marine autonomy',
     license='BSD-2-Clause',
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
## Summary

Migrate remaining `project11` and `project11_msgs` references in Python code to the new `marine_autonomy` and `marine_interfaces` package names, completing the rebranding started in earlier PRs.

### Changes by package

- **joy_to_helm**: `project11_msgs.msg` imports → `marine_interfaces.msg`; `project11/` topic prefixes → `marine/`
- **mission_manager**: `project11_msgs.msg` and `project11` imports → `marine_interfaces.msg` and `marine_autonomy`; topic prefixes and docstrings updated
- **command_bridge**: `project11/` topic prefixes → `marine/`; description text updated
- **marine_autonomy**: `project11_msgs.msg` imports → `marine_interfaces.msg`; topic prefix, docstrings, and a stale `project11.geodesic` code reference fixed

### Files not changed

- `package.xml` files (already correct)
- C++ code (already migrated)
- Anything outside the `unh_marine_autonomy` repo

Closes #51

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
