### PR TITLE
fix: GGGS grid/cell index and iterator bugs

### DIFF
--- a/marine_autonomy/include/marine_autonomy/gggs/cell_area_iterator.h
+++ b/marine_autonomy/include/marine_autonomy/gggs/cell_area_iterator.h
@@ -59,40 +59,30 @@ public:
   /// @param bounds Geographic bounding box to restrict iteration.
   CellAreaIterator(GridIndex grid, const gz4d::BoundsDegrees& bounds)
   {
-    CellIndex from(grid, bounds.minimum());
-    CellIndex to(grid, bounds.maximum());
+    // Extract bound coordinates as doubles for comparison with grid edges.
+    double min_lat = bounds.minimum().latitude;
+    double max_lat = bounds.maximum().latitude;
+    double min_lon = bounds.minimum().longitude;
+    double max_lon = bounds.maximum().longitude;
 
-    auto from_row = from.row();
-    if(from.grid().row() < grid.row())
-      from_row = 0;
-    if(from.grid().row() > grid.row())
-      from_row = cell_rows_per_grid;
-    
-    auto from_column = from.column();
-    if(from.grid().column() < grid.column())
-      from_column = 0;
-    if(from.grid().column() > grid.column())
-      from_column = cell_columns_per_grid;
+    // Check if bounds are entirely outside the grid in any direction.
+    if(max_lat <= grid.southLatitude())
+      return;  // bounds entirely south of grid
+    if(min_lat >= grid.northLatitude())
+      return;  // bounds entirely north of grid
+    if(max_lon <= grid.westLongitude())
+      return;  // bounds entirely west of grid
+    if(min_lon >= grid.eastLongitude())
+      return;  // bounds entirely east of grid
 
-    from_ = CellIndex(grid, from_row, from_column);
+    // Clamp the bounds to the grid extent, then compute cell indices.
+    double from_lat = std::max(min_lat, grid.southLatitude());
+    double to_lat = std::min(max_lat, grid.northLatitude());
+    double from_lon = std::max(min_lon, grid.westLongitude());
+    double to_lon = std::min(max_lon, grid.eastLongitude());
 
-    auto to_row = to.row();
-    if(to.grid().row() < grid.row())
-      to_row = cell_rows_per_grid;
-    if(to.grid().row() > grid.row())
-      to_row = cell_rows_per_grid - 1;
-    
-    auto to_column = to.column();
-    if(to.grid().column() < grid.column())
-      to_column = cell_columns_per_grid;
-    if(to.grid().column() > grid.column())
-      to_column = cell_columns_per_grid - 1;
-
-    to_ = CellIndex(grid, to_row, to_column);
-
-    if(to_row < from_row || to_column < from_column)
-      from_ = CellIndex(grid); // invalid index
-
+    from_ = CellIndex(grid, gz4d::PositionDegrees(from_lat, from_lon));
+    to_ = CellIndex(grid, gz4d::PositionDegrees(to_lat, to_lon));
     current_ = from_;
   }
 

--- a/marine_autonomy/include/marine_autonomy/gggs/cell_area_iterator.h
+++ b/marine_autonomy/include/marine_autonomy/gggs/cell_area_iterator.h
@@ -29,6 +29,7 @@
 #ifndef PROJECT11_GGGS_CELL_AREA_ITERATOR_H
 #define PROJECT11_GGGS_CELL_AREA_ITERATOR_H
 
+#include <algorithm>
 #include "cell_index.h"
 
 namespace gggs
@@ -66,13 +67,13 @@ public:
     double max_lon = bounds.maximum().longitude;
 
     // Check if bounds are entirely outside the grid in any direction.
-    if(max_lat <= grid.southLatitude())
+    if(max_lat < grid.southLatitude())
       return;  // bounds entirely south of grid
-    if(min_lat >= grid.northLatitude())
+    if(min_lat > grid.northLatitude())
       return;  // bounds entirely north of grid
-    if(max_lon <= grid.westLongitude())
+    if(max_lon < grid.westLongitude())
       return;  // bounds entirely west of grid
-    if(min_lon >= grid.eastLongitude())
+    if(min_lon > grid.eastLongitude())
       return;  // bounds entirely east of grid
 
     // Clamp the bounds to the grid extent, then compute cell indices.

--- a/marine_autonomy/include/marine_autonomy/gggs/cell_index.h
+++ b/marine_autonomy/include/marine_autonomy/gggs/cell_index.h
@@ -29,6 +29,7 @@
 #ifndef PROJECT11_GGGS_CELL_INDEX_H
 #define PROJECT11_GGGS_CELL_INDEX_H
 
