### PR TITLE
Add .agents/ directory with README and project principles

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -12,7 +12,7 @@
 | `joy_to_helm` | Python | Converts joystick input to helm commands for manual piloting |
 | `marine_autonomy` | C++/Python | Meta-package with launch files, geodesic utilities, and system configuration |
 | `marine_autonomy_integration_tests` | Python (CMake) | Cross-package integration tests for mission and navigation flows |
-| `marine_interfaces` | C++ (IDL) | ROS 2 message definitions for helm commands, heartbeats, navigation, and sensor data (22 msg types) |
+| `marine_interfaces` | C++ (IDL) | ROS 2 message definitions for helm commands, heartbeats, navigation, and sensor data (34 msg types) |
 | `mission_manager` | Python | Converts mission plans from CAMP GCS into navigation tasks and manages task execution |
 | `mission_manager_interfaces` | C++ (IDL) | Service definitions for task manipulation (3 srv types) |
 
@@ -46,7 +46,7 @@ unh_marine_autonomy/
 ├── marine_autonomy_integration_tests/
 │   └── test/                   # Launch-based integration tests
 ├── marine_interfaces/
-│   ├── msg/                    # 22 message definitions
+│   ├── msg/                    # 34 message definitions
 │   └── bmr/                    # Bag migration rules
 ├── mission_manager/
 │   ├── mission_manager/
@@ -61,12 +61,20 @@ unh_marine_autonomy/
 
 ## Architecture Overview
 
