### PR TITLE
[PLAN] GGGS: correct polar column handling in bounds and iterators

### DIFF
--- a/.agent/work-plans/PLAN_ISSUE-78.md
+++ b/.agent/work-plans/PLAN_ISSUE-78.md
@@ -1,0 +1,159 @@
+# Plan: GGGS — correct polar column handling in bounds and iterators
+
+## Issue
+
+https://github.com/rolker/unh_marine_autonomy/issues/78
+
+## Context
+
+The GGGS library uses latitude-dependent column counts: rows below 72° have
+the full column count, rows at 72–80° have 1/3 the columns (3x wider grids),
+and rows above 80° have 1/9 the columns (9x wider). The infrastructure for
+this (`LevelSpecs::columnCount(row)`, `latitudeScaleFactor(row)`) exists and
+works correctly. However, three components assume uniform column numbering:
+
+- `min(GridIndex, GridIndex)` / `max(GridIndex, GridIndex)` — component-wise
+  min/max of row+column, producing invalid column indices when rows span bands
+- `GridBounds::gridColumnCount()` — `1 + max.col - min.col`, meaningless
+  across band boundaries
+- `GridAreaIterator::next()` — iterates `from.col` to `to.col` on every row,
+  visiting nonexistent columns in bands with fewer columns
+
+**Blast radius**: `min`/`max` are called only from `GridBounds::expand()` and
+one test. `GridBounds` and `GridAreaIterator` are used only in tests and a doc
+example in `gggs.h`. No production code outside the test suite uses these APIs
+yet — #86 (bathymetric data store) will be the first consumer.
+
+## Approach
+
+### 1. Fix `GridAreaIterator` to use per-row column bounds
+
+In `next()`, after advancing to a new row, compute that row's valid column
+range using `LevelSpecs::columnCount(row)`. Clamp the iteration column to the
+valid range for each row.
+
+The key change: when iterating rows that cross a band boundary, the column
+range narrows. For a row with `columnCount(row) = C`, valid columns are
+`[0, C-1]`. The iterator should intersect the requested column range with
+the row's valid range.
+
+**Longitude-aware mapping**: column indices have different geographic meaning
+at different latitudes. Column 10 at the equator covers a different longitude
+range than column 10 at 75°. The iterator needs to decide: iterate by
+**column index** (visiting the same numbered columns, some of which may not
+exist) or by **longitude range** (visiting all columns that overlap the
+geographic extent). The longitude-range approach is correct for spatial
+queries.
+
+Implementation in `grid_area_iterator.h`:
+- Store the level (to access `LevelSpecs`)
+- In `next()`, when advancing to a new row:
+  - Compute the geographic longitude range from `from_` and `to_` columns at
+    their respective rows
+  - Map that longitude range to column indices at the new row using
+    `LevelSpecs::gridLongitudinalSpan(row)`
+  - Iterate those columns
+- Update `valid()` to check per-row column limits
+
+### 2. Fix `GridBounds` for cross-band awareness
+
+`GridBounds` tracks an axis-aligned bounding box. With varying column counts,
+it needs to track the geographic extent rather than raw column indices.
+
+Options (choose one):
+- **(A) Store row-based bounds**: keep `min_`/`max_` as `GridIndex` but make
+  `gridColumnCount()` return the max across all rows in the range. This is
+  simpler but `gridColumnCount()` becomes an approximation.
+- **(B) Deprecate `gridColumnCount()`**: remove or replace it with
+  `gridColumnCount(uint32_t row)` that returns the per-row count within the
+  bounds. `cellColumnCount()` would similarly become per-row.
+
+**Recommended: (B)** — per-row column count is the only correct answer when
+bounds span bands. A single `gridColumnCount()` is inherently misleading.
+
+### 3. Fix or restrict `min`/`max` on `GridIndex`
+
+These produce invalid indices when rows are in different bands. Options:
+- **(A) Remove them** — callers use `GridBounds::expand()` instead (which
+  would handle band differences internally)
+- **(B) Keep but throw on cross-band** — add a check that both indices have
+  the same `latitudeScaleFactor`
+- **(C) Make longitude-aware** — compute geographic min/max and map back to
+  indices at each row
+
+**Recommended: (A)** — `min`/`max` on `GridIndex` is conceptually broken for
+the cross-band case. `GridBounds::expand()` is the correct API for building
+bounding boxes. Remove the friend functions and update the one test caller.
+
+### 4. Update `GridBounds::expand()` to not use `min`/`max`
+
+If `min`/`max` are removed, `expand()` needs to track row bounds and
+longitude bounds separately:
+- Row: `min(row)` / `max(row)` — straightforward
+- Longitude: track west/east longitude extents, then compute per-row column
+  ranges when queried
+
+### 5. Add cross-polar tests
+
+Add test cases in `test_gggs.cpp`:
+- `GridAreaIterator` spanning 71°–73° (crosses 72° boundary, 1x→3x)
+- `GridAreaIterator` spanning 79°–81° (crosses 80° boundary, 3x→9x)
+- `GridAreaIterator` spanning 71°–81° (crosses both boundaries)
+- Verify every visited index passes `valid()`
+- Verify no valid index in the geographic extent is skipped
+- `GridBounds` column count queries across band boundaries
+- Southern hemisphere equivalents (negative latitudes)
+
+### 6. Update existing tests
+
+The `MultipleGrids` test in `test_gggs.cpp` currently uses `min(gi1, gi2)`
+and `max(gi1, gi2)` at lines 480–481. If `min`/`max` are removed, this test
+must be updated to use `GridBounds` or construct the iterator differently.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `include/marine_autonomy/gggs/grid_area_iterator.h` | Longitude-aware per-row column iteration |
+| `include/marine_autonomy/gggs/bounds.h` | Per-row column queries; remove `gridColumnCount()` or make it per-row |
+| `include/marine_autonomy/gggs/grid_index.h` | Remove `min`/`max` friend functions |
+| `test/test_gggs.cpp` | Cross-polar iterator/bounds tests; update `MultipleGrids` test |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Safety First | Correct spatial iteration prevents silent data corruption in downstream #86 |
+| Test what breaks | Tests target the exact failure modes: cross-band iteration, column validity |
+| A change includes its consequences | Removing `min`/`max` requires updating the one test caller in the same PR |
+| Only what's needed | Minimal API surface change — fix the broken parts, keep what works |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0002 — Worktree isolation | Yes | Working in `feature/issue-78` worktree |
+| 0008 — ROS 2 conventions | Marginal | C++ library; follows existing naming patterns |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `min`/`max` friend functions | Test callers (line 480–481) | Yes — step 6 |
+| `GridBounds` API | Test callers (5 test functions) | Yes — step 6 |
+| `GridAreaIterator` behavior | Existing iterator tests | Yes — step 6 |
+
+## Open Questions
+
+1. **Longitude-range vs column-index iteration**: should `GridAreaIterator`
+   iterate by geographic longitude extent (correct for spatial queries) or by
+   column index (simpler but breaks across bands)? Recommended: longitude-range.
+2. **`GridBounds::gridColumnCount()` removal vs per-row**: should it be
+   removed entirely, return the maximum across rows, or take a row parameter?
+3. **`min`/`max` removal vs restriction**: remove entirely (recommended) or
+   keep with a same-band assertion?
+
+## Estimated Scope
+
+Single PR. All changes are in header files + one test file, contained within
+the GGGS module.

