### PR TITLE
Add drix_description and drix_gazebo to workspace manifests

### DIFF
--- a/config/repos/platforms.repos
+++ b/config/repos/platforms.repos
@@ -23,6 +23,10 @@ repositories:
     type: git
     url: https://github.com/rolker/lr30_project11.git
     version: jazzy
+  drix_description:
+    type: git
+    url: https://github.com/rolker/drix_description.git
+    version: jazzy
   molab_description:
     type: git
     url: https://github.com/rolker/molab_description.git

--- a/config/repos/simulation.repos
+++ b/config/repos/simulation.repos
@@ -3,6 +3,10 @@ repositories:
     type: git
     url: https://github.com/rolker/ben_gazebo.git
     version: jazzy
+  drix_gazebo:
+    type: git
+    url: https://github.com/rolker/drix_gazebo.git
+    version: jazzy
   unh_marine_simulation:
     type: git
     url: https://github.com/rolker/unh_marine_simulation.git


### PR DESCRIPTION
## Summary

- Add `drix_description` (jazzy branch) to `platforms.repos`
- Add `drix_gazebo` (jazzy branch) to `simulation.repos`

## Context

The DriX USV now has both a description package (ported from ROS 1 to ROS 2 jazzy) and a Gazebo simulation package:

- [rolker/drix_description#2](https://github.com/rolker/drix_description/issues/2) — ROS 2 port
- [rolker/ros2_agent_workspace#351](https://github.com/rolker/ros2_agent_workspace/issues/351) — Gazebo simulation + manifest entries

## Test plan

- [ ] `make sync` imports both repos successfully
- [ ] `colcon build --packages-select drix_description` in platforms_ws
- [ ] `colcon build --packages-select drix_gazebo` in simulation_ws

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`

Closes #99
