### PR TITLE
Add marine_perception_tools to ui layer manifest (Closes #130)

### DIFF
--- a/config/repos/ui.repos
+++ b/config/repos/ui.repos
@@ -19,3 +19,7 @@ repositories:
     type: git
     url: https://github.com/rolker/rviz_sonar_image.git
     version: jazzy
+  marine_perception_tools:
+    type: git
+    url: https://github.com/rolker/marine_perception_tools.git
+    version: jazzy


### PR DESCRIPTION
## Summary

Adds `marine_perception_tools` to the ui layer manifest (`config/repos/ui.repos`)
so it clones into `ui_ws` alongside `camp` and the `rqt_*` tools.

```yaml
  marine_perception_tools:
    type: git
    url: https://github.com/rolker/marine_perception_tools.git
    version: jazzy
```

## Context

New `ui_ws` repo created to host the `sea_surface_tuner` C++/Qt bag-replay +
segmentation→costmap tuning tool (rolker/marine_perception_tools#1), enabled by
rolker/unh_marine_perception#23 and validating rolker/unh_marine_perception#22.
`ui_ws` is operator-station-only, so the tool's Qt dependency stays off the boat.

## Ordering caveat — resolved

The issue flagged that a `version: jazzy` entry won't resolve on `vcs import`
until the repo has a `jazzy` branch. That branch now exists — the package
skeleton was bootstrapped and pushed to `jazzy` (default branch), so the entry
resolves:

```
$ git ls-remote --heads https://github.com/rolker/marine_perception_tools.git jazzy
e700756...  refs/heads/jazzy
```

## Test plan

- [ ] `make sync` (or `vcs import`) checks out `marine_perception_tools` into `ui_ws/src/`
- [ ] `make build` builds the package in the ui layer

Closes #130.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