--- a/marine_autonomy/include/marine_autonomy/gggs/bounds.h
+++ b/marine_autonomy/include/marine_autonomy/gggs/bounds.h
@@ -97,7 +97,7 @@ public:
 
   uint32_t gridColumnCount(uint32_t row) const
   {
-    if(!valid())
+    if(!valid() || row < min_row_ || row > max_row_)
       return 0;
     return 1 + lastColumn(row) - firstColumn(row);
   }
@@ -125,7 +125,9 @@ private:
   uint32_t firstColumn(uint32_t row) const
   {
     double span = levels[level_].gridLongitudinalSpan(row);
-    return static_cast<uint32_t>((west_lon_ + 180.0) / span);
+    uint32_t col = static_cast<uint32_t>((west_lon_ + 180.0) / span);
+    uint32_t max_col = levels[level_].columnCount(row) - 1;
+    return std::min(col, max_col);
   }
 
   uint32_t lastColumn(uint32_t row) const
@@ -136,7 +138,8 @@ private:
     // it belongs to the previous column
     if(east_lon_ + 180.0 > 0.0 && std::fmod(east_lon_ + 180.0, span) < 1e-10)
       col--;
-    return col;
+    uint32_t max_col = levels[level_].columnCount(row) - 1;
+    return std::min(col, max_col);
   }
 
   uint8_t level_ = 255;

--- a/marine_autonomy/include/marine_autonomy/gggs/bounds.h
+++ b/marine_autonomy/include/marine_autonomy/gggs/bounds.h
@@ -36,15 +36,16 @@ namespace gggs
 
 /// @brief Axis-aligned bounding box over GridIndex values at a single level.
 ///
-/// Tracks the minimum and maximum grid row/column as grids are added
-/// via expand(). All grids must be at the same quadtree level.
+/// Tracks row range and geographic longitude extent as grids are added
+/// via expand(). Uses per-row column counts to correctly handle polar
+/// latitude bands where column counts change.
 class GridBounds
 {
 public:
   /// @brief Check if bounds contain at least one valid grid.
   bool valid() const
   {
-    return min_.valid() && max_.valid() && min_.level() == max_.level();
+    return level_ < levels.size();
   }
 
   /// @brief Expand bounds to include the given grid.
@@ -56,60 +57,93 @@ public:
     {
       if(valid())
       {
-        min_ = min(min_, index);
-        max_ = max(max_, index);
+        verifySameLevel(minimum(), index);
+        min_row_ = std::min(min_row_, index.row());
+        max_row_ = std::max(max_row_, index.row());
+        west_lon_ = std::min(west_lon_, index.westLongitude());
+        east_lon_ = std::max(east_lon_, index.eastLongitude());
       }
       else
       {
-        min_ = index;
-        max_ = index;
+        level_ = index.level();
+        min_row_ = index.row();
+        max_row_ = index.row();
+        west_lon_ = index.westLongitude();
+        east_lon_ = index.eastLongitude();
       }
     }
   }
 
-  const GridIndex& minimum() const
+  GridIndex minimum() const
   {
-    return min_;
+    if(!valid())
+      return GridIndex();
+    return GridIndex(level_, min_row_, firstColumn(min_row_));
   }
 
-  const GridIndex& maximum() const
+  GridIndex maximum() const
   {
-    return max_;
+    if(!valid())
+      return GridIndex();
+    return GridIndex(level_, max_row_, lastColumn(max_row_));
   }
 
   uint32_t gridRowCount() const
   {
-    return 1+max_.row()-min_.row();
+    if(!valid())
+      return 0;
+    return 1 + max_row_ - min_row_;
   }
 
-  uint32_t gridColumnCount() const
+  uint32_t gridColumnCount(uint32_t row) const
   {
-    if(min_.valid())
-      return 1+max_.column()-min_.column();
-    return 0;
+    if(!valid())
+      return 0;
+    return 1 + lastColumn(row) - firstColumn(row);
   }
 
   uint64_t cellRowCount() const
   {
-    return gridRowCount()*cell_rows_per_grid;
+    return gridRowCount() * cell_rows_per_grid;
   }
 
-  uint64_t cellColumnCount() const
+  uint64_t cellColumnCount(uint32_t row) const
   {
-    return gridColumnCount()*cell_columns_per_grid;
+    return gridColumnCount(row) * cell_columns_per_grid;
   }
 
   friend std::ostream& operator<< (std::ostream& stream, const GridBounds& bounds)
   {
-    stream << "min: " << bounds.min_ << " max: " << bounds.max_;
+    if(bounds.valid())
+      stream << "min: " << bounds.minimum() << " max: " << bounds.maximum();
+    else
+      stream << "invalid GridBounds";
     return stream;
   }
 
-
 private:
-  GridIndex min_;
-  GridIndex max_;
+  uint32_t firstColumn(uint32_t row) const
+  {
+    double span = levels[level_].gridLongitudinalSpan(row);
+    return static_cast<uint32_t>((west_lon_ + 180.0) / span);
+  }
 
