### PR TITLE
Research: NOAA Coast Pilot data for world generation

### DIFF
--- a/.agents/workspace-context/research_digest.md
+++ b/.agents/workspace-context/research_digest.md
@@ -119,3 +119,10 @@ Possible implementation approach:
 3. Upload the world SDF via the web form or automate via Fuel REST API
 4. Optionally factor out common feature types (buoy models, beacon models) into reusable Fuel models referenced by `<include>` instead of inline — this would reduce world SDF size and enable model reuse across worlds
 5. Add a `--fuel-upload` flag or post-generation script to `marine_charts_to_gazebo_world`
+
+Existing Fuel models relevant to `marine_charts_to_gazebo_world`:
+- **Buoys** (13 models): VRX/RobotX marker buoys (`mb_marker_buoy_{red,black,green,white}`, `mb_round_buoy_{orange,black}` by OpenRobotics; `surmark950410`, `surmark46104{white,black}` by ngxingyu) — mesh-based, colored; could replace parametric cylinder+cone buoys
+- **Coastal environment**: `Coast Waves`/`Coast Water` (6km wave visuals), `Dock` (MBZIRC), `Pier` (wooden pier), `Beach` (5.9km environment) — all by OpenRobotics
+- **Structures**: `Water tower`, `Radio tower`, `Tower crane`, `Truss bridge`, `Office Building`, `Apartment`, `Depot` — generic but usable for landmark features
+- **Bathymetric heightmaps**: `Monterey Bay` (GEBCO bathymetry, by jennuine), `Portuguese Ledge` (MBARI seafloor data, by OpenRobotics) — validates that sharing bathymetric terrain tiles on Fuel is an established pattern
+- **Gaps — no Fuel models exist for**: navigation beacons, navigation lights/lighthouses, shore constructions (breakwaters, seawalls, groynes, rip-rap), pontoons/floating docks, mooring facilities (bollards, dolphins), piles/posts, or realistic S57 BOYSHP-accurate buoy shapes (conical, can, pillar, spar)

--- a/.agents/workspace-context/research_digest.md
+++ b/.agents/workspace-context/research_digest.md
@@ -91,3 +91,31 @@ Key takeaways:
 - **Anchorage areas**: could be rendered as marked zones in the simulation world
 - **Prominent features**: Coast Pilot describes towers, tanks, stacks, and other landmarks with locations — could improve feature placement beyond what S57 provides
 - **Implementation approach**: a Coast Pilot XML parser would need (1) XML download/cache by volume+chapter, (2) `<CP_GEO_LOC>` extraction for spatial indexing, (3) regex/NLP extraction of numeric values from `<paraText>` for bridge clearances, wharf dimensions, and facility heights, (4) spatial matching to existing S57 features by proximity
