### PR TITLE
docs(adr): ADR-0002 persistent multi-source bathymetric data store

### DIFF
--- a/.agent/work-plans/issue-86/progress.md
+++ b/.agent/work-plans/issue-86/progress.md
@@ -33,9 +33,9 @@ issue: 86
 **CI**: all-pass (build ✅, copilot-pull-request-reviewer ✅)
 
 ### Findings
-- [ ] (valid, Copilot) §D5/§D6 tile `version` is "content hash **or** mtime" — ambiguous sync key; mtime unreliable across clock-skewed machines. Pin to content hash; mtime at most a local dirty-check. — `docs/decisions/0002-bathymetric-data-store.md`
-- [ ] (valid, Copilot) §D8 "gz4d no longer checked out as a source package" is misleading — `gz4d_geo.h` is vendored in `marine_autonomy` and used by GGGS headers (cell_index/level/grid_index/cell_area_iterator). Reword: retirement applies to new store code; gz4d stays at the GGGS boundary. Aligns with #141 open question. — same file
-- [ ] (valid, Copilot) Consequences cite "ADR-0008" but this repo holds only ADR-0001/0002; it's the **workspace** ADR. Qualify/link as workspace ADR-0008 (ROS 2 conventions) or reference REP-105 + Standards Compliance directly. — same file
+- [x] (valid, Copilot) §D5/§D6 tile `version` is "content hash **or** mtime" — ambiguous sync key; mtime unreliable across clock-skewed machines. Pin to content hash; mtime at most a local dirty-check. — `docs/decisions/0002-bathymetric-data-store.md` (done in `a65098f`)
+- [x] (valid, Copilot) §D8 "gz4d no longer checked out as a source package" is misleading — `gz4d_geo.h` is vendored in `marine_autonomy` and used by GGGS headers (cell_index/level/grid_index/cell_area_iterator). Reword: retirement applies to new store code; gz4d stays at the GGGS boundary. Aligns with #141 open question. — same file (done in `a65098f`)
+- [x] (valid, Copilot) Consequences cite "ADR-0008" but this repo holds only ADR-0001/0002; it's the **workspace** ADR. Qualify/link as workspace ADR-0008 (ROS 2 conventions) or reference REP-105 + Standards Compliance directly. — same file (done in `a65098f`)
 
 ### False positives
 - None — all three are accurate and improve the decision record's precision.
@@ -51,7 +51,7 @@ issue: 86
 **CI**: all-pass (build ✅)
 
 ### Findings
-- [ ] (minor, Copilot R2) Prior Integrated Review's 3 findings are still `[ ]` in `progress.md` but were all applied in `a65098f`; mark them `[x]` so the entry doesn't read as open must-fixes. — `.agent/work-plans/issue-86/progress.md`
+- [x] (minor, Copilot R2) Prior Integrated Review's 3 findings are still `[ ]` in `progress.md` but were all applied in `a65098f`; mark them `[x]` so the entry doesn't read as open must-fixes. — `.agent/work-plans/issue-86/progress.md`
 
 ### Addressed since Copilot R1 (fixed in `a65098f`, verified at head `a244be3`)
 - (Copilot R1) §D6 tile `version` ambiguity (content-hash vs mtime) — ADR now pins content hash as authoritative; mtime is a local dirty-check only.