+  uint32_t lastColumn(uint32_t row) const
+  {
+    double span = levels[level_].gridLongitudinalSpan(row);
+    uint32_t col = static_cast<uint32_t>((east_lon_ + 180.0) / span);
+    // east_lon_ is the east edge of a grid; if it falls exactly on a boundary,
+    // it belongs to the previous column
+    if(east_lon_ + 180.0 > 0.0 && std::fmod(east_lon_ + 180.0, span) < 1e-10)
+      col--;
+    return col;
+  }
+
+  uint8_t level_ = 255;
+  uint32_t min_row_ = 0;
+  uint32_t max_row_ = 0;
+  double west_lon_ = 0.0;
+  double east_lon_ = 0.0;
 };
 
 }

--- a/marine_autonomy/include/marine_autonomy/gggs/bounds.h
+++ b/marine_autonomy/include/marine_autonomy/gggs/bounds.h
@@ -57,7 +57,8 @@ public:
     {
       if(valid())
       {
-        verifySameLevel(minimum(), index);
+        if(index.level() != level_)
+          throw std::out_of_range("GridBounds: level mismatch");
         min_row_ = std::min(min_row_, index.row());
         max_row_ = std::max(max_row_, index.row());
         west_lon_ = std::min(west_lon_, index.westLongitude());

--- a/marine_autonomy/include/marine_autonomy/gggs/bounds.h
+++ b/marine_autonomy/include/marine_autonomy/gggs/bounds.h
@@ -105,12 +105,12 @@ public:
 
   uint64_t cellRowCount() const
   {
-    return gridRowCount() * cell_rows_per_grid;
+    return static_cast<uint64_t>(gridRowCount()) * cell_rows_per_grid;
   }
 
   uint64_t cellColumnCount(uint32_t row) const
   {
-    return gridColumnCount(row) * cell_columns_per_grid;
+    return static_cast<uint64_t>(gridColumnCount(row)) * cell_columns_per_grid;
   }
 
   friend std::ostream& operator<< (std::ostream& stream, const GridBounds& bounds)

--- a/marine_autonomy/include/marine_autonomy/gggs/grid_area_iterator.h
+++ b/marine_autonomy/include/marine_autonomy/gggs/grid_area_iterator.h
@@ -38,18 +38,27 @@ namespace gggs
 ///
 /// Traverses all grids in the rectangle defined by two corner GridIndex
 /// values (inclusive), row by row from south-west to north-east.
-/// Both corners must be at the same quadtree level.
+/// Uses longitude-based per-row column ranges to correctly handle
+/// polar latitude bands where column counts change.
 class GridAreaIterator
 {
 public:
   /// @brief Construct an iterator over grids from @p from to @p to (inclusive).
-  /// @param from South-west corner grid.
-  /// @param to North-east corner grid.
+  /// @param from One corner grid.
+  /// @param to Opposite corner grid.
   /// @throws std::out_of_range if levels differ.
-  GridAreaIterator(GridIndex from, GridIndex to):
-    from_(from), to_(to), current_(from)
+  GridAreaIterator(GridIndex from, GridIndex to)
   {
     verifySameLevel(from, to);
+    level_ = from.level();
+    from_row_ = std::min(from.row(), to.row());
+    to_row_ = std::max(from.row(), to.row());
+    west_lon_ = std::min(from.westLongitude(), to.westLongitude());
+    east_lon_ = std::max(from.eastLongitude(), to.eastLongitude());
+    current_row_ = from_row_;
+    computeRowColumns(current_row_);
+    current_col_ = row_first_col_;
+    updateCurrent();
   }
 
   const GridIndex& operator*() const
@@ -66,48 +75,63 @@ public:
   /// @return true if the iterator is valid after reset.
   bool reset()
   {
-    current_ = from_;
+    current_row_ = from_row_;
+    computeRowColumns(current_row_);
+    current_col_ = row_first_col_;
+    updateCurrent();
     return valid();
   }
 
   /// @brief Check if the iterator points to a valid grid.
   bool valid() const
   {
-    if(current_.valid())
-    {
-      return
-        current_.row() >= from_.row() &&
-        current_.column() >= from_.column() &&
-        current_.row() <= to_.row() &&
-        current_.column() <= to_.column();
-    }
-    return false;
+    return current_.valid() && current_row_ <= to_row_;
   }
 
   /// @brief Advance to the next grid.
   /// @return true if the iterator is valid after advancing.
   bool next()
   {
-    if(valid())
+    if(!valid())
+      return false;
+    current_col_++;
+    if(current_col_ > row_last_col_)
     {
-      auto new_row = current_.row();
-      auto new_column = current_.column()+1;
-      if(new_column > to_.column())
+      current_row_++;
+      if(current_row_ > to_row_)
       {
-        new_row += 1;
-        new_column = from_.column();
-      }
-      if(new_row > to_.row())
         current_ = GridIndex();
-      else
-        current_ = GridIndex(current_.level_, new_row, new_column);
+        return false;
+      }
+      computeRowColumns(current_row_);
+      current_col_ = row_first_col_;
     }
+    updateCurrent();
     return valid();
   }
 
 private:
-  GridIndex from_;
-  GridIndex to_;
+  void computeRowColumns(uint32_t row)
+  {
+    double span = levels[level_].gridLongitudinalSpan(row);
+    row_first_col_ = static_cast<uint32_t>((west_lon_ + 180.0) / span);
+    row_last_col_ = static_cast<uint32_t>((east_lon_ + 180.0) / span);
+    // east_lon_ is the east edge; if it falls exactly on a grid boundary,
+    // it belongs to the previous column
+    if(east_lon_ + 180.0 > 0.0 && std::fmod(east_lon_ + 180.0, span) < 1e-10)
+      row_last_col_--;
+  }
+
+  void updateCurrent()
+  {
+    current_ = GridIndex(level_, current_row_, current_col_);
+  }
+
+  uint8_t level_;
+  uint32_t from_row_, to_row_;
+  double west_lon_, east_lon_;
+  uint32_t current_row_, current_col_;
+  uint32_t row_first_col_, row_last_col_;
   GridIndex current_;
 };
 

--- a/marine_autonomy/include/marine_autonomy/gggs/grid_area_iterator.h
+++ b/marine_autonomy/include/marine_autonomy/gggs/grid_area_iterator.h
@@ -77,6 +77,8 @@ public:
   /// @return true if the iterator is valid after reset.
   bool reset()
   {
+    if(level_ >= levels.size())
+      return false;
     current_row_ = from_row_;
     computeRowColumns(current_row_);
     current_col_ = row_first_col_;

--- a/marine_autonomy/include/marine_autonomy/gggs/grid_area_iterator.h
+++ b/marine_autonomy/include/marine_autonomy/gggs/grid_area_iterator.h
@@ -50,6 +50,8 @@ public:
   GridAreaIterator(GridIndex from, GridIndex to)
   {
     verifySameLevel(from, to);
+    if(!from.valid() || !to.valid())
+      return;  // current_ stays default-invalid
     level_ = from.level();
     from_row_ = std::min(from.row(), to.row());
     to_row_ = std::max(from.row(), to.row());
@@ -120,6 +122,10 @@ private:
     // it belongs to the previous column
     if(east_lon_ + 180.0 > 0.0 && std::fmod(east_lon_ + 180.0, span) < 1e-10)
       row_last_col_--;
+    // Clamp to valid column range
+    uint32_t max_col = levels[level_].columnCount(row) - 1;
+    row_first_col_ = std::min(row_first_col_, max_col);
+    row_last_col_ = std::min(row_last_col_, max_col);
   }
 
   void updateCurrent()
@@ -127,11 +133,11 @@ private:
     current_ = GridIndex(level_, current_row_, current_col_);
   }
 
-  uint8_t level_;
-  uint32_t from_row_, to_row_;
-  double west_lon_, east_lon_;
-  uint32_t current_row_, current_col_;
-  uint32_t row_first_col_, row_last_col_;
+  uint8_t level_ = 255;
+  uint32_t from_row_ = 0, to_row_ = 0;
+  double west_lon_ = 0.0, east_lon_ = 0.0;
+  uint32_t current_row_ = 1, current_col_ = 0;
+  uint32_t row_first_col_ = 0, row_last_col_ = 0;
   GridIndex current_;
 };
 

