### PR TITLE
Add rqt_operator_tools to ui.repos

### DIFF
--- a/config/repos/ui.repos
+++ b/config/repos/ui.repos
@@ -3,6 +3,10 @@ repositories:
     type: git
     url: https://github.com/rolker/camp.git
     version: jazzy
+  rqt_operator_tools:
+    type: git
+    url: https://github.com/rolker/rqt_operator_tools.git
+    version: jazzy
   rqt_marine_radar:
     type: git
     url: https://github.com/rolker/rqt_marine_radar.git


### PR DESCRIPTION
## Summary

- Adds `rqt_operator_tools` repo to `config/repos/ui.repos` for the UI layer

New repo ([rolker/rqt_operator_tools](https://github.com/rolker/rqt_operator_tools)) will house operator station rqt plugins:
- `rqt_operator_log` — deployment logbook with bag recording and PDF export (#114)
- `rqt_checklist` — pre-deployment operational checklists (#113)

Closes #114

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
