### PR TITLE
feat: add missing repos from old workspace migration

### DIFF
--- a/config/repos/platforms.repos
+++ b/config/repos/platforms.repos
@@ -19,3 +19,11 @@ repositories:
     type: git
     url: https://github.com/rolker/unh_echoboats_project11.git
     version: jazzy
+  lr30_project11:
+    type: git
+    url: https://github.com/rolker/lr30_project11.git
+    version: jazzy
+  molab_description:
+    type: git
+    url: https://github.com/rolker/molab_description.git
+    version: jazzy

--- a/config/repos/sensors.repos
+++ b/config/repos/sensors.repos
@@ -11,3 +11,23 @@ repositories:
     type: git
     url: https://github.com/rolker/unh_marine_perception.git
     version: jazzy
+  marine_tools:
+    type: git
+    url: https://github.com/rolker/marine_tools.git
+    version: jazzy
+  norbit:
+    type: git
+    url: https://github.com/rolker/norbit.git
+    version: jazzy
+  imagenex_deltat:
+    type: git
+    url: https://github.com/rolker/imagenex_deltat.git
+    version: jazzy
+  edgetech_sonar:
+    type: git
+    url: https://github.com/rolker/edgetech_sonar.git
+    version: jazzy
+  ros2sonic:
+    type: git
+    url: https://github.com/rolker/ros2sonic.git
+    version: jazzy

--- a/config/repos/underlay.repos
+++ b/config/repos/underlay.repos
@@ -15,3 +15,15 @@ repositories:
     type: git
     url: https://github.com/rolker/audio_common.git
     version: port_sound_play_h_to_ros2
+  detection_visualizer:
+    type: git
+    url: https://github.com/rolker/detection_visualizer.git
+    version: support_rotation
+  nmea_navsat_driver:
+    type: git
+    url: https://github.com/rolker/nmea_navsat_driver.git
+    version: add_pashr
+  vrx:
+    type: git
+    url: https://github.com/rolker/vrx.git
+    version: add-santorini-seafloor


### PR DESCRIPTION
## Summary

Add 10 repositories that were identified as missing during migration from the old `project11/jazzy` workspace to `ros2_agent_workspace`:

- **underlay.repos** (3): `detection_visualizer`, `nmea_navsat_driver`, `vrx`
- **platforms.repos** (2): `lr30_project11`, `molab_description`
- **sensors.repos** (5): `marine_tools`, `norbit`, `imagenex_deltat`, `edgetech_sonar`, `ros2sonic`

All repos and their target branches have been verified to exist on GitHub.

Closes #67

## Test plan

- [x] YAML validity confirmed with `yaml.safe_load()` for all 3 files
- [ ] Run `vcs import` with modified `.repos` files to confirm repos clone correctly

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