--- a/marine_autonomy/include/marine_autonomy/gggs/grid_index.h
+++ b/marine_autonomy/include/marine_autonomy/gggs/grid_index.h
@@ -156,19 +156,6 @@ public:
     return !(lhs == rhs);
   }
 
-  friend GridIndex max(const GridIndex& lhs, const GridIndex& rhs)
-  {
-    verifySameLevel(lhs, rhs);
-    return GridIndex(lhs.level_, std::max(lhs.row_, rhs.row_), std::max(lhs.column_, rhs.column_));
-  }
-
-  friend GridIndex min(const GridIndex& lhs, const GridIndex& rhs)
-  {
-    verifySameLevel(lhs, rhs);
-    return GridIndex(lhs.level_, std::min(lhs.row_, rhs.row_), std::min(lhs.column_, rhs.column_));
-  }
-
-
   friend std::ostream& operator<< (std::ostream& stream, const GridIndex& index)
   {
     stream << "GridIndex level " << int(index.level_) << " row: " << index.row_ << " col: " << index.column_;
@@ -182,6 +169,7 @@ private:
 
   friend class Level;
   friend class GridAreaIterator;
+  friend class GridBounds;
 
   /// Level of the quad tree where 0 is top with 8 degree tiles
   uint8_t level_ = 255;

--- a/marine_autonomy/test/test_gggs.cpp
+++ b/marine_autonomy/test/test_gggs.cpp
@@ -27,6 +27,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include <gtest/gtest.h>
+#include <climits>
 #include <cmath>
 #include <type_traits>
 #include "marine_autonomy/gggs.h"
@@ -865,16 +866,43 @@ TEST(GGGSGridAreaIterator, CrossBand72)
   ASSERT_TRUE(gi1.valid());
   ASSERT_TRUE(gi2.valid());
 
+  uint32_t expected_min_row = std::min(gi1.row(), gi2.row());
+  uint32_t expected_max_row = std::max(gi1.row(), gi2.row());
+
   gggs::GridAreaIterator it(gi1, gi2);
   uint32_t count = 0;
+  uint32_t min_visited_row = UINT32_MAX;
+  uint32_t max_visited_row = 0;
   while(it.valid())
   {
     EXPECT_TRUE(it->valid()) << "Invalid index at row " << it->row()
       << " col " << it->column();
+    min_visited_row = std::min(min_visited_row, it->row());
+    max_visited_row = std::max(max_visited_row, it->row());
     count++;
     if(!it.next()) break;
   }
   EXPECT_GT(count, 0u);
+  EXPECT_EQ(min_visited_row, expected_min_row);
+  EXPECT_EQ(max_visited_row, expected_max_row);
+
+  // Verify count matches sum of per-row column counts
+  uint32_t expected_count = 0;
+  double west = std::min(gi1.westLongitude(), gi2.westLongitude());
+  double east = std::max(gi1.eastLongitude(), gi2.eastLongitude());
+  for(uint32_t r = expected_min_row; r <= expected_max_row; ++r)
+  {
+    double span = gggs::levels[0].gridLongitudinalSpan(r);
+    uint32_t first = static_cast<uint32_t>((west + 180.0) / span);
+    uint32_t last = static_cast<uint32_t>((east + 180.0) / span);
+    if(east + 180.0 > 0.0 && std::fmod(east + 180.0, span) < 1e-10)
+      last--;
+    uint32_t max_col = gggs::levels[0].columnCount(r) - 1;
+    first = std::min(first, max_col);
+    last = std::min(last, max_col);
+    expected_count += 1 + last - first;
+  }
+  EXPECT_EQ(count, expected_count);
 }
 
 TEST(GGGSGridAreaIterator, CrossBand80)
@@ -887,16 +915,43 @@ TEST(GGGSGridAreaIterator, CrossBand80)
   ASSERT_TRUE(gi1.valid());
   ASSERT_TRUE(gi2.valid());
 
+  uint32_t expected_min_row = std::min(gi1.row(), gi2.row());
+  uint32_t expected_max_row = std::max(gi1.row(), gi2.row());
+
   gggs::GridAreaIterator it(gi1, gi2);
   uint32_t count = 0;
