### PR TITLE
Move forked repos (norbit, ros2sonic) to underlay layer

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -136,10 +136,10 @@ defines the `.repos` files that pull in all project repos across 6 layers:
 
 | Layer | Config File | Repos |
 |-------|-------------|-------|
-| underlay | `config/repos/underlay.repos` | geographic_info, vrx, nmea_navsat_driver, + 4 more |
+| underlay | `config/repos/underlay.repos` | geographic_info, vrx, norbit, ros2sonic, + 5 more |
 | core | `config/repos/core.repos` | unh_marine_navigation, udp_bridge, marine_ais, + 3 more |
 | platforms | `config/repos/platforms.repos` | mru_transform, ben_project11, + 5 more |
-| sensors | `config/repos/sensors.repos` | unh_marine_radar, cube_bathymetry, + 6 more |
+| sensors | `config/repos/sensors.repos` | unh_marine_radar, cube_bathymetry, + 4 more |
 | simulation | `config/repos/simulation.repos` | unh_marine_simulation |
 | ui | `config/repos/ui.repos` | camp, rqt_marine_radar, + 2 more |
 

--- a/config/repos/sensors.repos
+++ b/config/repos/sensors.repos
@@ -15,10 +15,6 @@ repositories:
     type: git
     url: https://github.com/rolker/marine_tools.git
     version: jazzy
-  norbit:
-    type: git
-    url: https://github.com/rolker/norbit.git
-    version: jazzy
   imagenex_deltat:
     type: git
     url: https://github.com/rolker/imagenex_deltat.git
@@ -26,8 +22,4 @@ repositories:
   edgetech_sonar:
     type: git
     url: https://github.com/rolker/edgetech_sonar.git
-    version: jazzy
-  ros2sonic:
-    type: git
-    url: https://github.com/rolker/ros2sonic.git
     version: jazzy

--- a/config/repos/underlay.repos
+++ b/config/repos/underlay.repos
@@ -23,6 +23,14 @@ repositories:
     type: git
     url: https://github.com/rolker/nmea_navsat_driver.git
     version: add_pashr
+  norbit:
+    type: git
+    url: https://github.com/rolker/norbit.git
+    version: jazzy
+  ros2sonic:
+    type: git
+    url: https://github.com/rolker/ros2sonic.git
+    version: jazzy
   vrx:
     type: git
     url: https://github.com/rolker/vrx.git


### PR DESCRIPTION
## Summary

- Move `norbit` (fork of `uri-ocean-robotics/norbit`) from `sensors.repos` to `underlay.repos`
- Move `ros2sonic` (fork of `USF-COMIT/ros2sonic`) from `sensors.repos` to `underlay.repos`
- Update `.agents/README.md` layer repo counts to reflect the change

The underlay layer is the correct home for forked third-party dependencies. The sensors layer should contain UNH-authored sensor packages.

Closes #89

## Test plan

- [ ] Verify `sensors.repos` no longer lists norbit or ros2sonic
- [ ] Verify `underlay.repos` includes norbit and ros2sonic
- [ ] Run `make sync` and `make build` on a fresh workspace to confirm layer resolution works

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
