### PR TITLE
docs: operator-facing framework guide + marine/ topic-name cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ This repository is a collection of packages that form the core of the autonomy s
 *   **`mission_manager`**: High-level mission execution and state machine.
 *   **`camp`** (External): The CCOM Autonomous Mission Planner (UI).
 
+## Documentation
+
+Start with the operator/new-engineer overview, then drill into the reference docs:
+
+*   **[How the stack works](./docs/how_the_stack_works.md)** — plain-language tour
+    of the framework: platform self-advertisement to CAMP, piloting modes, the
+    autonomous control chain, obstacle handling, and the comms link. **Start here.**
+*   **[Autonomy modes](./docs/autonomy_modes.md)** — the helm manager's piloting-mode state machine.
+*   **[Data flows](./docs/data_flows.md)** — command and telemetry data flows in detail.
+*   **[Interfaces](./docs/interfaces.md)** — ROS topics, services, and actions.
+
 ## Getting Started
 This repository is typically part of a layered workspace setup.
 

--- a/command_bridge/README.md
+++ b/command_bridge/README.md
@@ -8,8 +8,8 @@ This package is designed to work with `udp_bridge` to ensure command delivery ac
 The `udp_bridge` typically transmits selected topics between these systems. However, effectively ensuring a command is received and executed over such a link requires a reliable protocol. This package implements a "send-until-acknowledged" pattern:
 
 1.  **Sender** (`command_bridge_sender`) publishes a command with a timestamp.
-2.  **UDP Bridge** transmits this topic (`project11/command`) to the remote system.
-3.  **Receiver** (`command_bridge_receiver`) on the remote system receives the command, executes it, and publishes an acknowledgement (`project11/response`).
+2.  **UDP Bridge** transmits this topic (`marine/command`) to the remote system.
+3.  **Receiver** (`command_bridge_receiver`) on the remote system receives the command, executes it, and publishes an acknowledgement (`marine/response`).
 4.  **UDP Bridge** transmits the response back to the sender.
 5.  **Sender** stops republishing the command once the acknowledgement is received.
 
@@ -19,25 +19,25 @@ The `udp_bridge` typically transmits selected topics between these systems. Howe
 Responsible for queuing commands and ensuring their delivery by repeatedly publishing them until acknowledged.
 
 **Subscribed Topics**
-*   `project11/send_command` (`std_msgs/String`): Input for commands to be sent locally.
+*   `marine/send_command` (`std_msgs/String`): Input for commands to be sent locally.
     *   Format: `command_name [arguments]`
-*   `project11/response` (`std_msgs/String`): Feedback channel for acknowledgments (typically received effectively from the remote `udp_bridge`).
+*   `marine/response` (`std_msgs/String`): Feedback channel for acknowledgments (typically received effectively from the remote `udp_bridge`).
 
 **Published Topics**
-*   `project11/command` (`std_msgs/String`): The active command being attempted. This topic is intended to be bridged to the remote system.
+*   `marine/command` (`std_msgs/String`): The active command being attempted. This topic is intended to be bridged to the remote system.
     *   Format: `timestamp command_name [arguments]`
 
 ### `command_bridge_receiver`
 Processes incoming commands, handles deduplication based on timestamps, routes them to the appropriate system components, and sends acknowledgments.
 
 **Subscribed Topics**
-*   `project11/command` (`std_msgs/String`): Incoming commands from the sender (via `udp_bridge`).
+*   `marine/command` (`std_msgs/String`): Incoming commands from the sender (via `udp_bridge`).
 
 **Published Topics**
-*   `project11/response` (`std_msgs/String`): Acknowledgment sent back to the sender (to be bridged back).
-*   `project11/mission_plan` (`std_msgs/String`): Publishes when `mission_plan` command is received.
+*   `marine/response` (`std_msgs/String`): Acknowledgment sent back to the sender (to be bridged back).
+*   `marine/mission_plan` (`std_msgs/String`): Publishes when `mission_plan` command is received.
 *   `piloting_mode` (`std_msgs/String`): Publishes when `piloting_mode` command is received.
-*   `project11/mission_manager/command` (`std_msgs/String`): Publishes for commands like `goto_line`, `start_line`, `hover`, etc.
+*   `marine/mission_manager/command` (`std_msgs/String`): Publishes for commands like `goto_line`, `start_line`, `hover`, etc.
 
 **Services Called**
 *   `sonar/control` (`kongsberg_em_control/srv/EMControl`): Called when `sonar_control` command is received (if package is available).