-The system follows a layered command flow: **CAMP** (ground control station, separate
-repo) sends mission plans through the **command bridge** (reliable delivery over lossy
-networks) to the **mission manager** (task decomposition), which delegates to the
-navigation stack (separate `unh_marine_navigation` repo) for path execution. The
-**helm manager** arbitrates between manual (joystick) and autonomous control sources,
-enforcing single-active-mode safety.
+This repository provides the **robot-side autonomy stack** — everything needed to
+receive missions, arbitrate control, and drive the vehicle. It is self-contained
+and can be deployed to a robot without operator-side dependencies.
+
+The internal command flow: the **mission manager** decomposes mission plans into
+navigation tasks, which are executed by the navigation stack. The **helm manager**
+arbitrates between manual (joystick) and autonomous control sources, enforcing
+single-active-mode safety. The **command bridge** provides reliable command delivery
+over lossy radio/satellite links.
+
+The full system includes external components in other repositories:
+- **CAMP** (ground control station, in `camp` repo) — operator UI for mission planning
+- **unh_marine_navigation** — path planning and task execution
+- **Platform drivers** — vehicle-specific hardware interfaces
 
 Key architectural patterns:
 - **Send-until-ack**: Command bridge uses timestamp-based deduplication for reliable

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,150 @@
+# Agent Guide: unh_marine_autonomy
+
+> Core autonomy framework for UNH marine robotics — mission management, control
+> arbitration, and reliable command transport for uncrewed surface vehicles.
+
+## Package Inventory
+
+| Package | Language | Description |
+|---------|----------|-------------|
+| `command_bridge` | Python | Reliable command delivery over lossy radio/satellite links (send-until-ack with timestamp deduplication) |
+| `helm_manager` | C++ | Control arbitrator ensuring single-active-mode command authority (standby/manual/autonomous) |
+| `joy_to_helm` | Python | Converts joystick input to helm commands for manual piloting |
+| `marine_autonomy` | C++/Python | Meta-package with launch files, geodesic utilities, and system configuration |
+| `marine_autonomy_integration_tests` | Python (CMake) | Cross-package integration tests for mission and navigation flows |
+| `marine_interfaces` | C++ (IDL) | ROS 2 message definitions for helm commands, heartbeats, navigation, and sensor data (22 msg types) |
+| `mission_manager` | Python | Converts mission plans from CAMP GCS into navigation tasks and manages task execution |
+| `mission_manager_interfaces` | C++ (IDL) | Service definitions for task manipulation (3 srv types) |
+
+## Repository Layout
+
+```
+unh_marine_autonomy/
+├── command_bridge/
+│   └── command_bridge/         # Python: sender + receiver nodes
+├── config/
+│   ├── bootstrap.yaml          # Workspace bootstrap config
+│   ├── layers.txt              # Layer order (underlay → core → ... → ui)
+│   └── repos/                  # .repos files for all 6 workspace layers
+├── docs/
+│   ├── autonomy_modes.md       # Piloting mode state machine
+│   ├── data_flows.md           # System data flow diagrams
+│   └── interfaces.md           # ROS topic/service/action reference
+├── helm_manager/
+│   ├── src/                    # C++: lifecycle node, piloting mode logic
+│   ├── launch/                 # helm_manager_launch.py
+│   └── test/                   # GTest: arbitration, mode, conversion tests
+├── joy_to_helm/
+│   ├── joy_to_helm/            # Python: joystick-to-helm converter
+│   └── launch/                 # joy_to_helm_launch.py
+├── marine_autonomy/
+│   ├── config/                 # operator.yaml, robot.yaml
+│   ├── launch/                 # robot_core_launch.py, operator_core_launch.py
+│   ├── marine_autonomy/        # Python: geodesic, nav, wgs84 utilities
+│   ├── src/                    # C++: utils
+│   └── docs/                   # system_architecture.md
+├── marine_autonomy_integration_tests/
+│   └── test/                   # Launch-based integration tests
+├── marine_interfaces/
+│   ├── msg/                    # 22 message definitions
+│   └── bmr/                    # Bag migration rules
+├── mission_manager/
+│   ├── mission_manager/
+│   │   ├── mission_manager/    # Python: core node, CAMP interface, coverage adapter
+│   │   └── test/               # Unit tests
+│   └── mission_manager_interfaces/
+│       └── srv/                # 3 service definitions
+├── PRINCIPLES.md               # Project principles
+├── VISION.md                   # Strategic vision and objectives
+└── README.md
+```
+
+## Architecture Overview
+
+The system follows a layered command flow: **CAMP** (ground control station, separate
+repo) sends mission plans through the **command bridge** (reliable delivery over lossy
+networks) to the **mission manager** (task decomposition), which delegates to the
+navigation stack (separate `unh_marine_navigation` repo) for path execution. The
+**helm manager** arbitrates between manual (joystick) and autonomous control sources,
+enforcing single-active-mode safety.
+
+Key architectural patterns:
+- **Send-until-ack**: Command bridge uses timestamp-based deduplication for reliable
+  delivery over unreliable radio/satellite links
+- **Single-active-mode arbitration**: Helm manager gates commands — only the active
+  piloting mode (standby/manual/autonomous) can reach the vehicle
+- **Lifecycle nodes**: Helm manager uses ROS 2 lifecycle for controlled state transitions
+- **Heartbeat status**: Nodes publish periodic heartbeat messages with key-value status
+
+See [`docs/data_flows.md`](../docs/data_flows.md) for detailed data flow diagrams,
+[`docs/interfaces.md`](../docs/interfaces.md) for the complete topic/service reference,
+and [`docs/autonomy_modes.md`](../docs/autonomy_modes.md) for the piloting mode state machine.
+
+## Key Files to Read First
+
+1. `marine_autonomy/launch/robot_core_launch.py` — Robot-side launch: brings up command
+   bridge, helm manager, mission manager, and platform sender
+2. `marine_autonomy/launch/operator_core_launch.py` — Operator-side launch: command
+   bridge sender, joystick, and joy-to-helm converter
+3. `helm_manager/src/helm_manager.h` — Core arbitration logic (lifecycle node)
+4. `marine_autonomy/config/robot.yaml` — Default robot parameters
+5. `marine_interfaces/msg/Helm.msg` — Primary control message (throttle + rudder)
+6. `docs/data_flows.md` — System-wide data flow documentation
+
+## Build & Test
+
+```bash
+# From the layer workspace directory (e.g., layers/main/core_ws/)
+colcon build --symlink-install
+colcon test && colcon test-result --verbose
+
+# Single package
+colcon build --packages-select helm_manager
+colcon test --packages-select helm_manager && colcon test-result --verbose
+```
+
+Known build requirements:
+- `marine_interfaces` must build before `helm_manager`, `mission_manager`, and
+  `marine_autonomy` (provides shared message types)
+- `mission_manager_interfaces` must build before `mission_manager`
+- Integration tests depend on `command_bridge`, `mission_manager`, `marine_interfaces`,
+  and `marine_nav_interfaces` (from `unh_marine_navigation`)
+
+## Cross-Layer Dependencies
+
+| Package | Depends On | Layer | What It Imports |
+|---------|-----------|-------|-----------------|
+| `marine_interfaces` | `geographic_msgs` | underlay (`geographic_info`) | Geographic coordinate message types |
+| `marine_interfaces` | `marine_acoustic_msgs` | system (apt) | Acoustic sensor message types |
+| `mission_manager` | `marine_nav_interfaces` | core (`unh_marine_navigation`) | `TaskInformation`, navigation action types |
+| `mission_manager` | `marine_nav_tasks` | core (`unh_marine_navigation`) | Task type definitions |
+| `mission_manager_interfaces` | `marine_nav_interfaces` | core (`unh_marine_navigation`) | `TaskInformation` message for service definitions |
+| `marine_autonomy_integration_tests` | `marine_nav_interfaces` | core (`unh_marine_navigation`) | Test fixtures for navigation flow |
+
+### Manifest Repo Role
+
+This repository also serves as the workspace **manifest repo** — the `config/` directory
+defines the `.repos` files that pull in all project repos across 6 layers:
+
+| Layer | Config File | Repos |
+|-------|-------------|-------|
+| underlay | `config/repos/underlay.repos` | geographic_info, vrx, nmea_navsat_driver, + 4 more |
+| core | `config/repos/core.repos` | unh_marine_navigation, udp_bridge, marine_ais, + 3 more |
+| platforms | `config/repos/platforms.repos` | mru_transform, ben_project11, + 5 more |
+| sensors | `config/repos/sensors.repos` | unh_marine_radar, cube_bathymetry, + 6 more |
+| simulation | `config/repos/simulation.repos` | unh_marine_simulation |
+| ui | `config/repos/ui.repos` | camp, rqt_marine_radar, + 2 more |
+
+## Common Pitfalls
+
+- **Build order matters**: `marine_interfaces` and `mission_manager_interfaces` are IDL
+  packages that generate code at build time. If you modify a `.msg` or `.srv` file,
+  dependent packages need a rebuild.
+- **Nested package structure**: `mission_manager` is a directory containing two separate
+  packages (`mission_manager/mission_manager/` and `mission_manager/mission_manager_interfaces/`).
+  The `--packages-select` flag takes the package name, not the directory path.
+- **Config files are workspace-level**: Files in `config/` (layers.txt, bootstrap.yaml,
+  .repos files) are consumed by the workspace infrastructure, not by ROS 2 nodes.
+  Changes here affect all workspace users.
+- **Legacy code**: Some launch files (`.launch` extension) use ROS 1 XML format and
+  are no longer active. The current launch files use Python (`.py` extension).

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -26,10 +26,9 @@ and `udp_bridge` are designed for community reuse outside this framework.
 
 ## Simulation-First Validation
 