+  uint32_t min_visited_row = UINT32_MAX;
+  uint32_t max_visited_row = 0;
   while(it.valid())
   {
     EXPECT_TRUE(it->valid()) << "Invalid index at row " << it->row()
       << " col " << it->column();
+    min_visited_row = std::min(min_visited_row, it->row());
+    max_visited_row = std::max(max_visited_row, it->row());
     count++;
     if(!it.next()) break;
   }
   EXPECT_GT(count, 0u);
+  EXPECT_EQ(min_visited_row, expected_min_row);
+  EXPECT_EQ(max_visited_row, expected_max_row);
+
+  // Verify count matches sum of per-row column counts
+  uint32_t expected_count = 0;
+  double west = std::min(gi1.westLongitude(), gi2.westLongitude());
+  double east = std::max(gi1.eastLongitude(), gi2.eastLongitude());
+  for(uint32_t r = expected_min_row; r <= expected_max_row; ++r)
+  {
+    double span = gggs::levels[0].gridLongitudinalSpan(r);
+    uint32_t first = static_cast<uint32_t>((west + 180.0) / span);
+    uint32_t last = static_cast<uint32_t>((east + 180.0) / span);
+    if(east + 180.0 > 0.0 && std::fmod(east + 180.0, span) < 1e-10)
+      last--;
+    uint32_t max_col = gggs::levels[0].columnCount(r) - 1;
+    first = std::min(first, max_col);
+    last = std::min(last, max_col);
+    expected_count += 1 + last - first;
+  }
+  EXPECT_EQ(count, expected_count);
 }
 
 TEST(GGGSGridAreaIterator, CrossBothBands)
@@ -909,8 +964,13 @@ TEST(GGGSGridAreaIterator, CrossBothBands)
   ASSERT_TRUE(gi1.valid());
   ASSERT_TRUE(gi2.valid());
 
+  uint32_t expected_min_row = std::min(gi1.row(), gi2.row());
+  uint32_t expected_max_row = std::max(gi1.row(), gi2.row());
+
   gggs::GridAreaIterator it(gi1, gi2);
   uint32_t count = 0;
+  uint32_t min_visited_row = UINT32_MAX;
+  uint32_t max_visited_row = 0;
   bool saw_scale_1 = false;
   bool saw_scale_3 = false;
   bool saw_scale_9 = false;
@@ -918,6 +978,8 @@ TEST(GGGSGridAreaIterator, CrossBothBands)
   {
     EXPECT_TRUE(it->valid()) << "Invalid index at row " << it->row()
       << " col " << it->column();
+    min_visited_row = std::min(min_visited_row, it->row());
+    max_visited_row = std::max(max_visited_row, it->row());
     auto sf = gggs::levels[0].latitudeScaleFactor(it->row());
     if(sf == 1) saw_scale_1 = true;
     if(sf == 3) saw_scale_3 = true;
@@ -929,6 +991,8 @@ TEST(GGGSGridAreaIterator, CrossBothBands)
   EXPECT_TRUE(saw_scale_1) << "Should visit scale-1 rows";
   EXPECT_TRUE(saw_scale_3) << "Should visit scale-3 rows";
   EXPECT_TRUE(saw_scale_9) << "Should visit scale-9 rows";
+  EXPECT_EQ(min_visited_row, expected_min_row);
+  EXPECT_EQ(max_visited_row, expected_max_row);
 }
 
 TEST(GGGSGridAreaIterator, SouthernHemisphere)
@@ -941,14 +1005,21 @@ TEST(GGGSGridAreaIterator, SouthernHemisphere)
   ASSERT_TRUE(gi1.valid());
   ASSERT_TRUE(gi2.valid());
 
+  uint32_t expected_min_row = std::min(gi1.row(), gi2.row());
+  uint32_t expected_max_row = std::max(gi1.row(), gi2.row());
+
   gggs::GridAreaIterator it(gi1, gi2);
   uint32_t count = 0;
+  uint32_t min_visited_row = UINT32_MAX;
+  uint32_t max_visited_row = 0;
   bool saw_scale_1 = false;
   bool saw_scale_3 = false;
   while(it.valid())
   {
     EXPECT_TRUE(it->valid()) << "Invalid index at row " << it->row()
       << " col " << it->column();
+    min_visited_row = std::min(min_visited_row, it->row());
+    max_visited_row = std::max(max_visited_row, it->row());
     auto sf = gggs::levels[0].latitudeScaleFactor(it->row());
     if(sf == 1) saw_scale_1 = true;
     if(sf == 3) saw_scale_3 = true;
@@ -958,6 +1029,26 @@ TEST(GGGSGridAreaIterator, SouthernHemisphere)
   EXPECT_GT(count, 0u);
   EXPECT_TRUE(saw_scale_1) << "Should visit scale-1 rows";
   EXPECT_TRUE(saw_scale_3) << "Should visit scale-3 rows";
+  EXPECT_EQ(min_visited_row, expected_min_row);
+  EXPECT_EQ(max_visited_row, expected_max_row);
+
+  // Verify count matches sum of per-row column counts
+  uint32_t expected_count = 0;
+  double west = std::min(gi1.westLongitude(), gi2.westLongitude());
+  double east = std::max(gi1.eastLongitude(), gi2.eastLongitude());
+  for(uint32_t r = expected_min_row; r <= expected_max_row; ++r)
+  {
+    double span = gggs::levels[0].gridLongitudinalSpan(r);
+    uint32_t first = static_cast<uint32_t>((west + 180.0) / span);
+    uint32_t last = static_cast<uint32_t>((east + 180.0) / span);
+    if(east + 180.0 > 0.0 && std::fmod(east + 180.0, span) < 1e-10)
+      last--;
+    uint32_t max_col = gggs::levels[0].columnCount(r) - 1;
+    first = std::min(first, max_col);
+    last = std::min(last, max_col);
+    expected_count += 1 + last - first;
+  }
+  EXPECT_EQ(count, expected_count);
 }
 
 TEST(GGGSGridBounds, CrossBand)

--- a/marine_autonomy/test/test_gggs.cpp
+++ b/marine_autonomy/test/test_gggs.cpp
@@ -320,7 +320,7 @@ TEST(GGGSGridBounds, ExpandSingleGrid)
   bounds.expand(gi);
   EXPECT_TRUE(bounds.valid());
   EXPECT_EQ(bounds.gridRowCount(), 1u);