+#include <cassert>
 #include "level_spec.h"
 
 namespace gggs
@@ -49,6 +50,8 @@ public:
   CellIndex(GridIndex grid, uint16_t row, uint16_t column):
     grid_index_(grid), row_(row), column_(column)
   {
+    assert(row < cell_rows_per_grid && "CellIndex row out of bounds");
+    assert(column < cell_columns_per_grid && "CellIndex column out of bounds");
   }
 
   // CellIndex(double latitude, double longitude, GridIndex grid)

--- a/marine_autonomy/include/marine_autonomy/gggs/cell_index.h
+++ b/marine_autonomy/include/marine_autonomy/gggs/cell_index.h
@@ -64,7 +64,7 @@ public:
   {
 
     // Note, we constrain to 1.0, but what we really need is up to 1.0.
-    double row_p = std::max(0.0, std::min(1.0, position.latitude-grid_index_.southLatitude())/grid_index_.latitudinalSpan());
+    double row_p = std::max(0.0, std::min(1.0, (position.latitude-grid_index_.southLatitude())/grid_index_.latitudinalSpan()));
     // This std::min should filter out 1.0 from above
     row_ = std::min<uint16_t>(cell_rows_per_grid-1, cell_rows_per_grid*row_p);
 

--- a/marine_autonomy/include/marine_autonomy/gggs/cell_index.h
+++ b/marine_autonomy/include/marine_autonomy/gggs/cell_index.h
@@ -110,8 +110,15 @@ public:
   }
 
   /// Less than operator allowing use as std::map key.
+  /// Invalid indices sort before all valid indices.
   friend bool operator<(const CellIndex& lhs, const CellIndex& rhs)
   {
+    if (!lhs.valid() && !rhs.valid())
+      return false;
+    if (!lhs.valid())
+      return true;
+    if (!rhs.valid())
+      return false;
     if (lhs.grid_index_ != rhs.grid_index_)
       return lhs.grid_index_ < rhs.grid_index_;
     if (lhs.row_ != rhs.row_)

--- a/marine_autonomy/include/marine_autonomy/gggs/cell_index.h
+++ b/marine_autonomy/include/marine_autonomy/gggs/cell_index.h
@@ -29,6 +29,7 @@
 #ifndef PROJECT11_GGGS_CELL_INDEX_H
 #define PROJECT11_GGGS_CELL_INDEX_H
 
+#include <algorithm>
 #include <cassert>
 #include "level_spec.h"
 

--- a/marine_autonomy/include/marine_autonomy/gggs/grid_index.h
+++ b/marine_autonomy/include/marine_autonomy/gggs/grid_index.h
@@ -116,7 +116,7 @@ public:
 
   double latitudinalSpan() const
   {
-    return levels[level_].grid_angular_span;
+    return northLatitude() - southLatitude();
   }
 
   double longitudinalSpan() const

--- a/marine_autonomy/include/marine_autonomy/gggs/grid_index.h
+++ b/marine_autonomy/include/marine_autonomy/gggs/grid_index.h
@@ -29,6 +29,7 @@
 #ifndef PROJECT11_GGGS_GRID_INDEX_H
 #define PROJECT11_GGGS_GRID_INDEX_H
 
+#include <algorithm>
 #include "level_spec.h"
 
 namespace gggs
@@ -85,12 +86,12 @@ public:
 
   double northLatitude() const
   {
-    return std::max(-90.0, -96.0+(row_+1)*levels[level_].grid_angular_span);
+    return std::clamp(-96.0+(row_+1)*levels[level_].grid_angular_span, -90.0, 90.0);
   }
 
   double southLatitude() const
   {
-    return std::max(-90.0, -96.0+row_*levels[level_].grid_angular_span);
+    return std::clamp(-96.0+row_*levels[level_].grid_angular_span, -90.0, 90.0);
   }
 
   double eastLongitude() const

--- a/marine_autonomy/include/marine_autonomy/gggs/grid_index.h
+++ b/marine_autonomy/include/marine_autonomy/gggs/grid_index.h
@@ -125,8 +125,15 @@ public:
   }
 
   /// Less than operator allowing use as std::map key.
