### PR TITLE
Add site layer for private configuration packages

### DIFF
--- a/config/layers.txt
+++ b/config/layers.txt
@@ -1,6 +1,7 @@
 underlay
 core
 platforms
+site
 sensors
 simulation
 ui

--- a/config/optional_layers.txt
+++ b/config/optional_layers.txt
@@ -1,0 +1,3 @@
+# Layers that are allowed to fail during setup (e.g., private repos).
+# One layer name per line. Blank lines and comments (#) are ignored.
+site

--- a/config/repos/site.repos
+++ b/config/repos/site.repos
@@ -1,0 +1,5 @@
+repositories:
+  ccomjhc_project11:
+    type: git
+    url: git@github.com:rolker/ccomjhc_project11.git
+    version: jazzy


### PR DESCRIPTION
## Summary

Adds the `site` layer for private, site-specific configuration packages (e.g., network hosts, VPN configs, machine-specific parameters).

Closes #107

## Changes

- **`config/layers.txt`**: Added `site` between `platforms` and `sensors`
- **`config/repos/site.repos`**: Points to `rolker/ccomjhc_project11` (jazzy branch, private repo)
- **`config/optional_layers.txt`**: New file listing `site` as optional — read by the workspace's `setup_layers.sh` and `validate_workspace.py` to skip gracefully when the repo is inaccessible

## Depends On

- rolker/ros2_agent_workspace#405 — optional layer support in setup/validate scripts (reads `optional_layers.txt`)

## Test Plan

- [ ] `make build` succeeds for users without access to `rolker/ccomjhc_project11`
- [ ] `make build` succeeds for users with access (site layer built)
- [ ] Layer source order correct: underlay → core → platforms → site → sensors → simulation → ui

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
