### PR TITLE
Bathymetric store — Phase 1: GGGS-backed store core + persistence

### DIFF
--- a/.agent/work-plans/issue-141/plan.md
+++ b/.agent/work-plans/issue-141/plan.md
@@ -19,22 +19,27 @@ Two layering facts shape the design:
   **cannot** `#include` cube. The store defines its **own** cell record; it does
   **not** reuse `cube::DepthAndUncertainty`. CUBE import (Phase 2) is designed
   later, cube-side or via `marine_interfaces`.
-- **GGGS's public API is being migrated off `gz4d`** (→ `geographic_msgs::GeoPoint`)
-  in [#144](https://github.com/rolker/unh_marine_autonomy/issues/144), a
-  **prerequisite for this issue** (ADR-0002 §D8 decision). Phase 1 targets the
-  post-migration GGGS API (`GeoPoint`-typed); if #144 hasn't landed when coding
-  starts, gate on it or rebase onto its branch — do **not** add new `gz4d` usage.
+- **GGGS's public API was migrated off `gz4d`** (→ `geographic_msgs::GeoPoint`) in
+  [#144](https://github.com/rolker/unh_marine_autonomy/issues/144), **MERGED
+  2026-06-11** (`426bbd7`) and merged into this branch. Phase 1 targets that
+  gz4d-free GGGS API; no new `gz4d` usage.
 
 ## Approach
 
 1. **New package `marine_bathymetry_store`** (ament_cmake, in this repo) — depends
-   on `marine_autonomy` (GGGS) and `GDAL` (system). Library only; no ROS node this
-   phase. Clean `ament_export` (GGGS + geodesy only; no consumer coupling).
-2. **Per-cell record** (`bathy_cell.hpp`) — `depth` (float, ellipsoidal m, WGS84,
-   NaN = no-data), `uncertainty` (float), `timestamp` (`builtin_interfaces`/seconds
-   as float band). Source is implied by which layer holds the cell (step 4).
+   on `marine_autonomy` (GGGS), `geographic_msgs` (`GeoPoint` for the region query),
+   and `GDAL` (system). Library only; no ROS node this phase. Clean `ament_export`.
+   (No `geodesy`: Phase-1 queries are GGGS-index-typed and persistence uses GridIndex
+   corners — geodesy enters only with the later map-frame query variants. Per
+   review-plan.) Also adds a one-line `gggs::Level::level()` accessor to
+   `marine_autonomy` (same repo) — the store needs the level number to validate cells.
+2. **Per-cell record** (`bathy_cell.hpp`) — `depth`, `uncertainty`, `timestamp`,
+   all **`double`** (NaN depth = no-data). Double (and a Float64 GeoTIFF) is
+   deliberate: a `float` timestamp band coarsens absolute Unix seconds to ~128 s,
+   silently degrading staleness info (ADR §D7). Per review-plan. Source is implied
+   by which layer holds the cell (step 4).
 3. **`BathymetryTile`** — one GGGS grid (960×960) of cells stored as **dense
-   column-major float arrays** (depth, uncertainty, timestamp), lazily allocated on
+   row-major double arrays** (depth, uncertainty, timestamp), lazily allocated on
    first write (GeoMapSheet's create-on-demand pattern). Dirty flag per tile.
    Cell addressing via `gggs::CellIndex` row/column.
 4. **`BathymetryStore`** — `enum class SourceLayer { Processed, Draft }` (Chart in
@@ -65,7 +70,8 @@ Two layering facts shape the design:
 
 | File | Change |
 |------|--------|
-| `marine_bathymetry_store/package.xml` | New ament package; deps `marine_autonomy`, `geodesy`, GDAL, ament_cmake_gtest |
+| `marine_bathymetry_store/package.xml` | New ament package; deps `marine_autonomy`, `geographic_msgs`, GDAL (`libgdal-dev`), ament_cmake_gtest |
+| `marine_autonomy/include/marine_autonomy/gggs/level.h` | Add `Level::level()` accessor (store needs the level number) |
 | `marine_bathymetry_store/CMakeLists.txt` | Library target + GDAL link + gtests (model cube CMake) |
 | `.../include/marine_bathymetry_store/bathy_cell.hpp` | Per-cell record + SourceLayer enum |
 | `.../include/marine_bathymetry_store/bathymetry_tile.hpp` | Dense 960×960 tile, dirty flag |
@@ -103,20 +109,41 @@ Two layering facts shape the design:
 
 ## Open Questions
 
-- ~~gz4d at the GGGS boundary (ADR §D8).~~ **Resolved (Roland, 2026-06-10): migrate
-  the GGGS public API off gz4d → `geographic_msgs::GeoPoint` first** —
-  [#144](https://github.com/rolker/unh_marine_autonomy/issues/144), a prerequisite
-  for this issue. Phase 1 targets the post-migration GGGS API; no new gz4d usage.
-- **Timestamp granularity.** Per-cell (ADR §D3 literal, +1 dense band ≈ +3.7 MB/tile)
-  vs per-tile last-update. Plan assumes **per-cell**; confirm acceptable.
-- **Tile storage = dense** (≈12 MB/allocated tile, 3 float bands). Fine for survey-scale
-  tile counts; flag if very sparse wide-area coverage is expected (→ sparse cell map).
-- **`reliable` threshold default** for shallowestReliable — API takes a param; default
-  value deferred to the costmap phase. OK to leave unset (caller-supplied) in Phase 1?
+- ~~gz4d at the GGGS boundary (ADR §D8).~~ **Resolved: #144 (GGGS gz4d→GeoPoint)
+  MERGED 2026-06-11** (`426bbd7`); merged into this branch. Phase 1 targets the
+  gz4d-free GGGS API.
+- ~~Timestamp granularity / precision.~~ **Resolved (review-plan): per-cell, stored
+  as `double` (Float64 GeoTIFF band)** — avoids the float ~128 s coarsening without
+  per-tile epoch bookkeeping.
+- ~~Tile storage = dense.~~ **Resolved: dense, all-`double` (≈22 MB/allocated tile,
+  lazily allocated).** Fine at survey scale; a sparse cell map remains the escape
+  hatch if very-sparse wide-area coverage shows up (not Phase 1).
+- **`reliable` threshold** for `shallowestReliable` — kept **caller-supplied** in
+  Phase 1 (no default); the costmap phase will set the policy. (Confirmed acceptable.)
 
 ## Estimated Scope
 
-Single PR (`feature/issue-141 → jazzy`). New package, ~8 source files + 3 test files.
-Independent of the ADR PR (#142) and of the mru_transform datum work. **Depends on
-the GGGS gz4d→`GeoPoint` migration ([#144](https://github.com/rolker/unh_marine_autonomy/issues/144))**
-— land or stack on it before coding so the store targets the gz4d-free GGGS API.
+Single PR (`feature/issue-141 → jazzy`). New `marine_bathymetry_store` package
+(5 headers, 3 sources, 3 gtests, README) + a one-line `gggs::Level::level()` accessor
+in `marine_autonomy`. Independent of the ADR PR (#142) and the mru_transform datum
+work; #144 (its prerequisite) is merged.
+
+## Implementation Notes
+
+- **All-`double` tile / Float64 GeoTIFF** (not float): resolves the review-plan
+  timestamp-precision finding. A single GeoTIFF has one band data type, so depth and
+  uncertainty ride along as Float64 too (lossless). Cost: denser tiles (~22 MB
+  allocated), accepted at survey scale; dense→sparse is a future option.
+- **Source not stored per-cell**: encoded as the per-layer tile map (and the
+  persistence layer subdirectory), so the GeoTIFF is **3 bands, not ADR §D5's 4**.
+  Cleaner than a redundant per-cell field; a one-line ADR-0002 §D3/§D5 cross-ref
+  addendum (ADR-0012) should record the deviation.
+- **`gggs::Level::level()` accessor** added to `marine_autonomy`: the store validates
+  that a `CellIndex` passed to `set()` is at the store's level, which needs the level
+  number (previously not exposed). Trivial, broadly useful, same repo.
+- **`GridIndex` reconstruction on load**: GGGS's `GridIndex(level,row,col)` ctor is
+  private (Level-friend), so `loadTile` recovers the grid from the file geotransform
+  (`level.gridIndex(center)`) and rejects geotransforms that don't match a grid at the
+  store's level — which also catches loading tiles saved at a different level.
+- **Depth = ellipsoidal height (up-positive)**, so `shallowestReliable` returns the
+  **greatest** height (shallowest/most hazardous), not the minimum. Documented + tested.

--- a/.agent/work-plans/issue-141/plan.md
+++ b/.agent/work-plans/issue-141/plan.md
@@ -19,8 +19,11 @@ Two layering facts shape the design:
   **cannot** `#include` cube. The store defines its **own** cell record; it does
   **not** reuse `cube::DepthAndUncertainty`. CUBE import (Phase 2) is designed
   later, cube-side or via `marine_interfaces`.
-- **GGGS's public API returns `gz4d` types** (`gz4d::PositionDegrees`,
-  `BoundsDegrees`). ADR-0002 §D8 says new code uses `geodesy`. See Open Questions.
+- **GGGS's public API is being migrated off `gz4d`** (→ `geographic_msgs::GeoPoint`)
+  in [#144](https://github.com/rolker/unh_marine_autonomy/issues/144), a
+  **prerequisite for this issue** (ADR-0002 §D8 decision). Phase 1 targets the
+  post-migration GGGS API (`GeoPoint`-typed); if #144 hasn't landed when coding
+  starts, gate on it or rebase onto its branch — do **not** add new `gz4d` usage.
 
 ## Approach
 
@@ -100,9 +103,10 @@ Two layering facts shape the design:
 
 ## Open Questions
 
-- **gz4d at the GGGS boundary (ADR §D8).** GGGS returns `gz4d::PositionDegrees`/`BoundsDegrees`.
-  Proposal: confine gz4d to a thin GGGS-adapter; keep store types plain/`geodesy`.
-  Is migrating GGGS's own API to `geodesy` in scope anywhere, or explicitly out? (Recommend out for Phase 1.)
+- ~~gz4d at the GGGS boundary (ADR §D8).~~ **Resolved (Roland, 2026-06-10): migrate
+  the GGGS public API off gz4d → `geographic_msgs::GeoPoint` first** —
+  [#144](https://github.com/rolker/unh_marine_autonomy/issues/144), a prerequisite
+  for this issue. Phase 1 targets the post-migration GGGS API; no new gz4d usage.
 - **Timestamp granularity.** Per-cell (ADR §D3 literal, +1 dense band ≈ +3.7 MB/tile)
   vs per-tile last-update. Plan assumes **per-cell**; confirm acceptable.
 - **Tile storage = dense** (≈12 MB/allocated tile, 3 float bands). Fine for survey-scale
@@ -113,4 +117,6 @@ Two layering facts shape the design:
 ## Estimated Scope
 
 Single PR (`feature/issue-141 → jazzy`). New package, ~8 source files + 3 test files.
-Independent of the ADR PR (#142) and of the mru_transform datum work.
+Independent of the ADR PR (#142) and of the mru_transform datum work. **Depends on
+the GGGS gz4d→`GeoPoint` migration ([#144](https://github.com/rolker/unh_marine_autonomy/issues/144))**
+— land or stack on it before coding so the store targets the gz4d-free GGGS API.

--- a/.agent/work-plans/issue-141/plan.md
+++ b/.agent/work-plans/issue-141/plan.md
@@ -54,7 +54,8 @@ Two layering facts shape the design:
    No-data returns an explicit "unknown" (so the future costmap can treat unknown
    as not-safe — ADR §D7). Pure, headless-unit-testable.
 6. **Persistence** (`tile_io.{hpp,cpp}`, GDAL) — one **3-band GeoTIFF per dirty
-   tile** (depth/uncertainty/timestamp), `GTiff` driver, `GDT_Float32`, NaN nodata,
+   tile** (depth/uncertainty/timestamp), `GTiff` driver, **`GDT_Float64`** (so the
+   absolute-Unix-seconds timestamp band keeps precision — see §2), NaN nodata,
    `SetGeoTransform` from the tile's `GridIndex` corners
    (`south/west/north/eastLongitude()`), mirroring `cube_bathymetry/src/bag_to_geotiff.cpp`.
    Filename encodes `level/row/column`; layer = subdirectory. `save(dir)` writes

--- a/.agent/work-plans/issue-141/plan.md
+++ b/.agent/work-plans/issue-141/plan.md
@@ -1,0 +1,116 @@
+# Plan: Bathymetric store — Phase 1: GGGS-backed store core + persistence
+
+## Issue
+
+https://github.com/rolker/unh_marine_autonomy/issues/141 (Part of #86; decisions in
+[ADR-0002](https://github.com/rolker/unh_marine_autonomy/blob/jazzy/docs/decisions/0002-bathymetric-data-store.md))
+
+## Context
+
+GGGS (`gggs::Level`/`GridIndex`/`CellIndex`, 960×960 cells) lives in the
+`marine_autonomy` package in this repo. `cube_bathymetry::GeoMapSheet`
+(`std::map<gggs::GridIndex, GeoGrid>`, `GeoGrid` = `std::map<gggs::CellIndex, Node>`)
+is the working model to mirror. Phase 1 builds a new **core-layer** package that
+stores a per-cell bathymetric record across priority source layers and persists
+dirty tiles as per-tile GeoTIFFs. No importers / ROS services / costmap / sync yet.
+
+Two layering facts shape the design:
+- **`cube_bathymetry` is in `sensors_ws`, above `core_ws`** — the store (core)
+  **cannot** `#include` cube. The store defines its **own** cell record; it does
+  **not** reuse `cube::DepthAndUncertainty`. CUBE import (Phase 2) is designed
+  later, cube-side or via `marine_interfaces`.
+- **GGGS's public API returns `gz4d` types** (`gz4d::PositionDegrees`,
+  `BoundsDegrees`). ADR-0002 §D8 says new code uses `geodesy`. See Open Questions.
+
+## Approach
+
+1. **New package `marine_bathymetry_store`** (ament_cmake, in this repo) — depends
+   on `marine_autonomy` (GGGS) and `GDAL` (system). Library only; no ROS node this
+   phase. Clean `ament_export` (GGGS + geodesy only; no consumer coupling).
+2. **Per-cell record** (`bathy_cell.hpp`) — `depth` (float, ellipsoidal m, WGS84,
+   NaN = no-data), `uncertainty` (float), `timestamp` (`builtin_interfaces`/seconds
+   as float band). Source is implied by which layer holds the cell (step 4).
+3. **`BathymetryTile`** — one GGGS grid (960×960) of cells stored as **dense
+   column-major float arrays** (depth, uncertainty, timestamp), lazily allocated on
+   first write (GeoMapSheet's create-on-demand pattern). Dirty flag per tile.
+   Cell addressing via `gggs::CellIndex` row/column.
+4. **`BathymetryStore`** — `enum class SourceLayer { Processed, Draft }` (Chart in
+   a later phase) → `std::map<gggs::GridIndex, BathymetryTile>` **per layer**.
+   Per-source maps (not one tagged map) so priority is a non-destructive query-time
+   overlay (ADR §D3) and layers persist/sync independently (ADR §D6). Configured
+   `gggs::Level` (from approximate cell-size, like `GeoMapSheet`). Write API:
+   `set(layer, CellIndex, BathyCell)`.
+5. **Queries** (`query.hpp`): `bestSource(CellIndex)` → highest-priority populated
+   cell; `shallowestReliable(CellIndex, max_uncertainty)` → shallowest depth among
+   layers whose uncertainty ≤ threshold; region variants over a `GridBounds`.
+   No-data returns an explicit "unknown" (so the future costmap can treat unknown
+   as not-safe — ADR §D7). Pure, headless-unit-testable.
+6. **Persistence** (`tile_io.{hpp,cpp}`, GDAL) — one **3-band GeoTIFF per dirty
+   tile** (depth/uncertainty/timestamp), `GTiff` driver, `GDT_Float32`, NaN nodata,
+   `SetGeoTransform` from the tile's `GridIndex` corners
+   (`south/west/north/eastLongitude()`), mirroring `cube_bathymetry/src/bag_to_geotiff.cpp`.
+   Filename encodes `level/row/column`; layer = subdirectory. `save(dir)` writes
+   **only dirty tiles** then clears dirty flags; `load(dir)` reconstructs tiles +
+   level. Round-trip equality is the key invariant.
+7. **Tests** (gtest, headless) — priority precedence (draft never clobbers
+   processed; processed supersedes draft), no-data cell behavior, shallowest-reliable
+   threshold edges, persistence round-trip (write→reload→compare within tol),
+   dirty-only-save (untouched tiles not rewritten), level/index edges.
+8. **Docs** — README via `document-package`; REP-2000 tier note (ADR-0008).
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `marine_bathymetry_store/package.xml` | New ament package; deps `marine_autonomy`, `geodesy`, GDAL, ament_cmake_gtest |
+| `marine_bathymetry_store/CMakeLists.txt` | Library target + GDAL link + gtests (model cube CMake) |
+| `.../include/marine_bathymetry_store/bathy_cell.hpp` | Per-cell record + SourceLayer enum |
+| `.../include/marine_bathymetry_store/bathymetry_tile.hpp` | Dense 960×960 tile, dirty flag |
+| `.../include/.../bathymetry_store.hpp` + `src/bathymetry_store.cpp` | Per-layer tile maps, write API, level mgmt |
+| `.../include/.../query.hpp` + `src/query.cpp` | bestSource / shallowestReliable / region queries |
+| `.../include/.../tile_io.hpp` + `src/tile_io.cpp` | GeoTIFF per-tile save/load (GDAL) |
+| `.../test/test_store.cpp`, `test_query.cpp`, `test_tile_io.cpp` | gtests above |
+| `.../README.md` | Package docs (verified workflow) |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Only what's needed | Processed+draft layers, two queries, persistence — no importers/services/sync. Phase boundary held. |
+| Test what breaks | Tests target priority precedence, no-data, round-trip, dirty-save — not coverage glue. |
+| Modularity & Decoupling (project) | Core library, no consumer/ROS-node logic; defines own cell record, no cube dependency. |
+| Safety First (project) | Queries return explicit "unknown" so the later costmap treats unknown as not-safe. |
+| A change includes its consequences | New package ships its own tests + README in this PR. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0002 (this repo) | Yes | Implements §D2 (GGGS reuse), §D3 (per-cell record + priority overlay), §D5 (per-tile GeoTIFF), §D9 (new package, phase 1). §D8 (geodesy) — see Open Questions. |
+| 0008 (ROS 2 conventions) | Yes | ament_cmake package, target Rolling conventions, REP-2000 tier note; no `.msg`/`.srv` this phase. |
+| 0002-workspace (worktree) | Yes | Work in `feature/issue-141` worktree; PR to `jazzy`. |
+
+## Consequences
+
+| If we change... | Also update... | Included? |
+|---|---|---|
+| Add new package | `core_ws` build picks it up; README via document-package | Yes |
+| Define per-cell record (future `.msg` for query API) | Phase 3 query interface, consumers | No — Phase 3 |
+| Persistence format (GeoTIFF tile layout) | Phase 6 sync manifest (`GridIndex`+version) | No — Phase 6 (format chosen to feed it) |
+
+## Open Questions
+
+- **gz4d at the GGGS boundary (ADR §D8).** GGGS returns `gz4d::PositionDegrees`/`BoundsDegrees`.
+  Proposal: confine gz4d to a thin GGGS-adapter; keep store types plain/`geodesy`.
+  Is migrating GGGS's own API to `geodesy` in scope anywhere, or explicitly out? (Recommend out for Phase 1.)
+- **Timestamp granularity.** Per-cell (ADR §D3 literal, +1 dense band ≈ +3.7 MB/tile)
+  vs per-tile last-update. Plan assumes **per-cell**; confirm acceptable.
+- **Tile storage = dense** (≈12 MB/allocated tile, 3 float bands). Fine for survey-scale
+  tile counts; flag if very sparse wide-area coverage is expected (→ sparse cell map).
+- **`reliable` threshold default** for shallowestReliable — API takes a param; default
+  value deferred to the costmap phase. OK to leave unset (caller-supplied) in Phase 1?
+
+## Estimated Scope
+
+Single PR (`feature/issue-141 → jazzy`). New package, ~8 source files + 3 test files.
+Independent of the ADR PR (#142) and of the mru_transform datum work.

--- a/.agent/work-plans/issue-141/progress.md
+++ b/.agent/work-plans/issue-141/progress.md
@@ -109,3 +109,21 @@ issue: 141
 
 ### Note
 Round 3 findings are packaging/comment hygiene only — substantive bugs (silent GDAL data loss, antimeridian, GDAL-private export) were caught in earlier rounds. Diminishing returns; PR is substantively complete.
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-11 (America/New_York)
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**PR**: #143 at `4cb7a80` (round 4; fixes pushed `f63ecd9`)
+**Sources**: Copilot R4 @ `4cb7a80` (+ R1-R3 stale, resolved)
+**Cross-source confirmations**: 0
+**CI**: all-pass (build ✅, copilot ✅)
+
+### Findings
+- [x] (valid, Copilot R4) `loadTile` didn't validate WGS84-geographic CRS before reading the geotransform as degrees. **Fixed (`f63ecd9`): reject non-geographic/non-WGS84 rasters (GetSpatialRef + IsGeographic + semi-major axis).**
+- [x] (valid, Copilot R4) `save()` "collect dirty grids first" comment inaccurate. **Fixed: explains why mid-iteration clearDirty is safe.**
+- [x] (valid, Copilot R4) `save()`/`load()` @throws docs didn't name filesystem_error (which is a runtime_error subclass). **Fixed: named explicitly.**
+
+### Note
+Round 4 = one robustness check + doc accuracy. Continuing to wind down.

--- a/.agent/work-plans/issue-141/progress.md
+++ b/.agent/work-plans/issue-141/progress.md
@@ -92,3 +92,20 @@ issue: 141
 
 ### False positives
 - (Copilot R1 @ `13488ef`, stale) GDALClose "won't compile" — already dismissed last round (CI compiled it; jazzy GDAL 3.8.4 returns CPLErr); Copilot dropped it in R2.
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-11 (America/New_York)
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**PR**: #143 at `0422236` (round 3; fixes pushed `0a832f3`)
+**Sources**: Copilot R3 @ `0422236` (+ R1/R2 stale, all resolved)
+**Cross-source confirmations**: 0
+**CI**: build pending on new head; prior head green
+
+### Findings
+- [x] (valid, Copilot R3) `CMakeLists.txt` doubled header install path (`include/<pkg>/<pkg>/`). **Fixed (`0a832f3`): DESTINATION/INTERFACE → `include` (single-nested, verified). marine_autonomy has the same quirk — separate optional cleanup.**
+- [x] (valid, Copilot R3) `tile_io.cpp:140` no-data comment implied all bands; only depth/uncertainty get it. **Fixed: clarified (timestamp = 0 unset, never NaN).**
+
+### Note
+Round 3 findings are packaging/comment hygiene only — substantive bugs (silent GDAL data loss, antimeridian, GDAL-private export) were caught in earlier rounds. Diminishing returns; PR is substantively complete.

--- a/.agent/work-plans/issue-141/progress.md
+++ b/.agent/work-plans/issue-141/progress.md
@@ -18,3 +18,18 @@ issue: 141
 - [ ] Timestamp granularity: per-cell (ADR §D3 literal, +1 dense band ≈ +3.7 MB/tile) vs per-tile last-update.
 - [ ] Tile storage dense (≈12 MB/allocated tile) — OK for survey-scale; revisit if very sparse wide-area coverage expected.
 - [ ] `shallowestReliable` reliability-threshold default deferred to costmap phase; OK as caller-supplied param in Phase 1?
+
+## Plan Review
+**Status**: complete
+**When**: 2026-06-11 (America/New_York)
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context)) (in-context — author self-review)
+
+**Plan**: `.agent/work-plans/issue-141/plan.md` at `c734227`
+**PR**: https://github.com/rolker/unh_marine_autonomy/pull/143
+**Verdict**: approve-with-suggestions
+
+### Findings
+- [ ] (suggestion) `geodesy` listed as a Phase-1 dep but unused — queries are CellIndex/GridBounds-typed, persistence uses GridIndex corners; geodesy only enters with map-frame query variants (later). Drop it or name a concrete use. — `plan.md` Approach §1 / Files-to-Change
+- [ ] (suggestion) `timestamp` as float32 band loses precision — Unix seconds (~1.78e9) in GDT_Float32 = ~128 s ulp; feeds future costmap staleness (ADR §D7). Use GDT_Float64 or a relative epoch. — `plan.md` Approach §2/§6
+- [ ] (watch) ADR-literal deviations (defensible): source encoded as per-layer map not a per-cell field (§D3); 3 GeoTIFF bands + layer-subdirectory not 4 bands incl. source (§D5). Add a one-line note / ADR-0012 cross-ref addendum. — `plan.md` Approach §2/§6
+- [ ] (note) Context still says "gate on #144"; #144 merged (426bbd7) — update inline during impl. — `plan.md` Context

--- a/.agent/work-plans/issue-141/progress.md
+++ b/.agent/work-plans/issue-141/progress.md
@@ -75,3 +75,20 @@ issue: 141
 
 ### CI note
 - `build` failure = `marine_autonomy_integration_tests.test_mission_command_flow` ("Expected Heartbeat with Navigator=active, got heartbeats: []") — a launch/timing mission-flow test, flaky and unrelated to #141 (a new package + a constexpr accessor can't affect mission_manager↔navigator). Re-triggered by the `63a312f` push.
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-11 (America/New_York)
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**PR**: #143 at `f1f46a6` (round 2; fixes pushed `6bb153a`)
+**Sources**: 2 (Copilot R2 @ `f1f46a6`; Copilot R1 @ `13488ef` stale — all resolved last round)
+**Cross-source confirmations**: 0
+**CI**: all-pass (build ✅ — last round's failure was the flaky mission test, confirmed)
+
+### Findings
+- [x] (valid, Copilot R2) `CMakeLists.txt`: `GDAL::GDAL` linked PUBLIC but not exported → downstream `find_package` can't resolve the GDAL target (static lib propagates `$<LINK_ONLY>`). **Fixed (`6bb153a`): GDAL → PRIVATE (not in public headers) + added to ament_export_dependencies.**
+- [x] (valid, Copilot R2) PR description stale (Float32/float). **Fixed: refreshed PR #143 body from the Float64 plan.**
+
+### False positives
+- (Copilot R1 @ `13488ef`, stale) GDALClose "won't compile" — already dismissed last round (CI compiled it; jazzy GDAL 3.8.4 returns CPLErr); Copilot dropped it in R2.

--- a/.agent/work-plans/issue-141/progress.md
+++ b/.agent/work-plans/issue-141/progress.md
@@ -14,7 +14,7 @@ issue: 141
 **Phases**: single PR (Phase 1 of the #86 epic)
 
 ### Open questions
-- [ ] gz4d at the GGGS boundary: GGGS's public API returns `gz4d` types vs ADR-0002 §D8 "use geodesy" — confine gz4d to a GGGS adapter, or migrate GGGS's API (recommend out of scope for Phase 1)?
+- [x] gz4d at the GGGS boundary — **resolved (Roland, 2026-06-10): migrate GGGS public API → `geographic_msgs::GeoPoint` first (#144), prerequisite for #141.** Phase 1 targets the gz4d-free GGGS API.
 - [ ] Timestamp granularity: per-cell (ADR §D3 literal, +1 dense band ≈ +3.7 MB/tile) vs per-tile last-update.
 - [ ] Tile storage dense (≈12 MB/allocated tile) — OK for survey-scale; revisit if very sparse wide-area coverage expected.
 - [ ] `shallowestReliable` reliability-threshold default deferred to costmap phase; OK as caller-supplied param in Phase 1?

--- a/.agent/work-plans/issue-141/progress.md
+++ b/.agent/work-plans/issue-141/progress.md
@@ -1,0 +1,20 @@
+---
+issue: 141
+---
+
+# Issue #141 — Bathymetric store — Phase 1: GGGS-backed store core + persistence
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-10 (America/New_York)
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Plan**: `.agent/work-plans/issue-141/plan.md` at `e5f245d`
+**PR**: https://github.com/rolker/unh_marine_autonomy/pull/143 (`[PLAN]` prefix)
+**Phases**: single PR (Phase 1 of the #86 epic)
+
+### Open questions
+- [ ] gz4d at the GGGS boundary: GGGS's public API returns `gz4d` types vs ADR-0002 §D8 "use geodesy" — confine gz4d to a GGGS adapter, or migrate GGGS's API (recommend out of scope for Phase 1)?
+- [ ] Timestamp granularity: per-cell (ADR §D3 literal, +1 dense band ≈ +3.7 MB/tile) vs per-tile last-update.
+- [ ] Tile storage dense (≈12 MB/allocated tile) — OK for survey-scale; revisit if very sparse wide-area coverage expected.
+- [ ] `shallowestReliable` reliability-threshold default deferred to costmap phase; OK as caller-supplied param in Phase 1?

--- a/.agent/work-plans/issue-141/progress.md
+++ b/.agent/work-plans/issue-141/progress.md
@@ -54,3 +54,24 @@ issue: 141
 - (Copilot) `GetRasterBand` null / timestamp-band no-data / `GDALAllRegister` per-call / accepting >3 bands — bands 1-3 always valid; no NaN timestamps written; idempotent idiom; intentional forward-compat.
 
 **Static analysis**: clean (copyright/cpplint/cppcheck/uncrustify/xmllint all pass).
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-11 (America/New_York)
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**PR**: #143 at `13488ef` (fixes pushed as `63a312f`)
+**Sources**: 2 (Copilot R1 @ `13488ef`; Local Review (Pre-Push) @ `b8d1058`)
+**Cross-source confirmations**: 0
+**CI**: build FAILURE — flaky/unrelated (see below); marine_bathymetry_store built + passed in CI
+
+### Findings
+- [x] (valid, Copilot) `tile_io.hpp:40` governance: PR closes #141 but ships 3-band + directory-source while #141/ADR §D5 said a 4th `source` band. **Resolved (`63a312f`/ADR `a244be3`): recorded the 3-band directory-source decision in ADR-0002 §D5 (PR #142) + #141 issue body — a tile is single-layer, so a source band is redundant.**
+- [x] (valid, Copilot) `bathymetry_store.hpp:55` `fromCellSize()` doc backwards (GGGS picks coarsest level with cells ≤ request). **Fixed (`63a312f`).**
+- [x] (valid, Copilot) `plan.md:58` stale `GDT_Float32` (impl is Float64). **Fixed (`63a312f`).**
+
+### False positives
+- (Copilot) `tile_io.cpp:166` `GDALClose()` "is void in common releases, won't compile" — disproven: jazzy GDAL 3.8.4 declares `CPLErr GDALClose` (gdal.h:1114); **CI compiled the package and ran 469 tests**; void-return is GDAL <3.7 (Humble-era), not a workspace target (ADR-0008: jazzy/rolling). Added a clarifying comment, no functional change.
+
+### CI note
+- `build` failure = `marine_autonomy_integration_tests.test_mission_command_flow` ("Expected Heartbeat with Navigator=active, got heartbeats: []") — a launch/timing mission-flow test, flaky and unrelated to #141 (a new package + a constexpr accessor can't affect mission_manager↔navigator). Re-triggered by the `63a312f` push.

--- a/.agent/work-plans/issue-141/progress.md
+++ b/.agent/work-plans/issue-141/progress.md
@@ -33,3 +33,24 @@ issue: 141
 - [ ] (suggestion) `timestamp` as float32 band loses precision — Unix seconds (~1.78e9) in GDT_Float32 = ~128 s ulp; feeds future costmap staleness (ADR §D7). Use GDT_Float64 or a relative epoch. — `plan.md` Approach §2/§6
 - [ ] (watch) ADR-literal deviations (defensible): source encoded as per-layer map not a per-cell field (§D3); 3 GeoTIFF bands + layer-subdirectory not 4 bands incl. source (§D5). Add a one-line note / ADR-0012 cross-ref addendum. — `plan.md` Approach §2/§6
 - [ ] (note) Context still says "gate on #144"; #144 merged (426bbd7) — update inline during impl. — `plan.md` Context
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-11 (America/New_York)
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved (must-fix found and fixed in-session)
+
+**Branch**: feature/issue-141 at `b8d1058`
+**Mode**: pre-push
+**Depth**: Deep (reason: new package, GDAL/file-I/O, cross-layer, ~1100 lines)
+**Must-fix**: 1 | **Suggestions**: 1
+
+### Findings
+- [x] (must-fix, cross-confirmed Claude+Copilot) `saveTile` silent data loss: `SetGeoTransform`/`SetProjection` returns ignored + `DatasetCloser` swallowed `GDALClose`'s `CPLErr` (GTiff flushes at close, after `save()` clears dirty). **Fixed (`b8d1058`): check those returns + explicit checked `GDALClose` before return.** — `tile_io.cpp` saveTile
+- [x] (suggestion) Polar edge cases (±72/±80 longitude scaling, ±90 clamp) make the linear geotransform approximate. **Addressed (`b8d1058`): documented non-polar (|lat|<72) limitation.** — `tile_io.hpp`
+
+### Dismissed (false positives)
+- (Copilot) `load()` silently loses data if `getOrCreateTile` throws — no try/catch, exceptions propagate (fail-loud); also unreachable (loadTile builds grid at store level).
+- (Copilot) `GetRasterBand` null / timestamp-band no-data / `GDALAllRegister` per-call / accepting >3 bands — bands 1-3 always valid; no NaN timestamps written; idempotent idiom; intentional forward-compat.
+
+**Static analysis**: clean (copyright/cpplint/cppcheck/uncrustify/xmllint all pass).

--- a/marine_autonomy/include/marine_autonomy/gggs/level.h
+++ b/marine_autonomy/include/marine_autonomy/gggs/level.h
@@ -69,6 +69,12 @@ public:
     return Level(clamped);
   }
 
+  /// @brief The quadtree level number (0-20).
+  constexpr uint8_t level() const noexcept
+  {
+    return level_;
+  }
+
   /// Approximate cell size in meters
   double cellSize() const noexcept
   {

--- a/marine_bathymetry_store/CMakeLists.txt
+++ b/marine_bathymetry_store/CMakeLists.txt
@@ -1,0 +1,61 @@
+cmake_minimum_required(VERSION 3.8)
+project(marine_bathymetry_store)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(marine_autonomy REQUIRED)
+find_package(geographic_msgs REQUIRED)
+find_package(GDAL CONFIG REQUIRED)
+
+add_library(${PROJECT_NAME}
+  src/bathymetry_store.cpp
+  src/query.cpp
+  src/tile_io.cpp
+)
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  marine_autonomy::marine_autonomy
+  ${geographic_msgs_TARGETS}
+  GDAL::GDAL
+)
+
+install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
+install(TARGETS ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_dependencies(marine_autonomy geographic_msgs)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+  find_package(ament_cmake_gtest REQUIRED)
+
+  ament_add_gtest(test_store test/test_store.cpp)
+  target_link_libraries(test_store ${PROJECT_NAME})
+
+  ament_add_gtest(test_query test/test_query.cpp)
+  target_link_libraries(test_query ${PROJECT_NAME})
+
+  ament_add_gtest(test_tile_io test/test_tile_io.cpp)
+  target_link_libraries(test_tile_io ${PROJECT_NAME})
+endif()
+
+ament_package()

--- a/marine_bathymetry_store/CMakeLists.txt
+++ b/marine_bathymetry_store/CMakeLists.txt
@@ -26,9 +26,16 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
 )
+# marine_autonomy + geographic_msgs are in the public headers (GGGS / GeoPoint);
+# GDAL is used only inside tile_io.cpp, so it is PRIVATE. It is still exported as
+# a dependency below because this is a static library — CMake propagates the
+# private link to consumers as $<LINK_ONLY:GDAL::GDAL>, so they must be able to
+# resolve the GDAL target via find_package(marine_bathymetry_store).
 target_link_libraries(${PROJECT_NAME} PUBLIC
   marine_autonomy::marine_autonomy
   ${geographic_msgs_TARGETS}
+)
+target_link_libraries(${PROJECT_NAME} PRIVATE
   GDAL::GDAL
 )
 
@@ -41,7 +48,7 @@ install(TARGETS ${PROJECT_NAME}
 )
 
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
-ament_export_dependencies(marine_autonomy geographic_msgs)
+ament_export_dependencies(marine_autonomy geographic_msgs GDAL)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/marine_bathymetry_store/CMakeLists.txt
+++ b/marine_bathymetry_store/CMakeLists.txt
@@ -24,7 +24,7 @@ add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+  "$<INSTALL_INTERFACE:include>"
 )
 # marine_autonomy + geographic_msgs are in the public headers (GGGS / GeoPoint);
 # GDAL is used only inside tile_io.cpp, so it is PRIVATE. It is still exported as
@@ -39,7 +39,11 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
   GDAL::GDAL
 )
 
-install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
+# Headers are laid out as include/${PROJECT_NAME}/*.hpp, so install the include/
+# tree to `include` (not include/${PROJECT_NAME}) to avoid a doubled
+# include/${PROJECT_NAME}/${PROJECT_NAME}/ path; the INSTALL_INTERFACE above is
+# `include` to match.
+install(DIRECTORY include/ DESTINATION include)
 install(TARGETS ${PROJECT_NAME}
   EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib

--- a/marine_bathymetry_store/README.md
+++ b/marine_bathymetry_store/README.md
@@ -1,0 +1,81 @@
+# marine_bathymetry_store
+
+Persistent multi-source bathymetric data store built on the GGGS spatial index.
+This package is **Phase 1 (the store core)** of the larger effort tracked by
+[unh_marine_autonomy#86](https://github.com/rolker/unh_marine_autonomy/issues/86)
+and designed in
+[ADR-0002](../docs/decisions/0002-bathymetric-data-store.md).
+
+## What this phase provides
+
+- An in-memory, GGGS-tiled store with **priority source layers**.
+- Two **queries** — best-available and shallowest-reliable.
+- **Per-tile GeoTIFF persistence** (incremental save / reload).
+
+It deliberately does **not** include importers (CUBE / bathy-BAG / GeoTIFF),
+ROS services/topics, a costmap plugin, or robot↔operator distribution — those
+are later phases of #86. The store core is a plain C++ library with no ROS-node
+or consumer-specific logic.
+
+## Concepts
+
+### Source layers (`bathy_cell.hpp`)
+
+`SourceLayer` is an ordered enum — `Processed` (highest priority) then `Draft`.
+`Chart` is reserved for a later phase (it depends on the `mru_transform`
+vertical-datum work). A cell's source is **implied by which layer holds it**:
+the store keeps one tile map per layer, so source is the map, not a per-cell
+field. Priority is a **non-destructive query-time overlay** — a noisy draft
+write never clobbers a trusted processed value, and a later processed import
+never has to merge with draft (ADR-0002 §D3).
+
+### Per-cell record (`BathyCell`)
+
+`depth` (ellipsoidal height, WGS84, metres — up-positive, so a *shallower*
+seafloor is a *greater* value), `uncertainty` (1-σ, metres), and `timestamp`
+(Unix seconds). All three are `double`: the timestamp band needs the range
+(absolute Unix seconds in `float` resolve to ~128-second granularity, which
+would silently coarsen the staleness information the costmap will rely on —
+ADR-0002 §D7). A fully-allocated 960×960 tile is therefore ≈22 MB; tiles are
+allocated lazily, only when first written.
+
+### Queries (`query.hpp`)
+
+- `bestSource(store, cell)` — the highest-priority layer with data.
+- `shallowestReliable(store, cell, max_uncertainty)` — the shallowest (greatest
+  ellipsoidal height) value among layers whose uncertainty is within tolerance.
+  For navigation-safety use.
+- `forEachCellBestSource(store, min, max, visitor)` — the region form, over a
+  geographic box.
+
+Every query returns `std::optional`: **`std::nullopt` means *unknown*** — no
+(reliable) layer covers the cell. A safety-conscious consumer must treat unknown
+as not-safe, never as deep water (ADR-0002 §D7).
+
+### Persistence (`tile_io.hpp`)
+
+Each dirty tile is written as a 3-band `Float64` GeoTIFF
+(`<dir>/<layer>/<level>_<row>_<col>.tif`), WGS84-georeferenced from its GGGS
+grid corners. `save()` writes only dirty tiles (incremental); `load()` rebuilds
+the store, recovering each tile's `GridIndex` from the file geotransform and
+rejecting tiles written at a different GGGS level.
+
+## Build & test
+
+This package lives in the `unh_marine_autonomy` repo and builds in `core_ws`:
+
+```bash
+colcon build --symlink-install --packages-select marine_bathymetry_store
+colcon test --packages-select marine_bathymetry_store
+```
+
+Tests (`test_store`, `test_query`, `test_tile_io`) are headless GTest and cover
+priority precedence, no-data handling, the height-aware shallowest-reliable
+semantics, persistence round-trip (including timestamp precision), incremental
+(dirty-only) save, and level-mismatch rejection.
+
+## Dependencies
+
+- `marine_autonomy` — the GGGS spatial index (`gggs::Level`/`GridIndex`/`CellIndex`).
+- `geographic_msgs` — `GeoPoint` for the region query API.
+- GDAL — GeoTIFF persistence.

--- a/marine_bathymetry_store/include/marine_bathymetry_store/bathy_cell.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/bathy_cell.hpp
@@ -1,0 +1,83 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef MARINE_BATHYMETRY_STORE__BATHY_CELL_HPP_
+#define MARINE_BATHYMETRY_STORE__BATHY_CELL_HPP_
+
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+
+namespace marine_bathymetry_store
+{
+
+/// @brief Source layers, ordered by query priority (highest first).
+///
+/// A cell's source is implied by which layer holds it (the store keeps one
+/// tile map per layer), so it is not stored in the per-cell record. This is a
+/// deliberate, cleaner realization of ADR-0002 §D3's "each cell stores a
+/// source layer": the layer is the map it lives in.
+///
+/// The numeric value is the priority rank (0 = highest). `Chart` is reserved
+/// for a later phase (it depends on the mru_transform vertical-datum work) and
+/// is intentionally not yet a member.
+enum class SourceLayer : uint8_t
+{
+  Processed = 0,  ///< Externally produced grids (bathy-BAG / GeoTIFF). Highest confidence.
+  Draft = 1,      ///< Real-time CUBE output. Valuable but potentially noisy.
+};
+
+/// @brief Source layers in descending priority order — iterate for best-source.
+inline constexpr std::array<SourceLayer, 2> source_layers_by_priority{
+  SourceLayer::Processed, SourceLayer::Draft};
+
+/// @brief Number of source layers present in this phase.
+inline constexpr std::size_t source_layer_count = source_layers_by_priority.size();
+
+/// @brief Per-cell bathymetric record.
+///
+/// All fields are `double`. Depth/uncertainty don't need the range, but the
+/// **timestamp does**: an absolute Unix-seconds timestamp (~1.8e9 in 2026) in
+/// `float` resolves to ~128 s granularity, which would silently coarsen the
+/// staleness information the costmap will eventually rely on (ADR-0002 §D7).
+/// Keeping the whole record `double` (and persisting as a `Float64` GeoTIFF)
+/// avoids that trap without per-tile epoch bookkeeping. The cost is denser
+/// tiles (≈22 MB per fully-allocated 960×960 tile); see `BathymetryTile`.
+struct BathyCell
+{
+  /// Ellipsoidal height (WGS84), metres. NaN = no data.
+  double depth = std::numeric_limits<double>::quiet_NaN();
+  /// 1-sigma vertical uncertainty, metres. NaN = unknown.
+  double uncertainty = std::numeric_limits<double>::quiet_NaN();
+  /// Acquisition / import time, seconds since the Unix epoch. 0 = unset.
+  double timestamp = 0.0;
+
+  /// @brief True if this cell carries a usable depth (depth is not NaN).
+  bool hasData() const noexcept
+  {
+    return !std::isnan(depth);
+  }
+};
+
+}  // namespace marine_bathymetry_store
+
+#endif  // MARINE_BATHYMETRY_STORE__BATHY_CELL_HPP_

--- a/marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_store.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_store.hpp
@@ -52,7 +52,8 @@ public:
   explicit BathymetryStore(uint8_t gggs_level)
   : level_(gggs_level) {}
 
-  /// @brief Construct a store at the finest GGGS level with cells ≥ @p cell_size_m.
+  /// @brief Construct a store at the coarsest GGGS level whose cells are no
+  ///        larger than @p cell_size_m (clamped to the finest level, 20).
   static BathymetryStore fromCellSize(float cell_size_m)
   {
     return BathymetryStore(gggs::Level::fromCellSize(cell_size_m).level());

--- a/marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_store.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_store.hpp
@@ -1,0 +1,111 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef MARINE_BATHYMETRY_STORE__BATHYMETRY_STORE_HPP_
+#define MARINE_BATHYMETRY_STORE__BATHYMETRY_STORE_HPP_
+
+#include <array>
+#include <map>
+#include <optional>
+
+#include "marine_autonomy/gggs.h"
+#include "marine_bathymetry_store/bathy_cell.hpp"
+#include "marine_bathymetry_store/bathymetry_tile.hpp"
+
+namespace marine_bathymetry_store
+{
+
+/// @brief In-memory, GGGS-tiled, multi-layer bathymetric store (Phase 1 core).
+///
+/// Holds one tile map per `SourceLayer`, keyed by `gggs::GridIndex`. All tiles
+/// live at a single GGGS level fixed at construction. Source priority is a
+/// **non-destructive query-time overlay** (see `query.hpp`): the layers are
+/// independent, so a noisy draft write never clobbers a trusted processed cell
+/// and a later processed import never has to merge with draft (ADR-0002 §D3).
+///
+/// This phase has no importers, ROS interface, or distribution — just storage,
+/// in-process queries (`query.hpp`), and per-tile GeoTIFF persistence
+/// (`tile_io.hpp`).
+class BathymetryStore
+{
+public:
+  /// @brief Construct a store whose tiles live at GGGS quadtree @p gggs_level.
+  /// @throws std::out_of_range if the level is invalid (via gggs::Level).
+  explicit BathymetryStore(uint8_t gggs_level)
+  : level_(gggs_level) {}
+
+  /// @brief Construct a store at the finest GGGS level with cells ≥ @p cell_size_m.
+  static BathymetryStore fromCellSize(float cell_size_m)
+  {
+    return BathymetryStore(gggs::Level::fromCellSize(cell_size_m).level());
+  }
+
+  /// @brief The GGGS level all tiles in this store use.
+  const gggs::Level & level() const noexcept {return level_;}
+
+  /// @brief CellIndex at this store's level for a geographic position.
+  ///
+  /// Convenience for callers who think in coordinates — guarantees the returned
+  /// CellIndex is at the store's level (so `set`/`get` won't be rejected).
+  gggs::CellIndex cellIndex(double latitude, double longitude) const
+  {
+    return level_.cellIndex(gggs::geoPoint(latitude, longitude));
+  }
+
+  /// @brief Write @p value into @p layer at @p cell.
+  ///
+  /// Creates the backing tile on first write to its grid. The cell's grid must
+  /// be at this store's level.
+  /// @throws std::invalid_argument if @p cell is invalid or at the wrong level.
+  void set(SourceLayer layer, const gggs::CellIndex & cell, const BathyCell & value);
+
+  /// @brief Read the raw cell in a single @p layer (no priority overlay).
+  /// @return The cell, or `std::nullopt` if @p layer has no tile for that grid.
+  ///         A returned cell may still be no-data (`!hasData()`).
+  std::optional<BathyCell> get(SourceLayer layer, const gggs::CellIndex & cell) const;
+
+  /// @brief The tiles of a layer (for persistence / iteration).
+  const std::map<gggs::GridIndex, BathymetryTile> & tiles(SourceLayer layer) const
+  {
+    return layerMap(layer);
+  }
+
+  /// @brief Find or create the tile for @p grid in @p layer (used by load).
+  /// @throws std::invalid_argument if @p grid is invalid or at the wrong level.
+  BathymetryTile & getOrCreateTile(SourceLayer layer, const gggs::GridIndex & grid);
+
+private:
+  std::map<gggs::GridIndex, BathymetryTile> & layerMap(SourceLayer layer)
+  {
+    return layers_[static_cast<std::size_t>(layer)];
+  }
+  const std::map<gggs::GridIndex, BathymetryTile> & layerMap(SourceLayer layer) const
+  {
+    return layers_[static_cast<std::size_t>(layer)];
+  }
+
+  gggs::Level level_;
+  std::array<std::map<gggs::GridIndex, BathymetryTile>, source_layer_count> layers_;
+};
+
+}  // namespace marine_bathymetry_store
+
+#endif  // MARINE_BATHYMETRY_STORE__BATHYMETRY_STORE_HPP_

--- a/marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_tile.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_tile.hpp
@@ -1,0 +1,118 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef MARINE_BATHYMETRY_STORE__BATHYMETRY_TILE_HPP_
+#define MARINE_BATHYMETRY_STORE__BATHYMETRY_TILE_HPP_
+
+#include <cassert>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+#include "marine_autonomy/gggs.h"
+#include "marine_bathymetry_store/bathy_cell.hpp"
+
+namespace marine_bathymetry_store
+{
+
+/// @brief One GGGS grid (960×960 cells) of bathymetric data for a single layer.
+///
+/// Stored as dense, row-major structure-of-arrays (one array each for depth,
+/// uncertainty, timestamp) in **GGGS cell coordinates**: row 0 is the southern
+/// edge and increases north; column 0 is the western edge and increases east.
+/// (Persistence flips rows to north-up GeoTIFF order — see `tile_io`.)
+///
+/// SoA mirrors the GeoTIFF band layout, making persistence a per-band copy.
+/// Arrays are allocated lazily by the owning `BathymetryStore` only when a
+/// tile is first written, so empty regions cost nothing. A fully-allocated
+/// tile holds 3 × 960 × 960 doubles ≈ 22 MB (see `BathyCell` for why double).
+class BathymetryTile
+{
+public:
+  /// @brief Number of cells along each grid edge (GGGS constant).
+  static constexpr uint16_t edge = gggs::cell_rows_per_grid;
+  /// @brief Total cells in a tile (edge × edge).
+  static constexpr uint32_t cell_count = gggs::grid_total_cell_count;
+
+  /// @brief Construct an empty tile for @p index (all cells no-data).
+  explicit BathymetryTile(gggs::GridIndex index)
+  : index_(index),
+    depth_(cell_count, std::numeric_limits<double>::quiet_NaN()),
+    uncertainty_(cell_count, std::numeric_limits<double>::quiet_NaN()),
+    timestamp_(cell_count, 0.0)
+  {
+  }
+
+  /// @brief The grid this tile covers.
+  const gggs::GridIndex & index() const noexcept {return index_;}
+
+  /// @brief Write a cell at (@p row, @p col) within the grid; marks the tile dirty.
+  void set(uint16_t row, uint16_t col, const BathyCell & cell)
+  {
+    const uint32_t i = offset(row, col);
+    depth_[i] = cell.depth;
+    uncertainty_[i] = cell.uncertainty;
+    timestamp_[i] = cell.timestamp;
+    dirty_ = true;
+  }
+
+  /// @brief Read the cell at (@p row, @p col) within the grid.
+  BathyCell get(uint16_t row, uint16_t col) const
+  {
+    const uint32_t i = offset(row, col);
+    return BathyCell{depth_[i], uncertainty_[i], timestamp_[i]};
+  }
+
+  /// @brief Whether this tile has unsaved changes.
+  bool dirty() const noexcept {return dirty_;}
+  /// @brief Mark all changes saved (called by persistence after a successful write).
+  void clearDirty() noexcept {dirty_ = false;}
+  /// @brief Force the dirty flag (used when reconstructing a tile in memory).
+  void markDirty() noexcept {dirty_ = true;}
+
+  /// @brief Raw band accessors (row-major, GGGS cell order) for persistence.
+  /// @{
+  const std::vector<double> & depthBand() const noexcept {return depth_;}
+  const std::vector<double> & uncertaintyBand() const noexcept {return uncertainty_;}
+  const std::vector<double> & timestampBand() const noexcept {return timestamp_;}
+  std::vector<double> & depthBand() noexcept {return depth_;}
+  std::vector<double> & uncertaintyBand() noexcept {return uncertainty_;}
+  std::vector<double> & timestampBand() noexcept {return timestamp_;}
+  /// @}
+
+  /// @brief Row-major offset of cell (@p row, @p col). Asserts in debug builds.
+  static uint32_t offset(uint16_t row, uint16_t col)
+  {
+    assert(row < edge && col < edge && "BathymetryTile cell out of bounds");
+    return static_cast<uint32_t>(row) * edge + col;
+  }
+
+private:
+  gggs::GridIndex index_;
+  std::vector<double> depth_;
+  std::vector<double> uncertainty_;
+  std::vector<double> timestamp_;
+  bool dirty_ = false;
+};
+
+}  // namespace marine_bathymetry_store
+
+#endif  // MARINE_BATHYMETRY_STORE__BATHYMETRY_TILE_HPP_

--- a/marine_bathymetry_store/include/marine_bathymetry_store/query.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/query.hpp
@@ -1,0 +1,83 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef MARINE_BATHYMETRY_STORE__QUERY_HPP_
+#define MARINE_BATHYMETRY_STORE__QUERY_HPP_
+
+#include <functional>
+#include <optional>
+
+#include "geographic_msgs/msg/geo_point.hpp"
+#include "marine_autonomy/gggs.h"
+#include "marine_bathymetry_store/bathy_cell.hpp"
+#include "marine_bathymetry_store/bathymetry_store.hpp"
+
+namespace marine_bathymetry_store
+{
+
+/// @brief A depth value resolved from the store, tagged with its winning layer.
+///
+/// `depth` is **ellipsoidal height** (WGS84, metres, up-positive): a seafloor
+/// below the ellipsoid has a negative value, and a *shallower* seafloor has a
+/// *greater* (less negative) value. See `shallowestReliable`.
+struct DepthSample
+{
+  double depth;          ///< Ellipsoidal height (WGS84, m, up-positive).
+  double uncertainty;    ///< 1-sigma vertical uncertainty (m).
+  double timestamp;      ///< Acquisition / import time (Unix seconds).
+  SourceLayer source;    ///< Which layer this value came from.
+};
+
+/// @brief Highest-priority layer that has data at @p cell.
+///
+/// Walks layers in `source_layers_by_priority` order and returns the first with
+/// usable data. `std::nullopt` means **unknown** — no layer has data here; a
+/// safety-conscious caller must treat that as not-safe (ADR-0002 §D7), not as
+/// deep water.
+std::optional<DepthSample> bestSource(
+  const BathymetryStore & store, const gggs::CellIndex & cell);
+
+/// @brief Shallowest reliable depth at @p cell (navigation-safety query).
+///
+/// Among all layers that (a) have data and (b) have uncertainty ≤
+/// @p max_uncertainty (a NaN uncertainty is never reliable), returns the
+/// **shallowest** — i.e. the greatest ellipsoidal height, the value closest to
+/// the surface and therefore the most hazardous. `std::nullopt` means no
+/// reliable layer covers the cell; the caller must treat that as not-safe.
+std::optional<DepthSample> shallowestReliable(
+  const BathymetryStore & store, const gggs::CellIndex & cell, double max_uncertainty);
+
+/// @brief Visit every GGGS cell overlapping the geographic box, with its best source.
+///
+/// Iterates the cells covered by the lat/lon box [@p minimum, @p maximum] at the
+/// store's level and invokes @p visitor with each `CellIndex` and its
+/// `bestSource` result (`std::nullopt` = unknown cell). Region form of
+/// `bestSource`; work is bounded by the requested box, so callers control cost.
+void forEachCellBestSource(
+  const BathymetryStore & store,
+  const geographic_msgs::msg::GeoPoint & minimum,
+  const geographic_msgs::msg::GeoPoint & maximum,
+  const std::function<void(const gggs::CellIndex &,
+  const std::optional<DepthSample> &)> & visitor);
+
+}  // namespace marine_bathymetry_store
+
+#endif  // MARINE_BATHYMETRY_STORE__QUERY_HPP_

--- a/marine_bathymetry_store/include/marine_bathymetry_store/tile_io.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/tile_io.hpp
@@ -1,0 +1,88 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef MARINE_BATHYMETRY_STORE__TILE_IO_HPP_
+#define MARINE_BATHYMETRY_STORE__TILE_IO_HPP_
+
+#include <cstddef>
+#include <string>
+
+#include "marine_autonomy/gggs.h"
+#include "marine_bathymetry_store/bathy_cell.hpp"
+#include "marine_bathymetry_store/bathymetry_store.hpp"
+#include "marine_bathymetry_store/bathymetry_tile.hpp"
+
+/// @file
+/// @brief Per-tile GeoTIFF persistence (ADR-0002 §D5).
+///
+/// Each tile is one 3-band `Float64` GeoTIFF (depth, uncertainty, timestamp),
+/// WGS84-georeferenced from its GGGS grid corners. The file carries no source
+/// field — the layer is encoded as the subdirectory (`processed/`, `draft/`).
+/// The GeoTIFF is written north-up (raster row 0 = north), so persistence flips
+/// rows relative to the in-memory GGGS cell order (row 0 = south).
+///
+/// `Float64` (not `Float32`) is deliberate: the timestamp band holds absolute
+/// Unix seconds, which `float` cannot represent at usable resolution. A single
+/// GeoTIFF has one band data type, so all three bands are `Float64`.
+
+namespace marine_bathymetry_store
+{
+
+/// @brief GeoTIFF filename (no directory) for a grid: `<level>_<row>_<col>.tif`.
+std::string tileFilename(const gggs::GridIndex & grid);
+
+/// @brief Subdirectory name for a source layer (`"processed"` / `"draft"`).
+std::string layerDirName(SourceLayer layer);
+
+/// @brief Write one tile as a 3-band Float64 GeoTIFF at @p path.
+/// @throws std::runtime_error on any GDAL failure.
+void saveTile(const BathymetryTile & tile, const std::string & path);
+
+/// @brief Load a tile GeoTIFF, reconstructing its GridIndex at @p level.
+///
+/// The grid is recovered from the file's geotransform (the cell center maps
+/// back through @p level), so a file written at a different level is rejected.
+/// The returned tile is clean (not dirty).
+/// @throws std::runtime_error on GDAL failure, wrong dimensions, or a
+///         geotransform that doesn't match any grid at @p level.
+BathymetryTile loadTile(const std::string & path, const gggs::Level & level);
+
+/// @brief Persist every **dirty** tile of @p store under @p dir, then clear
+///        their dirty flags.
+///
+/// Layout: `<dir>/<layer>/<level>_<row>_<col>.tif`. Creates directories as
+/// needed. Clean tiles are skipped (incremental save).
+/// @return The number of tiles written.
+/// @throws std::runtime_error on any GDAL/filesystem failure.
+std::size_t save(BathymetryStore & store, const std::string & dir);
+
+/// @brief Load every tile found under @p dir into @p store.
+///
+/// Scans `<dir>/<layer>/*.tif` for each known layer. @p store must already be
+/// at the level the tiles were written at (loadTile enforces per-file).
+/// Loaded tiles are clean.
+/// @return The number of tiles loaded.
+/// @throws std::runtime_error on any GDAL/filesystem failure or level mismatch.
+std::size_t load(BathymetryStore & store, const std::string & dir);
+
+}  // namespace marine_bathymetry_store
+
+#endif  // MARINE_BATHYMETRY_STORE__TILE_IO_HPP_

--- a/marine_bathymetry_store/include/marine_bathymetry_store/tile_io.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/tile_io.hpp
@@ -42,6 +42,14 @@
 /// `Float64` (not `Float32`) is deliberate: the timestamp band holds absolute
 /// Unix seconds, which `float` cannot represent at usable resolution. A single
 /// GeoTIFF has one band data type, so all three bands are `Float64`.
+///
+/// @note Round-trip persistence is validated for **non-polar** latitudes
+/// (|lat| < 72°), the intended lake/coastal survey envelope. Near GGGS's polar
+/// longitude-scaling boundaries (±72°, ±80°) and the ±90° latitude clamp, a
+/// grid's per-cell angular extent diverges from the single uniform pixel size a
+/// GeoTIFF geotransform can express, so the linear geotransform becomes an
+/// approximation and the level-match check on load may mis-fire. Polar tiles are
+/// out of scope for this phase.
 
 namespace marine_bathymetry_store
 {

--- a/marine_bathymetry_store/include/marine_bathymetry_store/tile_io.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/tile_io.hpp
@@ -79,7 +79,8 @@ BathymetryTile loadTile(const std::string & path, const gggs::Level & level);
 /// Layout: `<dir>/<layer>/<level>_<row>_<col>.tif`. Creates directories as
 /// needed. Clean tiles are skipped (incremental save).
 /// @return The number of tiles written.
-/// @throws std::runtime_error on any GDAL/filesystem failure.
+/// @throws std::runtime_error on any GDAL failure; std::filesystem::filesystem_error
+///         (a std::runtime_error subclass) on a directory-creation failure.
 std::size_t save(BathymetryStore & store, const std::string & dir);
 
 /// @brief Load every tile found under @p dir into @p store.
@@ -88,7 +89,9 @@ std::size_t save(BathymetryStore & store, const std::string & dir);
 /// at the level the tiles were written at (loadTile enforces per-file).
 /// Loaded tiles are clean.
 /// @return The number of tiles loaded.
-/// @throws std::runtime_error on any GDAL/filesystem failure or level mismatch.
+/// @throws std::runtime_error on any GDAL failure or level mismatch;
+///         std::filesystem::filesystem_error (a std::runtime_error subclass) on a
+///         directory-iteration failure.
 std::size_t load(BathymetryStore & store, const std::string & dir);
 
 }  // namespace marine_bathymetry_store

--- a/marine_bathymetry_store/package.xml
+++ b/marine_bathymetry_store/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>marine_bathymetry_store</name>
+  <version>0.0.0</version>
+  <description>
+    Persistent multi-source bathymetric data store built on the GGGS spatial
+    index. Phase 1 (core): a GGGS-tiled in-memory store with priority source
+    layers, best-source / shallowest-reliable queries, and per-tile GeoTIFF
+    persistence. See unh_marine_autonomy#86 / ADR-0002.
+  </description>
+  <maintainer email="roland.arsenault@unh.edu">Roland Arsenault</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>marine_autonomy</depend>
+  <depend>geographic_msgs</depend>
+  <depend>libgdal-dev</depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/marine_bathymetry_store/src/bathymetry_store.cpp
+++ b/marine_bathymetry_store/src/bathymetry_store.cpp
@@ -1,0 +1,80 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "marine_bathymetry_store/bathymetry_store.hpp"
+
+#include <stdexcept>
+#include <string>
+
+namespace marine_bathymetry_store
+{
+
+void BathymetryStore::set(
+  SourceLayer layer, const gggs::CellIndex & cell, const BathyCell & value)
+{
+  if (!cell.valid()) {
+    throw std::invalid_argument("BathymetryStore::set: invalid CellIndex");
+  }
+  if (cell.level() != level_.level()) {
+    throw std::invalid_argument(
+            "BathymetryStore::set: CellIndex at level " +
+            std::to_string(cell.level()) + " but store is at level " +
+            std::to_string(level_.level()));
+  }
+  BathymetryTile & tile = getOrCreateTile(layer, cell.grid());
+  tile.set(cell.row(), cell.column(), value);
+}
+
+std::optional<BathyCell> BathymetryStore::get(
+  SourceLayer layer, const gggs::CellIndex & cell) const
+{
+  if (!cell.valid()) {
+    return std::nullopt;
+  }
+  const auto & m = layerMap(layer);
+  const auto it = m.find(cell.grid());
+  if (it == m.end()) {
+    return std::nullopt;
+  }
+  return it->second.get(cell.row(), cell.column());
+}
+
+BathymetryTile & BathymetryStore::getOrCreateTile(
+  SourceLayer layer, const gggs::GridIndex & grid)
+{
+  if (!grid.valid()) {
+    throw std::invalid_argument("BathymetryStore::getOrCreateTile: invalid GridIndex");
+  }
+  if (grid.level() != level_.level()) {
+    throw std::invalid_argument(
+            "BathymetryStore::getOrCreateTile: GridIndex at level " +
+            std::to_string(grid.level()) + " but store is at level " +
+            std::to_string(level_.level()));
+  }
+  auto & m = layerMap(layer);
+  auto it = m.find(grid);
+  if (it == m.end()) {
+    it = m.emplace(grid, BathymetryTile(grid)).first;
+  }
+  return it->second;
+}
+
+}  // namespace marine_bathymetry_store

--- a/marine_bathymetry_store/src/query.cpp
+++ b/marine_bathymetry_store/src/query.cpp
@@ -1,0 +1,97 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "marine_bathymetry_store/query.hpp"
+
+#include <cmath>
+
+namespace marine_bathymetry_store
+{
+
+namespace
+{
+
+/// Resolve a single layer's sample at a cell, or nullopt if it has no usable data.
+std::optional<DepthSample> sampleFor(
+  const BathymetryStore & store, SourceLayer layer, const gggs::CellIndex & cell)
+{
+  const auto c = store.get(layer, cell);
+  if (!c || !c->hasData()) {
+    return std::nullopt;
+  }
+  return DepthSample{c->depth, c->uncertainty, c->timestamp, layer};
+}
+
+}  // namespace
+
+std::optional<DepthSample> bestSource(
+  const BathymetryStore & store, const gggs::CellIndex & cell)
+{
+  for (const SourceLayer layer : source_layers_by_priority) {
+    if (auto sample = sampleFor(store, layer, cell)) {
+      return sample;
+    }
+  }
+  return std::nullopt;
+}
+
+std::optional<DepthSample> shallowestReliable(
+  const BathymetryStore & store, const gggs::CellIndex & cell, double max_uncertainty)
+{
+  std::optional<DepthSample> shallowest;
+  for (const SourceLayer layer : source_layers_by_priority) {
+    const auto sample = sampleFor(store, layer, cell);
+    if (!sample) {
+      continue;
+    }
+    // A NaN uncertainty is never reliable; otherwise require it within tolerance.
+    if (std::isnan(sample->uncertainty) || sample->uncertainty > max_uncertainty) {
+      continue;
+    }
+    // depth is ellipsoidal height (up-positive): shallower == greater height.
+    if (!shallowest || sample->depth > shallowest->depth) {
+      shallowest = sample;
+    }
+  }
+  return shallowest;
+}
+
+void forEachCellBestSource(
+  const BathymetryStore & store,
+  const geographic_msgs::msg::GeoPoint & minimum,
+  const geographic_msgs::msg::GeoPoint & maximum,
+  const std::function<void(const gggs::CellIndex &,
+  const std::optional<DepthSample> &)> & visitor)
+{
+  const gggs::Level & level = store.level();
+  gggs::GridAreaIterator grid_it(
+    level.gridIndex(minimum.latitude, minimum.longitude),
+    level.gridIndex(maximum.latitude, maximum.longitude));
+  for (; grid_it.valid(); grid_it.next()) {
+    for (gggs::CellAreaIterator cell_it(*grid_it, minimum, maximum);
+      cell_it.valid(); cell_it.next())
+    {
+      visitor(*cell_it, bestSource(store, *cell_it));
+    }
+  }
+}
+
+}  // namespace marine_bathymetry_store

--- a/marine_bathymetry_store/src/tile_io.cpp
+++ b/marine_bathymetry_store/src/tile_io.cpp
@@ -159,6 +159,8 @@ void saveTile(const BathymetryTile & tile, const std::string & path)
   // clears the tile's dirty flag once this returns. (The DatasetCloser stays
   // as an exception-safety net for the error paths above; releasing the
   // handle here prevents a double close.)
+  // GDALClose returns CPLErr since GDAL 3.7; the workspace targets GDAL >= 3.8
+  // (ROS 2 jazzy / rolling), so checking it here is well-defined.
   GDALDataset * ds = out.ds;
   out.ds = nullptr;
   if (GDALClose(ds) != CE_None) {

--- a/marine_bathymetry_store/src/tile_io.cpp
+++ b/marine_bathymetry_store/src/tile_io.cpp
@@ -132,8 +132,9 @@ void saveTile(const BathymetryTile & tile, const std::string & path)
   CPLFree(wkt);
   checkCE(projection_result, "set projection");
 
-  // No-data is metadata only — NaN round-trips through the Float64 bands
-  // regardless — so its result is intentionally not treated as fatal.
+  // The depth/uncertainty no-data value is metadata only — NaN round-trips
+  // through the Float64 bands regardless — so its result is intentionally not
+  // treated as fatal. The timestamp band has no no-data (0 = unset, never NaN).
   const double nan = std::numeric_limits<double>::quiet_NaN();
   out.ds->GetRasterBand(kDepthBand)->SetNoDataValue(nan);
   out.ds->GetRasterBand(kUncertaintyBand)->SetNoDataValue(nan);

--- a/marine_bathymetry_store/src/tile_io.cpp
+++ b/marine_bathymetry_store/src/tile_io.cpp
@@ -1,0 +1,256 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "marine_bathymetry_store/tile_io.hpp"
+
+#include <gdal_priv.h>
+#include <cpl_string.h>
+#include <ogr_spatialref.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace marine_bathymetry_store
+{
+
+namespace
+{
+
+constexpr int kEdge = BathymetryTile::edge;       // 960
+constexpr int kCellCount = kEdge * kEdge;
+constexpr int kBandCount = 3;                     // depth, uncertainty, timestamp
+constexpr int kDepthBand = 1;                     // GDAL bands are 1-indexed
+constexpr int kUncertaintyBand = 2;
+constexpr int kTimestampBand = 3;
+
+/// RAII wrapper so a thrown exception still closes the GDAL dataset.
+struct DatasetCloser
+{
+  GDALDataset * ds = nullptr;
+  ~DatasetCloser() {if (ds) {GDALClose(ds);}}
+};
+
+/// Copy a band between GGGS cell order (row 0 = south) and north-up raster
+/// order (row 0 = north) — the two differ only by a vertical row flip.
+/// Works in both directions since the flip is its own inverse mapping.
+void flipRows(const std::vector<double> & src, std::vector<double> & dst)
+{
+  for (int r = 0; r < kEdge; ++r) {
+    const std::size_t flipped = static_cast<std::size_t>(kEdge - 1 - r);
+    const std::size_t dst_row = static_cast<std::size_t>(r);
+    std::copy_n(
+      src.begin() + flipped * kEdge, kEdge,
+      dst.begin() + dst_row * kEdge);
+  }
+}
+
+void checkCE(CPLErr err, const char * what)
+{
+  if (err != CE_None) {
+    throw std::runtime_error(std::string("GDAL error: ") + what);
+  }
+}
+
+}  // namespace
+
+std::string tileFilename(const gggs::GridIndex & grid)
+{
+  return std::to_string(static_cast<int>(grid.level())) + "_" +
+         std::to_string(grid.row()) + "_" + std::to_string(grid.column()) + ".tif";
+}
+
+std::string layerDirName(SourceLayer layer)
+{
+  switch (layer) {
+    case SourceLayer::Processed: return "processed";
+    case SourceLayer::Draft: return "draft";
+  }
+  throw std::runtime_error("layerDirName: unknown SourceLayer");
+}
+
+void saveTile(const BathymetryTile & tile, const std::string & path)
+{
+  GDALAllRegister();
+  GDALDriver * driver = GetGDALDriverManager()->GetDriverByName("GTiff");
+  if (driver == nullptr) {
+    throw std::runtime_error("saveTile: GTiff driver unavailable");
+  }
+
+  char ** options = nullptr;
+  options = CSLSetNameValue(options, "COMPRESS", "LZW");
+  DatasetCloser out;
+  out.ds = driver->Create(path.c_str(), kEdge, kEdge, kBandCount, GDT_Float64, options);
+  CSLDestroy(options);
+  if (out.ds == nullptr) {
+    throw std::runtime_error("saveTile: could not create " + path);
+  }
+
+  // North-up geotransform from the grid's corners.
+  const gggs::GridIndex & grid = tile.index();
+  const double west = grid.westLongitude();
+  const double north = grid.northLatitude();
+  const double pixel_x = grid.longitudinalSpan() / kEdge;
+  const double pixel_y = -grid.latitudinalSpan() / kEdge;   // negative: north-up
+  double geo_transform[6] = {west, pixel_x, 0.0, north, 0.0, pixel_y};
+  out.ds->SetGeoTransform(geo_transform);
+
+  OGRSpatialReference srs;
+  srs.SetWellKnownGeogCS("WGS84");
+  char * wkt = nullptr;
+  srs.exportToWkt(&wkt);
+  out.ds->SetProjection(wkt);
+  CPLFree(wkt);
+
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  out.ds->GetRasterBand(kDepthBand)->SetNoDataValue(nan);
+  out.ds->GetRasterBand(kUncertaintyBand)->SetNoDataValue(nan);
+
+  // Flip each band into north-up raster order, then write.
+  std::vector<double> raster(kCellCount);
+  const std::array<std::pair<int, const std::vector<double> *>, kBandCount> bands{{
+    {kDepthBand, &tile.depthBand()},
+    {kUncertaintyBand, &tile.uncertaintyBand()},
+    {kTimestampBand, &tile.timestampBand()},
+  }};
+  for (const auto & [band_index, data] : bands) {
+    flipRows(*data, raster);
+    checkCE(
+      out.ds->GetRasterBand(band_index)->RasterIO(
+        GF_Write, 0, 0, kEdge, kEdge, raster.data(), kEdge, kEdge, GDT_Float64, 0, 0),
+      "write band");
+  }
+}
+
+BathymetryTile loadTile(const std::string & path, const gggs::Level & level)
+{
+  GDALAllRegister();
+  DatasetCloser in;
+  in.ds = GDALDataset::FromHandle(GDALOpen(path.c_str(), GA_ReadOnly));
+  if (in.ds == nullptr) {
+    throw std::runtime_error("loadTile: could not open " + path);
+  }
+  if (in.ds->GetRasterXSize() != kEdge || in.ds->GetRasterYSize() != kEdge ||
+    in.ds->GetRasterCount() < kBandCount)
+  {
+    throw std::runtime_error("loadTile: unexpected dimensions/bands in " + path);
+  }
+
+  double geo_transform[6];
+  if (in.ds->GetGeoTransform(geo_transform) != CE_None) {
+    throw std::runtime_error("loadTile: missing geotransform in " + path);
+  }
+  const double west = geo_transform[0];
+  const double pixel_x = geo_transform[1];
+  const double north = geo_transform[3];
+  const double pixel_y = geo_transform[5];
+  const double east = west + pixel_x * kEdge;
+  const double south = north + pixel_y * kEdge;
+
+  // Recover the GridIndex: the cell center maps back through the level. (We
+  // cannot construct a GridIndex from raw row/col — that ctor is GGGS-private.)
+  const double center_lat = 0.5 * (north + south);
+  const double center_lon = 0.5 * (west + east);
+  const gggs::GridIndex grid = level.gridIndex(center_lat, center_lon);
+
+  // Reject a file whose grid edges don't match a grid at this level (e.g. saved
+  // at a different level): require agreement to within half a cell.
+  const double tol_lon = 0.5 * std::abs(pixel_x);
+  const double tol_lat = 0.5 * std::abs(pixel_y);
+  if (std::abs(grid.westLongitude() - west) > tol_lon ||
+    std::abs(grid.northLatitude() - north) > tol_lat)
+  {
+    throw std::runtime_error(
+            "loadTile: geotransform does not match any grid at level " +
+            std::to_string(level.level()) + " in " + path);
+  }
+
+  BathymetryTile tile(grid);
+  std::vector<double> raster(kCellCount);
+  const std::array<std::pair<int, std::vector<double> *>, kBandCount> bands{{
+    {kDepthBand, &tile.depthBand()},
+    {kUncertaintyBand, &tile.uncertaintyBand()},
+    {kTimestampBand, &tile.timestampBand()},
+  }};
+  for (const auto & [band_index, data] : bands) {
+    checkCE(
+      in.ds->GetRasterBand(band_index)->RasterIO(
+        GF_Read, 0, 0, kEdge, kEdge, raster.data(), kEdge, kEdge, GDT_Float64, 0, 0),
+      "read band");
+    flipRows(raster, *data);   // north-up raster back to GGGS cell order
+  }
+  // Filled via band accessors (not set()), so the tile stays clean.
+  return tile;
+}
+
+std::size_t save(BathymetryStore & store, const std::string & dir)
+{
+  namespace fs = std::filesystem;
+  std::size_t written = 0;
+  for (const SourceLayer layer : source_layers_by_priority) {
+    const fs::path layer_dir = fs::path(dir) / layerDirName(layer);
+    bool created_dir = false;
+    // Collect dirty grids first (we re-fetch mutably to clear their flags).
+    for (const auto & [grid, tile] : store.tiles(layer)) {
+      if (!tile.dirty()) {
+        continue;
+      }
+      if (!created_dir) {
+        fs::create_directories(layer_dir);
+        created_dir = true;
+      }
+      saveTile(tile, (layer_dir / tileFilename(grid)).string());
+      store.getOrCreateTile(layer, grid).clearDirty();
+      ++written;
+    }
+  }
+  return written;
+}
+
+std::size_t load(BathymetryStore & store, const std::string & dir)
+{
+  namespace fs = std::filesystem;
+  std::size_t loaded = 0;
+  for (const SourceLayer layer : source_layers_by_priority) {
+    const fs::path layer_dir = fs::path(dir) / layerDirName(layer);
+    if (!fs::is_directory(layer_dir)) {
+      continue;
+    }
+    for (const auto & entry : fs::directory_iterator(layer_dir)) {
+      if (!entry.is_regular_file() || entry.path().extension() != ".tif") {
+        continue;
+      }
+      BathymetryTile tile = loadTile(entry.path().string(), store.level());
+      store.getOrCreateTile(layer, tile.index()) = std::move(tile);
+      ++loaded;
+    }
+  }
+  return loaded;
+}
+
+}  // namespace marine_bathymetry_store

--- a/marine_bathymetry_store/src/tile_io.cpp
+++ b/marine_bathymetry_store/src/tile_io.cpp
@@ -118,15 +118,22 @@ void saveTile(const BathymetryTile & tile, const std::string & path)
   const double pixel_x = grid.longitudinalSpan() / kEdge;
   const double pixel_y = -grid.latitudinalSpan() / kEdge;   // negative: north-up
   double geo_transform[6] = {west, pixel_x, 0.0, north, 0.0, pixel_y};
-  out.ds->SetGeoTransform(geo_transform);
+  // The geotransform is load-bearing: loadTile recovers the GridIndex from it.
+  checkCE(out.ds->SetGeoTransform(geo_transform), "set geotransform");
 
   OGRSpatialReference srs;
   srs.SetWellKnownGeogCS("WGS84");
   char * wkt = nullptr;
-  srs.exportToWkt(&wkt);
-  out.ds->SetProjection(wkt);
+  if (srs.exportToWkt(&wkt) != OGRERR_NONE || wkt == nullptr) {
+    CPLFree(wkt);
+    throw std::runtime_error("saveTile: could not build WGS84 WKT for " + path);
+  }
+  const CPLErr projection_result = out.ds->SetProjection(wkt);
   CPLFree(wkt);
+  checkCE(projection_result, "set projection");
 
+  // No-data is metadata only — NaN round-trips through the Float64 bands
+  // regardless — so its result is intentionally not treated as fatal.
   const double nan = std::numeric_limits<double>::quiet_NaN();
   out.ds->GetRasterBand(kDepthBand)->SetNoDataValue(nan);
   out.ds->GetRasterBand(kUncertaintyBand)->SetNoDataValue(nan);
@@ -144,6 +151,18 @@ void saveTile(const BathymetryTile & tile, const std::string & path)
       out.ds->GetRasterBand(band_index)->RasterIO(
         GF_Write, 0, 0, kEdge, kEdge, raster.data(), kEdge, kEdge, GDT_Float64, 0, 0),
       "write band");
+  }
+
+  // Close explicitly and check the result. For a GTiff the (LZW-compressed)
+  // raster and directory are flushed to disk on close, so a disk-full / I/O
+  // failure surfaces only here — and saveTile must report it, because save()
+  // clears the tile's dirty flag once this returns. (The DatasetCloser stays
+  // as an exception-safety net for the error paths above; releasing the
+  // handle here prevents a double close.)
+  GDALDataset * ds = out.ds;
+  out.ds = nullptr;
+  if (GDALClose(ds) != CE_None) {
+    throw std::runtime_error("saveTile: failed to flush/close " + path);
   }
 }
 

--- a/marine_bathymetry_store/src/tile_io.cpp
+++ b/marine_bathymetry_store/src/tile_io.cpp
@@ -183,6 +183,18 @@ BathymetryTile loadTile(const std::string & path, const gggs::Level & level)
     throw std::runtime_error("loadTile: unexpected dimensions/bands in " + path);
   }
 
+  // The grid recovery below interprets the geotransform as degrees, so the file
+  // must be a geographic WGS84 raster. Reject a projected (e.g. UTM, coordinates
+  // in metres) or otherwise non-WGS84 file — accidental copy, corruption — rather
+  // than silently misreading its coordinates as lat/lon.
+  const OGRSpatialReference * srs = in.ds->GetSpatialRef();
+  OGRErr axis_error = OGRERR_NONE;
+  if (srs == nullptr || !srs->IsGeographic() ||
+    std::abs(srs->GetSemiMajor(&axis_error) - 6378137.0) > 1.0 || axis_error != OGRERR_NONE)
+  {
+    throw std::runtime_error("loadTile: not a geographic WGS84 raster: " + path);
+  }
+
   double geo_transform[6];
   if (in.ds->GetGeoTransform(geo_transform) != CE_None) {
     throw std::runtime_error("loadTile: missing geotransform in " + path);
@@ -237,7 +249,10 @@ std::size_t save(BathymetryStore & store, const std::string & dir)
   for (const SourceLayer layer : source_layers_by_priority) {
     const fs::path layer_dir = fs::path(dir) / layerDirName(layer);
     bool created_dir = false;
-    // Collect dirty grids first (we re-fetch mutably to clear their flags).
+    // Iterate the layer's tiles (a const view) and write each dirty one. The
+    // dirty flag is cleared via getOrCreateTile() on the same (existing) key:
+    // that's a lookup, not an insert, and clearDirty() only flips a bool on the
+    // tile value — neither mutates the map, so the iterator stays valid.
     for (const auto & [grid, tile] : store.tiles(layer)) {
       if (!tile.dirty()) {
         continue;

--- a/marine_bathymetry_store/test/test_query.cpp
+++ b/marine_bathymetry_store/test/test_query.cpp
@@ -1,0 +1,129 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstddef>
+#include <optional>
+
+#include "marine_autonomy/gggs.h"
+#include "marine_bathymetry_store/bathymetry_store.hpp"
+#include "marine_bathymetry_store/query.hpp"
+
+using marine_bathymetry_store::BathyCell;
+using marine_bathymetry_store::BathymetryStore;
+using marine_bathymetry_store::bestSource;
+using marine_bathymetry_store::DepthSample;
+using marine_bathymetry_store::forEachCellBestSource;
+using marine_bathymetry_store::shallowestReliable;
+using marine_bathymetry_store::SourceLayer;
+
+TEST(Query, BestSourcePrefersHigherPriorityLayer)
+{
+  BathymetryStore store(5);
+  const auto cell = store.cellIndex(43.0, -70.5);
+  store.set(SourceLayer::Draft, cell, BathyCell{-12.0, 2.0, 2.0});
+  store.set(SourceLayer::Processed, cell, BathyCell{-10.0, 0.1, 1.0});
+
+  const auto best = bestSource(store, cell);
+  ASSERT_TRUE(best.has_value());
+  EXPECT_EQ(best->source, SourceLayer::Processed);
+  EXPECT_DOUBLE_EQ(best->depth, -10.0);
+}
+
+TEST(Query, BestSourceFallsBackToLowerPriority)
+{
+  BathymetryStore store(5);
+  const auto cell = store.cellIndex(43.0, -70.5);
+  store.set(SourceLayer::Draft, cell, BathyCell{-12.0, 2.0, 2.0});
+
+  const auto best = bestSource(store, cell);
+  ASSERT_TRUE(best.has_value());
+  EXPECT_EQ(best->source, SourceLayer::Draft);
+}
+
+TEST(Query, UnknownCellIsNullopt)
+{
+  BathymetryStore store(5);
+  const auto cell = store.cellIndex(43.0, -70.5);
+  EXPECT_FALSE(bestSource(store, cell).has_value());
+
+  // A written-but-no-data cell is still unknown (not "deep water").
+  store.set(SourceLayer::Draft, cell, BathyCell{});
+  EXPECT_FALSE(bestSource(store, cell).has_value());
+}
+
+TEST(Query, ShallowestReliablePicksGreatestHeight)
+{
+  // depth is ellipsoidal height (up-positive): shallower == greater value.
+  BathymetryStore store(5);
+  const auto cell = store.cellIndex(43.0, -70.5);
+  store.set(SourceLayer::Processed, cell, BathyCell{-30.0, 0.1, 1.0});  // deeper
+  store.set(SourceLayer::Draft, cell, BathyCell{-25.0, 0.2, 2.0});      // shallower
+
+  const auto result = shallowestReliable(store, cell, 1.0);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_DOUBLE_EQ(result->depth, -25.0);
+  EXPECT_EQ(result->source, SourceLayer::Draft);
+}
+
+TEST(Query, ShallowestReliableExcludesOverUncertain)
+{
+  BathymetryStore store(5);
+  const auto cell = store.cellIndex(43.0, -70.5);
+  store.set(SourceLayer::Processed, cell, BathyCell{-30.0, 0.1, 1.0});  // reliable, deeper
+  store.set(SourceLayer::Draft, cell, BathyCell{-25.0, 5.0, 2.0});      // shallower, too uncertain
+
+  const auto result = shallowestReliable(store, cell, 1.0);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_DOUBLE_EQ(result->depth, -30.0);   // draft excluded
+  EXPECT_EQ(result->source, SourceLayer::Processed);
+}
+
+TEST(Query, ShallowestReliableTreatsNaNUncertaintyAsUnreliable)
+{
+  BathymetryStore store(5);
+  const auto cell = store.cellIndex(43.0, -70.5);
+  store.set(SourceLayer::Draft, cell, BathyCell{-25.0, std::nan(""), 2.0});
+  EXPECT_FALSE(shallowestReliable(store, cell, 1.0).has_value());
+}
+
+TEST(Query, ForEachRegionVisitsCoveredCells)
+{
+  BathymetryStore store(5);
+  const auto cell = store.cellIndex(43.0, -70.5);
+  store.set(SourceLayer::Draft, cell, BathyCell{-20.0, 0.5, 1.0});
+
+  std::size_t visited = 0;
+  std::size_t with_data = 0;
+  forEachCellBestSource(
+    store, gggs::geoPoint(42.999, -70.501), gggs::geoPoint(43.001, -70.499),
+    [&](const gggs::CellIndex &, const std::optional<DepthSample> & sample) {
+      ++visited;
+      if (sample) {
+        ++with_data;
+      }
+    });
+
+  EXPECT_GT(visited, 0u);
+  EXPECT_GE(with_data, 1u);   // the written cell falls inside the box
+}

--- a/marine_bathymetry_store/test/test_store.cpp
+++ b/marine_bathymetry_store/test/test_store.cpp
@@ -1,0 +1,104 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+
+#include "marine_autonomy/gggs.h"
+#include "marine_bathymetry_store/bathymetry_store.hpp"
+
+using marine_bathymetry_store::BathyCell;
+using marine_bathymetry_store::BathymetryStore;
+using marine_bathymetry_store::SourceLayer;
+
+TEST(Store, SetGetRoundTrip)
+{
+  BathymetryStore store(5);
+  const auto cell = store.cellIndex(43.0, -70.5);
+  store.set(SourceLayer::Draft, cell, BathyCell{-30.0, 0.5, 1000.0});
+
+  const auto got = store.get(SourceLayer::Draft, cell);
+  ASSERT_TRUE(got.has_value());
+  EXPECT_DOUBLE_EQ(got->depth, -30.0);
+  EXPECT_DOUBLE_EQ(got->uncertainty, 0.5);
+  EXPECT_DOUBLE_EQ(got->timestamp, 1000.0);
+}
+
+TEST(Store, GetEmptyLayerIsNullopt)
+{
+  BathymetryStore store(5);
+  EXPECT_FALSE(store.get(SourceLayer::Processed, store.cellIndex(43.0, -70.5)).has_value());
+}
+
+TEST(Store, LayersAreIndependent)
+{
+  // A draft write must not touch the processed layer at the same cell.
+  BathymetryStore store(5);
+  const auto cell = store.cellIndex(43.0, -70.5);
+  store.set(SourceLayer::Processed, cell, BathyCell{-10.0, 0.1, 1.0});
+  store.set(SourceLayer::Draft, cell, BathyCell{-12.0, 2.0, 2.0});
+  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Processed, cell)->depth, -10.0);
+  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Draft, cell)->depth, -12.0);
+}
+
+TEST(Store, TilesAllocatedLazilyPerLayer)
+{
+  BathymetryStore store(5);
+  EXPECT_TRUE(store.tiles(SourceLayer::Draft).empty());
+  EXPECT_TRUE(store.tiles(SourceLayer::Processed).empty());
+
+  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1.0});
+  EXPECT_EQ(store.tiles(SourceLayer::Draft).size(), 1u);
+  EXPECT_TRUE(store.tiles(SourceLayer::Processed).empty());
+}
+
+TEST(Store, NoDataCellReadsBackAsNoData)
+{
+  BathymetryStore store(5);
+  const auto cell = store.cellIndex(43.0, -70.5);
+  store.set(SourceLayer::Draft, cell, BathyCell{});  // depth NaN
+  const auto got = store.get(SourceLayer::Draft, cell);
+  ASSERT_TRUE(got.has_value());      // tile exists
+  EXPECT_FALSE(got->hasData());      // but the cell carries no usable depth
+}
+
+TEST(Store, WrongLevelCellThrows)
+{
+  BathymetryStore store(5);
+  gggs::Level other(6);
+  const auto level6_cell = other.cellIndex(gggs::geoPoint(43.0, -70.5));
+  EXPECT_THROW(store.set(SourceLayer::Draft, level6_cell, BathyCell{}), std::invalid_argument);
+}
+
+TEST(Store, InvalidCellThrows)
+{
+  BathymetryStore store(5);
+  EXPECT_THROW(store.set(SourceLayer::Draft, gggs::CellIndex{}, BathyCell{}),
+    std::invalid_argument);
+}
+
+TEST(Store, FromCellSizeChoosesAFiniteLevel)
+{
+  const auto store = BathymetryStore::fromCellSize(30.0f);
+  // The chosen level must produce valid cells for a normal position.
+  EXPECT_TRUE(store.cellIndex(43.0, -70.5).valid());
+}

--- a/marine_bathymetry_store/test/test_tile_io.cpp
+++ b/marine_bathymetry_store/test/test_tile_io.cpp
@@ -1,0 +1,125 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <filesystem>
+#include <stdexcept>
+#include <string>
+
+#include "marine_bathymetry_store/bathymetry_store.hpp"
+#include "marine_bathymetry_store/tile_io.hpp"
+
+using marine_bathymetry_store::BathyCell;
+using marine_bathymetry_store::BathymetryStore;
+using marine_bathymetry_store::SourceLayer;
+
+namespace fs = std::filesystem;
+
+class TileIoTest : public ::testing::Test
+{
+protected:
+  fs::path dir_;
+
+  void SetUp() override
+  {
+    const std::string name = ::testing::UnitTest::GetInstance()->current_test_info()->name();
+    dir_ = fs::temp_directory_path() / ("marine_bathy_store_" + name);
+    fs::remove_all(dir_);
+  }
+
+  void TearDown() override
+  {
+    fs::remove_all(dir_);
+  }
+};
+
+TEST_F(TileIoTest, RoundTripPreservesCells)
+{
+  BathymetryStore store(5);
+  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.123, 0.456, 1.78e9});
+  store.set(SourceLayer::Processed, store.cellIndex(44.0, -71.0), BathyCell{-12.5, 0.2, 1.79e9});
+
+  EXPECT_EQ(marine_bathymetry_store::save(store, dir_.string()), 2u);
+
+  BathymetryStore reloaded(5);
+  EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 2u);
+
+  const auto draft = reloaded.get(SourceLayer::Draft, reloaded.cellIndex(43.0, -70.5));
+  ASSERT_TRUE(draft.has_value());
+  EXPECT_DOUBLE_EQ(draft->depth, -30.123);
+  EXPECT_DOUBLE_EQ(draft->uncertainty, 0.456);
+  // Float64 timestamp band: absolute Unix seconds survive exactly.
+  // (A Float32 band would lose ~128 s here — this is the precision guard.)
+  EXPECT_DOUBLE_EQ(draft->timestamp, 1.78e9);
+
+  const auto processed = reloaded.get(SourceLayer::Processed, reloaded.cellIndex(44.0, -71.0));
+  ASSERT_TRUE(processed.has_value());
+  EXPECT_DOUBLE_EQ(processed->depth, -12.5);
+  EXPECT_DOUBLE_EQ(processed->timestamp, 1.79e9);
+}
+
+TEST_F(TileIoTest, LoadedTilesAreCleanAndDontResave)
+{
+  BathymetryStore store(5);
+  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1.0});
+
+  EXPECT_EQ(marine_bathymetry_store::save(store, dir_.string()), 1u);
+  // No changes since the last save -> nothing re-written (incremental save).
+  EXPECT_EQ(marine_bathymetry_store::save(store, dir_.string()), 0u);
+
+  // Reloaded tiles are clean, so saving the reloaded store writes nothing.
+  BathymetryStore reloaded(5);
+  marine_bathymetry_store::load(reloaded, dir_.string());
+  EXPECT_EQ(marine_bathymetry_store::save(reloaded, dir_.string()), 0u);
+}
+
+TEST_F(TileIoTest, WritingAfterSaveRedirties)
+{
+  BathymetryStore store(5);
+  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1.0});
+  EXPECT_EQ(marine_bathymetry_store::save(store, dir_.string()), 1u);
+
+  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-31.0, 0.4, 2.0});
+  EXPECT_EQ(marine_bathymetry_store::save(store, dir_.string()), 1u);
+}
+
+TEST_F(TileIoTest, LayersWriteToSeparateSubdirectories)
+{
+  BathymetryStore store(5);
+  store.set(SourceLayer::Processed, store.cellIndex(43.0, -70.5), BathyCell{-10.0, 0.1, 1.0});
+  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-12.0, 0.5, 2.0});
+  marine_bathymetry_store::save(store, dir_.string());
+
+  EXPECT_TRUE(fs::is_directory(dir_ / "processed"));
+  EXPECT_TRUE(fs::is_directory(dir_ / "draft"));
+}
+
+TEST_F(TileIoTest, LoadRejectsTilesFromAnotherLevel)
+{
+  BathymetryStore store(5);
+  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1.0});
+  marine_bathymetry_store::save(store, dir_.string());
+
+  BathymetryStore wrong_level(6);
+  EXPECT_THROW(marine_bathymetry_store::load(wrong_level, dir_.string()), std::runtime_error);
+}


