### PR TITLE
Add network monitoring repos to sensors manifest

### DIFF
--- a/config/repos/sensors.repos
+++ b/config/repos/sensors.repos
@@ -23,3 +23,11 @@ repositories:
     type: git
     url: https://github.com/rolker/edgetech_sonar.git
     version: jazzy
+  starlink_stats_ros:
+    type: git
+    url: https://github.com/rolker/starlink_stats_ros.git
+    version: jazzy
+  ros2_network_monitor:
+    type: git
+    url: https://github.com/rolker/ros2_network_monitor.git
+    version: jazzy


### PR DESCRIPTION
## Summary

- Add `starlink_stats_ros` and `ros2_network_monitor` to `config/repos/sensors.repos`
- Both repos have `jazzy` branches ready for `vcs import`

Closes #120

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
