### PR TITLE
fix: resolve flake8 I100 and D403 lint errors

### DIFF
--- a/command_bridge/test/test_command_bridge_sender.py
+++ b/command_bridge/test/test_command_bridge_sender.py
@@ -391,7 +391,7 @@ class TestThreadSafety:
         sender.lock.__enter__.assert_called()
 
     def test_lock_held_during_update(self):
-        """update acquires the lock."""
+        """Update acquires the lock."""
         sender = _make_sender()
         sender.lock = MagicMock()
         sender.lock.__enter__ = MagicMock(return_value=None)

--- a/mission_manager/mission_manager/mission_manager/camp_interface.py
+++ b/mission_manager/mission_manager/mission_manager/camp_interface.py
@@ -7,9 +7,9 @@ import math
 from typing import Optional
 
 from geometry_msgs.msg import PoseStamped, Quaternion
-from marine_nav_interfaces.msg import TaskInformation
 from marine_autonomy import nav
 from marine_interfaces.msg import BehaviorInformation, Heartbeat, KeyValue
+from marine_nav_interfaces.msg import TaskInformation
 from rclpy.lifecycle import Node, Publisher
 from rclpy.subscription import Subscription
 from std_msgs.msg import String

--- a/mission_manager/mission_manager/mission_manager/mission_manager.py
+++ b/mission_manager/mission_manager/mission_manager/mission_manager.py
@@ -3,11 +3,11 @@
 
 from typing import Dict, List, Optional
 
+from marine_interfaces.msg import BehaviorInformation
 from marine_nav_interfaces.action import RunTasks
 from marine_nav_interfaces.msg import TaskFeedback, TaskInformation
 from marine_nav_tasks import TaskList
 from mission_manager_interfaces.srv import TaskManagerCmd
-from marine_interfaces.msg import BehaviorInformation
 import rclpy
 from rclpy.action import ActionClient
 from rclpy.action.client import ClientGoalHandle

--- a/mission_manager/mission_manager/test/test_camp_interface.py
+++ b/mission_manager/mission_manager/test/test_camp_interface.py
@@ -28,11 +28,11 @@ _MOCK_MODULES = [
 for _mod in _MOCK_MODULES:
     sys.modules.setdefault(_mod, MagicMock())
 
+from mission_manager.camp_interface import CampInterface  # noqa: E402
+
 # We need *real* yaml for parseMission since it calls yaml.safe_load/safe_dump
 import yaml  # noqa: E402
 sys.modules['yaml'] = yaml
-
-from mission_manager.camp_interface import CampInterface  # noqa: E402
 
 # Provide a lightweight TaskInformation stand-in.
 # parseMission creates TaskInformation objects and sets attributes on them.


### PR DESCRIPTION
## Summary

- Reorder third-party imports in `mission_manager/camp_interface.py`, `mission_manager/mission_manager.py`, and `test/test_camp_interface.py` to satisfy flake8 `I100` (google import-order-style: alphabetical by full module path)
- Capitalize first word of docstring in `command_bridge/test/test_command_bridge_sender.py` to satisfy flake8 `D403`

Closes #55

## Test plan

- [x] `flake8` passes with zero errors on both `mission_manager` and `command_bridge`
- [x] All 43 `test_camp_interface.py` unit tests pass
- [ ] CI passes on this branch

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