+  /// Invalid indices sort before all valid indices.
   friend bool operator<(const GridIndex& lhs, const GridIndex& rhs)
   {
+    if (!lhs.valid() && !rhs.valid())
+      return false;
+    if (!lhs.valid())
+      return true;
+    if (!rhs.valid())
+      return false;
     if (lhs.level_ != rhs.level_)
       return lhs.level_ < rhs.level_;
     if (lhs.row_ != rhs.row_)

--- a/marine_autonomy/include/marine_autonomy/gggs/level_spec.h
+++ b/marine_autonomy/include/marine_autonomy/gggs/level_spec.h
@@ -106,7 +106,7 @@ public:
 };
 
 /// @brief Pre-computed metadata for all 21 quadtree levels (0-20).
-inline std::array<LevelSpecs, 21> levels = {{
+inline const std::array<LevelSpecs, 21> levels = {{
   LevelSpecs(0),  LevelSpecs(1),  LevelSpecs(2),  LevelSpecs(3),  LevelSpecs(4),  LevelSpecs(5),
   LevelSpecs(6),  LevelSpecs(7),  LevelSpecs(8),  LevelSpecs(9),  LevelSpecs(10), LevelSpecs(11),
   LevelSpecs(12), LevelSpecs(13), LevelSpecs(14), LevelSpecs(15), LevelSpecs(16), LevelSpecs(17),

--- a/marine_autonomy/test/test_gggs.cpp
+++ b/marine_autonomy/test/test_gggs.cpp
@@ -676,3 +676,27 @@ TEST(GGGSLevel, GridIndexLatitudeMinus91Throws)
   gggs::Level level(5);
   EXPECT_THROW(level.gridIndex(-91.0, 0.0), std::out_of_range);
 }
+
+// ============================================================================
+// Bug-fix regression tests (Issue #77)
+// ============================================================================
+
+// Bug 1: CellIndex position constructor parenthesization
+// std::min(1.0, delta_lat) clamps before dividing by span, giving wrong row
+// at level 0 (8° span).
+TEST(GGGSCellIndex, PositionConstructorLevel0)
+{
+  gggs::Level level(0);
+  // Level 0 grid_angular_span = 8.0°
+  // Place a grid whose south edge is at some known latitude.
+  // gridIndex(0.0, 0.0) → south edge at 0° (row 12, south = -96+12*8 = 0)
+  auto gi = level.gridIndex(0.0, 0.0);
+  ASSERT_TRUE(gi.valid());
+  double south = gi.southLatitude();
+  // Position 4° above the south edge of the grid
+  gz4d::PositionDegrees pos(south + 4.0, gi.westLongitude() + 1.0);
+  gggs::CellIndex ci(gi, pos);
+  ASSERT_TRUE(ci.valid());
+  // 4° into an 8° span = 50% → row ≈ 480
+  EXPECT_NEAR(ci.row(), 480, 2);
+}

--- a/marine_autonomy/test/test_gggs.cpp
+++ b/marine_autonomy/test/test_gggs.cpp
@@ -28,6 +28,7 @@
 
 #include <gtest/gtest.h>
 #include <cmath>
+#include <type_traits>
 #include "marine_autonomy/gggs.h"
 
 // ============================================================================
@@ -713,4 +714,11 @@ TEST(GGGSGridIndex, NorthLatitudeClampedAt90)
   ASSERT_TRUE(gi.valid());
   EXPECT_LE(gi.northLatitude(), 90.0);
   EXPECT_GE(gi.southLatitude(), -90.0);
+}
+
+// Bug 3: levels array is not const, allowing accidental mutation.
+TEST(GGGSLevelSpecs, LevelsArrayIsConst)
+{
+  static_assert(std::is_const_v<std::remove_reference_t<decltype(gggs::levels)>>,
+    "gggs::levels should be const");
 }

--- a/marine_autonomy/test/test_gggs.cpp
+++ b/marine_autonomy/test/test_gggs.cpp
@@ -700,3 +700,17 @@ TEST(GGGSCellIndex, PositionConstructorLevel0)
   // 4° into an 8° span = 50% → row ≈ 480
   EXPECT_NEAR(ci.row(), 480, 2);
 }
+
+// Bug 2: northLatitude() can exceed +90°
+// grid_index.h used std::max(-90.0, ...) but no upper clamp. The topmost
+// level-0 grid returns northLatitude() = 96.0.
+TEST(GGGSGridIndex, NorthLatitudeClampedAt90)
+{
+  gggs::Level level(0);
+  // Row 23 is the topmost level-0 row. south = -96+23*8 = 88°, north = 96°
+  // but it should be clamped to 90°.
+  auto gi = level.gridIndex(89.0, 0.0);
+  ASSERT_TRUE(gi.valid());
+  EXPECT_LE(gi.northLatitude(), 90.0);
+  EXPECT_GE(gi.southLatitude(), -90.0);
+}

--- a/marine_autonomy/test/test_gggs.cpp
+++ b/marine_autonomy/test/test_gggs.cpp
@@ -722,3 +722,44 @@ TEST(GGGSLevelSpecs, LevelsArrayIsConst)
   static_assert(std::is_const_v<std::remove_reference_t<decltype(gggs::levels)>>,
     "gggs::levels should be const");
 }