@@ -52,5 +52,5 @@ ros2 run command_bridge command_bridge_sender
 
 **Send a command (Manual Test):**
 ```bash
-ros2 topic pub --once /project11/send_command std_msgs/String "data: 'hover'"
+ros2 topic pub --once /marine/send_command std_msgs/String "data: 'hover'"
 ```

--- a/docs/data_flows.md
+++ b/docs/data_flows.md
@@ -22,15 +22,15 @@ This document illustrates the data flows through the UNH Marine Autonomy system,
 │  │ command_bridge_  │         (timestamp deduplication)             │
 │  │     sender       │◄────────────────────┐                         │
 │  └────────┬─────────┘                     │                         │
-│           │ project11/command             │                         │
+│           │ marine/command                │                         │
 │           ▼                                │                         │
-│  ┌──────────────────┐  project11/response │                         │
+│  ┌──────────────────┐  marine/response    │                         │
 │  │ command_bridge_  ├────────────────────►│                         │
 │  │    receiver      │                                                │
 │  └────────┬─────────┘                                                │
 │           │                                                          │
-│           ├─► project11/mission_plan                                │
-│           ├─► project11/mission_manager/command                     │
+│           ├─► marine/mission_plan                                   │
+│           ├─► marine/mission_manager/command                        │
 │           └─► piloting_mode                                         │
 └─────────────────────────────────────────────────────────────────────┘
          │              │                  │
@@ -56,15 +56,15 @@ This document illustrates the data flows through the UNH Marine Autonomy system,
 │ command_bridge_     │
 │     sender          │
 └──────┬──────────────┘
-       │ 2. project11/command (timestamped)
+       │ 2. marine/command (timestamped)
        ▼
 ┌─────────────────────┐
 │ command_bridge_     │
 │    receiver         │
 └──────┬──────────────┘
-       │ 3. project11/response (ack) ────┐
+       │ 3. marine/response (ack) ────┐
        │                                  │
-       ├─► 4a. project11/mission_plan    │
+       ├─► 4a. marine/mission_plan    │
        │                                  │
        ▼                                  │
 ┌─────────────────────┐                  │
@@ -96,7 +96,7 @@ This document illustrates the data flows through the UNH Marine Autonomy system,
 └─────────────────────┘                  │
                                           │
        ┌──────────────────────────────────┘
-       │ 10. project11/status/mission_manager (heartbeat)
+       │ 10. marine/status/mission_manager (heartbeat)
        ▼
 ┌─────────────────────┐
 │ command_bridge_     │
@@ -176,7 +176,7 @@ This document illustrates the data flows through the UNH Marine Autonomy system,
 ┌─────────────────────┐
 │ command_bridge      │
 └──────┬──────────────┘
-       │ 2. project11/mission_manager/command
+       │ 2. marine/mission_manager/command
        ▼
 ┌─────────────────────────────────────┐
 │  mission_manager (CampInterface)    │
@@ -233,8 +233,8 @@ This document illustrates the data flows through the UNH Marine Autonomy system,
 - **Purpose**: Handle lossy network links (WiFi, radio)
 - **Mechanism**: 
   - Sender adds timestamp to message
-  - Publishes on `project11/command`
-  - Receiver publishes ack on `project11/response`
+  - Publishes on `marine/command`
+  - Receiver publishes ack on `marine/response`
   - Sender retries if no ack received
   - Receiver deduplicates using timestamp
 