--- a/.agent/work-plans/issue-86/progress.md
+++ b/.agent/work-plans/issue-86/progress.md
@@ -21,3 +21,21 @@ issue: 86
 - [ ] Keep Distribution (Phase 6) deferred past June 15; `clear_grid` is the agreed interim for the #250 udp_bridge grid-size failure.
 - [ ] Confirm `geodesy` covers the resampling/conversion math the gz4d retirement assumes before committing to it in the ADR.
 - [ ] Define conservative no-data / stale-tile / uncertainty-above-threshold behavior for the costmap + "shallowest reliable depth" query (Safety First); validate consumers in sim before water (Simulation-First).
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-10 (America/New_York)
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**PR**: #142 at `fe8edb1`
+**Sources**: 1 (Copilot R1 @ `fe8edb1`; no local review-type entries for #86)
+**Cross-source confirmations**: 0
+**CI**: all-pass (build ✅, copilot-pull-request-reviewer ✅)
+
+### Findings
+- [ ] (valid, Copilot) §D5/§D6 tile `version` is "content hash **or** mtime" — ambiguous sync key; mtime unreliable across clock-skewed machines. Pin to content hash; mtime at most a local dirty-check. — `docs/decisions/0002-bathymetric-data-store.md`
+- [ ] (valid, Copilot) §D8 "gz4d no longer checked out as a source package" is misleading — `gz4d_geo.h` is vendored in `marine_autonomy` and used by GGGS headers (cell_index/level/grid_index/cell_area_iterator). Reword: retirement applies to new store code; gz4d stays at the GGGS boundary. Aligns with #141 open question. — same file
+- [ ] (valid, Copilot) Consequences cite "ADR-0008" but this repo holds only ADR-0001/0002; it's the **workspace** ADR. Qualify/link as workspace ADR-0008 (ROS 2 conventions) or reference REP-105 + Standards Compliance directly. — same file
+
+### False positives
+- None — all three are accurate and improve the decision record's precision.

--- a/.agent/work-plans/issue-86/progress.md
+++ b/.agent/work-plans/issue-86/progress.md
@@ -39,3 +39,24 @@ issue: 86
 
 ### False positives
 - None — all three are accurate and improve the decision record's precision.
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-11 20:03 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**PR**: #142 at `a244be3`
+**Sources**: 2 (Copilot R1 @ `fe8edb1`, Copilot R2 @ `a65098f`) + prior `## Integrated Review` @ `fe8edb1`
+**Cross-source confirmations**: 0 (Copilot R1 and the prior Integrated Review are the same triage round, not independent)
+**CI**: all-pass (build ✅)
+
+### Findings
+- [ ] (minor, Copilot R2) Prior Integrated Review's 3 findings are still `[ ]` in `progress.md` but were all applied in `a65098f`; mark them `[x]` so the entry doesn't read as open must-fixes. — `.agent/work-plans/issue-86/progress.md`
+
+### Addressed since Copilot R1 (fixed in `a65098f`, verified at head `a244be3`)
+- (Copilot R1) §D6 tile `version` ambiguity (content-hash vs mtime) — ADR now pins content hash as authoritative; mtime is a local dirty-check only.
+- (Copilot R1) §D8 misleading "gz4d no longer checked out" — reworded; gz4d confirmed still vendored (`gz4d_geo.h`) and exposed by GGGS API; decision is migrate GGGS off gz4d first.
+- (Copilot R1) Unresolvable "ADR-0008" reference — now a full link to the workspace `ros2_agent_workspace` ADR-0008 plus REP-105 and the Standards Compliance principle.
+
+### False positives
+- None — all four Copilot comments were accurate when written.

--- a/.agent/work-plans/issue-86/progress.md
+++ b/.agent/work-plans/issue-86/progress.md
@@ -60,3 +60,26 @@ issue: 86
 
 ### False positives
 - None — all four Copilot comments were accurate when written.
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-11 20:50 -0400
+**By**: Claude Code Agent (Fable 5)
+
+**PR**: #142 at `3b91bc6`
+**Sources**: 4 Copilot rounds this session (R3 @ `253fe6f`, R4 @ `0dc17de`, R5 @ `ac74fe9`, R6/R7 @ `3b91bc6`) + prior Integrated Reviews @ `fe8edb1`/`a244be3`
+**Cross-source confirmations**: 0
+**CI**: build green at each merged round (final head pending at triage time)
+
+### Findings
+- [x] (valid, Copilot R3) "GDAL is already a dependency" overstated this repo's state — reworded to attribute GDAL to importer tooling / Phase 1. — `docs/decisions/0002-bathymetric-data-store.md` (fixed in `ebaf408`)
+- [x] (valid, Copilot R3) Issue Review action items completed by this PR/Phase-1 still unchecked — ticked, except the sim-validation-before-water gate, deliberately left open. — `.agent/work-plans/issue-86/progress.md` (fixed in `0dc17de`)
+- [x] (valid, Copilot R4) §D2 cited `std::map<gggs::GridIndex, GeoGrid>` but `geo_map_sheet.h:76` holds `std::map<gggs::GridIndex, std::shared_ptr<GeoGrid>>` — corrected, verified against source. — same file (fixed in `3086dd5`)
+- [x] (valid, Copilot R4) Bare "ADR-0008" in progress action item implied an in-repo ADR — qualified as workspace ADR. — `.agent/work-plans/issue-86/progress.md` (fixed in `ddfb4d1`)
+- [x] (valid, Copilot R5) §D8 "currently exposed by the GGGS public API" stale after #145 merged — reworded to past tense + completion note. — same file (fixed in `ac74fe9`)
+- [x] (valid-minor, Copilot R6) Header citations (`gggs/core.h`, `cell_index.h`, unscoped `geo_map_sheet.h`) not resolvable as repo paths — fully qualified. — same file (fixed in `3b91bc6`)
+
+### False positives
+- (Copilot R3) §D5 "As-built in the Phase-1 store, #141" implies implementation exists — it does: #141 closed by merged PR #143 (`marine_bathymetry_store` on jazzy). The PR being docs-only doesn't make the cross-reference an overclaim.
+- (Copilot R7) "GGGS headers still expose gz4d types" — true only of this branch's stale tree (29 behind jazzy, branched pre-#145); origin/jazzy GGGS headers contain zero gz4d references. Resolved by syncing the branch with jazzy, not by rewording the ADR.
+- (Copilot R7) "no bathymetric-store package present in the current repo checkout" — same stale-tree artifact; `marine_bathymetry_store` exists on origin/jazzy (PR #143 merged). Resolved by the same branch sync.

--- a/.agent/work-plans/issue-86/progress.md
+++ b/.agent/work-plans/issue-86/progress.md
@@ -15,7 +15,7 @@ issue: 86
 
 ### Actions
 - [x] Reclassify #86 as an epic/tracking issue; open per-phase sub-issues (`Part of #86`), starting with Phase 1 (store core + persistence). — Phase 1 sub-issue #141 / PR #143 merged.
-- [x] Write a project ADR in `docs/decisions/` capturing the store architecture (source-layer priority, WGS84-ellipsoid datum strategy, persistence format, gz4d→geodesy migration, distribution-by-tile-manifest) — issue body is the draft. (Capture-decisions principle; ADR-0001/ADR-0008.) — this PR.
+- [x] Write a project ADR in `docs/decisions/` capturing the store architecture (source-layer priority, WGS84-ellipsoid datum strategy, persistence format, gz4d→geodesy migration, distribution-by-tile-manifest) — issue body is the draft. (Capture-decisions principle; ADR-0001 / workspace ADR-0008.) — this PR.
 - [x] State explicitly that Phase 1 does NOT block on mru_transform#7/#8; only the chart/S57 layer does. — §D9 / Consequences.
 - [x] Pin the persistence format (GeoTIFF vs binary) in the ADR — it constrains the Phase-6 sync manifest (`GridIndex` + version). — §D5 (per-tile multi-band GeoTIFF).
 - [x] Keep Distribution (Phase 6) deferred past June 15; `clear_grid` is the agreed interim for the #250 udp_bridge grid-size failure. — deferral recorded in ADR.

--- a/.agent/work-plans/issue-86/progress.md
+++ b/.agent/work-plans/issue-86/progress.md
@@ -14,13 +14,13 @@ issue: 86
 **Scope verdict**: needs-splitting
 
 ### Actions
-- [ ] Reclassify #86 as an epic/tracking issue; open per-phase sub-issues (`Part of #86`), starting with Phase 1 (store core + persistence).
-- [ ] Write a project ADR in `docs/decisions/` capturing the store architecture (source-layer priority, WGS84-ellipsoid datum strategy, persistence format, gz4d→geodesy migration, distribution-by-tile-manifest) — issue body is the draft. (Capture-decisions principle; ADR-0001/ADR-0008.)
-- [ ] State explicitly that Phase 1 does NOT block on mru_transform#7/#8; only the chart/S57 layer does.
-- [ ] Pin the persistence format (GeoTIFF vs binary) in the ADR — it constrains the Phase-6 sync manifest (`GridIndex` + version).
-- [ ] Keep Distribution (Phase 6) deferred past June 15; `clear_grid` is the agreed interim for the #250 udp_bridge grid-size failure.
-- [ ] Confirm `geodesy` covers the resampling/conversion math the gz4d retirement assumes before committing to it in the ADR.
-- [ ] Define conservative no-data / stale-tile / uncertainty-above-threshold behavior for the costmap + "shallowest reliable depth" query (Safety First); validate consumers in sim before water (Simulation-First).
+- [x] Reclassify #86 as an epic/tracking issue; open per-phase sub-issues (`Part of #86`), starting with Phase 1 (store core + persistence). — Phase 1 sub-issue #141 / PR #143 merged.
+- [x] Write a project ADR in `docs/decisions/` capturing the store architecture (source-layer priority, WGS84-ellipsoid datum strategy, persistence format, gz4d→geodesy migration, distribution-by-tile-manifest) — issue body is the draft. (Capture-decisions principle; ADR-0001/ADR-0008.) — this PR.
+- [x] State explicitly that Phase 1 does NOT block on mru_transform#7/#8; only the chart/S57 layer does. — §D9 / Consequences.
+- [x] Pin the persistence format (GeoTIFF vs binary) in the ADR — it constrains the Phase-6 sync manifest (`GridIndex` + version). — §D5 (per-tile multi-band GeoTIFF).
+- [x] Keep Distribution (Phase 6) deferred past June 15; `clear_grid` is the agreed interim for the #250 udp_bridge grid-size failure. — deferral recorded in ADR.
+- [x] Confirm `geodesy` covers the resampling/conversion math the gz4d retirement assumes before committing to it in the ADR. — §D8; GGGS gz4d→`geographic_msgs/GeoPoint` migration (#145) merged.
+- [ ] Define conservative no-data / stale-tile / uncertainty-above-threshold behavior for the costmap + "shallowest reliable depth" query (Safety First); validate consumers in sim before water (Simulation-First). — policy captured in ADR; **sim validation before water still pending** (deliberately left open).
 
 ## Integrated Review
 **Status**: complete

--- a/.agent/work-plans/issue-86/progress.md
+++ b/.agent/work-plans/issue-86/progress.md
@@ -1,0 +1,23 @@
+---
+issue: 86
+---
+
+# Issue #86 — Persistent multi-source bathymetric data store using GGGS
+
+## Issue Review
+**Status**: complete
+**When**: 2026-06-10 (America/New_York)
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Issue**: #86
+**Comment**: https://github.com/rolker/unh_marine_autonomy/issues/86#issuecomment-4676374134
+**Scope verdict**: needs-splitting
+
+### Actions
+- [ ] Reclassify #86 as an epic/tracking issue; open per-phase sub-issues (`Part of #86`), starting with Phase 1 (store core + persistence).
+- [ ] Write a project ADR in `docs/decisions/` capturing the store architecture (source-layer priority, WGS84-ellipsoid datum strategy, persistence format, gz4d→geodesy migration, distribution-by-tile-manifest) — issue body is the draft. (Capture-decisions principle; ADR-0001/ADR-0008.)
+- [ ] State explicitly that Phase 1 does NOT block on mru_transform#7/#8; only the chart/S57 layer does.
+- [ ] Pin the persistence format (GeoTIFF vs binary) in the ADR — it constrains the Phase-6 sync manifest (`GridIndex` + version).
+- [ ] Keep Distribution (Phase 6) deferred past June 15; `clear_grid` is the agreed interim for the #250 udp_bridge grid-size failure.
+- [ ] Confirm `geodesy` covers the resampling/conversion math the gz4d retirement assumes before committing to it in the ADR.
+- [ ] Define conservative no-data / stale-tile / uncertainty-above-threshold behavior for the costmap + "shallowest reliable depth" query (Safety First); validate consumers in sim before water (Simulation-First).

--- a/docs/decisions/0002-bathymetric-data-store.md
+++ b/docs/decisions/0002-bathymetric-data-store.md
@@ -44,7 +44,7 @@ The spatial-indexing substrate already exists and is already shared:
 `marine_autonomy`'s **GGGS** (`gggs::Level` / `GridIndex` / `CellIndex`, 960×960
 cells per grid — verified in `gggs/core.h`, `cell_index.h`), and
 `cube_bathymetry`'s `GeoMapSheet` already keys its grids by `gggs::GridIndex`
-(`geo_map_sheet.h` holds `std::map<gggs::GridIndex, GeoGrid>`). The store is the
+(`geo_map_sheet.h` holds `std::map<gggs::GridIndex, std::shared_ptr<GeoGrid>>`). The store is the
 missing layer that turns per-source, in-memory, single-datum grids into one
 persistent, multi-source, queryable surface.
 

--- a/docs/decisions/0002-bathymetric-data-store.md
+++ b/docs/decisions/0002-bathymetric-data-store.md
@@ -42,9 +42,11 @@ Consequences observed in the field:
 
 The spatial-indexing substrate already exists and is already shared:
 `marine_autonomy`'s **GGGS** (`gggs::Level` / `GridIndex` / `CellIndex`, 960×960
-cells per grid — verified in `gggs/core.h`, `cell_index.h`), and
-`cube_bathymetry`'s `GeoMapSheet` already keys its grids by `gggs::GridIndex`
-(`geo_map_sheet.h` holds `std::map<gggs::GridIndex, std::shared_ptr<GeoGrid>>`). The store is the
+cells per grid — verified in `marine_autonomy/include/marine_autonomy/gggs/core.h`
+and `gggs/cell_index.h` alongside it), and `cube_bathymetry`'s `GeoMapSheet`
+already keys its grids by `gggs::GridIndex` (that repo's
+`cube_bathymetry/include/cube_bathymetry/geo_map_sheet.h` holds
+`std::map<gggs::GridIndex, std::shared_ptr<GeoGrid>>`). The store is the
 missing layer that turns per-source, in-memory, single-datum grids into one
 persistent, multi-source, queryable surface.
 