+
+// Bug 4: operator< inconsistent with operator== for invalid indices.
+// operator== treats all invalid indices as equal, but operator< compared raw
+// fields, breaking strict-weak-ordering guarantees.
+
+TEST(GGGSGridIndex, LessThanBothInvalid)
+{
+  gggs::GridIndex a;
+  gggs::GridIndex b;
+  // Both invalid: neither should be less than the other
+  EXPECT_FALSE(a < b);
+  EXPECT_FALSE(b < a);
+}
+
+TEST(GGGSGridIndex, LessThanInvalidVsValid)
+{
+  gggs::GridIndex invalid;
+  gggs::Level level(5);
+  auto valid = level.gridIndex(43.0, -70.5);
+  // Invalid sorts before valid (invalid < valid is true)
+  EXPECT_TRUE(invalid < valid);
+  EXPECT_FALSE(valid < invalid);
+}
+
+TEST(GGGSCellIndex, LessThanBothInvalid)
+{
+  gggs::CellIndex a;
+  gggs::CellIndex b;
+  EXPECT_FALSE(a < b);
+  EXPECT_FALSE(b < a);
+}
+
+TEST(GGGSCellIndex, LessThanInvalidVsValid)
+{
+  gggs::CellIndex invalid;
+  gggs::Level level(5);
+  auto gi = level.gridIndex(43.0, -70.5);
+  gggs::CellIndex valid(gi, 0, 0);
+  EXPECT_TRUE(invalid < valid);
+  EXPECT_FALSE(valid < invalid);
+}

--- a/marine_autonomy/test/test_gggs.cpp
+++ b/marine_autonomy/test/test_gggs.cpp
@@ -763,3 +763,56 @@ TEST(GGGSCellIndex, LessThanInvalidVsValid)
   EXPECT_TRUE(invalid < valid);
   EXPECT_FALSE(valid < invalid);
 }
+
+// Bug 5: CellAreaIterator asymmetric invalid marking.
+// When bounds are entirely outside the target grid, some directions left a
+// corrupted range that iterates 961 rows instead of producing an empty iterator.
+
+TEST(GGGSCellAreaIterator, BoundsEntirelyBelowGrid)
+{
+  gggs::Level level(5);
+  auto gi = level.gridIndex(43.0, -70.5);
+  // Create bounds entirely south of the grid
+  double south = gi.southLatitude();
+  gz4d::PositionDegrees sw(south - 2.0, gi.westLongitude());
+  gz4d::PositionDegrees ne(south - 1.0, gi.eastLongitude());
+  gz4d::BoundsDegrees bounds(sw, ne);
+  gggs::CellAreaIterator it(gi, bounds);
+  EXPECT_FALSE(it.valid());
+}
+
+TEST(GGGSCellAreaIterator, BoundsEntirelyAboveGrid)
+{
+  gggs::Level level(5);
+  auto gi = level.gridIndex(43.0, -70.5);
+  double north = gi.northLatitude();
+  gz4d::PositionDegrees sw(north + 1.0, gi.westLongitude());
+  gz4d::PositionDegrees ne(north + 2.0, gi.eastLongitude());
+  gz4d::BoundsDegrees bounds(sw, ne);
+  gggs::CellAreaIterator it(gi, bounds);
+  EXPECT_FALSE(it.valid());
+}
+
+TEST(GGGSCellAreaIterator, BoundsEntirelyLeftOfGrid)
+{
+  gggs::Level level(5);
+  auto gi = level.gridIndex(43.0, -70.5);
+  double west = gi.westLongitude();
+  gz4d::PositionDegrees sw(gi.southLatitude(), west - 2.0);
+  gz4d::PositionDegrees ne(gi.northLatitude(), west - 1.0);
+  gz4d::BoundsDegrees bounds(sw, ne);
+  gggs::CellAreaIterator it(gi, bounds);
+  EXPECT_FALSE(it.valid());
+}
+
+TEST(GGGSCellAreaIterator, BoundsEntirelyRightOfGrid)
+{
+  gggs::Level level(5);
+  auto gi = level.gridIndex(43.0, -70.5);
+  double east = gi.eastLongitude();
+  gz4d::PositionDegrees sw(gi.southLatitude(), east + 1.0);
+  gz4d::PositionDegrees ne(gi.northLatitude(), east + 2.0);
+  gz4d::BoundsDegrees bounds(sw, ne);
+  gggs::CellAreaIterator it(gi, bounds);
+  EXPECT_FALSE(it.valid());
+}