-No behavior reaches the water without passing through simulation. The workspace
-layers (`unh_marine_simulation` in the simulation layer, `vrx` in the underlay)
-provide a Gazebo-based test environment where missions, safety behaviors, and new
-algorithms are validated before field trials.
+No behavior reaches the water without passing through simulation. The
+`unh_marine_simulation` package provides a simulation environment where missions,
+safety behaviors, and new algorithms are validated before field trials.
 
 ## Iterative, Validated Evolution
 

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -1,0 +1,46 @@
+# Principles
+
+Guiding principles for the UNH Marine Autonomy Framework. Each traces to the
+project's [Vision](./VISION.md) and existing architecture.
+
+## Safety First
+
+Operational reliability takes priority over capability. The system defaults to a
+safe standby mode where no commands reach the vehicle. Every increment of autonomy
+is validated in simulation before field deployment, and operators always retain
+override authority.
+
+## Hardware Agnosticism
+
+Interfaces are generic — control flows through abstract helm commands (throttle/rudder)
+and standard ROS 2 messages, not platform-specific APIs. This enables the same
+autonomy stack to drive USVs, coordinate with AUVs, and extend to new vehicle types
+without rewriting core logic.
+
+## Modularity and Decoupling
+
+Each package solves one problem and can be adopted independently. The helm manager
+arbitrates control without knowing what generates commands; the mission manager
+decomposes tasks without knowing how they're executed. Packages like `marine_interfaces`
+and `udp_bridge` are designed for community reuse outside this framework.
+
+## Simulation-First Validation
+
+No behavior reaches the water without passing through simulation. The workspace
+layers (`unh_marine_simulation` in the simulation layer, `vrx` in the underlay)
+provide a Gazebo-based test environment where missions, safety behaviors, and new
+algorithms are validated before field trials.
+
+## Iterative, Validated Evolution
+
+The system evolves from supervised teleoperation toward autonomous operations in
+deliberate, incremental steps. Each step is validated through simulation and field
+testing before the next is attempted — the path from "backseat driver" to full
+autonomy is a ladder, not a leap.
+
+## Standards Compliance
+
+The framework adheres to ROS 2 community standards: REP-2000 for package quality
+and support tiers, REP-105 for coordinate frame conventions, and standard ROS 2
+lifecycle patterns for node management. This ensures interoperability with the
+broader ROS ecosystem and lowers the barrier for new contributors.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ This repository is typically part of a layered workspace setup.
 colcon build --symlink-install
 ```
 
+### Workspace Integration
+
+This repository is the core layer of the
+[ros2_agent_workspace](https://github.com/rolker/ros2_agent_workspace), which
+provides layered `colcon` workspace management, CI tooling, and AI-agent support
+across all project repos. The `config/` directory in this repo defines the `.repos`
+files that pull in dependencies across six layers (underlay, core, platforms, sensors,
+simulation, ui). See the workspace repo for setup instructions.
+
 ### Community & Contributing
 Contributions from the marine robotics community are welcome.
 - **Issues**: Please use GitHub Issues for bug reports and feature requests.

--- a/README.md
+++ b/README.md
@@ -29,12 +29,13 @@ colcon build --symlink-install
 
 ### Workspace Integration
 
-This repository is the core layer of the
+This repository works standalone — clone it, build with `colcon`, and run. It can
+also be used with the
 [ros2_agent_workspace](https://github.com/rolker/ros2_agent_workspace), which
-provides layered `colcon` workspace management, CI tooling, and AI-agent support
-across all project repos. The `config/` directory in this repo defines the `.repos`
-files that pull in dependencies across six layers (underlay, core, platforms, sensors,
-simulation, ui). See the workspace repo for setup instructions.
+provides layered workspace management, CI tooling, and AI-agent support. The
+`config/` directory contains `.repos` files that the workspace uses to pull in
+dependencies across six layers (underlay, core, platforms, sensors, simulation, ui).
+See the workspace repo for setup instructions.
 
 ### Community & Contributing
 Contributions from the marine robotics community are welcome.


### PR DESCRIPTION
## Summary

- Add `.agents/README.md` — agent onboarding guide with package inventory (8 packages), architecture overview, cross-layer dependency table, build instructions, and common pitfalls
- Add `PRINCIPLES.md` — six guiding principles (safety first, hardware agnosticism, modularity, simulation-first validation, iterative evolution, standards compliance) each traced to VISION.md
- Update `README.md` with workspace integration section linking to ros2_agent_workspace

## Verification

- [x] Every package listed matches a `package.xml` in the repo (8/8)
- [x] Language column matches actual build system (CMakeLists.txt / setup.py)
- [x] Architecture summary verified against source code and existing docs/
- [x] Cross-layer dependencies verified by grepping package.xml and source imports
- [x] All key file paths exist at listed locations
- [x] Each principle traces to specific VISION.md section
- [x] Workspace link uses correct GitHub repo name

Closes #87

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