--- a/docs/how_the_stack_works.md
+++ b/docs/how_the_stack_works.md
@@ -1,0 +1,276 @@
+# How the Marine Autonomy Stack Works
+
+A plain-language tour of the Project11 marine autonomy framework: how an operator
+at CAMP and a boat on the water find each other, how commands flow, and what is
+actually steering the boat. The goal is **understanding** — enough of the moving
+parts that, when something looks wrong on the water, you can reason about *which*
+part to look at rather than guess.
+
+This is the operator/new-engineer overview. For depth, follow the links:
+
+- [`autonomy_modes.md`](autonomy_modes.md) — the helm manager's piloting-mode state machine
+- [`data_flows.md`](data_flows.md) — command/telemetry data flows in detail
+- [`interfaces.md`](interfaces.md) — every ROS topic/service/action
+
+> **Topic naming.** Deployed topics use a `marine/` prefix under a per-boat
+> namespace (e.g. `/bizzy/marine/heartbeat`). One exception: `piloting_mode` is
+> a bare topic with no `marine/` prefix. The launch and node source are the
+> source of truth.
+
+---
+
+## 1. It's a framework, not one boat
+
+Project11 is a **vehicle-agnostic autonomy framework**. The same core
+(`unh_marine_autonomy` + `unh_marine_navigation`) runs on very different
+platforms — for example **Ben**, **DriX**, and the **EchoBoat** family
+(BizzyBoat / IzzyBoat). The autonomy layer thinks in terms of *where to go* and
+*how fast*, and emits a generic velocity / helm command. Each platform then
+adapts that command to its own propulsion and low-level control:
+
+- **BizzyBoat (EchoBoat 240)** routes the command through **ArduPilot/MAVROS**
+  to its thrusters.
+- **Ben** and **DriX** do **not** use ArduPilot — they have their own low-level
+  backends.
+
+So "the stack outputs `cmd_vel`" is a framework fact; "ArduPilot drives the
+thrusters" is a *BizzyBoat* fact. Throughout this guide, anything tied to a
+specific sensor rig or hull (the obstacle layers, the reflex zones, the control
+gains) is **per-platform configuration**, and is called out as such. The
+EchoBoat/BizzyBoat configuration is used below as the worked example because it
+is the most fully built-out.
+
+---
+
+## 2. The whole system in one picture
+
+```
+  OPERATOR STATION                                    PLATFORM (boat)
+ ┌──────────────────┐                              ┌────────────────────────┐
+ │      CAMP        │   commands  (send-until-ack) │  command_bridge        │
+ │  (mission plan,  │ ───────────────────────────► │  → mission_manager     │
+ │   overrides,     │       UDP bridge link        │  → piloting_mode        │
+ │   live display)  │ ◄─────────────────────────── │                        │
+ │                  │   telemetry / heartbeat /    │  navigation → helm →    │
+ │  PlatformManager │   /marine/platforms          │  thrusters              │
+ └──────────────────┘                              └────────────────────────┘
+```
+
+Two programs, one radio/UDP link between them. CAMP is the operator's window and
+mission planner; everything autonomous happens **on the boat**. The link can drop
+(over-the-horizon operation is normal) without stopping the boat — see §7.
+
+---
+
+## 3. How a platform advertises itself to CAMP
+
+CAMP does not need to be pre-configured for each boat. A platform **announces
+itself**, and CAMP draws it.
+
+- On the boat, **`platform_send.py`** (node `platform_publisher`, a managed
+  *lifecycle* node) publishes a **`PlatformList`** message on **`/marine/platforms`**
+  once per second.
+- Each entry is a **`Platform`** message
+  (`marine_interfaces/msg/Platform`) describing one boat:
+
+  | Field | Meaning |
+  |-------|---------|
+  | `name` | Display name (becomes the CAMP tab label) |
+  | `platform_namespace` | ROS namespace the boat's topics live under |
+  | `robot_description` | URDF — the boat's shape/model |
+  | `nav_sources[]` | Named nav feeds (position/orientation/velocity topics) with a `priority` |
+  | `width`, `length` | Hull dimensions, for drawing to scale |
+  | `reference_x`, `reference_y` | Reference point on the hull |
+  | `color` | RGBA the boat is drawn in |
+
+  These values come from per-boat ROS parameters (set in the platform's config),
+  so each boat ships its own identity.
+
+- In CAMP, **`PlatformManager`** subscribes to `/marine/platforms`. The first
+  time it sees a platform `name`, it **creates a new tab and a map drawing** for
+  it; subsequent messages just update it. This is why a boat "just appears" in
+  CAMP when it comes online, and how CAMP knows *which topics* to read for that
+  boat's position (from `nav_sources`).
+
+The practical upshot for an operator: **if a boat is not showing up in CAMP, the
+question is whether `/marine/platforms` is reaching the operator station** — the
+link, the bridge, and the platform publisher being active (it's a lifecycle node,
+so it must be *activated*, not merely launched).
+
+---
+
+## 4. Who is allowed to drive: piloting modes
+
+All control authority funnels through one node: the **helm manager**
+(`helm_manager`). It is a **single-active-mode mux** — only one source commands
+the boat at a time, so manual and autonomous commands can never fight. The three
+modes (full detail in [`autonomy_modes.md`](autonomy_modes.md)):
+
+- **Standby** — nothing is forwarded to the thrusters. This is the safe/idle
+  state. (On BizzyBoat, standby hands the vehicle back to direct RC control, so
+  the boat may drift with wind/current — that is expected, not a fault.)
+- **Manual** — operator joystick/helm goes straight through.
+- **Autonomous** — the navigation stack drives (see §5).
+
+The helm manager publishes a **heartbeat** on **`marine/heartbeat`**
+(`marine_interfaces/Heartbeat`) reporting the currently active mode and status.
+**The heartbeat is the acknowledgment**: when you command a mode or override from
+CAMP, you know it took effect because the heartbeat comes back reporting the new
+state. If the heartbeat lags, that is usually **link saturation**, not a stuck
+command.
+
+The helm manager's outputs are remapped to the platform's control topics:
+
+- `out/cmd_vel` → **`marine/control/cmd_vel`** (`geometry_msgs/TwistStamped`)
+- `out/helm` → **`marine/control/helm`** (`marine_interfaces/Helm`: `throttle`,
+  `rudder`, each −1.0…1.0)
+
+A platform consumes whichever of these it needs — BizzyBoat's MAVROS backend
+takes the velocity command from here.
+
+---
+
+## 5. The autonomous control chain (EchoBoat worked example)
+
+When the boat is in **autonomous** mode running a mission, this is the chain of
+hands the command passes through. The components are stock Nav2 where possible,
+with marine-specific plugins where the water demands it.
+
+```
+ mission (tasks)
+      │
+      ▼
+ BT task navigator        marine_nav_bt_task_navigator::TaskNavigator
+   run_tasks.xml          task types: hover · goto · survey_line ·
+      │                                survey_line_set · survey_area
+      ▼
+ planner  "GridBased"     nav2_smac_planner::SmacPlannerHybrid  (Hybrid-A*)
+      │                   (240: minimum_turning_radius 1.5 m)
+      ▼
+ path smoother            nav2_smoother::SimpleSmoother   (active)
+      │
+      ▼
+ controller "FollowPath"  marine_nav_crabbing_path_follower::CrabbingPathFollower
+      │   publishes cmd_vel → remapped to  cmd_vel_nav
+      ▼
+ ┌─────────────────────────────────────────────────────────────┐
+ │  velocity_smoother   ── INTENTIONALLY NOT IN THE PATH (#170)  │
+ └─────────────────────────────────────────────────────────────┘
+      │  cmd_vel_nav
+      ▼
+ Collision Monitor        nav2_collision_monitor  (the safety gate)
+      │   cmd_vel_in: cmd_vel_nav  →  cmd_vel_out: piloting_mode/autonomous/cmd_vel
+      ▼
+ helm manager (autonomous mode) ──► marine/control/cmd_vel + marine/control/helm
+      ▼
+ platform backend (BizzyBoat: ArduPilot/MAVROS) ──► thrusters
+```
+
+Things worth knowing as an operator:
+
+- **The controller is a *crabbing* path follower.** It can hold a line while the
+  hull points off-heading to fight current — important for survey quality. Its
+  speed comes from the task/path (per-pose), not a fixed constant.
+- **The `velocity_smoother` is deliberately disconnected** on these boats
+  (issue #170). The controller feeds the Collision Monitor directly. This is a
+  conscious choice — re-enabling it would put a second publisher on the helm
+  topic and fight the safety gate. (Don't confuse this with the *path*
+  `smoother_server`, which **is** active — that smooths the planned path, not the
+  velocity command.)
+- **The Collision Monitor is the last thing between the controller and the
+  thrusters** — see §6.
+- **Turning is vectored thrust**, not a rudder: yaw rate is produced by
+  differential/steered thrust, so it scales with thrust, not boat speed. Don't
+  reason about it with rudder-boat intuition.
+
+---
+
+## 6. How the boat sees obstacles — two independent systems
+
+There are **two** obstacle systems, at different levels, and they are easy to
+confuse. Both are EchoBoat sensor-rig configuration, not framework guarantees.
+
+**Deliberative — the costmap (planning).** The planner avoids obstacles by
+planning around them in a costmap built from:
+
+- a **`sea_surface_layer`** fusing segmentation from **all four OAK cameras**
+  (forward, port, starboard, aft) into one shared, persistent buffer — an
+  obstacle seen by any camera accumulates evidence and survives the handoff
+  between camera views;
+- an **S57 chart layer** (charted hazards, shoreline);
+- inflation.
+
+This is *deliberative*: it reshapes the planned path ahead of time.
+
+**Reflex — the Collision Monitor (safety floor).** Independently, the Nav2
+**Collision Monitor** watches a **reflex point cloud** and gates the velocity
+command in real time. On BizzyBoat (240) it has two zones:
+
+- **`CollisionSlowdown`** — a ~20 m × 6 m box ahead; an intrusion scales speed
+  down (to 0.3×).
+- **`CollisionStop`** — a ~5 m × 4 m box close in; an intrusion **stops** the
+  boat.
+
+Its input (`collision_monitor/pointcloud`) is the **forward OAK camera's**
+segmentation projected to the boat's reference level by `segments_to_pointcloud`
+— **forward camera only**, unlike the four-camera costmap. With no reflex feed
+configured, the monitor is a harmless pass-through.
+
+The mental model: **the costmap is how the boat plans politely around things; the
+Collision Monitor is the binary safety floor that doesn't care about the plan.**
+A boat can be following a perfectly planned path and still get slowed or stopped
+by the reflex if something enters the forward zone.
+
+---
+
+## 7. Limits and governors
+
+- **Helm clamp.** The helm manager clamps speed and yaw (`max_speed`,
+  `max_yaw_speed`). These are *capability backstops*, not the survey limit — the
+  survey speed/turn limits belong in the navigation config.
+- **Turning radius.** The planner's `minimum_turning_radius` (1.5 m on the 240)
+  keeps planned paths flyable by the hull.
+- **Footprint.** The costmap uses the real hull footprint (re-tuned to the 240
+  hull) so it doesn't plan through gaps the boat can't fit.
+
+---
+
+## 8. The link between boat and operator
+
+Commands and telemetry cross the water over a **UDP bridge** (`udp_bridge`),
+typically WiFi backhaul with a Starlink/VPN fallback path.
+
+- **Commands** use a **send-until-acknowledged** protocol with timestamp
+  deduplication: CAMP's `command_bridge_sender` keeps resending until the boat's
+  `command_bridge_receiver` acks on `marine/response`. The receiver fans commands
+  out to mission management (`marine/mission_manager/command`), mission plans
+  (`marine/mission_plan`), and mode changes (`piloting_mode`).
+- **Telemetry** flowing back includes nav (position/orientation/velocity),
+  display data, mission-manager status, the helm output (for monitoring), `/tf`,
+  and the **heartbeat**.
+
+**A dropped link is a normal operating mode, not an error.** Over-the-horizon
+operation is expected; the boat keeps executing its mission, and the bridge
+reconciles when the link returns. Diagnostics treat a wireless drop as data, not
+as an `ERROR`.
+
+---
+
+## 9. Quick "where do I look?" map
+
+| Symptom | Most likely area |
+|---------|------------------|
+| Boat doesn't appear in CAMP | `/marine/platforms` not arriving — link, bridge, or `platform_publisher` not activated (§3) |
+| Command "didn't take" | Watch the **heartbeat** for the new state; lag usually means link saturation (§4) |
+| Boat went to Standby and drifted | Expected — Standby hands back to RC; wind/current drift is normal (§4) |
+| Boat slowed/stopped for "no reason" | Collision Monitor reflex on the **forward** camera (§6) |
+| Boat planned a wide path around open water | Costmap obstacle (chart layer or a segmentation false-positive) (§6) |
+| Turn feels weak/strong vs. speed | Turning is vectored thrust — scales with thrust, not speed (§5) |
+
+---
+
+*Audience note: this guide favors the operational mental model over exhaustive
+parameter lists. Every component, topic, and behavior above is drawn from the
+launch and config in `unh_marine_autonomy`, `unh_marine_navigation`, and the
+EchoBoat platform packages — verify against those before relying on a specific
+value, since per-boat config changes in the field.*

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -6,33 +6,33 @@ This document describes all ROS communication interfaces (topics, services, acti
 
 ### Command Bridge (CAMP ↔ System Communication)
 
-#### `project11/command`
+#### `marine/command`
 - **Type**: `std_msgs/String`
 - **Publisher**: `command_bridge_sender`
 - **Subscriber**: `command_bridge_receiver`
 - **Purpose**: Reliable command transport with timestamp tagging for deduplication
 - **Format**: JSON string with timestamp metadata
 
-#### `project11/response`
+#### `marine/response`
 - **Type**: `std_msgs/String`
 - **Publisher**: `command_bridge_receiver`
 - **Subscriber**: `command_bridge_sender`
 - **Purpose**: Acknowledgment for sent commands (send-until-acked protocol)
 
-#### `project11/mission_plan`
+#### `marine/mission_plan`
 - **Type**: `std_msgs/String`
 - **Publisher**: `command_bridge_receiver`
 - **Subscriber**: `mission_manager`
 - **Purpose**: Mission plan upload from CAMP to mission manager
 - **Format**: JSON mission definition
 
-#### `project11/send_command`
+#### `marine/send_command`
 - **Type**: `std_msgs/String`
 - **Publisher**: External (CAMP)
 - **Subscriber**: `command_bridge_sender`
 - **Purpose**: Input queue for commands to be reliably transmitted
 
-#### `project11/mission_manager/command`
+#### `marine/mission_manager/command`
 - **Type**: `std_msgs/String`
 - **Publisher**: `command_bridge_receiver`
 - **Subscriber**: `mission_manager` (CampInterface node)
@@ -47,8 +47,8 @@ This document describes all ROS communication interfaces (topics, services, acti
 
 ### Mission Manager
 
-#### `project11/status/mission_manager`
-- **Type**: `project11_msgs/Heartbeat`
+#### `marine/status/mission_manager`
+- **Type**: `marine_interfaces/Heartbeat`
 - **Publisher**: `mission_manager` (CampInterface node)
 - **Subscriber**: CAMP/monitoring systems
 - **Purpose**: Status feedback with current task information and timestamps

--- a/marine_autonomy/docs/system_architecture.md
+++ b/marine_autonomy/docs/system_architecture.md
@@ -34,9 +34,9 @@ sequenceDiagram
     participant HW as Hardware
 
     UI->>CB_S: "Execute Survey Plan"
-    CB_S->>UDP: Bridge (project11/command)
+    CB_S->>UDP: Bridge (marine/command)
     UDP->>CB_R: Receive Command
-    CB_R->>CB_S: Acknowledge (project11/response)
+    CB_R->>CB_S: Acknowledge (marine/response)
     CB_R->>MM: Request Mission Execution
     MM->>Nav: Send Task List (project11_nav_msgs/TaskInformation)
     Nav->>HM: Output Helm/Twist (autonomous/helm)

--- a/mission_manager/mission_manager/README.md
+++ b/mission_manager/mission_manager/README.md
@@ -10,15 +10,15 @@ Repository containing the 'mission_manager_node.py' ROS node which uses SMACH fo
 
 ## Theory-of-Operation
 
-The node provides high-level control for a mobile vehicle.  It is designed to react to mission commands provided as std_msgs/String messages on topic `/project11/mission_manager/command`.  This is implemented by two objects, MissionManagerCore and a smach.StateMachine that capture and manage the "system-state", which consists of a queue of "tasks".  The MissionManagerCore interfaces with the user (often through the CAMP GUI) to build and modify the active queue of tasks.
+The node provides high-level control for a mobile vehicle.  It is designed to react to mission commands provided as std_msgs/String messages on topic `/marine/mission_manager/command`.  This is implemented by two objects, MissionManagerCore and a smach.StateMachine that capture and manage the "system-state", which consists of a queue of "tasks".  The MissionManagerCore interfaces with the user (often through the CAMP GUI) to build and modify the active queue of tasks.
 
 ### MissionManagerCore
 
-This singelton object receives command (`project11/mission_manager/command`), piloting_mode (`project11/piloting_mode`)  and heartbeat (`project11/heartbeat`)  messages from the system as a way for the operator to supervise and interact with system at a high level.
+This singelton object receives command (`marine/mission_manager/command`), piloting_mode (`piloting_mode`)  and heartbeat (`marine/heartbeat`)  messages from the system as a way for the operator to supervise and interact with system at a high level.
 
 The object also subscribes to the vehicle Odometry state on `odom` and stores it as an object attribute for use by the state-machine.
 
-The object published the status of the object as a Heartbeat message on `project11/status/mission_manager`.
+The object published the status of the object as a Heartbeat message on `marine/status/mission_manager`.
 
 The interface between MissionManagerCore and smach.StateMachine consists of...
 
@@ -57,7 +57,7 @@ Publications:
  * /path_planner_action/cancel [actionlib_msgs/GoalID]
  * /path_planner_action/goal [path_planner/path_plannerActionGoal]
      * path_plannier.action.goal : geographic_msgs/GeoPath path
- * /project11/status/mission_manager [project11_msgs/Heartbeat]
+ * /marine/status/mission_manager [marine_interfaces/Heartbeat]
  * /rosout [rosgraph_msgs/Log]
  * /survey_area_action/cancel [actionlib_msgs/GoalID]
  * /survey_area_action/goal [manda_coverage/manda_coverageActionGoal]
@@ -75,9 +75,9 @@ Subscriptions:
  * /path_planner_action/feedback [unknown type]
  * /path_planner_action/result [unknown type]
  * /path_planner_action/status [unknown type]
- * /project11/heartbeat [unknown type]
- * /project11/mission_manager/command [unknown type]
- * /project11/piloting_mode [unknown type]
+ * /marine/heartbeat [unknown type]
+ * /marine/mission_manager/command [unknown type]
+ * /piloting_mode [unknown type]
  * /survey_area_action/feedback [unknown type]
  * /survey_area_action/result [unknown type]
  * /survey_area_action/status [unknown type]


### PR DESCRIPTION
## Summary

Adds an operator-facing **framework guide** and cleans up stale topic naming in
the existing docs. Part of the Summer-Hydro documentation push — this is the
standalone "how it works" doc that the forthcoming BizzyBoat operator manual
(rolker/unh_echoboats_project11#202) and CAMP user manual (rolker/camp#61) will
link to instead of carrying their own troubleshooting sections.

## What's here

**1. New guide — `docs/how_the_stack_works.md`** (+ a README Documentation section)

A plain-language tour aimed at operators and new engineers:
- **Platform-agnostic framing** — Ben, DriX, and the EchoBoat family share the
  autonomy layer; `cmd_vel`/helm is the framework boundary, and ArduPilot/MAVROS
  is only *BizzyBoat's* low-level backend (Ben/DriX use their own).
- **Platform self-advertisement** — `platform_send.py` publishes a `PlatformList`
  on `/marine/platforms`; CAMP's `PlatformManager` auto-creates a tab/drawing per
  platform. Explains why a boat "just appears" in CAMP.
- **Piloting modes** — the helm-manager single-active-mode mux; heartbeat as the
  command-applied ack.
- **The autonomous control chain** (verified from launch/config, EchoBoat as the
  worked example): BT task navigator → Smac Hybrid-A* planner → SimpleSmoother →
  CrabbingPathFollower → `cmd_vel_nav` → **Collision Monitor** →
  `piloting_mode/autonomous/cmd_vel` → helm. Notes that `velocity_smoother` is
  deliberately disconnected (#170) while the *path* smoother stays active.
- **Two obstacle systems** — deliberative costmap (4-OAK `sea_surface_layer` +
  S57 chart) vs the reflex Collision Monitor (forward-OAK only).
- **Comms link** — send-until-ack command bridge; over-the-horizon/link-drop is a
  normal mode, not an error.
- A **"where do I look?"** symptom map.

**2. Topic-naming cleanup — `project11/` → `marine/`**

The node source already uses the `marine/` prefix; several docs lagged behind
(and still referenced the old `project11_msgs` package). Aligned
`interfaces.md`, `data_flows.md` (incl. realigned ASCII diagram),
`command_bridge/README.md`, `mission_manager/README.md`, and
`marine_autonomy/docs/system_architecture.md`. `piloting_mode` is left bare (no
prefix, matching source); workspace *path* references are left unchanged.

## Verification

Every component, topic, and behavior in the guide was read from the launch files
and configs in `unh_marine_autonomy`, `unh_marine_navigation`, and the EchoBoat
platform packages (`seafloor_echoboat_project11`, `unh_echoboats_project11`) —
not from assumptions. Naming replacements were checked against the actual
`create_publisher`/`create_subscription` calls.

## Notes for review

- Docs-only change; no code or build impact.
- Opened as **draft** for content review (rendered guide + diagram alignment).

Closes #132.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
