### PR TITLE
feat: add manda_coverage to core.repos

### DIFF
--- a/config/repos/core.repos
+++ b/config/repos/core.repos
@@ -1,4 +1,8 @@
 repositories:
+  manda_coverage:
+    type: git
+    url: https://github.com/rolker/manda_coverage.git
+    version: jazzy
   marine_ais:
     type: git
     url: https://github.com/rolker/marine_ais.git


### PR DESCRIPTION
## Summary

- Add `manda_coverage` (`rolker/manda_coverage`, `jazzy` branch) to `core.repos`
- The navigation stack launches a `manda_coverage` lifecycle node in both `vrx_project11` and `ben_project11`, but the package was never included in the workspace

Closes https://github.com/rolker/unh_marine_autonomy/issues/63

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`