### PR TITLE
Add SoundSpeed.msg to marine_interfaces

### DIFF
--- a/marine_interfaces/CMakeLists.txt
+++ b/marine_interfaces/CMakeLists.txt
@@ -39,6 +39,7 @@ set(MSG_FILES
   msg/Platform.msg
   msg/PlatformList.msg
   msg/RangeBearing.msg
+  msg/SoundSpeed.msg
   # Formerly project11_nav_msgs
   msg/BoundingBox.msg
   msg/Curve.msg

--- a/marine_interfaces/msg/SoundSpeed.msg
+++ b/marine_interfaces/msg/SoundSpeed.msg
@@ -1,0 +1,15 @@
+# Single-point sound speed measurement from a real-time sensor at a fixed
+# installed location (e.g., AML SVS at the sonar head).
+#
+# This message is NOT intended to represent a sample from a sound speed
+# profile (cast). A dedicated profile message type should be used for that
+# case, since profiles have additional structure (per-sample depth and/or
+# pose, shared cast metadata) that does not belong here.
+
+std_msgs/Header header
+
+# Speed of sound in water in m/s. NaN if unavailable.
+float64 sound_speed
+
+# Variance on sound_speed in (m/s)^2. 0 is interpreted as variance unknown.
+float64 variance


### PR DESCRIPTION
## Summary

- Add `marine_interfaces/msg/SoundSpeed.msg` — a standalone message for single-point sound-speed measurements from real-time sensors (AML SVS, Valeport miniSVS, etc.).
- Wire it into `marine_interfaces/CMakeLists.txt` MSG_FILES list (alphabetically placed after `RangeBearing.msg`).
- No code changes elsewhere — this is interface-only.

## Schema

```
std_msgs/Header header

# Speed of sound in water in m/s. NaN if unavailable.
float64 sound_speed

# Variance on sound_speed in (m/s)^2. 0 is interpreted as variance unknown.
float64 variance
```

## Design rationale

See #123 for the full motivation and design discussion. Highlights:

- **`sound_speed` (not `sound_velocity`)** matches the workspace's existing convention (`marine_acoustic_msgs/PingInfo.sound_speed`, `cube_bathymetry`, `marine_tools`). Vendor protocols use "sound velocity"; ROS-side abstractions use "sound speed."
- **`float64` + `variance` with `0 = unknown` sentinel** mirrors `sensor_msgs/Temperature` and `sensor_msgs/FluidPressure`.
- **`NaN` for unavailable measurement** disambiguates from a stuck-at-zero sensor (deliberate divergence from `PingInfo`'s 0-as-sentinel pattern, which is older).
- **Auxiliary readings** (water temperature, pressure) are intentionally NOT bundled — sensors that report them should publish separate `sensor_msgs/Temperature` / `sensor_msgs/FluidPressure` topics with shared timestamps.
- **Profile / cast use is explicitly out of scope** — the message comment states this. A dedicated profile message type can be added when a ROS-side cast consumer materializes.

## Test plan

- [x] `colcon build --packages-select marine_interfaces` succeeds
- [x] `ros2 interface show marine_interfaces/msg/SoundSpeed` renders the expected schema with the expanded `std_msgs/Header`
- [ ] Will be exercised by the `sound_speed_bridge` driver in `rolker/marine_tools` (separate, follow-up issue) — that work will be the first real publisher and confirm the schema is sufficient before any upstream proposal to `marine_acoustic_msgs`.

Closes #123

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