--- a/marine_autonomy/test/test_gggs.cpp
+++ b/marine_autonomy/test/test_gggs.cpp
@@ -816,3 +816,32 @@ TEST(GGGSCellAreaIterator, BoundsEntirelyRightOfGrid)
   gggs::CellAreaIterator it(gi, bounds);
   EXPECT_FALSE(it.valid());
 }
+
+// Bug 6: CellIndex public constructor now asserts on out-of-bounds row/column.
+// After Bug 5, no internal code passes out-of-bounds values.
+TEST(GGGSCellIndex, OutOfBoundsRowAssertsInDebug)
+{
+  gggs::Level level(5);
+  auto gi = level.gridIndex(43.0, -70.5);
+#ifdef NDEBUG
+  // In release builds, assert is disabled; verify valid() returns false.
+  gggs::CellIndex ci(gi, gggs::cell_rows_per_grid, 0);
+  EXPECT_FALSE(ci.valid());
+#else
+  EXPECT_DEATH(gggs::CellIndex(gi, gggs::cell_rows_per_grid, 0),
+    "CellIndex row out of bounds");
+#endif
+}
+
+TEST(GGGSCellIndex, OutOfBoundsColumnAssertsInDebug)
+{
+  gggs::Level level(5);
+  auto gi = level.gridIndex(43.0, -70.5);
+#ifdef NDEBUG
+  gggs::CellIndex ci(gi, 0, gggs::cell_columns_per_grid);
+  EXPECT_FALSE(ci.valid());
+#else
+  EXPECT_DEATH(gggs::CellIndex(gi, 0, gggs::cell_columns_per_grid),
+    "CellIndex column out of bounds");
+#endif
+}


### PR DESCRIPTION
## Summary

Fixes 6 bugs identified in the GGGS library during code review:

1. **CellIndex position constructor parenthesization** (HIGH) — `std::min(1.0, delta_lat)` clamped before dividing by span, giving incorrect cell rows at level 0 (8° grids)
2. **northLatitude() exceeds +90°** (MEDIUM) — Missing upper clamp allowed the topmost level-0 grid to return 96°
3. **Mutable inline global `levels` array** (LOW) — `gggs::levels` was not `const`, allowing accidental mutation
4. **operator< inconsistent with operator==** (LOW) — `operator==` treats all invalid indices as equal, but `operator<` compared raw fields, potentially breaking strict-weak-ordering
5. **CellAreaIterator asymmetric invalid marking** (LOW) — Out-of-grid bounds left corrupted iteration ranges instead of producing empty iterators
6. **CellIndex constructor allows out-of-bounds values** (LOW) — No validation on row/column parameters; added `assert()` guards

Each bug has its own atomic commit containing both the regression test and the fix.

## Test plan

- [x] All 65 GGGS unit tests pass (13 new regression tests added)
- [x] All 5 marine_autonomy test targets pass (gtest, cppcheck, copyright, lint_cmake, xmllint)
- [x] Verify Bug 1: `GGGSCellIndex_PositionConstructorLevel0` — cell row near 480 for 4° into 8° grid
- [x] Verify Bug 2: `GGGSGridIndex_NorthLatitudeClampedAt90` — northLatitude() ≤ 90°
- [x] Verify Bug 3: `GGGSLevelSpecs_LevelsArrayIsConst` — static_assert const
- [x] Verify Bug 4: `GGGSGridIndex_LessThanBothInvalid`, `LessThanInvalidVsValid` (and CellIndex mirrors)
- [x] Verify Bug 5: `BoundsEntirelyBelowGrid`, `AboveGrid`, `LeftOfGrid`, `RightOfGrid` — all empty
- [x] Verify Bug 6: `OutOfBoundsRowAssertsInDebug`, `OutOfBoundsColumnAssertsInDebug` — EXPECT_DEATH

Closes #77

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
