### PR TITLE
Replace molab_description with consolidated mobile_lab repo

### DIFF
--- a/config/repos/platforms.repos
+++ b/config/repos/platforms.repos
@@ -27,7 +27,7 @@ repositories:
     type: git
     url: https://github.com/rolker/drix_description.git
     version: jazzy
-  molab_description:
+  mobile_lab:
     type: git
-    url: https://github.com/rolker/molab_description.git
+    url: https://github.com/rolker/mobile_lab.git
     version: jazzy


### PR DESCRIPTION
## Summary

- Consolidated `molab_description` and `molab_hardware` into a single [`mobile_lab`](https://github.com/rolker/mobile_lab) repo (renamed from `molab_hardware`, with `molab_description` history merged in)
- Updated `platforms.repos` to point to `mobile_lab` instead of `molab_description`

The `mobile_lab` repo now contains two ROS packages:
- `molab_description` — URDF model, meshes, launch files
- `molab_hardware` — hardware interface nodes

Git history from both original repos is preserved.

Closes #112

## Test plan

- [ ] `vcs import` with updated manifest pulls `mobile_lab` correctly
- [ ] Both `molab_description` and `molab_hardware` packages build

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