### PR DESCRIPTION
Closes #141

# Plan: Bathymetric store — Phase 1: GGGS-backed store core + persistence

## Issue

https://github.com/rolker/unh_marine_autonomy/issues/141 (Part of #86; decisions in
[ADR-0002](https://github.com/rolker/unh_marine_autonomy/blob/jazzy/docs/decisions/0002-bathymetric-data-store.md))

## Context

GGGS (`gggs::Level`/`GridIndex`/`CellIndex`, 960×960 cells) lives in the
`marine_autonomy` package in this repo. `cube_bathymetry::GeoMapSheet`
(`std::map<gggs::GridIndex, GeoGrid>`, `GeoGrid` = `std::map<gggs::CellIndex, Node>`)
is the working model to mirror. Phase 1 builds a new **core-layer** package that
stores a per-cell bathymetric record across priority source layers and persists
dirty tiles as per-tile GeoTIFFs. No importers / ROS services / costmap / sync yet.

Two layering facts shape the design:
- **`cube_bathymetry` is in `sensors_ws`, above `core_ws`** — the store (core)
  **cannot** `#include` cube. The store defines its **own** cell record; it does
  **not** reuse `cube::DepthAndUncertainty`. CUBE import (Phase 2) is designed
  later, cube-side or via `marine_interfaces`.
- **GGGS's public API was migrated off `gz4d`** (→ `geographic_msgs::GeoPoint`) in
  [#144](https://github.com/rolker/unh_marine_autonomy/issues/144), **MERGED
  2026-06-11** (`426bbd7`) and merged into this branch. Phase 1 targets that
  gz4d-free GGGS API; no new `gz4d` usage.

## Approach

1. **New package `marine_bathymetry_store`** (ament_cmake, in this repo) — depends
   on `marine_autonomy` (GGGS), `geographic_msgs` (`GeoPoint` for the region query),
   and `GDAL` (system). Library only; no ROS node this phase. Clean `ament_export`.
   (No `geodesy`: Phase-1 queries are GGGS-index-typed and persistence uses GridIndex
   corners — geodesy enters only with the later map-frame query variants. Per
   review-plan.) Also adds a one-line `gggs::Level::level()` accessor to
   `marine_autonomy` (same repo) — the store needs the level number to validate cells.
2. **Per-cell record** (`bathy_cell.hpp`) — `depth`, `uncertainty`, `timestamp`,
   all **`double`** (NaN depth = no-data). Double (and a Float64 GeoTIFF) is
   deliberate: a `float` timestamp band coarsens absolute Unix seconds to ~128 s,
   silently degrading staleness info (ADR §D7). Per review-plan. Source is implied
   by which layer holds the cell (step 4).
3. **`BathymetryTile`** — one GGGS grid (960×960) of cells stored as **dense
   row-major double arrays** (depth, uncertainty, timestamp), lazily allocated on
   first write (GeoMapSheet's create-on-demand pattern). Dirty flag per tile.
   Cell addressing via `gggs::CellIndex` row/column.
4. **`BathymetryStore`** — `enum class SourceLayer { Processed, Draft }` (Chart in
   a later phase) → `std::map<gggs::GridIndex, BathymetryTile>` **per layer**.
   Per-source maps (not one tagged map) so priority is a non-destructive query-time
   overlay (ADR §D3) and layers persist/sync independently (ADR §D6). Configured
   `gggs::Level` (from approximate cell-size, like `GeoMapSheet`). Write API:
   `set(layer, CellIndex, BathyCell)`.
5. **Queries** (`query.hpp`): `bestSource(CellIndex)` → highest-priority populated
   cell; `shallowestReliable(CellIndex, max_uncertainty)` → shallowest depth among
   layers whose uncertainty ≤ threshold; region variants over a `GridBounds`.
   No-data returns an explicit "unknown" (so the future costmap can treat unknown
   as not-safe — ADR §D7). Pure, headless-unit-testable.
6. **Persistence** (`tile_io.{hpp,cpp}`, GDAL) — one **3-band GeoTIFF per dirty
   tile** (depth/uncertainty/timestamp), `GTiff` driver, **`GDT_Float64`** (so the
   absolute-Unix-seconds timestamp band keeps precision — see §2), NaN nodata,
   `SetGeoTransform` from the tile's `GridIndex` corners
   (`south/west/north/eastLongitude()`), mirroring `cube_bathymetry/src/bag_to_geotiff.cpp`.
   Filename encodes `level/row/column`; layer = subdirectory. `save(dir)` writes
   **only dirty tiles** then clears dirty flags; `load(dir)` reconstructs tiles +
   level. Round-trip equality is the key invariant.
7. **Tests** (gtest, headless) — priority precedence (draft never clobbers
   processed; processed supersedes draft), no-data cell behavior, shallowest-reliable
   threshold edges, persistence round-trip (write→reload→compare within tol),
   dirty-only-save (untouched tiles not rewritten), level/index edges.
8. **Docs** — README via `document-package`; REP-2000 tier note (ADR-0008).

## Files to Change

| File | Change |
|------|--------|
| `marine_bathymetry_store/package.xml` | New ament package; deps `marine_autonomy`, `geographic_msgs`, GDAL (`libgdal-dev`), ament_cmake_gtest |
| `marine_autonomy/include/marine_autonomy/gggs/level.h` | Add `Level::level()` accessor (store needs the level number) |
| `marine_bathymetry_store/CMakeLists.txt` | Library target + GDAL link + gtests (model cube CMake) |
| `.../include/marine_bathymetry_store/bathy_cell.hpp` | Per-cell record + SourceLayer enum |
| `.../include/marine_bathymetry_store/bathymetry_tile.hpp` | Dense 960×960 tile, dirty flag |
| `.../include/.../bathymetry_store.hpp` + `src/bathymetry_store.cpp` | Per-layer tile maps, write API, level mgmt |
| `.../include/.../query.hpp` + `src/query.cpp` | bestSource / shallowestReliable / region queries |
| `.../include/.../tile_io.hpp` + `src/tile_io.cpp` | GeoTIFF per-tile save/load (GDAL) |
| `.../test/test_store.cpp`, `test_query.cpp`, `test_tile_io.cpp` | gtests above |
| `.../README.md` | Package docs (verified workflow) |

## Principles Self-Check

| Principle | Consideration |
|---|---|
| Only what's needed | Processed+draft layers, two queries, persistence — no importers/services/sync. Phase boundary held. |
| Test what breaks | Tests target priority precedence, no-data, round-trip, dirty-save — not coverage glue. |
| Modularity & Decoupling (project) | Core library, no consumer/ROS-node logic; defines own cell record, no cube dependency. |
| Safety First (project) | Queries return explicit "unknown" so the later costmap treats unknown as not-safe. |
| A change includes its consequences | New package ships its own tests + README in this PR. |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| 0002 (this repo) | Yes | Implements §D2 (GGGS reuse), §D3 (per-cell record + priority overlay), §D5 (per-tile GeoTIFF), §D9 (new package, phase 1). §D8 (geodesy) — see Open Questions. |
| 0008 (ROS 2 conventions) | Yes | ament_cmake package, target Rolling conventions, REP-2000 tier note; no `.msg`/`.srv` this phase. |
| 0002-workspace (worktree) | Yes | Work in `feature/issue-141` worktree; PR to `jazzy`. |

## Consequences

| If we change... | Also update... | Included? |
|---|---|---|
| Add new package | `core_ws` build picks it up; README via document-package | Yes |
| Define per-cell record (future `.msg` for query API) | Phase 3 query interface, consumers | No — Phase 3 |
| Persistence format (GeoTIFF tile layout) | Phase 6 sync manifest (`GridIndex`+version) | No — Phase 6 (format chosen to feed it) |

## Open Questions

- ~~gz4d at the GGGS boundary (ADR §D8).~~ **Resolved: #144 (GGGS gz4d→GeoPoint)
  MERGED 2026-06-11** (`426bbd7`); merged into this branch. Phase 1 targets the
  gz4d-free GGGS API.
- ~~Timestamp granularity / precision.~~ **Resolved (review-plan): per-cell, stored
  as `double` (Float64 GeoTIFF band)** — avoids the float ~128 s coarsening without
  per-tile epoch bookkeeping.
- ~~Tile storage = dense.~~ **Resolved: dense, all-`double` (≈22 MB/allocated tile,
  lazily allocated).** Fine at survey scale; a sparse cell map remains the escape
  hatch if very-sparse wide-area coverage shows up (not Phase 1).
- **`reliable` threshold** for `shallowestReliable` — kept **caller-supplied** in
  Phase 1 (no default); the costmap phase will set the policy. (Confirmed acceptable.)

## Estimated Scope

Single PR (`feature/issue-141 → jazzy`). New `marine_bathymetry_store` package
(5 headers, 3 sources, 3 gtests, README) + a one-line `gggs::Level::level()` accessor
in `marine_autonomy`. Independent of the ADR PR (#142) and the mru_transform datum
work; #144 (its prerequisite) is merged.

## Implementation Notes

- **All-`double` tile / Float64 GeoTIFF** (not float): resolves the review-plan
  timestamp-precision finding. A single GeoTIFF has one band data type, so depth and
  uncertainty ride along as Float64 too (lossless). Cost: denser tiles (~22 MB
  allocated), accepted at survey scale; dense→sparse is a future option.
- **Source not stored per-cell**: encoded as the per-layer tile map (and the
  persistence layer subdirectory), so the GeoTIFF is **3 bands, not ADR §D5's 4**.
  Cleaner than a redundant per-cell field; a one-line ADR-0002 §D3/§D5 cross-ref
  addendum (ADR-0012) should record the deviation.
- **`gggs::Level::level()` accessor** added to `marine_autonomy`: the store validates
  that a `CellIndex` passed to `set()` is at the store's level, which needs the level
  number (previously not exposed). Trivial, broadly useful, same repo.
- **`GridIndex` reconstruction on load**: GGGS's `GridIndex(level,row,col)` ctor is
  private (Level-friend), so `loadTile` recovers the grid from the file geotransform
  (`level.gridIndex(center)`) and rejects geotransforms that don't match a grid at the
  store's level — which also catches loading tiles saved at a different level.
- **Depth = ellipsoidal height (up-positive)**, so `shallowestReliable` returns the
  **greatest** height (shallowest/most hazardous), not the minimum. Documented + tested.