-  EXPECT_EQ(bounds.gridColumnCount(), 1u);
+  EXPECT_EQ(bounds.gridColumnCount(gi.row()), 1u);
 }
 
 TEST(GGGSGridBounds, ExpandMultipleGrids)
@@ -333,7 +333,8 @@ TEST(GGGSGridBounds, ExpandMultipleGrids)
   bounds.expand(gi2);
   EXPECT_TRUE(bounds.valid());
   EXPECT_GE(bounds.gridRowCount(), 1u);
-  EXPECT_GE(bounds.gridColumnCount(), 1u);
+  // Per-row column count; both grids are in the same latitude band
+  EXPECT_GE(bounds.gridColumnCount(gi1.row()), 1u);
 }
 
 TEST(GGGSGridBounds, CellCounts)
@@ -343,7 +344,7 @@ TEST(GGGSGridBounds, CellCounts)
   gggs::GridBounds bounds;
   bounds.expand(gi);
   EXPECT_EQ(bounds.cellRowCount(), static_cast<uint64_t>(gggs::cell_rows_per_grid));
-  EXPECT_EQ(bounds.cellColumnCount(), static_cast<uint64_t>(gggs::cell_columns_per_grid));
+  EXPECT_EQ(bounds.cellColumnCount(gi.row()), static_cast<uint64_t>(gggs::cell_columns_per_grid));
 }
 
 TEST(GGGSGridBounds, LevelMismatchThrows)
@@ -472,20 +473,24 @@ TEST(GGGSGridAreaIterator, MultipleGrids)
     // Same grid, skip count test
     return;
   }
-  uint32_t expected_rows = 1 + gi2.row() - gi1.row();
-  uint32_t expected_cols = 1 + gi2.column() - gi1.column();
-  if (gi1.row() > gi2.row()) expected_rows = 1 + gi1.row() - gi2.row();
-  if (gi1.column() > gi2.column()) expected_cols = 1 + gi1.column() - gi2.column();
-
-  auto from = min(gi1, gi2);
-  auto to = max(gi1, gi2);
-  gggs::GridAreaIterator it(from, to);
+  // Both points are in the same latitude band (scale factor 1),
+  // so column count is uniform across all rows in this range.
+  gggs::GridAreaIterator it(gi1, gi2);
   uint32_t count = 0;
   if (it.valid())
   {
     count = 1;
     while (it.next()) count++;
   }
+  // Compute expected count: the iterator extracts longitude range from the
+  // two GridIndex corners, so it covers the correct rectangular area.
+  uint32_t min_row = std::min(gi1.row(), gi2.row());
+  uint32_t max_row = std::max(gi1.row(), gi2.row());
+  uint32_t expected_rows = 1 + max_row - min_row;
+  // Same band, so column count is the same for all rows
+  uint32_t min_col = std::min(gi1.column(), gi2.column());
+  uint32_t max_col = std::max(gi1.column(), gi2.column());
+  uint32_t expected_cols = 1 + max_col - min_col;
   EXPECT_EQ(count, expected_rows * expected_cols);
 }
 
@@ -844,4 +849,161 @@ TEST(GGGSCellIndex, OutOfBoundsColumnAssertsInDebug)
   EXPECT_DEATH(gggs::CellIndex(gi, 0, gggs::cell_columns_per_grid),
     "CellIndex column out of bounds");
 #endif
