### PR TITLE
Migrate GGGS public API from gz4d to geographic_msgs/GeoPoint

### DIFF
--- a/.agent/work-plans/issue-144/plan.md
+++ b/.agent/work-plans/issue-144/plan.md
@@ -37,7 +37,7 @@ with the ROS-standard `geographic_msgs::msg::GeoPoint` (the `geodesy` convention
 2. **Outputs → `GeoPoint`.** Change return type of `GridIndex::southWestPosition()`,
    `northEastPosition()`, and `CellIndex::position()` from `gz4d::PositionDegrees` to
    `GeoPoint` (built from the existing double corner accessors; can't overload by
-   return type, so this is a direct swap — see Open Questions).
+   return type, so this is a direct swap — decided).
 3. **Bounds input.** `CellAreaIterator(grid, gz4d::BoundsDegrees)` → take two
    `GeoPoint` corners (no external consumer per audit, so minimal blast). Avoid a new
    bespoke bounds type unless needed.
@@ -48,7 +48,7 @@ with the ROS-standard `geographic_msgs::msg::GeoPoint` (the `geodesy` convention
 5. **Update `test_gggs.cpp`** to the new types; **add an antimeridian test** (a
    GeoPoint with lon just past ±180 normalizes correctly).
 
-**B. cube_bathymetry (separate issue + PR in that repo, sensors_ws) — coordinated**
+**B. cube_bathymetry ([cube_bathymetry#41](https://github.com/rolker/cube_bathymetry/issues/41), separate PR, sensors_ws) — coordinated**
 
 6. At `geo_map_sheet.cpp:71-72`, call `gridIndex(min.latitude, min.longitude)` (the
    double overload) instead of passing `gz4d::PositionDegrees`. Audit for any GGGS
@@ -95,17 +95,22 @@ with the ROS-standard `geographic_msgs::msg::GeoPoint` (the `geodesy` convention
 | Drop gz4d from GGGS headers | cube's transitive `gz4d_geo.h` include may vanish | Yes — add explicit include if build shows it |
 | `marine_autonomy` gains `geographic_msgs` dep | rosdep / package.xml | Yes |
 
+## Decisions (resolved 2026-06-10, Roland)
+
+- **Output methods: direct return-type swap.** `southWestPosition()` /
+  `northEastPosition()` / `CellIndex::position()` change return type
+  `gz4d::PositionDegrees → geographic_msgs::msg::GeoPoint`, same names. No
+  deprecated/parallel accessors.
+- **cube_bathymetry tracked by its own issue:**
+  [rolker/cube_bathymetry#41](https://github.com/rolker/cube_bathymetry/issues/41)
+  (`Part of #144`) — separate worktree + PR.
+- **Merge ordering: stage cube ready, merge both together.** No transitional gz4d
+  overloads kept; cube PR is review-clean before the marine_autonomy PR merges, then
+  cube merges immediately after.
+
 ## Open Questions
 
-- **Output methods: direct return-type swap vs new-named accessors?** Recommend the
-  **direct swap** (gz4d::PositionDegrees → GeoPoint on `southWestPosition()` etc.) —
-  trivial, no lingering deprecated API, and no GGGS-return consumers found in cube.
-  Confirm acceptable (it is a breaking signature change cube must move with).
-- **cube_bathymetry issue.** This needs its own issue in the `cube_bathymetry` repo
-  for the lockstep PR (`Part of rolker/unh_marine_autonomy#144`). OK to open it?
-- **Merge ordering.** marine_autonomy PR and cube PR must merge together (cube won't
-  build against the new GGGS API until its conversion lands). Stage cube ready first,
-  then merge both. Acceptable?
+- None outstanding — plan is review-plan-ready.
 
 ## Estimated Scope
 

--- a/.agent/work-plans/issue-144/plan.md
+++ b/.agent/work-plans/issue-144/plan.md
@@ -1,0 +1,114 @@
+# Plan: Replace gz4d types in GGGS public API with geographic_msgs/GeoPoint
+
+## Issue
+
+https://github.com/rolker/unh_marine_autonomy/issues/144 (prerequisite for #141;
+ADR-0002 §D8)
+
+## Context
+
+GGGS (`marine_autonomy` package) exposes two `gz4d` value-types in its public API —
+`gz4d::PositionDegrees` (lat/lon) and `gz4d::BoundsDegrees` (box) — across `Level`,
+`GridIndex`, `CellIndex`, `CellAreaIterator`. Goal: remove `gz4d` from that interface
+so downstream packages stop inheriting the dependency, replacing the position type
+with the ROS-standard `geographic_msgs::msg::GeoPoint` (the `geodesy` convention).
+
+**Two findings that de-risk this:**
+- **The gz4d-typed input methods are already thin wrappers over `(double, double)`
+  primitives.** `Level::gridIndex(double,double)` (level.h:83) is the real worker;
+  `gridIndex(const gz4d::PositionDegrees&)` just calls `gridIndex(p.latitude, p.longitude)`.
+  Same for `cellIndex`. So swapping the typed overload carries no algorithmic risk.
+- **`cube_bathymetry` (sensors_ws) is the only external consumer of the gz4d-typed
+  GGGS API**, and only at two sites (`grid_level_.gridIndex(bounds.minimum()/maximum())`,
+  `geo_map_sheet.cpp:71-72`). It can switch to the `(double,double)` overload it
+  already has the values for. cube's *internal* gz4d (`GeoSounding : public
+  gz4d::PositionDegrees`, `gz4d::BoundsDegrees::radiusFromCenter`) is **out of scope** —
+  that's a separate, deeper cube gz4d-retirement, not forced by this API change.
+
+## Approach
+
+**A. marine_autonomy / GGGS (this issue, this PR)**
+
+1. **Inputs → `GeoPoint`.** Keep the `(double,double)` primitives untouched. Replace
+   the `gz4d::PositionDegrees` input overloads (`Level::gridIndex/cellIndex`,
+   `CellIndex(grid, position)`) with `geographic_msgs::msg::GeoPoint` overloads that
+   **normalize longitude to ±180°** (replicating gz4d's `Angle` wraparound — see
+   Caveat) then delegate to the double primitive.
+2. **Outputs → `GeoPoint`.** Change return type of `GridIndex::southWestPosition()`,
+   `northEastPosition()`, and `CellIndex::position()` from `gz4d::PositionDegrees` to
+   `GeoPoint` (built from the existing double corner accessors; can't overload by
+   return type, so this is a direct swap — see Open Questions).
+3. **Bounds input.** `CellAreaIterator(grid, gz4d::BoundsDegrees)` → take two
+   `GeoPoint` corners (no external consumer per audit, so minimal blast). Avoid a new
+   bespoke bounds type unless needed.
+4. **De-gz4d the four headers' API.** Ensure `cell_index.h`, `grid_index.h`,
+   `level.h`, `cell_area_iterator.h` reference no `gz4d` in signatures. `gz4d_geo.h`
+   stays vendored (still used by `utils.h`); add `geometry/geographic_msgs` dep to
+   `package.xml` + `CMakeLists.txt`.
+5. **Update `test_gggs.cpp`** to the new types; **add an antimeridian test** (a
+   GeoPoint with lon just past ±180 normalizes correctly).
+
+**B. cube_bathymetry (separate issue + PR in that repo, sensors_ws) — coordinated**
+
+6. At `geo_map_sheet.cpp:71-72`, call `gridIndex(min.latitude, min.longitude)` (the
+   double overload) instead of passing `gz4d::PositionDegrees`. Audit for any GGGS
+   *return*-position consumers (none found in grep) and adapt if present.
+7. Add explicit `#include "marine_autonomy/gz4d_geo.h"` if cube's transitive include
+   of it disappears (verify at build; cube keeps internal gz4d).
+8. Build + run cube tests.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `marine_autonomy/include/marine_autonomy/gggs/level.h` | gz4d→GeoPoint input overloads (normalize lon); keep double primitives |
+| `.../gggs/cell_index.h` | `CellIndex(grid, GeoPoint)` ctor + `position()→GeoPoint` |
+| `.../gggs/grid_index.h` | `southWestPosition()/northEastPosition()→GeoPoint` |
+| `.../gggs/cell_area_iterator.h` | bounds ctor takes GeoPoint corners |
+| `marine_autonomy/package.xml`, `CMakeLists.txt` | add `geographic_msgs` dep |
+| `marine_autonomy/test/test_gggs.cpp` | new types + antimeridian normalization test |
+| `cube_bathymetry` (separate repo/PR) | call double `gridIndex` overload; build/test |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Improve incrementally | API swap leans on existing double primitives; cube change is 2 sites. No big rewrite. |
+| Only what's needed | Replaces 2 types; does not chase cube's internal gz4d or the other gz4d copies (marine_nav_utilities, camp). |
+| A change includes its consequences | cube PR lands in lockstep; antimeridian test added for the dropped Angle semantics. |
+| Standards Compliance (project) / ADR-0008 | `geographic_msgs::GeoPoint` is the ROS-standard geo type; no bespoke position type invented. |
+| Test what breaks | Antimeridian normalization is the one real behavior change — explicitly tested. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0002 §D8 (this repo) | Yes | Implements the "migrate GGGS API first" decision; unblocks #141. |
+| Workspace ADR-0008 | Yes | Standard ROS message type; package/CMake conventions; no new ADR needed. |
+| Workspace ADR-0002 (worktree) | Yes | Work in `feature/issue-144` (marine_autonomy) + a cube worktree; PRs to `jazzy`. |
+
+## Consequences
+
+| If we change... | Also update... | Included? |
+|---|---|---|
+| GGGS public API (gz4d→GeoPoint) | `cube_bathymetry` (only external consumer) | Yes — coordinated PR (needs its own cube issue) |
+| Drop gz4d from GGGS headers | cube's transitive `gz4d_geo.h` include may vanish | Yes — add explicit include if build shows it |
+| `marine_autonomy` gains `geographic_msgs` dep | rosdep / package.xml | Yes |
+
+## Open Questions
+
+- **Output methods: direct return-type swap vs new-named accessors?** Recommend the
+  **direct swap** (gz4d::PositionDegrees → GeoPoint on `southWestPosition()` etc.) —
+  trivial, no lingering deprecated API, and no GGGS-return consumers found in cube.
+  Confirm acceptable (it is a breaking signature change cube must move with).
+- **cube_bathymetry issue.** This needs its own issue in the `cube_bathymetry` repo
+  for the lockstep PR (`Part of rolker/unh_marine_autonomy#144`). OK to open it?
+- **Merge ordering.** marine_autonomy PR and cube PR must merge together (cube won't
+  build against the new GGGS API until its conversion lands). Stage cube ready first,
+  then merge both. Acceptable?
+
+## Estimated Scope
+
+**Two coordinated PRs** (one per repo): `marine_autonomy` (this issue, the bulk) +
+`cube_bathymetry` (small, ~2 call sites). Each modest; the cross-repo coordination is
+the only complexity. Unblocks #141.

--- a/.agent/work-plans/issue-144/plan.md
+++ b/.agent/work-plans/issue-144/plan.md
@@ -19,11 +19,14 @@ with the ROS-standard `geographic_msgs::msg::GeoPoint` (the `geodesy` convention
   `gridIndex(const gz4d::PositionDegrees&)` just calls `gridIndex(p.latitude, p.longitude)`.
   Same for `cellIndex`. So swapping the typed overload carries no algorithmic risk.
 - **`cube_bathymetry` (sensors_ws) is the only external consumer of the gz4d-typed
-  GGGS API**, and only at two sites (`grid_level_.gridIndex(bounds.minimum()/maximum())`,
-  `geo_map_sheet.cpp:71-72`). It can switch to the `(double,double)` overload it
-  already has the values for. cube's *internal* gz4d (`GeoSounding : public
+  GGGS API** (verified: `marine_nav` and `camp` use gz4d but never the GGGS
+  Position/Bounds API). It consumes it at **three** sites in two files:
+  `geo_map_sheet.cpp:71-72` (`gridIndex(min/max)`) and `geo_grid.cpp:73,77` (the CUBE
+  insert hot loop — `CellAreaIterator(grid, BoundsDegrees)` ctor **and**
+  `CellIndex::position().distanceFrom(...)`, which relies on a gz4d-only method).
+  See §B for the per-site migration. cube's *internal* gz4d (`GeoSounding : public
   gz4d::PositionDegrees`, `gz4d::BoundsDegrees::radiusFromCenter`) is **out of scope** —
-  that's a separate, deeper cube gz4d-retirement, not forced by this API change.
+  a separate, deeper cube gz4d-retirement, not forced by this API change.
 
 ## Approach
 
@@ -39,23 +42,39 @@ with the ROS-standard `geographic_msgs::msg::GeoPoint` (the `geodesy` convention
    `GeoPoint` (built from the existing double corner accessors; can't overload by
    return type, so this is a direct swap — decided).
 3. **Bounds input.** `CellAreaIterator(grid, gz4d::BoundsDegrees)` → take two
-   `GeoPoint` corners (no external consumer per audit, so minimal blast). Avoid a new
-   bespoke bounds type unless needed.
+   `GeoPoint` corners. **This ctor IS consumed externally** — `cube_bathymetry`
+   `geo_grid.cpp:73` constructs it (handled in §B). Avoid a new bespoke bounds type
+   unless needed.
 4. **De-gz4d the four headers' API.** Ensure `cell_index.h`, `grid_index.h`,
    `level.h`, `cell_area_iterator.h` reference no `gz4d` in signatures. `gz4d_geo.h`
-   stays vendored (still used by `utils.h`); add `geometry/geographic_msgs` dep to
-   `package.xml` + `CMakeLists.txt`.
+   stays vendored (still used by `utils.h`). `geographic_msgs` is **already** a
+   marine_autonomy dependency (`CMakeLists.txt:13` `find_package` +
+   `ament_export_dependencies`) — just verify `package.xml` lists it; no dep to add.
 5. **Update `test_gggs.cpp`** to the new types; **add an antimeridian test** (a
    GeoPoint with lon just past ±180 normalizes correctly).
 
 **B. cube_bathymetry ([cube_bathymetry#41](https://github.com/rolker/cube_bathymetry/issues/41), separate PR, sensors_ws) — coordinated**
 
-6. At `geo_map_sheet.cpp:71-72`, call `gridIndex(min.latitude, min.longitude)` (the
-   double overload) instead of passing `gz4d::PositionDegrees`. Audit for any GGGS
-   *return*-position consumers (none found in grep) and adapt if present.
-7. Add explicit `#include "marine_autonomy/gz4d_geo.h"` if cube's transitive include
-   of it disappears (verify at build; cube keeps internal gz4d).
-8. Build + run cube tests.
+6. **`geo_map_sheet.cpp:71-72`** — call `gridIndex(min.latitude, min.longitude)` (the
+   double overload) instead of passing `gz4d::PositionDegrees`.
+7. **`geo_grid.cpp:73,77`** (the CUBE insert hot loop) — this site consumes **both**
+   changing APIs and must be migrated:
+   - line 73: `gggs::CellAreaIterator i(index_, bounds)` where `bounds` is
+     `gz4d::BoundsDegrees::radiusFromCenter(...)` → construct the iterator from two
+     `GeoPoint` corners (derive from cube's radius/center; cube keeps its internal
+     gz4d for `radiusFromCenter` if convenient, converting corners to `GeoPoint` at
+     the ctor call).
+   - line 77: `i->position().distanceFrom(geo_sounding)` — `CellIndex::position()`
+     now returns `GeoPoint`, which has no `distanceFrom`. Replace with **`geodesy`'s
+     Vincenty inverse** (`geodesy/geodesics.h` → `AzimuthDistance{azimuth, distance}`),
+     computing metres between the cell `GeoPoint` and `geo_sounding`. This advances
+     the gz4d retirement rather than re-introducing a gz4d convert, and discharges
+     ADR-0002 §D8's "confirm geodesy exposes the needed functions."
+8. Add explicit `#include "marine_autonomy/gz4d_geo.h"` if cube's transitive include
+   of it disappears (verify at build; cube keeps internal gz4d for `GeoSounding` /
+   `radiusFromCenter`).
+9. Build + run cube tests; confirm the distance values match (Vincenty vs gz4d's
+   `ellipsoid::inverse`, both WGS84 — should agree to numerical tolerance).
 
 ## Files to Change
 
@@ -65,15 +84,16 @@ with the ROS-standard `geographic_msgs::msg::GeoPoint` (the `geodesy` convention
 | `.../gggs/cell_index.h` | `CellIndex(grid, GeoPoint)` ctor + `position()→GeoPoint` |
 | `.../gggs/grid_index.h` | `southWestPosition()/northEastPosition()→GeoPoint` |
 | `.../gggs/cell_area_iterator.h` | bounds ctor takes GeoPoint corners |
-| `marine_autonomy/package.xml`, `CMakeLists.txt` | add `geographic_msgs` dep |
+| `marine_autonomy/package.xml` | verify `geographic_msgs` listed (already in `CMakeLists.txt`) |
 | `marine_autonomy/test/test_gggs.cpp` | new types + antimeridian normalization test |
-| `cube_bathymetry` (separate repo/PR) | call double `gridIndex` overload; build/test |
+| `cube_bathymetry/src/geo_map_sheet.cpp` (separate PR) | `gridIndex` double overload at :71-72 |
+| `cube_bathymetry/src/geo_grid.cpp` (separate PR) | `CellAreaIterator` GeoPoint-corner ctor (:73) + `distanceFrom`→geodesy Vincenty inverse (:77) |
 
 ## Principles Self-Check
 
 | Principle | Consideration |
 |---|---|
-| Improve incrementally | API swap leans on existing double primitives; cube change is 2 sites. No big rewrite. |
+| Improve incrementally | API swap leans on existing double primitives; cube change is 3 sites in 2 files. No big rewrite. |
 | Only what's needed | Replaces 2 types; does not chase cube's internal gz4d or the other gz4d copies (marine_nav_utilities, camp). |
 | A change includes its consequences | cube PR lands in lockstep; antimeridian test added for the dropped Angle semantics. |
 | Standards Compliance (project) / ADR-0008 | `geographic_msgs::GeoPoint` is the ROS-standard geo type; no bespoke position type invented. |
@@ -91,9 +111,9 @@ with the ROS-standard `geographic_msgs::msg::GeoPoint` (the `geodesy` convention
 
 | If we change... | Also update... | Included? |
 |---|---|---|
-| GGGS public API (gz4d→GeoPoint) | `cube_bathymetry` (only external consumer) | Yes — coordinated PR (needs its own cube issue) |
+| GGGS public API (gz4d→GeoPoint) | `cube_bathymetry` (only external consumer; 3 sites, incl. `distanceFrom`→geodesy Vincenty) | Yes — coordinated PR ([cube#41](https://github.com/rolker/cube_bathymetry/issues/41)) |
 | Drop gz4d from GGGS headers | cube's transitive `gz4d_geo.h` include may vanish | Yes — add explicit include if build shows it |
-| `marine_autonomy` gains `geographic_msgs` dep | rosdep / package.xml | Yes |
+| `marine_autonomy` uses `GeoPoint` in public headers | `geographic_msgs` — already a dep (verify package.xml) | Yes |
 
 ## Decisions (resolved 2026-06-10, Roland)
 
@@ -115,5 +135,6 @@ with the ROS-standard `geographic_msgs::msg::GeoPoint` (the `geodesy` convention
 ## Estimated Scope
 
 **Two coordinated PRs** (one per repo): `marine_autonomy` (this issue, the bulk) +
-`cube_bathymetry` (small, ~2 call sites). Each modest; the cross-repo coordination is
-the only complexity. Unblocks #141.
+`cube_bathymetry` (3 sites in 2 files; the `distanceFrom`→geodesy Vincenty swap is the
+only non-mechanical part). Each modest; cross-repo coordination is the main complexity.
+Unblocks #141.

--- a/.agent/work-plans/issue-144/plan.md
+++ b/.agent/work-plans/issue-144/plan.md
@@ -34,9 +34,13 @@ with the ROS-standard `geographic_msgs::msg::GeoPoint` (the `geodesy` convention
 
 1. **Inputs → `GeoPoint`.** Keep the `(double,double)` primitives untouched. Replace
    the `gz4d::PositionDegrees` input overloads (`Level::gridIndex/cellIndex`,
-   `CellIndex(grid, position)`) with `geographic_msgs::msg::GeoPoint` overloads that
-   **normalize longitude to ±180°** (replicating gz4d's `Angle` wraparound — see
-   Caveat) then delegate to the double primitive.
+   `CellIndex(grid, position)`) with `geographic_msgs::msg::GeoPoint` overloads.
+   **Longitude normalization** (replicating gz4d's `Angle` wraparound — see Caveat):
+   `gridIndex(double,double)` already wrapped longitude into [-180,180), refactored to
+   a shared `gggs::normalizeLongitude()` helper (in `core.h`); the `CellIndex(grid,
+   GeoPoint)` ctor now applies the same wrap (its column math previously relied on the
+   angle type self-normalizing). A `gggs::geoPoint(lat, lon)` builder also lives in
+   `core.h`.
 2. **Outputs → `GeoPoint`.** Change return type of `GridIndex::southWestPosition()`,
    `northEastPosition()`, and `CellIndex::position()` from `gz4d::PositionDegrees` to
    `GeoPoint` (built from the existing double corner accessors; can't overload by
@@ -45,11 +49,13 @@ with the ROS-standard `geographic_msgs::msg::GeoPoint` (the `geodesy` convention
    `GeoPoint` corners. **This ctor IS consumed externally** — `cube_bathymetry`
    `geo_grid.cpp:73` constructs it (handled in §B). Avoid a new bespoke bounds type
    unless needed.
-4. **De-gz4d the four headers' API.** Ensure `cell_index.h`, `grid_index.h`,
-   `level.h`, `cell_area_iterator.h` reference no `gz4d` in signatures. `gz4d_geo.h`
-   stays vendored (still used by `utils.h`). `geographic_msgs` is **already** a
-   marine_autonomy dependency (`CMakeLists.txt:13` `find_package` +
-   `ament_export_dependencies`) — just verify `package.xml` lists it; no dep to add.
+4. **De-gz4d the four headers' API.** `cell_index.h`, `grid_index.h`, `level.h`,
+   `cell_area_iterator.h` (+ the `gggs.h` doc example) reference no `gz4d` in
+   signatures. `gz4d_geo.h` stays vendored (still used by `utils.h`). **Dependency
+   fix:** `geographic_msgs` was in `CMakeLists.txt` (`find_package` +
+   `ament_export_dependencies`) but **missing from `package.xml` `<depend>` and from
+   the target's `target_link_libraries`** — added both (`${geographic_msgs_TARGETS}`)
+   so the `GeoPoint` headers resolve for the library and its consumers.
 5. **Update `test_gggs.cpp`** to the new types; **add an antimeridian test** (a
    GeoPoint with lon just past ±180 normalizes correctly).
 
@@ -80,12 +86,15 @@ with the ROS-standard `geographic_msgs::msg::GeoPoint` (the `geodesy` convention
 
 | File | Change |
 |------|--------|
-| `marine_autonomy/include/marine_autonomy/gggs/level.h` | gz4d→GeoPoint input overloads (normalize lon); keep double primitives |
-| `.../gggs/cell_index.h` | `CellIndex(grid, GeoPoint)` ctor + `position()→GeoPoint` |
+| `.../gggs/core.h` | add `geoPoint()` + `normalizeLongitude()` helpers + `geo_point.hpp` include |
+| `.../gggs/level.h` | gz4d→GeoPoint input overloads; double primitive uses `normalizeLongitude()` |
+| `.../gggs/cell_index.h` | `CellIndex(grid, GeoPoint)` ctor (normalizes lon) + `position()→GeoPoint` |
 | `.../gggs/grid_index.h` | `southWestPosition()/northEastPosition()→GeoPoint` |
-| `.../gggs/cell_area_iterator.h` | bounds ctor takes GeoPoint corners |
-| `marine_autonomy/package.xml` | verify `geographic_msgs` listed (already in `CMakeLists.txt`) |
-| `marine_autonomy/test/test_gggs.cpp` | new types + antimeridian normalization test |
+| `.../gggs/cell_area_iterator.h` | bounds ctor takes two `GeoPoint` corners |
+| `.../gggs.h` | doc-example uses `geoPoint()` |
+| `marine_autonomy/package.xml` | add `<depend>geographic_msgs</depend>` (was missing) |
+| `marine_autonomy/CMakeLists.txt` | add `${geographic_msgs_TARGETS}` to `target_link_libraries` (was missing) |
+| `marine_autonomy/test/test_gggs.cpp` | new types + `geoPoint`/`normalizeLongitude`/antimeridian tests |
 | `cube_bathymetry/src/geo_map_sheet.cpp` (separate PR) | `gridIndex` double overload at :71-72 |
 | `cube_bathymetry/src/geo_grid.cpp` (separate PR) | `CellAreaIterator` GeoPoint-corner ctor (:73) + `distanceFrom`→geodesy Vincenty inverse (:77) |
 

--- a/.agent/work-plans/issue-144/progress.md
+++ b/.agent/work-plans/issue-144/progress.md
@@ -28,6 +28,6 @@ issue: 144
 **Verdict**: changes-requested
 
 ### Findings
-- [ ] (must-fix) cube `geo_grid.cpp:73,77` consumes BOTH changing APIs — `CellAreaIterator(grid, BoundsDegrees)` ctor and `CellIndex::position()` return, then calls `gz4d::Position::distanceFrom` (GeoPoint has none). Won't compile post-swap. Add to cube #41 scope; pick local-gz4d-convert vs geodesy Vincenty inverse. — `plan.md` §B
-- [ ] (must-fix) Correct the false "no external consumer per audit" (CellAreaIterator) and "none found" (return positions) claims in plan §B + Files-to-Change AND in the cube_bathymetry#41 issue body. — `plan.md` §B
-- [ ] (suggestion) `geographic_msgs` is already a marine_autonomy dep (CMakeLists find_package + ament_export_dependencies) — downgrade the "add dep" step to "verify package.xml". — `plan.md` Approach step 4 / Files-to-Change
+- [x] (must-fix) cube `geo_grid.cpp:73,77` consumes BOTH changing APIs — `CellAreaIterator(grid, BoundsDegrees)` ctor and `CellIndex::position()` return, then calls `gz4d::Position::distanceFrom` (GeoPoint has none). Won't compile post-swap. **Resolved (`9baacf9`): both sites added to plan §B + cube #41 scope; distance → geodesy Vincenty inverse (Roland's call).**
+- [x] (must-fix) Correct the false "no external consumer per audit" (CellAreaIterator) and "none found" (return positions) claims. **Resolved (`9baacf9`): plan Context/§B/Files-to-Change corrected; cube_bathymetry#41 issue body corrected.**
+- [x] (suggestion) `geographic_msgs` already a marine_autonomy dep. **Resolved (`9baacf9`): plan downgraded to "verify package.xml".**

--- a/.agent/work-plans/issue-144/progress.md
+++ b/.agent/work-plans/issue-144/progress.md
@@ -31,3 +31,21 @@ issue: 144
 - [x] (must-fix) cube `geo_grid.cpp:73,77` consumes BOTH changing APIs — `CellAreaIterator(grid, BoundsDegrees)` ctor and `CellIndex::position()` return, then calls `gz4d::Position::distanceFrom` (GeoPoint has none). Won't compile post-swap. **Resolved (`9baacf9`): both sites added to plan §B + cube #41 scope; distance → geodesy Vincenty inverse (Roland's call).**
 - [x] (must-fix) Correct the false "no external consumer per audit" (CellAreaIterator) and "none found" (return positions) claims. **Resolved (`9baacf9`): plan Context/§B/Files-to-Change corrected; cube_bathymetry#41 issue body corrected.**
 - [x] (suggestion) `geographic_msgs` already a marine_autonomy dep. **Resolved (`9baacf9`): plan downgraded to "verify package.xml".**
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-11 (America/New_York)
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved (must-fix found and fixed in-session)
+
+**Branch**: feature/issue-144 at `55ae896`
+**Mode**: pre-push
+**Depth**: Standard (reason: cross-layer shared-API migration, ~160 code lines)
+**Must-fix**: 1 | **Suggestions**: 2
+
+### Findings
+- [x] (must-fix, cross-confirmed Claude+Copilot) `CellAreaIterator(grid, min, max)` read corner longitudes raw while `gridIndex`/`CellIndex` normalized — antimeridian asymmetry, wrongly rejected >180° bounds as empty. **Fixed (`55ae896`): `normalizeLongitude()` on both corners + regression test.** — `cell_area_iterator.h`
+- [ ] (suggestion) Direct `CellIndex(grid, GeoPoint)` no longer throws on |lat|>90 (old gz4d threw); silently clamps row to edge. Entry points (`gridIndex`/`cellIndex`) still guard; internal `CellAreaIterator` pre-clamps. Low impact — left as-is. — `cell_index.h:66-81`
+- [ ] (suggestion) `CellIndex(grid, GeoPoint)` at exactly lon 180.0 → -180.0 (half-open convention), opposite column vs old at an antimeridian-abutting grid. Consistent with `gridIndex` normalization; defensible. — `cell_index.h:72`
+
+**Static analysis**: only pre-existing ament-cpplint style (PROJECT11_ guards, non-explicit ctors, namespace terminators, >100-char lines); no new violations introduced by this diff.

--- a/.agent/work-plans/issue-144/progress.md
+++ b/.agent/work-plans/issue-144/progress.md
@@ -59,3 +59,19 @@ issue: 144
 **cube_bathymetry (lockstep)**: [rolker/cube_bathymetry#42](https://github.com/rolker/cube_bathymetry/pull/42) (closes cube#41), branch `feature/issue-41`. geo_map_sheet `gridIndex` double overload; geo_grid `CellAreaIterator` GeoPoint corners + `distanceFrom`→`geodesy::wgs84::inverse`; geodesy dep added. Built against this branch's marine_autonomy (overlay); 221 cube tests pass incl. `test_geo_grid.MultipleSoundingsConverge` (distance-equivalence evidence).
 
 **Merge order**: merge #145, then #42 immediately after. Per Roland's rule, wait for a clean Copilot round on #145 before merging.
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-11 (America/New_York)
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**PR**: #145 at `91fe906` (Copilot review at `ef78c12`; delta = progress.md only, comment still current)
+**Sources**: 2 (Copilot R1 @ `ef78c12`; Local Review (Pre-Push) @ `ef78c12`)
+**Cross-source confirmations**: 0
+**CI**: all-pass (build ✅)
+
+### Findings
+- [ ] No actionable findings — single Copilot comment classified false positive; ready to merge-together with cube #42.
+
+### False positives
+- (Copilot) `CMakeLists.txt:35` `${geographic_msgs_TARGETS}` "may be undefined / won't propagate, prefer ament_target_dependencies" — disproven: it's the rosidl-standard variable defined by `find_package(geographic_msgs)` on Jazzy (verified in the package's cmake config) and the modern/Rolling idiom; CI `build` passed and `test_gggs` compiled; cube_bathymetry built against this target and compiled `GeoPoint` usage (downstream propagation confirmed); also internally consistent with the file's namespaced-target style. No change.

--- a/.agent/work-plans/issue-144/progress.md
+++ b/.agent/work-plans/issue-144/progress.md
@@ -49,3 +49,13 @@ issue: 144
 - [ ] (suggestion) `CellIndex(grid, GeoPoint)` at exactly lon 180.0 → -180.0 (half-open convention), opposite column vs old at an antimeridian-abutting grid. Consistent with `gridIndex` normalization; defensible. — `cell_index.h:72`
 
 **Static analysis**: only pre-existing ament-cpplint style (PROJECT11_ guards, non-explicit ctors, namespace terminators, >100-char lines); no new violations introduced by this diff.
+
+## Implementation
+**Status**: complete (both sides implemented; awaiting review + merge-together)
+**When**: 2026-06-11 (America/New_York)
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**marine_autonomy (this PR)**: GGGS API gz4d→GeoPoint. PR #145 (draft), head `ef78c12` pushed. Build + 132 tests pass.
+**cube_bathymetry (lockstep)**: [rolker/cube_bathymetry#42](https://github.com/rolker/cube_bathymetry/pull/42) (closes cube#41), branch `feature/issue-41`. geo_map_sheet `gridIndex` double overload; geo_grid `CellAreaIterator` GeoPoint corners + `distanceFrom`→`geodesy::wgs84::inverse`; geodesy dep added. Built against this branch's marine_autonomy (overlay); 221 cube tests pass incl. `test_geo_grid.MultipleSoundingsConverge` (distance-equivalence evidence).
+
+**Merge order**: merge #145, then #42 immediately after. Per Roland's rule, wait for a clean Copilot round on #145 before merging.

--- a/.agent/work-plans/issue-144/progress.md
+++ b/.agent/work-plans/issue-144/progress.md
@@ -1,0 +1,19 @@
+---
+issue: 144
+---
+
+# Issue #144 — Replace gz4d types in GGGS public API with geographic_msgs/GeoPoint
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-10 (America/New_York)
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Plan**: `.agent/work-plans/issue-144/plan.md` at `59e38bf`
+**PR**: https://github.com/rolker/unh_marine_autonomy/pull/145 (`[PLAN]` prefix)
+**Phases**: two coordinated PRs (marine_autonomy + cube_bathymetry)
+
+### Open questions
+- [ ] Output methods: direct return-type swap (gz4d→GeoPoint on southWestPosition()/position()) vs new-named accessors — recommend direct swap (no GGGS-return consumers found in cube). Confirm.
+- [ ] Open a `cube_bathymetry` issue for the lockstep conversion PR (`Part of #144`)?
+- [ ] Merge ordering: stage cube PR ready, then merge both together (cube won't build against new GGGS API until its PR lands). Acceptable?

--- a/.agent/work-plans/issue-144/progress.md
+++ b/.agent/work-plans/issue-144/progress.md
@@ -17,3 +17,17 @@ issue: 144
 - [x] Output methods → **direct return-type swap** (gz4d→GeoPoint, same names). Decided 2026-06-10.
 - [x] cube lockstep → own issue **rolker/cube_bathymetry#41** (`Part of #144`). Decided 2026-06-10.
 - [x] Merge ordering → **stage cube ready, merge both together**; no transitional gz4d overloads. Decided 2026-06-10.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-06-10 (America/New_York)
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context)) (in-context — author self-review)
+
+**Plan**: `.agent/work-plans/issue-144/plan.md` at `0dc33f9`
+**PR**: https://github.com/rolker/unh_marine_autonomy/pull/145
+**Verdict**: changes-requested
+
+### Findings
+- [ ] (must-fix) cube `geo_grid.cpp:73,77` consumes BOTH changing APIs — `CellAreaIterator(grid, BoundsDegrees)` ctor and `CellIndex::position()` return, then calls `gz4d::Position::distanceFrom` (GeoPoint has none). Won't compile post-swap. Add to cube #41 scope; pick local-gz4d-convert vs geodesy Vincenty inverse. — `plan.md` §B
+- [ ] (must-fix) Correct the false "no external consumer per audit" (CellAreaIterator) and "none found" (return positions) claims in plan §B + Files-to-Change AND in the cube_bathymetry#41 issue body. — `plan.md` §B
+- [ ] (suggestion) `geographic_msgs` is already a marine_autonomy dep (CMakeLists find_package + ament_export_dependencies) — downgrade the "add dep" step to "verify package.xml". — `plan.md` Approach step 4 / Files-to-Change

--- a/.agent/work-plans/issue-144/progress.md
+++ b/.agent/work-plans/issue-144/progress.md
@@ -14,6 +14,6 @@ issue: 144
 **Phases**: two coordinated PRs (marine_autonomy + cube_bathymetry)
 
 ### Open questions
-- [ ] Output methods: direct return-type swap (gz4d→GeoPoint on southWestPosition()/position()) vs new-named accessors — recommend direct swap (no GGGS-return consumers found in cube). Confirm.
-- [ ] Open a `cube_bathymetry` issue for the lockstep conversion PR (`Part of #144`)?
-- [ ] Merge ordering: stage cube PR ready, then merge both together (cube won't build against new GGGS API until its PR lands). Acceptable?
+- [x] Output methods → **direct return-type swap** (gz4d→GeoPoint, same names). Decided 2026-06-10.
+- [x] cube lockstep → own issue **rolker/cube_bathymetry#41** (`Part of #144`). Decided 2026-06-10.
+- [x] Merge ordering → **stage cube ready, merge both together**; no transitional gz4d overloads. Decided 2026-06-10.

--- a/marine_autonomy/CMakeLists.txt
+++ b/marine_autonomy/CMakeLists.txt
@@ -30,6 +30,7 @@ target_include_directories(${PROJECT_NAME}
     "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
 )
 target_link_libraries(${PROJECT_NAME} PUBLIC
+  ${geographic_msgs_TARGETS}
   rclcpp::rclcpp
   rclcpp_lifecycle::rclcpp_lifecycle
   tf2::tf2

--- a/marine_autonomy/include/marine_autonomy/gggs.h
+++ b/marine_autonomy/include/marine_autonomy/gggs.h
@@ -41,8 +41,7 @@
 /// auto grid = level.gridIndex(43.07, -70.76);
 ///
 /// // Get the specific cell within that grid
-/// gz4d::PositionDegrees pos(43.07, -70.76);
-/// auto cell = level.cellIndex(pos);
+/// auto cell = level.cellIndex(gggs::geoPoint(43.07, -70.76));
 ///
 /// // Iterate over all grids in a bounding box
 /// auto from = level.gridIndex(43.0, -71.0);

--- a/marine_autonomy/include/marine_autonomy/gggs/cell_area_iterator.h
+++ b/marine_autonomy/include/marine_autonomy/gggs/cell_area_iterator.h
@@ -64,10 +64,15 @@ public:
     const geographic_msgs::msg::GeoPoint& maximum)
   {
     // Extract bound coordinates as doubles for comparison with grid edges.
+    // Normalize each corner's longitude into [-180, 180) so the
+    // outside-grid checks and clamp below compare against grid edges on the
+    // same scale — matching gridIndex() and the CellIndex(grid, GeoPoint)
+    // ctor. (GeoPoint, unlike the previous angle-aware type, does not
+    // self-normalize, so a corner at e.g. 181° must be read as -179°.)
     double min_lat = minimum.latitude;
     double max_lat = maximum.latitude;
-    double min_lon = minimum.longitude;
-    double max_lon = maximum.longitude;
+    double min_lon = normalizeLongitude(minimum.longitude);
+    double max_lon = normalizeLongitude(maximum.longitude);
 
     // Check if bounds are entirely outside the grid in any direction.
     if(max_lat < grid.southLatitude())

--- a/marine_autonomy/include/marine_autonomy/gggs/cell_area_iterator.h
+++ b/marine_autonomy/include/marine_autonomy/gggs/cell_area_iterator.h
@@ -57,14 +57,17 @@ public:
   /// Indices are inclusive — the "to" cell is visited. If the bounds
   /// fall outside the grid, the iterator may be empty (invalid from start).
   /// @param grid The grid to iterate within.
-  /// @param bounds Geographic bounding box to restrict iteration.
-  CellAreaIterator(GridIndex grid, const gz4d::BoundsDegrees& bounds)
+  /// @param minimum South-west corner of the bounding box.
+  /// @param maximum North-east corner of the bounding box.
+  CellAreaIterator(GridIndex grid,
+    const geographic_msgs::msg::GeoPoint& minimum,
+    const geographic_msgs::msg::GeoPoint& maximum)
   {
     // Extract bound coordinates as doubles for comparison with grid edges.
-    double min_lat = bounds.minimum().latitude;
-    double max_lat = bounds.maximum().latitude;
-    double min_lon = bounds.minimum().longitude;
-    double max_lon = bounds.maximum().longitude;
+    double min_lat = minimum.latitude;
+    double max_lat = maximum.latitude;
+    double min_lon = minimum.longitude;
+    double max_lon = maximum.longitude;
 
     // Check if bounds are entirely outside the grid in any direction.
     if(max_lat < grid.southLatitude())
@@ -82,8 +85,8 @@ public:
     double from_lon = std::max(min_lon, grid.westLongitude());
     double to_lon = std::min(max_lon, grid.eastLongitude());
 
-    from_ = CellIndex(grid, gz4d::PositionDegrees(from_lat, from_lon));
-    to_ = CellIndex(grid, gz4d::PositionDegrees(to_lat, to_lon));
+    from_ = CellIndex(grid, geoPoint(from_lat, from_lon));
+    to_ = CellIndex(grid, geoPoint(to_lat, to_lon));
     current_ = from_;
   }
 

--- a/marine_autonomy/include/marine_autonomy/gggs/cell_index.h
+++ b/marine_autonomy/include/marine_autonomy/gggs/cell_index.h
@@ -63,16 +63,20 @@ public:
   /// @brief Construct a CellIndex from a geographic position within a grid.
   /// @param grid The grid containing the position.
   /// @param position Geographic coordinates (latitude, longitude).
-  CellIndex(GridIndex grid, const gz4d::PositionDegrees &position):
+  CellIndex(GridIndex grid, const geographic_msgs::msg::GeoPoint &position):
     grid_index_(grid)
   {
+    // Wrap longitude into [-180, 180) so positions near the antimeridian
+    // resolve relative to the grid's western edge (GeoPoint, unlike the
+    // previous angle-aware type, does not self-normalize).
+    const double longitude = normalizeLongitude(position.longitude);
 
     // Note, we constrain to 1.0, but what we really need is up to 1.0.
     double row_p = std::max(0.0, std::min(1.0, (position.latitude-grid_index_.southLatitude())/grid_index_.latitudinalSpan()));
     // This std::min should filter out 1.0 from above
     row_ = std::min<uint16_t>(cell_rows_per_grid-1, cell_rows_per_grid*row_p);
 
-    double column_p = std::max(0.0, (position.longitude-grid_index_.westLongitude())/grid_index_.longitudinalSpan());
+    double column_p = std::max(0.0, (longitude-grid_index_.westLongitude())/grid_index_.longitudinalSpan());
     column_ = std::min<uint16_t>(cell_columns_per_grid-1, cell_columns_per_grid*column_p);
   }
 
@@ -104,13 +108,13 @@ public:
 
   /// @brief Compute the geographic position of this cell's south-west corner.
   /// @return Position in degrees.
-  gz4d::PositionDegrees position() const
+  geographic_msgs::msg::GeoPoint position() const
   {
     double row_p = row_/double(cell_rows_per_grid);
     double column_p = column_/double(cell_columns_per_grid);
     auto latitude = grid_index_.southLatitude()+row_p*grid_index_.latitudinalSpan();
     auto longitude = grid_index_.westLongitude()+column_p*grid_index_.longitudinalSpan();
-    return gz4d::PositionDegrees(latitude, longitude);
+    return geoPoint(latitude, longitude);
   }
 
   /// Less than operator allowing use as std::map key.

--- a/marine_autonomy/include/marine_autonomy/gggs/core.h
+++ b/marine_autonomy/include/marine_autonomy/gggs/core.h
@@ -33,6 +33,8 @@
 #include <cmath>
 #include <sstream>
 
+#include <geographic_msgs/msg/geo_point.hpp>
+
 #include "marine_autonomy/utils.h"
 
 /// @file core.h
@@ -98,6 +100,35 @@ inline uint8_t latitudeScaleFactor(double latitude)
   if (std::abs(latitude) < 80.0)
     return 3;
   return 9;
+}
+
+/// @brief Wrap a longitude in degrees into the half-open range [-180, 180).
+///
+/// GGGS positions are carried as plain doubles / @c geographic_msgs::msg::GeoPoint,
+/// which (unlike the previous angle-aware type) do not self-normalize. This
+/// helper restores that behavior at the API boundary so positions near the
+/// antimeridian resolve to the correct grid and cell.
+/// @param longitude Longitude in degrees (any range).
+/// @return Equivalent longitude in [-180, 180).
+inline double normalizeLongitude(double longitude)
+{
+  longitude = std::fmod(longitude + 180.0, 360.0);
+  if (longitude < 0.0)
+    longitude += 360.0;
+  return longitude - 180.0;
+}
+
+/// @brief Build a @c geographic_msgs::msg::GeoPoint from latitude/longitude.
+/// @param latitude Latitude in degrees.
+/// @param longitude Longitude in degrees.
+/// @return GeoPoint with the given latitude/longitude and altitude 0.
+inline geographic_msgs::msg::GeoPoint geoPoint(double latitude, double longitude)
+{
+  geographic_msgs::msg::GeoPoint point;
+  point.latitude = latitude;
+  point.longitude = longitude;
+  point.altitude = 0.0;
+  return point;
 }
 
 /// @brief Verify that two GGGS objects are at the same quadtree level.

--- a/marine_autonomy/include/marine_autonomy/gggs/grid_index.h
+++ b/marine_autonomy/include/marine_autonomy/gggs/grid_index.h
@@ -104,14 +104,14 @@ public:
     return -180.0+column_*levels[level_].gridLongitudinalSpan(row_);
   }
 
-  gz4d::PositionDegrees southWestPosition() const
+  geographic_msgs::msg::GeoPoint southWestPosition() const
   {
-    return gz4d::PositionDegrees(southLatitude(), westLongitude());
+    return geoPoint(southLatitude(), westLongitude());
   }
 
-  gz4d::PositionDegrees northEastPosition() const
+  geographic_msgs::msg::GeoPoint northEastPosition() const
   {
-    return gz4d::PositionDegrees(northLatitude(), eastLongitude());
+    return geoPoint(northLatitude(), eastLongitude());
   }
 
   double latitudinalSpan() const

--- a/marine_autonomy/include/marine_autonomy/gggs/level.h
+++ b/marine_autonomy/include/marine_autonomy/gggs/level.h
@@ -83,9 +83,7 @@ public:
   GridIndex gridIndex(double latitude, double longitude) const
   {
     // Wrap longitude into [-180, 180).
-    longitude = std::fmod(longitude + 180.0, 360.0);
-    if (longitude < 0.0) longitude += 360.0;
-    longitude -= 180.0;
+    longitude = normalizeLongitude(longitude);
 
     // Clamp latitude for small floating-point overshoot; throw for clearly invalid values.
     constexpr double lat_epsilon = 1e-6;
@@ -101,13 +99,13 @@ public:
   }
 
   /// @brief Get the GridIndex containing the given position.
-  GridIndex gridIndex(const gz4d::PositionDegrees & position) const
+  GridIndex gridIndex(const geographic_msgs::msg::GeoPoint & position) const
   {
     return gridIndex(position.latitude, position.longitude);
   }
 
   /// @brief Get the CellIndex for a position (grid + cell within that grid).
-  CellIndex cellIndex(const gz4d::PositionDegrees & position) const
+  CellIndex cellIndex(const geographic_msgs::msg::GeoPoint & position) const
   {
     return CellIndex(gridIndex(position), position);
   }

--- a/marine_autonomy/package.xml
+++ b/marine_autonomy/package.xml
@@ -9,6 +9,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
+  <depend>geographic_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>marine_interfaces</depend>
   <depend>rclpy</depend>

--- a/marine_autonomy/test/test_gggs.cpp
+++ b/marine_autonomy/test/test_gggs.cpp
@@ -865,6 +865,37 @@ TEST(GGGSAntimeridian, CellIndexNormalizesLongitude)
   EXPECT_EQ(wrapped, direct);
 }
 
+// The CellAreaIterator bounds ctor must normalize its corner longitudes too,
+// matching gridIndex() and the CellIndex(grid, GeoPoint) ctor. Corners shifted
+// by a full turn (+360°) must iterate the identical cells, not be rejected as
+// outside the grid. (Regression: the iterator originally read raw longitudes
+// while the other two paths normalized — an antimeridian asymmetry.)
+TEST(GGGSAntimeridian, CellAreaIteratorNormalizesCornerLongitude)
+{
+  gggs::Level level(5);
+  auto gi = level.gridIndex(43.0, -70.5);
+  // Interior fractions of the grid (deliberately off cell boundaries so a
+  // +360° round-trip's floating-point rounding can't nudge a corner into an
+  // adjacent cell). Before the iterator ctor normalized its corners, the
+  // raw >180° longitudes were rejected as "east of grid" → empty iterator.
+  const double lat0 = gi.southLatitude() + gi.latitudinalSpan() * 0.317;
+  const double lat1 = gi.southLatitude() + gi.latitudinalSpan() * 0.583;
+  const double lon0 = gi.westLongitude() + gi.longitudinalSpan() * 0.317;
+  const double lon1 = gi.westLongitude() + gi.longitudinalSpan() * 0.583;
+
+  gggs::CellAreaIterator ref(gi, gggs::geoPoint(lat0, lon0), gggs::geoPoint(lat1, lon1));
+  gggs::CellAreaIterator wrapped(gi,
+    gggs::geoPoint(lat0, lon0 + 360.0), gggs::geoPoint(lat1, lon1 + 360.0));
+
+  uint32_t ref_count = 0;
+  if (ref.valid()) { ref_count = 1; while (ref.next()) ref_count++; }
+  uint32_t wrapped_count = 0;
+  if (wrapped.valid()) { wrapped_count = 1; while (wrapped.next()) wrapped_count++; }
+
+  EXPECT_GT(ref_count, 0u);
+  EXPECT_EQ(wrapped_count, ref_count);
+}
+
 // Bug 6: CellIndex public constructor now asserts on out-of-bounds row/column.
 // After Bug 5, no internal code passes out-of-bounds values.
 TEST(GGGSCellIndex, OutOfBoundsRowAssertsInDebug)

--- a/marine_autonomy/test/test_gggs.cpp
+++ b/marine_autonomy/test/test_gggs.cpp
@@ -381,7 +381,7 @@ TEST(GGGSCellIndex, ConstructFromGridIsValid)
 TEST(GGGSCellIndex, PositionRoundTrip)
 {
   gggs::Level level(5);
-  gz4d::PositionDegrees pos(43.0, -70.5);
+  auto pos = gggs::geoPoint(43.0, -70.5);
   auto ci = level.cellIndex(pos);
   EXPECT_TRUE(ci.valid());
 
@@ -396,7 +396,7 @@ TEST(GGGSCellIndex, PositionRoundTrip)
 TEST(GGGSCellIndex, RowColumnWithinBounds)
 {
   gggs::Level level(5);
-  gz4d::PositionDegrees pos(43.0, -70.5);
+  auto pos = gggs::geoPoint(43.0, -70.5);
   auto ci = level.cellIndex(pos);
   EXPECT_LT(ci.row(), gggs::cell_rows_per_grid);
   EXPECT_LT(ci.column(), gggs::cell_columns_per_grid);
@@ -420,7 +420,7 @@ TEST(GGGSCellIndex, EdgesConsistent)
 TEST(GGGSCellIndex, EqualityForSameCell)
 {
   gggs::Level level(5);
-  gz4d::PositionDegrees pos(43.0, -70.5);
+  auto pos = gggs::geoPoint(43.0, -70.5);
   auto ci1 = level.cellIndex(pos);
   auto ci2 = level.cellIndex(pos);
   EXPECT_TRUE(ci1 == ci2);
@@ -534,8 +534,7 @@ TEST(GGGSCellAreaIterator, SingleCell)
   // position() returns the SW corner of the cell, which when used to create
   // a new CellIndex, may map to the cell below/left due to floating-point
   // truncation. The CellIndex from position maps to (99, 199).
-  gz4d::BoundsDegrees bounds(pos, pos);
-  gggs::CellAreaIterator it(gi, bounds);
+  gggs::CellAreaIterator it(gi, pos, pos);
   EXPECT_TRUE(it.valid());
   EXPECT_EQ(it->row(), 99);
   EXPECT_EQ(it->column(), 199);
@@ -549,8 +548,7 @@ TEST(GGGSCellAreaIterator, SubRegion)
   // Create bounds that span a portion of the grid
   auto sw = gggs::CellIndex(gi, 10, 20).position();
   auto ne = gggs::CellIndex(gi, 14, 24).position();
-  gz4d::BoundsDegrees bounds(sw, ne);
-  gggs::CellAreaIterator it(gi, bounds);
+  gggs::CellAreaIterator it(gi, sw, ne);
 
   uint32_t count = 0;
   if (it.valid())
@@ -568,8 +566,7 @@ TEST(GGGSCellAreaIterator, Reset)
   auto gi = level.gridIndex(43.0, -70.5);
   gggs::CellIndex ci(gi, 100, 200);
   auto pos = ci.position();
-  gz4d::BoundsDegrees bounds(pos, pos);
-  gggs::CellAreaIterator it(gi, bounds);
+  gggs::CellAreaIterator it(gi, pos, pos);
   EXPECT_TRUE(it.valid());
   it.next();
   EXPECT_FALSE(it.valid());
@@ -700,7 +697,7 @@ TEST(GGGSCellIndex, PositionConstructorLevel0)
   ASSERT_TRUE(gi.valid());
   double south = gi.southLatitude();
   // Position 4° above the south edge of the grid
-  gz4d::PositionDegrees pos(south + 4.0, gi.westLongitude() + 1.0);
+  auto pos = gggs::geoPoint(south + 4.0, gi.westLongitude() + 1.0);
   gggs::CellIndex ci(gi, pos);
   ASSERT_TRUE(ci.valid());
   // 4° into an 8° span = 50% → row ≈ 480
@@ -779,10 +776,9 @@ TEST(GGGSCellAreaIterator, BoundsEntirelyBelowGrid)
   auto gi = level.gridIndex(43.0, -70.5);
   // Create bounds entirely south of the grid
   double south = gi.southLatitude();
-  gz4d::PositionDegrees sw(south - 2.0, gi.westLongitude());
-  gz4d::PositionDegrees ne(south - 1.0, gi.eastLongitude());
-  gz4d::BoundsDegrees bounds(sw, ne);
-  gggs::CellAreaIterator it(gi, bounds);
+  auto sw = gggs::geoPoint(south - 2.0, gi.westLongitude());
+  auto ne = gggs::geoPoint(south - 1.0, gi.eastLongitude());
+  gggs::CellAreaIterator it(gi, sw, ne);
   EXPECT_FALSE(it.valid());
 }
 
@@ -791,10 +787,9 @@ TEST(GGGSCellAreaIterator, BoundsEntirelyAboveGrid)
   gggs::Level level(5);
   auto gi = level.gridIndex(43.0, -70.5);
   double north = gi.northLatitude();
-  gz4d::PositionDegrees sw(north + 1.0, gi.westLongitude());
-  gz4d::PositionDegrees ne(north + 2.0, gi.eastLongitude());
-  gz4d::BoundsDegrees bounds(sw, ne);
-  gggs::CellAreaIterator it(gi, bounds);
+  auto sw = gggs::geoPoint(north + 1.0, gi.westLongitude());
+  auto ne = gggs::geoPoint(north + 2.0, gi.eastLongitude());
+  gggs::CellAreaIterator it(gi, sw, ne);
   EXPECT_FALSE(it.valid());
 }
 
@@ -803,10 +798,9 @@ TEST(GGGSCellAreaIterator, BoundsEntirelyLeftOfGrid)
   gggs::Level level(5);
   auto gi = level.gridIndex(43.0, -70.5);
   double west = gi.westLongitude();
-  gz4d::PositionDegrees sw(gi.southLatitude(), west - 2.0);
-  gz4d::PositionDegrees ne(gi.northLatitude(), west - 1.0);
-  gz4d::BoundsDegrees bounds(sw, ne);
-  gggs::CellAreaIterator it(gi, bounds);
+  auto sw = gggs::geoPoint(gi.southLatitude(), west - 2.0);
+  auto ne = gggs::geoPoint(gi.northLatitude(), west - 1.0);
+  gggs::CellAreaIterator it(gi, sw, ne);
   EXPECT_FALSE(it.valid());
 }
 
@@ -815,11 +809,60 @@ TEST(GGGSCellAreaIterator, BoundsEntirelyRightOfGrid)
   gggs::Level level(5);
   auto gi = level.gridIndex(43.0, -70.5);
   double east = gi.eastLongitude();
-  gz4d::PositionDegrees sw(gi.southLatitude(), east + 1.0);
-  gz4d::PositionDegrees ne(gi.northLatitude(), east + 2.0);
-  gz4d::BoundsDegrees bounds(sw, ne);
-  gggs::CellAreaIterator it(gi, bounds);
+  auto sw = gggs::geoPoint(gi.southLatitude(), east + 1.0);
+  auto ne = gggs::geoPoint(gi.northLatitude(), east + 2.0);
+  gggs::CellAreaIterator it(gi, sw, ne);
   EXPECT_FALSE(it.valid());
+}
+
+// ============================================================================
+// core.h — geoPoint / normalizeLongitude helpers and antimeridian handling
+// ============================================================================
+
+TEST(GGGSCore, GeoPointSetsFields)
+{
+  auto p = gggs::geoPoint(43.0, -70.5);
+  EXPECT_DOUBLE_EQ(p.latitude, 43.0);
+  EXPECT_DOUBLE_EQ(p.longitude, -70.5);
+  EXPECT_DOUBLE_EQ(p.altitude, 0.0);
+}
+
+TEST(GGGSCore, NormalizeLongitudeWraps)
+{
+  // In-range values are unchanged.
+  EXPECT_DOUBLE_EQ(gggs::normalizeLongitude(-70.5), -70.5);
+  EXPECT_DOUBLE_EQ(gggs::normalizeLongitude(0.0), 0.0);
+  EXPECT_DOUBLE_EQ(gggs::normalizeLongitude(179.0), 179.0);
+  // Just past the antimeridian wraps to the western hemisphere and vice versa.
+  EXPECT_DOUBLE_EQ(gggs::normalizeLongitude(181.0), -179.0);
+  EXPECT_DOUBLE_EQ(gggs::normalizeLongitude(-181.0), 179.0);
+  // The half-open convention: ±180 maps to -180.
+  EXPECT_DOUBLE_EQ(gggs::normalizeLongitude(180.0), -180.0);
+  EXPECT_DOUBLE_EQ(gggs::normalizeLongitude(-180.0), -180.0);
+  // Multiple wraps.
+  EXPECT_DOUBLE_EQ(gggs::normalizeLongitude(540.0 + 1.0), -179.0);
+}
+
+// The previous angle-aware position type self-normalized longitude; GeoPoint
+// does not, so the GGGS API must restore that behavior at its boundary. An
+// un-normalized longitude must resolve to the same grid/cell as its wrapped
+// equivalent.
+TEST(GGGSAntimeridian, GridIndexNormalizesLongitude)
+{
+  gggs::Level level(5);
+  auto wrapped = level.gridIndex(43.0, 181.0);
+  auto direct = level.gridIndex(43.0, -179.0);
+  EXPECT_TRUE(wrapped.valid());
+  EXPECT_EQ(wrapped, direct);
+}
+
+TEST(GGGSAntimeridian, CellIndexNormalizesLongitude)
+{
+  gggs::Level level(5);
+  auto wrapped = level.cellIndex(gggs::geoPoint(43.0, 181.0));
+  auto direct = level.cellIndex(gggs::geoPoint(43.0, -179.0));
+  EXPECT_TRUE(wrapped.valid());
+  EXPECT_EQ(wrapped, direct);
 }
 
 // Bug 6: CellIndex public constructor now asserts on out-of-bounds row/column.


### PR DESCRIPTION
Closes #144

# Plan: Replace gz4d types in GGGS public API with geographic_msgs/GeoPoint

## Issue

https://github.com/rolker/unh_marine_autonomy/issues/144 (prerequisite for #141;
ADR-0002 §D8)

## Context

GGGS (`marine_autonomy` package) exposes two `gz4d` value-types in its public API —
`gz4d::PositionDegrees` (lat/lon) and `gz4d::BoundsDegrees` (box) — across `Level`,
`GridIndex`, `CellIndex`, `CellAreaIterator`. Goal: remove `gz4d` from that interface
so downstream packages stop inheriting the dependency, replacing the position type
with the ROS-standard `geographic_msgs::msg::GeoPoint` (the `geodesy` convention).

**Two findings that de-risk this:**
- **The gz4d-typed input methods are already thin wrappers over `(double, double)`
  primitives.** `Level::gridIndex(double,double)` (level.h:83) is the real worker;
  `gridIndex(const gz4d::PositionDegrees&)` just calls `gridIndex(p.latitude, p.longitude)`.
  Same for `cellIndex`. So swapping the typed overload carries no algorithmic risk.
- **`cube_bathymetry` (sensors_ws) is the only external consumer of the gz4d-typed
  GGGS API** (verified: `marine_nav` and `camp` use gz4d but never the GGGS
  Position/Bounds API). It consumes it at **three** sites in two files:
  `geo_map_sheet.cpp:71-72` (`gridIndex(min/max)`) and `geo_grid.cpp:73,77` (the CUBE
  insert hot loop — `CellAreaIterator(grid, BoundsDegrees)` ctor **and**
  `CellIndex::position().distanceFrom(...)`, which relies on a gz4d-only method).
  See §B for the per-site migration. cube's *internal* gz4d (`GeoSounding : public
  gz4d::PositionDegrees`, `gz4d::BoundsDegrees::radiusFromCenter`) is **out of scope** —
  a separate, deeper cube gz4d-retirement, not forced by this API change.

## Approach

**A. marine_autonomy / GGGS (this issue, this PR)**

1. **Inputs → `GeoPoint`.** Keep the `(double,double)` primitives untouched. Replace
   the `gz4d::PositionDegrees` input overloads (`Level::gridIndex/cellIndex`,
   `CellIndex(grid, position)`) with `geographic_msgs::msg::GeoPoint` overloads that
   **normalize longitude to ±180°** (replicating gz4d's `Angle` wraparound — see
   Caveat) then delegate to the double primitive.
2. **Outputs → `GeoPoint`.** Change return type of `GridIndex::southWestPosition()`,
   `northEastPosition()`, and `CellIndex::position()` from `gz4d::PositionDegrees` to
   `GeoPoint` (built from the existing double corner accessors; can't overload by
   return type, so this is a direct swap — decided).
3. **Bounds input.** `CellAreaIterator(grid, gz4d::BoundsDegrees)` → take two
   `GeoPoint` corners. **This ctor IS consumed externally** — `cube_bathymetry`
   `geo_grid.cpp:73` constructs it (handled in §B). Avoid a new bespoke bounds type
   unless needed.
4. **De-gz4d the four headers' API.** Ensure `cell_index.h`, `grid_index.h`,
   `level.h`, `cell_area_iterator.h` reference no `gz4d` in signatures. `gz4d_geo.h`
   stays vendored (still used by `utils.h`). `geographic_msgs` is **already** a
   marine_autonomy dependency (`CMakeLists.txt:13` `find_package` +
   `ament_export_dependencies`) — just verify `package.xml` lists it; no dep to add.
5. **Update `test_gggs.cpp`** to the new types; **add an antimeridian test** (a
   GeoPoint with lon just past ±180 normalizes correctly).

**B. cube_bathymetry ([cube_bathymetry#41](https://github.com/rolker/cube_bathymetry/issues/41), separate PR, sensors_ws) — coordinated**

6. **`geo_map_sheet.cpp:71-72`** — call `gridIndex(min.latitude, min.longitude)` (the
   double overload) instead of passing `gz4d::PositionDegrees`.
7. **`geo_grid.cpp:73,77`** (the CUBE insert hot loop) — this site consumes **both**
   changing APIs and must be migrated:
   - line 73: `gggs::CellAreaIterator i(index_, bounds)` where `bounds` is
     `gz4d::BoundsDegrees::radiusFromCenter(...)` → construct the iterator from two
     `GeoPoint` corners (derive from cube's radius/center; cube keeps its internal
     gz4d for `radiusFromCenter` if convenient, converting corners to `GeoPoint` at
     the ctor call).
   - line 77: `i->position().distanceFrom(geo_sounding)` — `CellIndex::position()`
     now returns `GeoPoint`, which has no `distanceFrom`. Replace with **`geodesy`'s
     Vincenty inverse** (`geodesy/geodesics.h` → `AzimuthDistance{azimuth, distance}`),
     computing metres between the cell `GeoPoint` and `geo_sounding`. This advances
     the gz4d retirement rather than re-introducing a gz4d convert, and discharges
     ADR-0002 §D8's "confirm geodesy exposes the needed functions."
8. Add explicit `#include "marine_autonomy/gz4d_geo.h"` if cube's transitive include
   of it disappears (verify at build; cube keeps internal gz4d for `GeoSounding` /
   `radiusFromCenter`).
9. Build + run cube tests; confirm the distance values match (Vincenty vs gz4d's
   `ellipsoid::inverse`, both WGS84 — should agree to numerical tolerance).

## Files to Change

| File | Change |
|------|--------|
| `marine_autonomy/include/marine_autonomy/gggs/level.h` | gz4d→GeoPoint input overloads (normalize lon); keep double primitives |
| `.../gggs/cell_index.h` | `CellIndex(grid, GeoPoint)` ctor + `position()→GeoPoint` |
| `.../gggs/grid_index.h` | `southWestPosition()/northEastPosition()→GeoPoint` |
| `.../gggs/cell_area_iterator.h` | bounds ctor takes GeoPoint corners |
| `marine_autonomy/package.xml` | verify `geographic_msgs` listed (already in `CMakeLists.txt`) |
| `marine_autonomy/test/test_gggs.cpp` | new types + antimeridian normalization test |
| `cube_bathymetry/src/geo_map_sheet.cpp` (separate PR) | `gridIndex` double overload at :71-72 |
| `cube_bathymetry/src/geo_grid.cpp` (separate PR) | `CellAreaIterator` GeoPoint-corner ctor (:73) + `distanceFrom`→geodesy Vincenty inverse (:77) |

## Principles Self-Check

| Principle | Consideration |
|---|---|
| Improve incrementally | API swap leans on existing double primitives; cube change is 3 sites in 2 files. No big rewrite. |
| Only what's needed | Replaces 2 types; does not chase cube's internal gz4d or the other gz4d copies (marine_nav_utilities, camp). |
| A change includes its consequences | cube PR lands in lockstep; antimeridian test added for the dropped Angle semantics. |
| Standards Compliance (project) / ADR-0008 | `geographic_msgs::GeoPoint` is the ROS-standard geo type; no bespoke position type invented. |
| Test what breaks | Antimeridian normalization is the one real behavior change — explicitly tested. |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| ADR-0002 §D8 (this repo) | Yes | Implements the "migrate GGGS API first" decision; unblocks #141. |
| Workspace ADR-0008 | Yes | Standard ROS message type; package/CMake conventions; no new ADR needed. |
| Workspace ADR-0002 (worktree) | Yes | Work in `feature/issue-144` (marine_autonomy) + a cube worktree; PRs to `jazzy`. |

## Consequences

| If we change... | Also update... | Included? |
|---|---|---|
| GGGS public API (gz4d→GeoPoint) | `cube_bathymetry` (only external consumer; 3 sites, incl. `distanceFrom`→geodesy Vincenty) | Yes — coordinated PR ([cube#41](https://github.com/rolker/cube_bathymetry/issues/41)) |
| Drop gz4d from GGGS headers | cube's transitive `gz4d_geo.h` include may vanish | Yes — add explicit include if build shows it |
| `marine_autonomy` uses `GeoPoint` in public headers | `geographic_msgs` — already a dep (verify package.xml) | Yes |

## Decisions (resolved 2026-06-10, Roland)

- **Output methods: direct return-type swap.** `southWestPosition()` /
  `northEastPosition()` / `CellIndex::position()` change return type
  `gz4d::PositionDegrees → geographic_msgs::msg::GeoPoint`, same names. No
  deprecated/parallel accessors.
- **cube_bathymetry tracked by its own issue:**
  [rolker/cube_bathymetry#41](https://github.com/rolker/cube_bathymetry/issues/41)
  (`Part of #144`) — separate worktree + PR.
- **Merge ordering: stage cube ready, merge both together.** No transitional gz4d
  overloads kept; cube PR is review-clean before the marine_autonomy PR merges, then
  cube merges immediately after.

## Open Questions

- None outstanding — plan is review-plan-ready.

## Estimated Scope

**Two coordinated PRs** (one per repo): `marine_autonomy` (this issue, the bulk) +
`cube_bathymetry` (3 sites in 2 files; the `distanceFrom`→geodesy Vincenty swap is the
only non-mechanical part). Each modest; cross-repo coordination is the main complexity.
Unblocks #141.
