### PR TITLE
ci: scope CI to unh_marine_autonomy packages only

### DIFF
--- a/.github/workflows/ros-base-docker.yml
+++ b/.github/workflows/ros-base-docker.yml
@@ -46,5 +46,5 @@ jobs:
       run: bash -c 'source /opt/ros/jazzy/setup.bash && colcon test --packages-select marine_interfaces marine_autonomy helm_manager joy_to_helm command_bridge mission_manager mission_manager_interfaces --event-handlers console_direct+ --return-code-on-test-failure'
     - name: Test results
       working-directory: ../jazzy_ws/
-      run: bash -c 'source /opt/ros/jazzy/setup.bash && colcon test-result --verbose --packages-select marine_interfaces marine_autonomy helm_manager joy_to_helm command_bridge mission_manager mission_manager_interfaces'
+      run: bash -c 'source /opt/ros/jazzy/setup.bash && colcon test-result --verbose'
       if: always()

--- a/.github/workflows/ros-base-docker.yml
+++ b/.github/workflows/ros-base-docker.yml
@@ -31,10 +31,6 @@ jobs:
       run: |
         vcs import --input config/repos/underlay.repos ../jazzy_ws/src/
         vcs import --input config/repos/core.repos ../jazzy_ws/src/
-        vcs import --input config/repos/platforms.repos ../jazzy_ws/src/
-        vcs import --input config/repos/sensors.repos ../jazzy_ws/src/
-        vcs import --input config/repos/simulation.repos ../jazzy_ws/src/
-        vcs import --input config/repos/ui.repos ../jazzy_ws/src/
     - name: Replace checked-out unh_marine_autonomy with PR branch
       run: |
         rm -rf ../jazzy_ws/src/unh_marine_autonomy
@@ -44,11 +40,11 @@ jobs:
       run: DEBIAN_FRONTEND=noninteractive rosdep install --from-paths src --ignore-src -r -y
     - name: Colcon build
       working-directory: ../jazzy_ws/
-      run: bash -c 'source /opt/ros/jazzy/setup.bash && colcon build'
+      run: bash -c 'source /opt/ros/jazzy/setup.bash && colcon build --packages-up-to helm_manager command_bridge mission_manager joy_to_helm marine_autonomy'
     - name: Colcon test
       working-directory: ../jazzy_ws/
-      run: bash -c 'source /opt/ros/jazzy/setup.bash && colcon test --event-handlers console_direct+ --return-code-on-test-failure'
+      run: bash -c 'source /opt/ros/jazzy/setup.bash && colcon test --packages-select marine_interfaces marine_autonomy helm_manager joy_to_helm command_bridge mission_manager mission_manager_interfaces --event-handlers console_direct+ --return-code-on-test-failure'
     - name: Test results
       working-directory: ../jazzy_ws/
-      run: bash -c 'source /opt/ros/jazzy/setup.bash && colcon test-result --verbose'
+      run: bash -c 'source /opt/ros/jazzy/setup.bash && colcon test-result --verbose --packages-select marine_interfaces marine_autonomy helm_manager joy_to_helm command_bridge mission_manager mission_manager_interfaces'
       if: always()


### PR DESCRIPTION
## Summary

- Import only underlay + core repos (8 repos instead of 20) — platforms, sensors, simulation, and ui are not build dependencies
- Scope `colcon build` with `--packages-up-to` to build only our leaf packages and their transitive deps
- Scope `colcon test` and `colcon test-result` with `--packages-select` to test only our 7 packages

## Motivation

The CI workflow takes ~18 min per PR. 95% of that time is spent on rosdep install (5.6 min) and colcon build (11.2 min) for packages that aren't dependencies of unh_marine_autonomy. This also produces 500+ unrelated test failures that obscure real results.

Expected reduction: ~18 min → ~6-7 min.

## Test plan

- [ ] CI workflow triggers on this PR and passes
- [ ] All 7 unh_marine_autonomy packages build successfully
- [ ] Tests run only for our packages (no unrelated failures)
- [ ] Total CI time is significantly reduced

Closes #53

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