+}
+
+// ============================================================================
+// Cross-polar GridAreaIterator tests (Issue #78)
+// ============================================================================
+
+TEST(GGGSGridAreaIterator, CrossBand72)
+{
+  // Iterate from 71 to 73 latitude at level 0.
+  // This crosses the 72-degree boundary where scale factor changes from 1 to 3.
+  gggs::Level level(0);
+  auto gi1 = level.gridIndex(71.0, 0.0);
+  auto gi2 = level.gridIndex(73.0, 0.0);
+  ASSERT_TRUE(gi1.valid());
+  ASSERT_TRUE(gi2.valid());
+
+  gggs::GridAreaIterator it(gi1, gi2);
+  uint32_t count = 0;
+  while(it.valid())
+  {
+    EXPECT_TRUE(it->valid()) << "Invalid index at row " << it->row()
+      << " col " << it->column();
+    count++;
+    if(!it.next()) break;
+  }
+  EXPECT_GT(count, 0u);
+}
+
+TEST(GGGSGridAreaIterator, CrossBand80)
+{
+  // Iterate from 79 to 81 latitude at level 0.
+  // This crosses the 80-degree boundary where scale factor changes from 3 to 9.
+  gggs::Level level(0);
+  auto gi1 = level.gridIndex(79.0, 0.0);
+  auto gi2 = level.gridIndex(81.0, 0.0);
+  ASSERT_TRUE(gi1.valid());
+  ASSERT_TRUE(gi2.valid());
+
+  gggs::GridAreaIterator it(gi1, gi2);
+  uint32_t count = 0;
+  while(it.valid())
+  {
+    EXPECT_TRUE(it->valid()) << "Invalid index at row " << it->row()
+      << " col " << it->column();
+    count++;
+    if(!it.next()) break;
+  }
+  EXPECT_GT(count, 0u);
+}
+
+TEST(GGGSGridAreaIterator, CrossBothBands)
+{
+  // Iterate from 71 to 81 latitude at level 0.
+  // This crosses both the 72-degree and 80-degree boundaries.
+  gggs::Level level(0);
+  auto gi1 = level.gridIndex(71.0, 0.0);
+  auto gi2 = level.gridIndex(81.0, 0.0);
+  ASSERT_TRUE(gi1.valid());
+  ASSERT_TRUE(gi2.valid());
+
+  gggs::GridAreaIterator it(gi1, gi2);
+  uint32_t count = 0;
+  bool saw_scale_1 = false;
+  bool saw_scale_3 = false;
+  bool saw_scale_9 = false;
+  while(it.valid())
+  {
+    EXPECT_TRUE(it->valid()) << "Invalid index at row " << it->row()
+      << " col " << it->column();
+    auto sf = gggs::levels[0].latitudeScaleFactor(it->row());
+    if(sf == 1) saw_scale_1 = true;
+    if(sf == 3) saw_scale_3 = true;
+    if(sf == 9) saw_scale_9 = true;
+    count++;
+    if(!it.next()) break;
+  }
+  EXPECT_GT(count, 0u);
+  EXPECT_TRUE(saw_scale_1) << "Should visit scale-1 rows";
+  EXPECT_TRUE(saw_scale_3) << "Should visit scale-3 rows";
+  EXPECT_TRUE(saw_scale_9) << "Should visit scale-9 rows";
+}
+
+TEST(GGGSGridAreaIterator, SouthernHemisphere)
+{
+  // Iterate from -73 to -71 latitude at level 0.
+  // This crosses the -72 degree boundary (symmetric with northern hemisphere).
+  gggs::Level level(0);
+  auto gi1 = level.gridIndex(-73.0, 0.0);
+  auto gi2 = level.gridIndex(-71.0, 0.0);
+  ASSERT_TRUE(gi1.valid());
+  ASSERT_TRUE(gi2.valid());
+
+  gggs::GridAreaIterator it(gi1, gi2);
+  uint32_t count = 0;
+  bool saw_scale_1 = false;
+  bool saw_scale_3 = false;
+  while(it.valid())
+  {
+    EXPECT_TRUE(it->valid()) << "Invalid index at row " << it->row()
+      << " col " << it->column();
+    auto sf = gggs::levels[0].latitudeScaleFactor(it->row());
+    if(sf == 1) saw_scale_1 = true;
+    if(sf == 3) saw_scale_3 = true;
+    count++;
+    if(!it.next()) break;
+  }
+  EXPECT_GT(count, 0u);
+  EXPECT_TRUE(saw_scale_1) << "Should visit scale-1 rows";
+  EXPECT_TRUE(saw_scale_3) << "Should visit scale-3 rows";
+}
+
+TEST(GGGSGridBounds, CrossBand)
+{
+  // Expand bounds across the 72-degree boundary.
+  gggs::Level level(0);
+  auto gi1 = level.gridIndex(71.0, 0.0);
+  auto gi2 = level.gridIndex(73.0, 0.0);
+
+  gggs::GridBounds bounds;
+  bounds.expand(gi1);
+  bounds.expand(gi2);
+  EXPECT_TRUE(bounds.valid());
+
+  // Per-row column counts should differ across the band boundary
+  uint32_t cols_at_71_row = bounds.gridColumnCount(gi1.row());
+  uint32_t cols_at_73_row = bounds.gridColumnCount(gi2.row());
+  // The scale-1 row should have more columns than the scale-3 row for the
+  // same longitude range (or the same if the range is narrow enough to fit
+  // in one grid on both sides)
+  EXPECT_GE(cols_at_71_row, cols_at_73_row);
+}
+
+TEST(GGGSGridBounds, PerRowColumnCount)
+{
+  // Single-band bounds: verify gridColumnCount(row) matches old behavior
+  gggs::Level level(5);
+  auto gi1 = level.gridIndex(43.0, -71.0);
+  auto gi2 = level.gridIndex(43.5, -70.0);
+
+  gggs::GridBounds bounds;
+  bounds.expand(gi1);
+  bounds.expand(gi2);
+  EXPECT_TRUE(bounds.valid());
+
+  // Both grids are in the same band (scale factor 1), so gridColumnCount
+  // should be the same for any row in the bounds
+  uint32_t cols = bounds.gridColumnCount(gi1.row());
+  EXPECT_GE(cols, 1u);
+
+  // All rows in the bounds should have the same column count
+  auto min_gi = bounds.minimum();
+  auto max_gi = bounds.maximum();
+  for(uint32_t r = min_gi.row(); r <= max_gi.row(); ++r)
+  {
+    EXPECT_EQ(bounds.gridColumnCount(r), cols)
+      << "Column count should be uniform in same band at row " << r;
+  }
 }

--- a/marine_autonomy/test/test_gggs.cpp
+++ b/marine_autonomy/test/test_gggs.cpp
@@ -27,7 +27,6 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include <gtest/gtest.h>
-#include <climits>
 #include <cmath>
 #include <type_traits>
 #include "marine_autonomy/gggs.h"

--- a/marine_autonomy/test/test_gggs.cpp
+++ b/marine_autonomy/test/test_gggs.cpp
@@ -992,6 +992,24 @@ TEST(GGGSGridAreaIterator, CrossBothBands)
   EXPECT_TRUE(saw_scale_9) << "Should visit scale-9 rows";
   EXPECT_EQ(min_visited_row, expected_min_row);
   EXPECT_EQ(max_visited_row, expected_max_row);
+
+  // Verify count matches sum of per-row column counts
+  uint32_t expected_count = 0;
+  double west = std::min(gi1.westLongitude(), gi2.westLongitude());
+  double east = std::max(gi1.eastLongitude(), gi2.eastLongitude());
+  for(uint32_t r = expected_min_row; r <= expected_max_row; ++r)
+  {
+    double span = gggs::levels[0].gridLongitudinalSpan(r);
+    uint32_t first = static_cast<uint32_t>((west + 180.0) / span);
+    uint32_t last = static_cast<uint32_t>((east + 180.0) / span);
+    if(east + 180.0 > 0.0 && std::fmod(east + 180.0, span) < 1e-10)
+      last--;
+    uint32_t max_col = gggs::levels[0].columnCount(r) - 1;
+    first = std::min(first, max_col);
+    last = std::min(last, max_col);
+    expected_count += 1 + last - first;
+  }
+  EXPECT_EQ(count, expected_count);
 }
 
 TEST(GGGSGridAreaIterator, SouthernHemisphere)


### PR DESCRIPTION
Closes #78

# Plan: GGGS — correct polar column handling in bounds and iterators

## Issue

https://github.com/rolker/unh_marine_autonomy/issues/78

## Context

The GGGS library uses latitude-dependent column counts: rows below 72° have
the full column count, rows at 72–80° have 1/3 the columns (3x wider grids),
and rows above 80° have 1/9 the columns (9x wider). The infrastructure for
this (`LevelSpecs::columnCount(row)`, `latitudeScaleFactor(row)`) exists and
works correctly. However, three components assume uniform column numbering:

- `min(GridIndex, GridIndex)` / `max(GridIndex, GridIndex)` — component-wise
  min/max of row+column, producing invalid column indices when rows span bands