--- a/docs/decisions/0002-bathymetric-data-store.md
+++ b/docs/decisions/0002-bathymetric-data-store.md
@@ -118,8 +118,9 @@ tile map per layer, D3), so a per-cell source band would be a constant and pure
 overhead. (As-built in the Phase-1 store, #141; this supersedes an earlier draft
 of this section that listed a 4th `source` band.) Bands are `Float64` so the
 absolute-Unix-seconds timestamp keeps usable precision — a single GeoTIFF has one
-band data type, so depth/uncertainty ride along as `Float64` too. Rationale: GDAL
-is already a dependency (used by the bathy-BAG / GeoTIFF importers); GeoTIFF
+band data type, so depth/uncertainty ride along as `Float64` too. Rationale:
+GeoTIFF I/O relies on GDAL, which the bathy-BAG / GeoTIFF importer tooling
+already uses (Phase 1 brings that dependency into the store itself); GeoTIFF
 carries its own georeferencing; per-tile files make incremental ("save only dirty
 tiles") and
 the distribution manifest (D6) fall out naturally — the manifest is

--- a/docs/decisions/0002-bathymetric-data-store.md
+++ b/docs/decisions/0002-bathymetric-data-store.md
@@ -1,0 +1,209 @@
+# ADR-0002: Persistent Multi-Source Bathymetric Data Store (GGGS-backed)
+
+## Status
+
+Proposed (2026-06-10). Tracked by
+[rolker/unh_marine_autonomy#86](https://github.com/rolker/unh_marine_autonomy/issues/86).
+
+The full design is in the issue body; this ADR records the load-bearing
+architecture decisions and their rationale so they survive the issue. It is a
+**cross-cutting** decision in the sense ADR-0001 establishes for this repo's
+`docs/decisions/`: it spans `marine_autonomy` (GGGS), `cube_bathymetry`,
+`s57_tools`, and `mru_transform`.
+
+## Context
+
+Depth data reaches the system from three independent sources, handled in three
+disconnected ways:
+
+- **S57 nautical charts** flow through `s57_tools` directly into a Nav2 costmap
+  layer. Broad coverage, low resolution, referenced to a **chart datum** (MLLW /
+  LAT), not the ellipsoid the rest of the stack navigates in.
+- **Processed survey grids** (bathy-BAG, GeoTIFF) exist only as files a human
+  loads out-of-band; nothing in the running system consumes them.
+- **Real-time CUBE output** lives only in `cube_bathymetry`'s in-memory
+  `GeoMapSheet` and is **lost between sessions**.
+
+Consequences observed in the field:
+
+1. **Navigation only sees charts.** Collision avoidance cannot use a fresh
+   high-resolution survey grid or live CUBE output, even when it is the best
+   available knowledge of an area.
+2. **No persistence.** Accumulated CUBE knowledge evaporates at shutdown; every
+   session re-discovers the bottom.
+3. **No unified query.** A survey planner cannot ask "what do we already know
+   about depths here?" across sources — there is no place to ask.
+4. **Monolithic-grid downlink failure (deployment #250, 2026-06-10).** The
+   operator station stopped receiving M3 CUBE grid updates mid-survey: the
+   monolithic `GridMap` message grows with survey extent and eventually
+   **outgrows `udp_bridge`**. "Worked for a while, then stopped." Interim
+   mitigation is a manual `clear_grid` service; the durable fix is a
+   bounded-payload, change-only sync — which only a tiled store can provide.
+
+The spatial-indexing substrate already exists and is already shared:
+`marine_autonomy`'s **GGGS** (`gggs::Level` / `GridIndex` / `CellIndex`, 960×960
+cells per grid — verified in `gggs/core.h`, `cell_index.h`), and
+`cube_bathymetry`'s `GeoMapSheet` already keys its grids by `gggs::GridIndex`
+(`geo_map_sheet.h` holds `std::map<gggs::GridIndex, GeoGrid>`). The store is the
+missing layer that turns per-source, in-memory, single-datum grids into one
+persistent, multi-source, queryable surface.
+
+## Decision
+
+Build a single persistent bathymetric store, GGGS-tiled, that unifies all depth
+sources behind one query interface. The decisions below are the ones future work
+must not silently re-litigate.
+
+### D1 — One store, not per-source plumbing
+
+A single store ingests all sources and answers all queries. Rejected
+alternatives: (a) each consumer continues to reach into each source directly
+(today's state — N×M coupling, no persistence); (b) a general spatial database
+(PostGIS) — heavyweight, an external service on a vehicle, and redundant with
+GGGS, which we already have and already share with the CUBE producer.
+
+### D2 — GGGS is the spatial index; the store is internally geographic
+
+Reuse `gggs::Level` / `GridIndex` / `CellIndex`; do **not** invent a tiling
+scheme. GGGS is geographic (WGS84 lat/lon), so the store is internally geographic
+(lat/lon + ellipsoidal height). The query API additionally accepts and returns
+**map-frame** (cartesian) coordinates, converting via the `geodesy` ellipsoid
+functions and the `earth`→`map` TF from `mru_transform`. This reuses the exact
+tiling the CUBE producer already emits, so draft ingest is a tile handoff, not a
+resample.
+
+### D3 — Per-cell record and source-layer priority
+
+Each cell stores at minimum **depth** (ellipsoidal height, WGS84),
+**uncertainty**, **source layer**, and **timestamp**. Three source layers,
+queried by descending priority:
+
+1. **Processed** — externally produced grids (bathy-BAG / GeoTIFF), highest
+   confidence.
+2. **Draft** — real-time CUBE output, valuable but potentially noisy.
+3. **Chart** — S57-derived depths (after datum correction), broad but coarse.
+
+Default query returns the highest-priority source present per cell. A separate
+**"shallowest reliable depth"** mode is available for navigation-safety queries
+(see D7). Layering by *priority overlay* (not destructive merge) means a noisy
+draft never overwrites a trusted processed value, and a later processed import
+supersedes draft without data loss.
+
+### D4 — All depths on the WGS84 ellipsoid; datum conversion happens at import
+
+The store holds a single vertical reference: **ellipsoidal height (WGS84)**.
+Source data in other references is converted **at the import boundary**, never
+stored mixed:
+
+- **Chart (S57)** depths are referenced to a chart datum and require conversion
+  before import. This depends on the `chart_datum` TF frame / VDatum service
+  being designed in
+  [mru_transform#8](https://github.com/rolker/mru_transform/issues/8) /
+  [mru_transform#7](https://github.com/rolker/mru_transform/issues/7). The
+  **chart layer is therefore gated on that work**; the processed and draft layers
+  are not.
+- Real-time navigation relates stored ellipsoidal depths to current water level
+  via the `map_tide` frame from `mru_transform`.
+
+Storing one datum and converting at the edge keeps every query datum-consistent
+and confines datum logic to the importers.
+
+### D5 — Persistence: one GeoTIFF per dirty GGGS tile
+
+Persist each dirty tile as a **multi-band GeoTIFF** (bands: depth, uncertainty,
+source, timestamp) named by its `GridIndex`. Rationale: GDAL is already a
+dependency (used by the bathy-BAG / GeoTIFF importers); GeoTIFF carries its own
+georeferencing; per-tile files make incremental ("save only dirty tiles") and
+the distribution manifest (D6) fall out naturally — the manifest is
+`{GridIndex → version}`, and version is the tile file's content hash or mtime.
+On startup, load persisted tiles; save incrementally as data arrives. A raw
+binary tile format is the fallback **only if** GeoTIFF write amplification proves
+too costly; that change would not alter the manifest contract. This decision is
+made here (rather than deferred to code) because it constrains D6.
+
+### D6 — Distribution is change-only tile sync, not whole-grid shipping
+
+Robot and operator each hold an **independent local store**. Chart and processed
+data load independently on both (no sync). Draft CUBE tiles sync **one-way,
+robot → operator**, by exchanging tile manifests (`GridIndex` + version) and
+transferring **only changed tiles**, prioritizing tiles near the vehicle when
+bandwidth-limited. The **dirty-region notification** topic (changed `GridIndex`
+values) is the change feed.
+
+This is the architectural answer to the #250 failure: per-message payload is
+bounded by tile size and change rate, **independent of total survey extent** —
+the property the monolithic `GridMap` downlink lacked. Distribution is the last
+implementation phase and stays **deferred past the June 15 survey**; `clear_grid`
+remains the agreed interim. The store core is nonetheless designed so the sync
+layer is additive.
+
+### D7 — Consumers depend on the store, not on sources
+
+- **Costmap**: a Nav2 costmap layer plugin (same pattern as the existing
+  `s57_layer`) queries the store for best-available depth and converts to cost,
+  using the **shallowest-reliable** mode (D3) and a **conservative no-data /
+  stale-tile / over-uncertainty policy** (unknown is treated as obstacle / not
+  safe), per this repo's **Safety First** principle. Per **Simulation-First**,
+  the plugin is validated in `unh_marine_simulation` before field use.
+- **Coverage visualization** and **survey planning** (swath prediction, line
+  spacing, gap-driven replanning) consume the same query interface.
+
+Eventually S57 depths flow *through* the store rather than directly to the
+costmap; that reroute of `s57_tools` is a later phase, flagged not done here.
+
+### D8 — Coordinate math uses `geodesy`, not `gz4d`
+
+New code uses the underlay `geodesy` package for ellipsoid math (spans, Vincenty
+geodesics, ECEF), continuing the `gz4d` retirement. (`gz4d` is no longer checked
+out as a source package.) Before committing importer/resampling code to
+`geodesy`, confirm it exposes the needed functions — recorded as an
+implementation precondition, not assumed.
+
+### D9 — Package placement and phasing
+
+The store is a **new package in this repo** (`unh_marine_autonomy`), depending on
+`marine_autonomy` for GGGS — it builds on the spatial-index foundation that lives
+here and is consumed across repos, so it belongs beside GGGS rather than inside a
+single consumer. It keeps **store core free of consumer-specific logic**
+(Modularity and Decoupling). Implementation proceeds in the issue's six phases,
+each as its own sub-issue and PR (`Part of #86`):
+
+1. **Store core** — GGGS-backed in-memory store, source layers (processed +
+   draft), per-cell best-source query, disk persistence. **No datum dependency.**
+2. Import — CUBE `GeoMapSheet`, bathy-BAG, GeoTIFF.
+3. Query interface — ROS services (bounding box, profile, gap) + dirty-region
+   topic.
+4. Costmap plugin.
+5. Coverage + planning.
+6. Distribution (deferred past June 15).
+
+Phase 1 is decoupled from the mru_transform datum work (D4); only the chart layer
+waits on it.
+
+## Consequences
+
+- **Positive:** navigation and planning see the best available depth from any
+  source; CUBE knowledge persists across sessions; one place to ask "what do we
+  know here?"; the #250 downlink failure has a durable, extent-independent fix;
+  no new tiling scheme or external database — GGGS is reused end to end.
+- **Cost:** a new package and a new persistence path to maintain; a real
+  inter-package contract (the per-cell record, the manifest format, the query
+  API) that downstream consumers pin to. New `.msg`/`.srv` for the query
+  interface carry the usual downstream-update obligation (ADR-0008; REP-105 for
+  frames). The costmap consumer touches collision avoidance, so its no-data /
+  staleness policy is safety-relevant and must be validated in simulation.
+- **Sequencing risk if ignored:** building import/query/costmap/distribution
+  before the core + one real consumer exist would be speculative (workspace
+  "Only what's needed"). The phase split (D9) is the mitigation; each phase lands
+  reviewable.
+- **Datum coupling is explicit:** the chart layer cannot land before
+  mru_transform#7/#8; isolating it to one layer (D4) keeps the rest moving.
+
+## References
+
+- Umbrella / design: [rolker/unh_marine_autonomy#86](https://github.com/rolker/unh_marine_autonomy/issues/86)
+- Datum frames / VDatum: [rolker/mru_transform#8](https://github.com/rolker/mru_transform/issues/8),
+  [rolker/mru_transform#7](https://github.com/rolker/mru_transform/issues/7)
+- CUBE draft-tile persistence: [rolker/cube_bathymetry#21](https://github.com/rolker/cube_bathymetry/issues/21)
+- Field evidence (monolithic-grid downlink failure): [rolker/unh_echoboats_project11#250](https://github.com/rolker/unh_echoboats_project11/issues/250)
+- Spatial index: `marine_autonomy` GGGS (`marine_autonomy/include/marine_autonomy/gggs/`)

--- a/docs/decisions/0002-bathymetric-data-store.md
+++ b/docs/decisions/0002-bathymetric-data-store.md
@@ -115,7 +115,11 @@ source, timestamp) named by its `GridIndex`. Rationale: GDAL is already a
 dependency (used by the bathy-BAG / GeoTIFF importers); GeoTIFF carries its own
 georeferencing; per-tile files make incremental ("save only dirty tiles") and
 the distribution manifest (D6) fall out naturally — the manifest is
-`{GridIndex → version}`, and version is the tile file's content hash or mtime.
+`{GridIndex → version}`, and **version is a content hash of the tile's cell
+data** (not file mtime: mtime is unreliable across the clock-skewed robot and
+operator machines that D6 sync compares, so it cannot be the interoperability
+key). An mtime check may still be used as a cheap *local* dirty-detection
+optimization, but the hash is the authoritative sync version.
 On startup, load persisted tiles; save incrementally as data arrives. A raw
 binary tile format is the fallback **only if** GeoTIFF write amplification proves
 too costly; that change would not alter the manifest contract. This decision is
@@ -151,13 +155,27 @@ layer is additive.
 Eventually S57 depths flow *through* the store rather than directly to the
 costmap; that reroute of `s57_tools` is a later phase, flagged not done here.
 
-### D8 — Coordinate math uses `geodesy`, not `gz4d`
+### D8 — Coordinate math uses `geodesy`, not `gz4d`; migrate the GGGS API first
 
-New code uses the underlay `geodesy` package for ellipsoid math (spans, Vincenty
-geodesics, ECEF), continuing the `gz4d` retirement. (`gz4d` is no longer checked
-out as a source package.) Before committing importer/resampling code to
-`geodesy`, confirm it exposes the needed functions — recorded as an
-implementation precondition, not assumed.
+New store code uses the underlay `geodesy` package for ellipsoid math (spans,
+Vincenty geodesics, ECEF), continuing the `gz4d` retirement. `gz4d` is **not** a
+standalone package — it is vendored as headers in `marine_autonomy`
+(`gz4d_geo.h`) and is currently exposed by the **GGGS public API** itself: GGGS
+returns/accepts `gz4d::PositionDegrees` and `gz4d::BoundsDegrees`
+(`Level`/`GridIndex`/`CellIndex`/`CellAreaIterator`). (A second, independent copy
+of `gz4d` also lives in `marine_nav_utilities`, and `camp` uses `gz4d`; full
+retirement is a multi-repo effort beyond this store.)
+
+Decision: **migrate the GGGS public API off `gz4d` before Phase 1**, so the store
+consumes a `gz4d`-free GGGS rather than adapting `gz4d` types at its seam. The
+GGGS surface is narrow — those two value types replaced by
+`geographic_msgs::msg::GeoPoint` plus a small lat/lon bounds type, preserving
+`gz4d`'s longitude-normalization at the boundary, with `cube_bathymetry` updated
+in lockstep. Tracked as
+[#144](https://github.com/rolker/unh_marine_autonomy/issues/144); it is a
+prerequisite for [#141](https://github.com/rolker/unh_marine_autonomy/issues/141).
+Before committing importer/resampling code to `geodesy`, confirm it exposes the
+needed functions — an implementation precondition, not assumed.
 
 ### D9 — Package placement and phasing
 
@@ -189,9 +207,11 @@ waits on it.
 - **Cost:** a new package and a new persistence path to maintain; a real
   inter-package contract (the per-cell record, the manifest format, the query
   API) that downstream consumers pin to. New `.msg`/`.srv` for the query
-  interface carry the usual downstream-update obligation (ADR-0008; REP-105 for
-  frames). The costmap consumer touches collision avoidance, so its no-data /
-  staleness policy is safety-relevant and must be validated in simulation.
+  interface carry the usual downstream-update obligation (ROS 2 conventions — see
+  this repo's **Standards Compliance** principle and the workspace
+  [ADR-0008](https://github.com/rolker/ros2_agent_workspace/blob/main/docs/decisions/0008-follow-ros2-official-conventions.md);
+  REP-105 for frames). The costmap consumer touches collision avoidance, so its
+  no-data / staleness policy is safety-relevant and must be validated in simulation.
 - **Sequencing risk if ignored:** building import/query/costmap/distribution
   before the core + one real consumer exist would be speculative (workspace
   "Only what's needed"). The phase split (D9) is the mitigation; each phase lands

--- a/docs/decisions/0002-bathymetric-data-store.md
+++ b/docs/decisions/0002-bathymetric-data-store.md
@@ -169,8 +169,8 @@ costmap; that reroute of `s57_tools` is a later phase, flagged not done here.
 New store code uses the underlay `geodesy` package for ellipsoid math (spans,
 Vincenty geodesics, ECEF), continuing the `gz4d` retirement. `gz4d` is **not** a
 standalone package — it is vendored as headers in `marine_autonomy`
-(`gz4d_geo.h`) and is currently exposed by the **GGGS public API** itself: GGGS
-returns/accepts `gz4d::PositionDegrees` and `gz4d::BoundsDegrees`
+(`gz4d_geo.h`) and, when this ADR was drafted, was exposed by the **GGGS public
+API** itself: GGGS returned/accepted `gz4d::PositionDegrees` and `gz4d::BoundsDegrees`
 (`Level`/`GridIndex`/`CellIndex`/`CellAreaIterator`). (A second, independent copy
 of `gz4d` also lives in `marine_nav_utilities`, and `camp` uses `gz4d`; full
 retirement is a multi-repo effort beyond this store.)
@@ -181,8 +181,11 @@ GGGS surface is narrow — those two value types replaced by
 `geographic_msgs::msg::GeoPoint` plus a small lat/lon bounds type, preserving
 `gz4d`'s longitude-normalization at the boundary, with `cube_bathymetry` updated
 in lockstep. Tracked as
-[#144](https://github.com/rolker/unh_marine_autonomy/issues/144); it is a
-prerequisite for [#141](https://github.com/rolker/unh_marine_autonomy/issues/141).
+[#144](https://github.com/rolker/unh_marine_autonomy/issues/144), a
+prerequisite for [#141](https://github.com/rolker/unh_marine_autonomy/issues/141);
+**completed** in [PR #145](https://github.com/rolker/unh_marine_autonomy/pull/145)
+(with `cube_bathymetry` updated via cube#42), so GGGS no longer exports `gz4d`
+types.
 Before committing importer/resampling code to `geodesy`, confirm it exposes the
 needed functions — an implementation precondition, not assumed.
 

--- a/docs/decisions/0002-bathymetric-data-store.md
+++ b/docs/decisions/0002-bathymetric-data-store.md
@@ -110,10 +110,18 @@ and confines datum logic to the importers.
 
 ### D5 — Persistence: one GeoTIFF per dirty GGGS tile
 
-Persist each dirty tile as a **multi-band GeoTIFF** (bands: depth, uncertainty,
-source, timestamp) named by its `GridIndex`. Rationale: GDAL is already a
-dependency (used by the bathy-BAG / GeoTIFF importers); GeoTIFF carries its own
-georeferencing; per-tile files make incremental ("save only dirty tiles") and
+Persist each dirty tile as a **multi-band GeoTIFF** named by its `GridIndex`.
+The bands are **depth, uncertainty, timestamp** (3 bands); the **source layer is
+not a band** — it is encoded as the on-disk subdirectory (`processed/`,
+`draft/`), because a tile is single-layer by construction (the store keeps one
+tile map per layer, D3), so a per-cell source band would be a constant and pure
+overhead. (As-built in the Phase-1 store, #141; this supersedes an earlier draft
+of this section that listed a 4th `source` band.) Bands are `Float64` so the
+absolute-Unix-seconds timestamp keeps usable precision — a single GeoTIFF has one
+band data type, so depth/uncertainty ride along as `Float64` too. Rationale: GDAL
+is already a dependency (used by the bathy-BAG / GeoTIFF importers); GeoTIFF
+carries its own georeferencing; per-tile files make incremental ("save only dirty
+tiles") and
 the distribution manifest (D6) fall out naturally — the manifest is
 `{GridIndex → version}`, and **version is a content hash of the tile's cell
 data** (not file mtime: mtime is unreliable across the clock-skewed robot and


### PR DESCRIPTION
## What

Adds **ADR-0002: Persistent Multi-Source Bathymetric Data Store (GGGS-backed)** (Status: *Proposed*), plus the governance `progress.md` issue-review entry for #86.

This is the **decision record only** — no implementation. It captures the load-bearing architecture decisions for the bathymetric store so they survive the issue body, and unblocks the phased build by pinning the choices the phases must not silently re-litigate.

## Why

#86 is a large, cross-repo design (six phases, four import sources, three consumers, robot↔operator sync). The `/review-issue` pass flagged that the design lived only in the issue body — the "decision buried in an issue" antipattern — and that this repo's ADR-0001 already establishes `docs/decisions/` as the home for cross-cutting marine-architecture decisions. This ADR is the response.

## Decisions captured

- One GGGS-tiled store (not per-source plumbing; not a spatial DB)
- Per-cell record + source-layer priority (processed > draft > chart); shallowest-reliable safety mode
- All depths on the **WGS84 ellipsoid**, datum conversion **at the import boundary** → only the chart layer is gated on mru_transform #7/#8
- **Per-tile multi-band GeoTIFF** persistence; manifest = `GridIndex` + version (feeds distribution)
- **Change-only tile sync** — the durable fix for the deployment-#250 monolithic-grid `udp_bridge` downlink failure (deferred past June 15; `clear_grid` interim)
- `gz4d → geodesy` for coordinate math
- New package beside GGGS; six-phase split, Phase 1 decoupled from the datum work

All structural claims (GGGS 960×960 / `Level`/`GridIndex`/`CellIndex`, `GeoMapSheet`'s `gggs::GridIndex` keying, `geodesy` presence, `gz4d` absence) were verified against source before assertion.

## Scope / non-goals

- Docs only. No package, no code, no interface changes.
- Status is **Proposed** — flip to *Accepted* on review.

## Follow-up

- Phase 1 implementation tracked by #141 (GGGS-backed store core + persistence), on its own branch.

Part of #86. Refs #141.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