+
+---
+
+## Gazebo Fuel — Sharing Generated Worlds
+
+**Added**: 2026-03-12 | **Sources**: [Fuel portal](https://app.gazebosim.org), [About Fuel](https://gazebosim.org/docs/latest/fuel/), [gz-fuel-tools](https://github.com/gazebosim/gz-fuel-tools), [Contributing a world](https://gazebosim.org/docs/latest/fuel_contributing_world/), [Importing a mesh to Fuel](https://gazebosim.org/api/sim/7/meshtofuel.html), [fuel_tools library](https://gazebosim.org/libs/fuel_tools/)
+
+Key takeaways:
+- Gazebo Fuel (app.gazebosim.org) is a community repository for sharing simulation **models** and **worlds**; both asset types are supported
+- **Model upload**: via CLI (`gz fuel upload -m ~/path --header 'Private-token: <TOKEN>'`) or web UI drag-and-drop; requires `model.config` + `model.sdf` + meshes/textures in a standard directory layout; thumbnails (5 PNGs) recommended
+- **World upload**: via web form only (`app.gazebosim.org/fuel/worlds/upload`); accepts name, description, tags, and world SDF file; no CLI world upload documented as of gz-fuel-tools 10
+- **Authentication**: access tokens generated at `app.gazebosim.org/settings#access_tokens`; stored in `~/.gz/fuel/config.yaml` for automatic use
+- **World referencing models**: worlds on Fuel typically reference models by Fuel URI (`https://fuel.gazebosim.org/1.0/<owner>/models/<name>`); Gazebo auto-downloads referenced models at runtime
+- **Self-contained worlds**: worlds with inline `<model>` elements and local heightmaps work but require `GZ_SIM_RESOURCE_PATH` to be set for resource discovery — not ideal for Fuel distribution
+
+Challenges for `marine_charts_to_gazebo_world` (rolker/unh_marine_simulation#42):
+- **Terrain heightmaps are separate model directories**: the generator outputs terrain as `terrain_{name}/` with `model.config`, `model.sdf`, and `heightmap.png`; the world SDF references these via `<include><uri>model://terrain_{name}</uri></include>` — these would need to be uploaded as separate Fuel models first
+- **Feature models are inline**: buildings, buoys, bridges, and shore constructions are generated as inline `<model>` elements in the world SDF (not separate model directories) — this is compatible with Fuel world upload but means thousands of inline models in a single SDF file
+- **No mesh files**: all geometry is parametric (cylinders, cones, boxes, polylines) — no COLLADA/OBJ meshes, so the standard Fuel model structure (meshes/ directory) doesn't apply
+- **Generated textures**: terrain textures are simple 16x16 PNGs embedded in the terrain model directory; these would transfer to Fuel with the terrain model upload
+- **Reproducibility vs. sharing**: worlds are deterministically generated from S57 charts + parameters, so sharing the generation recipe (region bounds, flags) may be more useful than sharing the output — but pre-built worlds lower the barrier for users without ENC data access
+
+Possible implementation approach:
+1. Upload terrain heightmap models to Fuel as individual models (each with `model.config` + `model.sdf` + `heightmap.png` + textures)
+2. Rewrite terrain `<include>` URIs in the world SDF to point to Fuel model URIs instead of local `model://` paths
+3. Upload the world SDF via the web form or automate via Fuel REST API
+4. Optionally factor out common feature types (buoy models, beacon models) into reusable Fuel models referenced by `<include>` instead of inline — this would reduce world SDF size and enable model reuse across worlds
+5. Add a `--fuel-upload` flag or post-generation script to `marine_charts_to_gazebo_world`

--- a/.agents/workspace-context/research_digest.md
+++ b/.agents/workspace-context/research_digest.md
@@ -1,6 +1,6 @@
 # Research Digest: Marine Robotics
 
-<!-- Last updated: 2026-02-27 -->
+<!-- Last updated: 2026-03-12 -->
 <!-- If older than 30 days, consider running /research --refresh; entries older than 90 days should be flagged for review -->
 
 ## ROS 2 Autonomous Surface Vehicles (ASVs)
@@ -69,3 +69,25 @@ Key takeaways:
 - The combination leverages MOOS-IvP for mission planning/behavior arbitration and ROS 2 for communications, perception, and low-level control
 
 **Relevance**: Relevant to `unh_marine_autonomy`'s mission management architecture; MOOS-IvP integration patterns could inform behavior planning approaches
+
+---
+
+## NOAA Coast Pilot — Structured Marine Data for World Generation
+
+**Added**: 2026-03-12 | **Sources**: [Coast Pilot portal](https://nauticalcharts.noaa.gov/publications/coast-pilot/index.html), [Coast Pilot XML viewer](https://nauticalcharts.noaa.gov/publications/coast-pilot/xml2html.html?book=2), [Coast Pilot e-Publishing (PDF)](https://ocsdata.ncd.noaa.gov/media/noaa-industry-day/2017/01_03_Coast_Pilot_Software_Integration.pdf), [InPort metadata](https://www.fisheries.noaa.gov/inport/item/39970), [XML example (CP5 Ch6)](https://nauticalcharts.noaa.gov/publications/coast-pilot/files/cp5/CPB5_C06_WEB.xml)
+
+Key takeaways:
+- The U.S. Coast Pilot is a 10-volume NOAA publication supplementing nautical charts with data that is difficult to portray on a chart: bridge clearances, wharf dimensions, anchorage depths, prominent features, pilotage, weather, ice conditions, and facility descriptions
+- **XML format available**: chapters are published as XML alongside PDF/HTML; URL pattern `files/cp{N}/CPB{N}_C{NN}_WEB.xml`; weekly updates
+- **Geotagged features**: `<CP_GEO_LOC>` elements carry `lat_dec`/`long_dec` decimal coordinates, GNIS source IDs, feature class (Bay, Building, Tower, etc.), and state/county
+- **Bridge data**: `<bridge bridgeid="...">` elements link to clearance values in surrounding text; vertical and horizontal clearances are described in prose, not structured attributes — NLP extraction needed
+- **Wharf/facility dimensions**: lengths, depths alongside, and construction materials are embedded in `<paraText>` prose, not machine-structured fields
+- **Volume 1** covers Maine to Cape Cod (including NH/Portsmouth); **Volume 2** covers Cape Cod to Sandy Hook — these are the primary volumes for UNH operations
+- The main extraction challenge is that numeric data (heights, clearances, depths) is in natural-language paragraphs, not dedicated XML attributes; the `<CP_GEO_LOC>` tags provide spatial anchoring but the measurements require text parsing
+
+**Relevance to `marine_charts_to_gazebo_world`** (rolker/unh_marine_simulation#40):
+- **Bridge enrichment**: S57 BRIDGE features often lack vertical clearance (VERCLR); Coast Pilot provides specific clearance values that could fill these gaps
+- **Building/wharf heights**: the package currently uses hardcoded heights (12m buildings, 2.5m wharves); Coast Pilot describes actual wharf lengths, depths, and sometimes heights
+- **Anchorage areas**: could be rendered as marked zones in the simulation world
+- **Prominent features**: Coast Pilot describes towers, tanks, stacks, and other landmarks with locations — could improve feature placement beyond what S57 provides
+- **Implementation approach**: a Coast Pilot XML parser would need (1) XML download/cache by volume+chapter, (2) `<CP_GEO_LOC>` extraction for spatial indexing, (3) regex/NLP extraction of numeric values from `<paraText>` for bridge clearances, wharf dimensions, and facility heights, (4) spatial matching to existing S57 features by proximity


### PR DESCRIPTION
## Summary

- Add research digest entry on NOAA Coast Pilot XML data and its potential for enriching Gazebo world generation
- Covers data format analysis, geographic coverage, extraction challenges, and specific enrichment opportunities for `marine_charts_to_gazebo_world`
- Context: rolker/unh_marine_simulation#40

## Key findings

- Coast Pilot chapters are available as geotagged XML (weekly updates)
- `<CP_GEO_LOC>` elements provide decimal lat/lon with GNIS feature classification
- Numeric data (bridge clearances, wharf dimensions) requires NLP extraction from prose paragraphs
- Volume 1 (Eastport ME to Cape Cod MA) covers the UNH operating area

Closes #101

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