- `GridBounds::gridColumnCount()` — `1 + max.col - min.col`, meaningless
  across band boundaries
- `GridAreaIterator::next()` — iterates `from.col` to `to.col` on every row,
  visiting nonexistent columns in bands with fewer columns

**Blast radius**: `min`/`max` are called only from `GridBounds::expand()` and
one test. `GridBounds` and `GridAreaIterator` are used only in tests and a doc
example in `gggs.h`. No production code outside the test suite uses these APIs
yet — #86 (bathymetric data store) will be the first consumer.

## Approach

### 1. Fix `GridAreaIterator` to use per-row column bounds

In `next()`, after advancing to a new row, compute that row's valid column
range using `LevelSpecs::columnCount(row)`. Clamp the iteration column to the
valid range for each row.

The key change: when iterating rows that cross a band boundary, the column
range narrows. For a row with `columnCount(row) = C`, valid columns are
`[0, C-1]`. The iterator should intersect the requested column range with
the row's valid range.

**Longitude-aware mapping**: column indices have different geographic meaning
at different latitudes. Column 10 at the equator covers a different longitude
range than column 10 at 75°. The iterator needs to decide: iterate by
**column index** (visiting the same numbered columns, some of which may not
exist) or by **longitude range** (visiting all columns that overlap the
geographic extent). The longitude-range approach is correct for spatial
queries.

Implementation in `grid_area_iterator.h`:
- Store the level (to access `LevelSpecs`)
- In `next()`, when advancing to a new row:
  - Compute the geographic longitude range from `from_` and `to_` columns at
    their respective rows
  - Map that longitude range to column indices at the new row using
    `LevelSpecs::gridLongitudinalSpan(row)`
  - Iterate those columns
- Update `valid()` to check per-row column limits

### 2. Fix `GridBounds` for cross-band awareness

`GridBounds` tracks an axis-aligned bounding box. With varying column counts,
it needs to track the geographic extent rather than raw column indices.

Options (choose one):
- **(A) Store row-based bounds**: keep `min_`/`max_` as `GridIndex` but make
  `gridColumnCount()` return the max across all rows in the range. This is
  simpler but `gridColumnCount()` becomes an approximation.
- **(B) Deprecate `gridColumnCount()`**: remove or replace it with
  `gridColumnCount(uint32_t row)` that returns the per-row count within the
  bounds. `cellColumnCount()` would similarly become per-row.

**Recommended: (B)** — per-row column count is the only correct answer when
bounds span bands. A single `gridColumnCount()` is inherently misleading.

### 3. Fix or restrict `min`/`max` on `GridIndex`

These produce invalid indices when rows are in different bands. Options:
- **(A) Remove them** — callers use `GridBounds::expand()` instead (which
  would handle band differences internally)
- **(B) Keep but throw on cross-band** — add a check that both indices have
  the same `latitudeScaleFactor`
- **(C) Make longitude-aware** — compute geographic min/max and map back to
  indices at each row

**Recommended: (A)** — `min`/`max` on `GridIndex` is conceptually broken for
the cross-band case. `GridBounds::expand()` is the correct API for building
bounding boxes. Remove the friend functions and update the one test caller.

### 4. Update `GridBounds::expand()` to not use `min`/`max`

If `min`/`max` are removed, `expand()` needs to track row bounds and
longitude bounds separately:
- Row: `min(row)` / `max(row)` — straightforward
- Longitude: track west/east longitude extents, then compute per-row column
  ranges when queried

### 5. Add cross-polar tests

Add test cases in `test_gggs.cpp`:
- `GridAreaIterator` spanning 71°–73° (crosses 72° boundary, 1x→3x)
- `GridAreaIterator` spanning 79°–81° (crosses 80° boundary, 3x→9x)
- `GridAreaIterator` spanning 71°–81° (crosses both boundaries)
- Verify every visited index passes `valid()`
- Verify no valid index in the geographic extent is skipped
- `GridBounds` column count queries across band boundaries
- Southern hemisphere equivalents (negative latitudes)

### 6. Update existing tests

The `MultipleGrids` test in `test_gggs.cpp` currently uses `min(gi1, gi2)`
and `max(gi1, gi2)` at lines 480–481. If `min`/`max` are removed, this test
must be updated to use `GridBounds` or construct the iterator differently.

## Files to Change

| File | Change |
|------|--------|
| `include/marine_autonomy/gggs/grid_area_iterator.h` | Longitude-aware per-row column iteration |
| `include/marine_autonomy/gggs/bounds.h` | Per-row column queries; remove `gridColumnCount()` or make it per-row |
| `include/marine_autonomy/gggs/grid_index.h` | Remove `min`/`max` friend functions |
| `test/test_gggs.cpp` | Cross-polar iterator/bounds tests; update `MultipleGrids` test |

## Principles Self-Check

| Principle | Consideration |
|---|---|
| Safety First | Correct spatial iteration prevents silent data corruption in downstream #86 |
| Test what breaks | Tests target the exact failure modes: cross-band iteration, column validity |
| A change includes its consequences | Removing `min`/`max` requires updating the one test caller in the same PR |
| Only what's needed | Minimal API surface change — fix the broken parts, keep what works |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| 0002 — Worktree isolation | Yes | Working in `feature/issue-78` worktree |
| 0008 — ROS 2 conventions | Marginal | C++ library; follows existing naming patterns |

## Consequences

| If we change... | Also update... | Included in plan? |
|---|---|---|
| `min`/`max` friend functions | Test callers (line 480–481) | Yes — step 6 |
| `GridBounds` API | Test callers (5 test functions) | Yes — step 6 |
| `GridAreaIterator` behavior | Existing iterator tests | Yes — step 6 |

## Open Questions

1. **Longitude-range vs column-index iteration**: should `GridAreaIterator`
   iterate by geographic longitude extent (correct for spatial queries) or by
   column index (simpler but breaks across bands)? Recommended: longitude-range.
2. **`GridBounds::gridColumnCount()` removal vs per-row**: should it be
   removed entirely, return the maximum across rows, or take a row parameter?
3. **`min`/`max` removal vs restriction**: remove entirely (recommended) or
   keep with a same-band assertion?

## Estimated Scope

Single PR. All changes are in header files + one test file, contained within
the GGGS module.
