### PR TITLE
Bathymetric store Phase 2: epoch-model imports (ADR-0002 A1 + importers)

### DIFF
--- a/.agent/work-plans/issue-147/progress.md
+++ b/.agent/work-plans/issue-147/progress.md
@@ -176,3 +176,14 @@ its public API.
 
 ### False positives
 - (none)
+
+## Post-PR Review — PR #148 @ 75528a4fd — 2026-06-14 (coordinator-dispatched reviewer; Copilot quota out)
+
+**Verdict: CHANGES NEEDED.** The epoch model, GeoTIFF importer, error handling, and provenance immutability are high quality and well-tested. Blockers are timing/contract:
+
+- **M1 (must-fix): single-level store/query contradicts the now-merged multi-level ADR (#151 / ADR amendment #153).** Hard-coded single level throughout: `requireGridAtLevel` throws on off-level tiles (set/importEpoch/getOrCreateTile); `forEachCellBestSource`/`bestSource`/`shallowestReliable` resolve within one `store.level()` only; `tile_io::loadTile` + `importGeoTiff` pin to `store.level()` and the test `LoadRejectsTilesFromAnotherLevel` bakes in behavior the ADR now forbids. Per #151 this is "mostly removing the single-`level_` assumption + single-level query iteration" — must land the level-aware best-available query before A2/B2 consumers lock onto it this week.
+- **M2 (must-fix): in-PR ADR copy (Amendment A1) predates #153** and still says single-level; merge `jazzy` and reconcile A1 with the D2 heterogeneous-levels paragraph (epoch dirs compose with mixed-level `<GridIndex>` filenames — state it).
+- **M3 (must-fix): PR marked Ready but body says "Draft until importers land";** GeoMapSheet (live path) + bag-replay importers and the cross-session 1/σ² fusion rule are unimplemented (CMakeLists builds only geotiff_import). Split to "epoch + GeoTIFF import" with follow-on issues, or finish — and fix the stale body so scope is legible.
+- Nits: signature Model says `Fable 5` (cosmetic); consider a coverage-change iterator (cells in exactly one epoch) as a follow-on for survey QC.
+
+Full strengths confirmed: datum-at-import (depth_scale/offset before write), zero/neg-uncertainty guard, GDAL error surfacing before clearing dirty, CRLF-safe provenance sidecar, supersedes_disk stale-tile cleanup — all tested.

--- a/.agent/work-plans/issue-147/progress.md
+++ b/.agent/work-plans/issue-147/progress.md
@@ -144,3 +144,35 @@ tool (adding epoch-tagged store import per ADR-0002 A1) rather than starting
 from scratch. Note layering: the store cannot depend on cube (ADR-0002), so the
 harness lives cube-side or as a bridge package, importing into the store via
 its public API.
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-13 05:17 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**PR**: #148 at `a5a2824`
+**Sources**: 1 (Copilot @ `a5a2824`)
+**Cross-source confirmations**: 0 (no prior Local Review entries on the timeline)
+**CI**: all-pass (build success)
+
+### Findings
+- [x] (high, Copilot) `readProvenance()` treated a CRLF sidecar (`\r`) as a parse
+  failure → silently downgraded a Replayed epoch to LiveFused, allowing live writes
+  over replayed data after reload — `src/tile_io.cpp`. Fixed: trim trailing
+  whitespace + CRLF round-trip regression test.
+- [x] (med, Copilot) `importEpoch()` validated the map key grid but not that the
+  tile was built for the same grid → file-name/georef mismatch corruption on
+  `load()` — `src/bathymetry_store.cpp`. Fixed: explicit `tile.index() == grid`
+  check (throws) + test.
+- [x] (med, Copilot) `import_geotiff` called `provenanceFromToken()` unguarded →
+  uncaught `std::invalid_argument` on bad CLI input — `src/import_geotiff_main.cpp`.
+  Fixed: guard parse, print expected values, exit 1 (matches `layerFromName`).
+- [x] (med, Copilot) `writeTestTiff()` dereferenced GDAL driver/dataset with no
+  null-check → test-runner crash on GDAL failure; also missing `<stdexcept>` —
+  `test/test_geotiff_import.cpp`. Fixed: null-checks that throw + explicit include.
+- [x] (low, Copilot) `DepthSample` doc said "tagged with its provenance" but the
+  struct carries source + epoch — `include/marine_bathymetry_store/query.hpp`.
+  Fixed: reworded comment.
+
+### False positives
+- (none)

--- a/.agent/work-plans/issue-147/progress.md
+++ b/.agent/work-plans/issue-147/progress.md
@@ -71,6 +71,28 @@ evenings, dev replays the day's bags → compacted epoch → copied back (Phase-
 sync later). The concrete path + `store_dir` parameter land in `bizzyboat.yaml`
 with the Phase-3 node — record it as a config item in that sub-issue.
 
+### Distribution transport decision (Roland, 2026-06-12) — for the Phase-6 sub-issue
+
+Per ADR-0002 §D6, robot and operator each hold a **full independent store**;
+sync is manifest-diff (`{layer/epoch/GridIndex → content-hash}`), single-writer
+per epoch (draft = boat-produced, processed = operator/dev-produced — no merge
+case), and epochs are immutable after compaction so only today's live-fused
+epoch is ever hot. Transport in two stages:
+
+- **Interim / dockside: rsync (or plain cp).** The store is directories of
+  immutable files — rsync is already a correct sync protocol for it, zero
+  code. Compacted epochs ride the evening bag-offload, copy back the same way.
+- **Phase 6 / underway: ROS-msg protocol over udp_bridge.** During ops
+  udp_bridge is the managed link (rate-limited, prioritized); a node pair does
+  manifest exchange + tile chunks as messages, idempotent by content-hash.
+  "rsync semantics, udp_bridge transport." This is the bounded, change-only
+  payload that durably fixes the unh_echoboats_project11#250 monolithic-grid
+  downlink failure (`clear_grid` stays the interim until then).
+
+Nothing in the tile format, layout, or epoch rules changes for Phase 6 — the
+sync layer is additive, and camp#90's directory watcher works identically
+whichever transport filled the operator store.
+
 ### Tooling gotchas found driving the corpus (2026-06-12)
 
 - `detections_to_pointcloud` is a **lifecycle node**: replay harnesses must

--- a/.agent/work-plans/issue-147/progress.md
+++ b/.agent/work-plans/issue-147/progress.md
@@ -187,3 +187,50 @@ its public API.
 - Nits: signature Model says `Fable 5` (cosmetic); consider a coverage-change iterator (cells in exactly one epoch) as a follow-on for survey QC.
 
 Full strengths confirmed: datum-at-import (depth_scale/offset before write), zero/neg-uncertainty guard, GDAL error surfacing before clearing dirty, CRLF-safe provenance sidecar, supersedes_disk stale-tile cleanup — all tested.
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-14 10:42 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**PR**: #148 at `5922b7b`
+**Sources**: 3 (Copilot R1 @ `a5a2824`, Post-PR Review @ `75528a4`, CI rollup @ `5922b7b`)
+**Cross-source confirmations**: 0 (Copilot's code-hardening set and the Post-PR contract/timing set do not overlap)
+**CI**: all-pass (build success @ `5922b7b`)
+
+Round 2 of triage. Copilot R1's 6 inline comments were already integrated and
+fixed in the prior `## Integrated Review` (@ `a5a2824`, commits `0d25fef`..`99c03ca`);
+re-verified addressed at current head. Copilot R2 @ `75528a4` returned no comments
+(reviewer quota exhausted). The live open items are the local Post-PR Review's
+three must-fix blockers (contract/timing, not code-quality), verified against
+current code below.
+
+### Findings
+- [ ] (M1, high, Post-PR Review) Store/query are hard-coded single-level, contradicting
+  the now-merged multi-level ADR amendment (jazzy `0d27447` "store holds heterogeneous
+  GGGS levels", #151/#153). `requireGridAtLevel` throws on off-level grids
+  (`set`/`importEpoch`/`getOrCreateTile`); `bestSource`/`shallowestReliable`/
+  `forEachCellBestSource` resolve within one `store.level()`; `tile_io::loadTile`
+  + `importGeoTiff` pin to `store.level()`; `test_tile_io.cpp:216
+  LoadRejectsTilesFromAnotherLevel` bakes in the forbidden behavior. Land the
+  level-aware best-available query before A2/B2 consumers lock onto the API —
+  `src/bathymetry_store.cpp`, `src/query.cpp`, `src/geotiff_import.cpp`,
+  `src/tile_io.cpp`, `test/test_tile_io.cpp`.
+- [ ] (M2, high, Post-PR Review) In-PR `docs/decisions/0002-bathymetric-data-store.md`
+  predates the merged heterogeneous-levels amendment — branch is 7 behind jazzy and
+  the ADR copy still carries only the single-level Amendment A1. Merge `jazzy` and
+  reconcile A1 with the D2 heterogeneous-levels paragraph (epoch dirs compose with
+  mixed-level `<GridIndex>` filenames) — `docs/decisions/0002-bathymetric-data-store.md`.
+- [ ] (M3, med, Post-PR Review) PR marked Ready but body says "Draft until the importers
+  land"; CMake builds only `import_geotiff` (no GeoMapSheet live-path or bag-replay
+  importer, no cross-session 1/σ² fusion rule). Either split scope to "epoch + GeoTIFF
+  import" with follow-on issues for the remaining importers, or finish them — and fix
+  the stale PR body so scope is legible — `marine_bathymetry_store/CMakeLists.txt`, PR body.
+- [ ] (nit, low, Post-PR Review) Follow-on: a coverage-change iterator (cells observed in
+  exactly one epoch) would aid survey QC — enhancement, not a blocker.
+- [ ] (nit, cosmetic, Post-PR Review) Corpus Inventory entry signature says model `Fable 5`
+  — cosmetic, no action required.
+
+### False positives
+- (none) — all Copilot R1 findings were valid and are fixed; the Post-PR blockers all
+  reproduce against current code.

--- a/.agent/work-plans/issue-147/progress.md
+++ b/.agent/work-plans/issue-147/progress.md
@@ -1,0 +1,45 @@
+---
+issue: 147
+---
+
+# Issue #147 — Bathymetric store Phase 2: import (bag-replay, GeoMapSheet, GeoTIFF) with per-day epoch model
+
+## Corpus Inventory
+**Status**: complete
+**When**: 2026-06-11 21:55 -0400
+**By**: Claude Code Agent (Fable 5)
+
+Surveyed `~/data/logs` (144 GB) for ROS-bag M3 multibeam coverage to drive the
+Phase-2 bag-replay importer.
+
+### M3 detection coverage (ROS bags)
+
+| Day | Source | Sessions | M3 det msgs | Hours |
+|-----|--------|----------|-------------|-------|
+| 2026-06-09 | `gabby/logs/bizzy_m3/bag_2026-06-09T14.51.50_m3_detections` | 1 | 55,100 | 1.6 |
+| 2026-06-10 | `gabby/logs/bizzyboat_sonar/2026-06-10T17-57-25+00-00` | 1 | 104,979 | 2.4 |
+| 2026-06-11 | `gabby/logs/bizzyboat_sonar/2026-06-11T{16-30-24,19-29-20}+00-00` | 2 | 253,044 | 3.7 |
+
+Total: **3 days / 4 sessions / 413k SonarDetections messages**. June 11's two
+same-day sessions are a natural test case for the within-epoch cross-session
+fusion rule (ADR-0002 A1.2); the three days exercise the multi-day epoch model.
+
+### Replayability
+
+- June-9 standalone bag is self-contained: `/bizzy/sensors/m3/detections`
+  (SonarDetections) **and** `/bizzy/sensors/m3/soundings` (PointCloud2),
+  `/bizzy/odom`, `/tf` (188k msgs), `/tf_static`, sound speed.
+- June-10/11 sonar-recorder bags carry detections + `/bizzy/odom` + `/tf` +
+  `/tf_static` (no pre-projected soundings topic).
+- 98 of 101 sonar-recorder sessions (Apr 6 – Jun 8) contain **no** M3 topics —
+  M3 recording in bags begins 2026-06-09. Earlier M3 data lives in QINSy
+  projects on mercat (`mercat/QPS-Projects`, not ROS bags) and would enter the
+  store as processed-layer products (BAG/GeoTIFF export), not via bag replay.
+
+### Open verification items (next step)
+
+- [ ] Confirm `/tf` in these bags carries the earth-frame chain needed to
+  georeference a cold CUBE replay (cube pose source = TF + odom per cube#31/#33).
+- [ ] Confirm which input `cube_bathymetry` consumes (SonarDetections vs
+  PointCloud2 soundings) and whether sound-speed is applied upstream or needed
+  at replay.

--- a/.agent/work-plans/issue-147/progress.md
+++ b/.agent/work-plans/issue-147/progress.md
@@ -53,6 +53,35 @@ fusion rule (ADR-0002 A1.2); the three days exercise the multi-day epoch model.
   bag also recorded the pre-projected `soundings` topic; June-10/11 bags need
   the detections→soundings stage re-run.
 
+### Boat layout decision (Roland, 2026-06-12)
+
+Store root is a **sibling of the log root, not nested in it** — bags are the
+append-only raw record, the store is derived working knowledge (re-derivable
+from bags, so no special backup discipline):
+
+```
+<data root>/logs/...                 # existing per-session bags, untouched
+<data root>/bathymetry/store/        # persists across sessions & reboots
+    draft/<date>/                    # today live-fused; past dates compacted
+    processed/<date>/
+```
+
+Flow: underway, live importer (Phase 3) writes `draft/<today>/` incrementally;
+evenings, dev replays the day's bags → compacted epoch → copied back (Phase-6
+sync later). The concrete path + `store_dir` parameter land in `bizzyboat.yaml`
+with the Phase-3 node — record it as a config item in that sub-issue.
+
+### Tooling gotchas found driving the corpus (2026-06-12)
+
+- `detections_to_pointcloud` is a **lifecycle node**: replay harnesses must
+  configure+activate it or it records nothing, silently (cost a 25-min no-op).
+  Conversion script fixed; durable fix is the projection-refactor
+  (rolker/cube_bathymetry#43) which removes the live-replay step entirely.
+- Replay rate is capped (~5x) by the node's best-effort `SensorDataQoS` — no
+  backpressure, silent drops. Same refactor removes the cap (direct bag
+  reader, in-process, deterministic — required for content-hash-stable
+  compaction per ADR-0002 §D6).
+
 ### Key discovery
 
 `cube_bathymetry` already ships **`bag_to_geotiff`** — an offline multi-bag

--- a/.agent/work-plans/issue-147/progress.md
+++ b/.agent/work-plans/issue-147/progress.md
@@ -104,6 +104,35 @@ whichever transport filled the operator store.
   reader, in-process, deterministic — required for content-hash-stable
   compaction per ADR-0002 §D6).
 
+### First end-to-end run (2026-06-12, overnight)
+
+Bags → per-day CUBE replay → `import_geotiff` → epoch store → change maps,
+all real data:
+
+- **Pier store** (`~/data/logs/analysis/2026-06-11_pier_grid/store`): three
+  replayed draft epochs — 2026-06-09 (133,406 cells), -10 (274,573), -11
+  (215,228; both sessions through ONE CUBE run = A1.2 compaction), 8 tiles,
+  15 MB. Conversions ran ≥99.9% faithful at 5x replay.
+- **Change maps**: 09→10 = 59k doubly-observed cells, median +0.08 m,
+  95th |Δ| 0.39 m. 10→11 = 134k cells, median +0.14 m, 95th |Δ| 2.26 m
+  (June-11 includes the sidescan/range-experiment sessions — noisier).
+  Small positive medians look like day-to-day datum/tide residual — exactly
+  the systematic signal the epoch model is meant to expose.
+- **No cross-day combined CUBE run was made — deliberately**: the "all data
+  combined" view is the store's newest-epoch composite (369k cells), per
+  A1.1; fusing days in CUBE would violate the model.
+- **Lake Massabesic store** (`~/data/bathymetry/massabesic/store`):
+  chart/2026-06-12 prior from the CCOMJHC/ccomjhc_project11#55 contour
+  GeoTIFF — 69,157,035 cells, 142 tiles, 242 MB, uncertainty 3.0 m const,
+  `--depth-scale -1`. **OPEN: --depth-offset 0** — chart heights are
+  lake-surface-relative until day-1 M3-vs-prior change-map calibration
+  measures the surface's ellipsoidal height; then re-import (one command).
+- Import guard added en route: non-positive uncertainty = missing (real
+  June-9 product had 5,971 cells with uncertainty 0).
+
+Renders: `pier_epochs_and_change.png`, `june09_pier_0.5m.png` (analysis dir),
+`store_chart_preview.png` (massabesic dir).
+
 ### Key discovery
 
 `cube_bathymetry` already ships **`bag_to_geotiff`** — an offline multi-bag

--- a/.agent/work-plans/issue-147/progress.md
+++ b/.agent/work-plans/issue-147/progress.md
@@ -36,10 +36,31 @@ fusion rule (ADR-0002 A1.2); the three days exercise the multi-day epoch model.
   projects on mercat (`mercat/QPS-Projects`, not ROS bags) and would enter the
   store as processed-layer products (BAG/GeoTIFF export), not via bag replay.
 
-### Open verification items (next step)
+### Verification items — both PASS (2026-06-11)
 
-- [ ] Confirm `/tf` in these bags carries the earth-frame chain needed to
-  georeference a cold CUBE replay (cube pose source = TF + odom per cube#31/#33).
-- [ ] Confirm which input `cube_bathymetry` consumes (SonarDetections vs
-  PointCloud2 soundings) and whether sound-speed is applied upstream or needed
-  at replay.
+- [x] **Earth-frame chain present in bags.** June-10 bag's `/tf` carries
+  `earth -> bizzy/map` plus the full cube pose chain
+  (`bizzy/map -> bizzy/base_link_north_up` level frame,
+  `bizzy/odom -> bizzy/map_tide` tide frame) and `/tf_static` has the sensor
+  mounts (`bizzy/base_link -> bizzy/m3`). A cold replay georeferences from the
+  bag alone. (Boat config: `map_frame: bizzy/map`; georeferencing goes through
+  the ECEF `earth` frame — same pattern `bag_to_geotiff.cpp:280,314` uses.)
+- [x] **Pipeline inputs confirmed.** `detections_to_pointcloud` consumes
+  `SonarDetections` + `Odometry` and produces PointCloud2 `soundings`;
+  `cube_bathymetry_node` consumes `soundings` and transforms into `map_frame`.
+  Sound speed is embedded per-ping (`ping_info.sound_speed` in
+  `SonarDetections`) — no external sound-speed feed needed at replay. June-9
+  bag also recorded the pre-projected `soundings` topic; June-10/11 bags need
+  the detections→soundings stage re-run.
+
+### Key discovery
+
+`cube_bathymetry` already ships **`bag_to_geotiff`** — an offline multi-bag
+reader (merges bags by timestamp, builds a `GeoMapSheet` via the bag's
+earth-frame TF, exports GeoTIFF). The boat config comment confirms the intent:
+"Logging detections lets soundings + grid be re-derived offline by replaying
+through the pipeline." The Phase-2 replay harness should extend or mirror this
+tool (adding epoch-tagged store import per ADR-0002 A1) rather than starting
+from scratch. Note layering: the store cannot depend on cube (ADR-0002), so the
+harness lives cube-side or as a bridge package, importing into the store via
+its public API.

--- a/docs/decisions/0002-bathymetric-data-store.md
+++ b/docs/decisions/0002-bathymetric-data-store.md
@@ -233,9 +233,66 @@ waits on it.
 - **Datum coupling is explicit:** the chart layer cannot land before
   mru_transform#7/#8; isolating it to one layer (D4) keeps the rest moving.
 
+## Amendment A1 — Per-day epochs (2026-06-11)
+
+Decided with Phase 2
+([#147](https://github.com/rolker/unh_marine_autonomy/issues/147)); amends
+D3, D5, D6, and D7. Motivation: repeat surveys of the same area on different
+days carry information in their *differences* (shoaling detection, survey QC);
+a single-valued cell would average that change away or silently discard it.
+
+### A1.1 — Epochs
+
+A **layer is held as dated instances ("epochs"), one per local acquisition
+date**. A cell surveyed on N days keeps N (depth, uncertainty) records — one
+per epoch. **Epochs are never fused across days**; differencing two epochs
+yields a change map, normalized by combined uncertainty. The per-cell record
+(D3) and the 3-band tile GeoTIFF (D5) are unchanged; the epoch is one more
+level of the on-disk encoding alongside the source layer
+(`draft/2026-06-12/<GridIndex>.tif`), and the D6 manifest key generalizes to
+`{layer/epoch/GridIndex → content-hash}`. The day boundary is the local
+acquisition date stored as a **labeled key**, so the span could change later
+without a format migration.
+
+### A1.2 — Within-epoch update rules
+
+- Successive snapshots of the **same** CUBE session are cumulative
+  refinements: plain replace. Grid imports therefore carry a **session
+  identity** tag to distinguish this case from the next.
+- Across **different** live sessions in one epoch (node relaunch, mid-day
+  restart): **variance-weighted fusion (1/σ²)** per cell. This is safe within
+  the epoch by construction — the 1-day span is the declared
+  seafloor-stability window; cross-day change remains visible because epochs
+  are never fused.
+- **End-of-day compaction**: replaying the full day's data through a single
+  CUBE run produces the authoritative epoch, which **supersedes the epoch
+  wholesale** (never per-cell — mixing live-fused and replayed values in one
+  epoch would create a surface with two inconsistent provenances). Provenance
+  ordering: `replayed` beats `live-fused` for the same epoch, never the
+  reverse. Epochs become **immutable after compaction** (not at creation);
+  the D6 content-hash manifest absorbs the one extra sync this implies.
+
+### A1.3 — Queries over epochs
+
+- Default query: **latest epoch** per cell.
+- **Shallowest-reliable (D7) walks epochs newest-first and returns the first
+  value passing the uncertainty gate.** A fresh noisy pass fails the gate and
+  falls through to the prior epoch's confident value, so a recently observed
+  shoal keeps protecting navigation without any cross-epoch fusion.
+
+### A1.4 — CUBE is not seeded with prior epochs (deliberate non-decision)
+
+Estimator-level seeding (initializing CUBE with the previous epoch's surface)
+would anchor each day's estimates to the prior day's, biasing change maps
+toward zero and slow-rolling detection of real change — defeating the purpose
+of A1.1. "Seeding the day's survey" therefore means **query-layer fallback**
+(display, planning, and the costmap read latest-reliable per A1.3), not CUBE
+priors. CUBE starts each day cold; the store provides the continuity.
+
 ## References
 
 - Umbrella / design: [rolker/unh_marine_autonomy#86](https://github.com/rolker/unh_marine_autonomy/issues/86)
+- Phase 2 / epoch model (Amendment A1): [rolker/unh_marine_autonomy#147](https://github.com/rolker/unh_marine_autonomy/issues/147)
 - Datum frames / VDatum: [rolker/mru_transform#8](https://github.com/rolker/mru_transform/issues/8),
   [rolker/mru_transform#7](https://github.com/rolker/mru_transform/issues/7)
 - CUBE draft-tile persistence: [rolker/cube_bathymetry#21](https://github.com/rolker/cube_bathymetry/issues/21)

--- a/marine_bathymetry_store/CMakeLists.txt
+++ b/marine_bathymetry_store/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(GDAL CONFIG REQUIRED)
 
 add_library(${PROJECT_NAME}
   src/bathymetry_store.cpp
+  src/geotiff_import.cpp
   src/query.cpp
   src/tile_io.cpp
 )
@@ -43,12 +44,18 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
 # tree to `include` (not include/${PROJECT_NAME}) to avoid a doubled
 # include/${PROJECT_NAME}/${PROJECT_NAME}/ path; the INSTALL_INTERFACE above is
 # `include` to match.
+add_executable(import_geotiff src/import_geotiff_main.cpp)
+target_link_libraries(import_geotiff ${PROJECT_NAME})
+
 install(DIRECTORY include/ DESTINATION include)
 install(TARGETS ${PROJECT_NAME}
   EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
+)
+install(TARGETS import_geotiff
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
 )
 
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
@@ -67,6 +74,11 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_tile_io test/test_tile_io.cpp)
   target_link_libraries(test_tile_io ${PROJECT_NAME})
+
+  # The test writes synthetic GeoTIFFs itself, so it links GDAL directly
+  # (the library keeps GDAL private).
+  ament_add_gtest(test_geotiff_import test/test_geotiff_import.cpp)
+  target_link_libraries(test_geotiff_import ${PROJECT_NAME} GDAL::GDAL)
 endif()
 
 ament_package()

--- a/marine_bathymetry_store/include/marine_bathymetry_store/bathy_cell.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/bathy_cell.hpp
@@ -37,18 +37,24 @@ namespace marine_bathymetry_store
 /// deliberate, cleaner realization of ADR-0002 §D3's "each cell stores a
 /// source layer": the layer is the map it lives in.
 ///
-/// The numeric value is the priority rank (0 = highest). `Chart` is reserved
-/// for a later phase (it depends on the mru_transform vertical-datum work) and
-/// is intentionally not yet a member.
+/// The numeric value is the priority rank (0 = highest).
+///
+/// `Chart` holds cartographic priors — S57 depths, contour-derived lake
+/// bathymetry — broad but coarse, so it ranks *below* survey data: any
+/// surveyed cell beats it, and it fills cells nothing else covers. Datum
+/// conversion happens at import (ADR-0002 §D4): a constant offset suffices
+/// for lake sources; tidal S57 imports stay gated on the mru_transform
+/// vertical-datum work.
 enum class SourceLayer : uint8_t
 {
   Processed = 0,  ///< Externally produced grids (bathy-BAG / GeoTIFF). Highest confidence.
   Draft = 1,      ///< Real-time CUBE output. Valuable but potentially noisy.
+  Chart = 2,      ///< Cartographic priors (S57 / contour-derived). Broad but coarse.
 };
 
 /// @brief Source layers in descending priority order — iterate for best-source.
-inline constexpr std::array<SourceLayer, 2> source_layers_by_priority{
-  SourceLayer::Processed, SourceLayer::Draft};
+inline constexpr std::array<SourceLayer, 3> source_layers_by_priority{
+  SourceLayer::Processed, SourceLayer::Draft, SourceLayer::Chart};
 
 /// @brief Number of source layers present in this phase.
 inline constexpr std::size_t source_layer_count = source_layers_by_priority.size();

--- a/marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_store.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_store.hpp
@@ -25,25 +25,41 @@
 #include <array>
 #include <map>
 #include <optional>
+#include <utility>
 
 #include "marine_autonomy/gggs.h"
 #include "marine_bathymetry_store/bathy_cell.hpp"
 #include "marine_bathymetry_store/bathymetry_tile.hpp"
+#include "marine_bathymetry_store/epoch.hpp"
 
 namespace marine_bathymetry_store
 {
 
-/// @brief In-memory, GGGS-tiled, multi-layer bathymetric store (Phase 1 core).
+/// @brief One epoch's tile set within a layer, with its provenance.
 ///
-/// Holds one tile map per `SourceLayer`, keyed by `gggs::GridIndex`. All tiles
-/// live at a single GGGS level fixed at construction. Source priority is a
-/// **non-destructive query-time overlay** (see `query.hpp`): the layers are
-/// independent, so a noisy draft write never clobbers a trusted processed cell
-/// and a later processed import never has to merge with draft (ADR-0002 §D3).
+/// `supersedes_disk` is set by a wholesale import (`BathymetryStore::importEpoch`)
+/// and tells persistence that any files previously written for this epoch are
+/// stale and must be removed before saving — a compacted epoch may legitimately
+/// cover fewer grids than the live surface it replaces, and a leftover tile
+/// file would otherwise be silently resurrected on the next load.
+struct EpochTiles
+{
+  Provenance provenance = Provenance::LiveFused;
+  bool supersedes_disk = false;
+  std::map<gggs::GridIndex, BathymetryTile> tiles;
+};
+
+/// @brief In-memory, GGGS-tiled, multi-layer, multi-epoch bathymetric store.
 ///
-/// This phase has no importers, ROS interface, or distribution — just storage,
-/// in-process queries (`query.hpp`), and per-tile GeoTIFF persistence
-/// (`tile_io.hpp`).
+/// Holds, per `SourceLayer`, a map of **epochs** (dated layer instances,
+/// ADR-0002 Amendment A1) each holding a tile map keyed by `gggs::GridIndex`.
+/// All tiles live at a single GGGS level fixed at construction. Source priority
+/// is a **non-destructive query-time overlay** (see `query.hpp`), and epochs
+/// are never fused across days — queries resolve a layer by walking its epochs
+/// newest-first (epoch labels sort chronologically; see `Epoch`).
+///
+/// This phase has no ROS interface or distribution — storage, in-process
+/// queries (`query.hpp`), and per-tile GeoTIFF persistence (`tile_io.hpp`).
 class BathymetryStore
 {
 public:
@@ -71,40 +87,81 @@ public:
     return level_.cellIndex(gggs::geoPoint(latitude, longitude));
   }
 
-  /// @brief Write @p value into @p layer at @p cell.
+  /// @brief Write @p value into @p layer's @p epoch at @p cell (live path).
   ///
-  /// Creates the backing tile on first write to its grid. The cell's grid must
-  /// be at this store's level.
-  /// @throws std::invalid_argument if @p cell is invalid or at the wrong level.
-  void set(SourceLayer layer, const gggs::CellIndex & cell, const BathyCell & value);
+  /// Creates the epoch (as `LiveFused`) and the backing tile on first write.
+  /// The cell's grid must be at this store's level.
+  /// @return `false` (a no-op) if the epoch is already `Replayed`: a compacted
+  ///         epoch is immutable, and a live write must never regress it
+  ///         (ADR-0002 §A1.2 provenance ordering). The caller should log this —
+  ///         it means a live snapshot arrived after the day was compacted.
+  /// @throws std::invalid_argument if @p cell is invalid or at the wrong level,
+  ///         or @p epoch is not a valid label (`validateEpochLabel`).
+  bool set(
+    SourceLayer layer, const Epoch & epoch, const gggs::CellIndex & cell,
+    const BathyCell & value);
 
-  /// @brief Read the raw cell in a single @p layer (no priority overlay).
-  /// @return The cell, or `std::nullopt` if @p layer has no tile for that grid.
+  /// @brief Read the raw cell of one @p epoch in one @p layer (no overlay).
+  /// @return The cell, or `std::nullopt` if the epoch or its tile is absent.
   ///         A returned cell may still be no-data (`!hasData()`).
-  std::optional<BathyCell> get(SourceLayer layer, const gggs::CellIndex & cell) const;
+  std::optional<BathyCell> get(
+    SourceLayer layer, const Epoch & epoch, const gggs::CellIndex & cell) const;
 
-  /// @brief The tiles of a layer (for persistence / iteration).
-  const std::map<gggs::GridIndex, BathymetryTile> & tiles(SourceLayer layer) const
+  /// @brief Replace @p layer's @p epoch wholesale with @p tiles (import path).
+  ///
+  /// Used both for compaction products (@p provenance = `Replayed`: a full-day
+  /// replay superseding the live surface) and for whole-epoch imports such as
+  /// processed GeoTIFFs. All imported tiles are marked dirty and the epoch is
+  /// flagged `supersedes_disk` so persistence removes any stale files first.
+  /// @return `false` (a no-op) if the existing epoch is `Replayed` and
+  ///         @p provenance is `LiveFused` — the §A1.2 ordering: live-fused
+  ///         never replaces replayed. Re-importing at equal-or-higher
+  ///         provenance (e.g. a re-compaction) is allowed.
+  /// @throws std::invalid_argument if @p epoch is not a valid label, or any
+  ///         tile is keyed at the wrong level.
+  bool importEpoch(
+    SourceLayer layer, const Epoch & epoch,
+    std::map<gggs::GridIndex, BathymetryTile> tiles, Provenance provenance);
+
+  /// @brief A layer's epochs, ascending by label (oldest first; `rbegin()` =
+  ///        newest). Empty map if the layer holds no data.
+  const std::map<Epoch, EpochTiles> & epochs(SourceLayer layer) const
   {
     return layerMap(layer);
   }
 
-  /// @brief Find or create the tile for @p grid in @p layer (used by load).
-  /// @throws std::invalid_argument if @p grid is invalid or at the wrong level.
-  BathymetryTile & getOrCreateTile(SourceLayer layer, const gggs::GridIndex & grid);
+  /// @brief Find or create @p epoch in @p layer with @p provenance (load path).
+  ///
+  /// If the epoch already exists its provenance is left unchanged — creation
+  /// is the only time the argument applies.
+  /// @throws std::invalid_argument if @p epoch is not a valid label.
+  EpochTiles & getOrCreateEpoch(
+    SourceLayer layer, const Epoch & epoch, Provenance provenance);
+
+  /// @brief Find or create the tile for @p grid in @p layer's @p epoch.
+  ///
+  /// Creates the epoch (as `LiveFused`) if absent — used by load and by
+  /// persistence to clear dirty flags on existing tiles.
+  /// @throws std::invalid_argument if @p grid is invalid or at the wrong
+  ///         level, or @p epoch is not a valid label.
+  BathymetryTile & getOrCreateTile(
+    SourceLayer layer, const Epoch & epoch, const gggs::GridIndex & grid);
 
 private:
-  std::map<gggs::GridIndex, BathymetryTile> & layerMap(SourceLayer layer)
+  std::map<Epoch, EpochTiles> & layerMap(SourceLayer layer)
   {
     return layers_[static_cast<std::size_t>(layer)];
   }
-  const std::map<gggs::GridIndex, BathymetryTile> & layerMap(SourceLayer layer) const
+  const std::map<Epoch, EpochTiles> & layerMap(SourceLayer layer) const
   {
     return layers_[static_cast<std::size_t>(layer)];
   }
 
+  /// @brief Validate a GridIndex against this store's level (shared guard).
+  void requireGridAtLevel(const gggs::GridIndex & grid, const char * who) const;
+
   gggs::Level level_;
-  std::array<std::map<gggs::GridIndex, BathymetryTile>, source_layer_count> layers_;
+  std::array<std::map<Epoch, EpochTiles>, source_layer_count> layers_;
 };
 
 }  // namespace marine_bathymetry_store

--- a/marine_bathymetry_store/include/marine_bathymetry_store/epoch.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/epoch.hpp
@@ -1,0 +1,102 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef MARINE_BATHYMETRY_STORE__EPOCH_HPP_
+#define MARINE_BATHYMETRY_STORE__EPOCH_HPP_
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+namespace marine_bathymetry_store
+{
+
+/// @brief A dated instance of a source layer (ADR-0002 Amendment A1).
+///
+/// An epoch is a **labeled key**, by convention the local acquisition date in
+/// ISO-8601 form (`"2026-06-10"`). Labels must sort chronologically as plain
+/// strings — ISO dates do — because epoch resolution walks a `std::map` keyed
+/// by this string newest-first. The label is also used as an on-disk directory
+/// name, so it must be filesystem-safe (see `validateEpochLabel`).
+///
+/// Epochs are never fused across days: a cell surveyed on N days keeps N
+/// records, and differencing two epochs yields a change map (A1.1).
+using Epoch = std::string;
+
+/// @brief How an epoch's surface was produced (ADR-0002 §A1.2).
+///
+/// Ordering rule: `Replayed` (the authoritative end-of-day compaction, one
+/// CUBE run over the full day) supersedes `LiveFused` (incrementally merged
+/// live session snapshots) for the same epoch — **never the reverse**. Once
+/// an epoch is `Replayed` it is immutable.
+enum class Provenance : uint8_t
+{
+  LiveFused = 0,  ///< Built incrementally from live session snapshots.
+  Replayed = 1,   ///< Authoritative full-day replay (compaction product).
+};
+
+/// @brief On-disk / manifest token for a provenance (`"live-fused"` / `"replayed"`).
+inline std::string provenanceToken(Provenance provenance)
+{
+  switch (provenance) {
+    case Provenance::LiveFused: return "live-fused";
+    case Provenance::Replayed: return "replayed";
+  }
+  throw std::runtime_error("provenanceToken: unknown Provenance");
+}
+
+/// @brief Parse a provenance token; throws std::invalid_argument on anything else.
+inline Provenance provenanceFromToken(const std::string & token)
+{
+  if (token == "live-fused") {
+    return Provenance::LiveFused;
+  }
+  if (token == "replayed") {
+    return Provenance::Replayed;
+  }
+  throw std::invalid_argument("provenanceFromToken: unknown token '" + token + "'");
+}
+
+/// @brief Throw std::invalid_argument unless @p label is a usable epoch key.
+///
+/// Requires a non-empty label of `[0-9A-Za-z._-]` characters that is neither
+/// `"."` nor `".."` — i.e. safe as a single directory-name component and free
+/// of path separators. (Chronological ordering is a convention the caller
+/// owns: use ISO-8601 dates.)
+inline void validateEpochLabel(const Epoch & label)
+{
+  if (label.empty() || label == "." || label == "..") {
+    throw std::invalid_argument("validateEpochLabel: empty or reserved label");
+  }
+  for (const char c : label) {
+    const bool ok = (c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') ||
+      (c >= 'a' && c <= 'z') || c == '.' || c == '_' || c == '-';
+    if (!ok) {
+      throw std::invalid_argument(
+              "validateEpochLabel: character '" + std::string(1, c) +
+              "' not allowed in epoch label '" + label + "'");
+    }
+  }
+}
+
+}  // namespace marine_bathymetry_store
+
+#endif  // MARINE_BATHYMETRY_STORE__EPOCH_HPP_

--- a/marine_bathymetry_store/include/marine_bathymetry_store/geotiff_import.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/geotiff_import.hpp
@@ -35,9 +35,12 @@
 ///
 /// Imports a depth/uncertainty GeoTIFF — a `cube_bathymetry` `bag_to_geotiff`
 /// replay product, or any north-up geographic WGS84 raster — as **one epoch**
-/// of a source layer. Each pixel center is mapped to the store-level GGGS cell
-/// containing it; when the input lattice is GGGS-aligned at the store's level
-/// (cube products are), this is a cell-exact copy with no resampling.
+/// of a source layer. Each pixel fills its **footprint** of store-level GGGS
+/// cells: when the input lattice is GGGS-aligned at the store's level (cube
+/// products are) that is a cell-exact copy with no resampling; a coarser
+/// source (e.g. a 5 m contour prior into a 0.5 m store) nearest-neighbour
+/// fills every cell it covers; a finer source resolves per cell by lowest
+/// uncertainty.
 ///
 /// One epoch = one import call: the epoch is replaced **wholesale**
 /// (`BathymetryStore::importEpoch`), per the ADR-0002 §A1.2 compaction

--- a/marine_bathymetry_store/include/marine_bathymetry_store/geotiff_import.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/geotiff_import.hpp
@@ -1,0 +1,87 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef MARINE_BATHYMETRY_STORE__GEOTIFF_IMPORT_HPP_
+#define MARINE_BATHYMETRY_STORE__GEOTIFF_IMPORT_HPP_
+
+#include <cstddef>
+#include <limits>
+#include <optional>
+#include <string>
+
+#include "marine_bathymetry_store/bathymetry_store.hpp"
+#include "marine_bathymetry_store/epoch.hpp"
+
+/// @file
+/// @brief GeoTIFF → store epoch importer (ADR-0002 Phase 2).
+///
+/// Imports a depth/uncertainty GeoTIFF — a `cube_bathymetry` `bag_to_geotiff`
+/// replay product, or any north-up geographic WGS84 raster — as **one epoch**
+/// of a source layer. Each pixel center is mapped to the store-level GGGS cell
+/// containing it; when the input lattice is GGGS-aligned at the store's level
+/// (cube products are), this is a cell-exact copy with no resampling.
+///
+/// One epoch = one import call: the epoch is replaced **wholesale**
+/// (`BathymetryStore::importEpoch`), per the ADR-0002 §A1.2 compaction
+/// semantics. Re-importing supersedes, subject to the provenance ordering.
+
+namespace marine_bathymetry_store
+{
+
+/// @brief Options for `importGeoTiff`.
+struct GeoTiffImportOptions
+{
+  /// 1-based raster band holding depth as **ellipsoidal height** (WGS84, m,
+  /// up-positive — the store convention; `bag_to_geotiff` band 1). Non-finite
+  /// pixels are no-data and skipped.
+  int depth_band = 1;
+  /// 1-based raster band holding 1-sigma vertical uncertainty (m), or 0 if
+  /// the file has none (cells then get `default_uncertainty`).
+  int uncertainty_band = 2;
+  /// Uncertainty assigned when `uncertainty_band == 0` or the band reads
+  /// non-finite. NaN (the default) makes such cells never-reliable in the
+  /// safety query — the conservative choice for an unattributed source.
+  double default_uncertainty = std::numeric_limits<double>::quiet_NaN();
+  /// Acquisition time (Unix seconds) recorded on every imported cell — a
+  /// whole-file product carries no per-cell time. 0 = unset.
+  double timestamp = 0.0;
+};
+
+/// @brief Import @p path as the **whole content** of @p layer's @p epoch.
+///
+/// Pixels whose depth is non-finite are skipped. When several pixels of a
+/// finer-than-store input land in one cell, the **lowest-uncertainty** value
+/// wins (a finite uncertainty always beats NaN; among equal candidates the
+/// first read is kept).
+/// @return The number of cells imported, or `std::nullopt` if the import was
+///         refused by the §A1.2 provenance ordering (existing epoch is
+///         `Replayed`, @p provenance is `LiveFused`).
+/// @throws std::runtime_error on GDAL failure, a non-geographic / non-WGS84
+///         raster, or a rotated geotransform; std::invalid_argument on a bad
+///         epoch label or band index.
+std::optional<std::size_t> importGeoTiff(
+  BathymetryStore & store, SourceLayer layer, const Epoch & epoch,
+  const std::string & path, Provenance provenance,
+  const GeoTiffImportOptions & options = GeoTiffImportOptions{});
+
+}  // namespace marine_bathymetry_store
+
+#endif  // MARINE_BATHYMETRY_STORE__GEOTIFF_IMPORT_HPP_

--- a/marine_bathymetry_store/include/marine_bathymetry_store/geotiff_import.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/geotiff_import.hpp
@@ -63,6 +63,14 @@ struct GeoTiffImportOptions
   /// Acquisition time (Unix seconds) recorded on every imported cell — a
   /// whole-file product carries no per-cell time. 0 = unset.
   double timestamp = 0.0;
+  /// Vertical conversion applied at import (ADR-0002 §D4):
+  /// `height = depth_scale * pixel + depth_offset`. The defaults pass
+  /// store-convention inputs (ellipsoidal height, up-positive) through
+  /// unchanged. A positive-down depths-below-lake-surface product imports
+  /// with `depth_scale = -1` and `depth_offset` = the lake surface's
+  /// ellipsoidal height.
+  double depth_scale = 1.0;
+  double depth_offset = 0.0;
 };
 
 /// @brief Import @p path as the **whole content** of @p layer's @p epoch.

--- a/marine_bathymetry_store/include/marine_bathymetry_store/geotiff_import.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/geotiff_import.hpp
@@ -60,8 +60,10 @@ struct GeoTiffImportOptions
   /// the file has none (cells then get `default_uncertainty`).
   int uncertainty_band = 2;
   /// Uncertainty assigned when `uncertainty_band == 0` or the band reads
-  /// non-finite. NaN (the default) makes such cells never-reliable in the
-  /// safety query — the conservative choice for an unattributed source.
+  /// non-finite **or non-positive** (zero uncertainty is treated as missing,
+  /// not perfect — it would pass every reliability gate and carry infinite
+  /// weight in 1/sigma^2 fusion). NaN (the default) makes such cells
+  /// never-reliable in the safety query — the conservative choice.
   double default_uncertainty = std::numeric_limits<double>::quiet_NaN();
   /// Acquisition time (Unix seconds) recorded on every imported cell — a
   /// whole-file product carries no per-cell time. 0 = unset.

--- a/marine_bathymetry_store/include/marine_bathymetry_store/query.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/query.hpp
@@ -29,11 +29,12 @@
 #include "marine_autonomy/gggs.h"
 #include "marine_bathymetry_store/bathy_cell.hpp"
 #include "marine_bathymetry_store/bathymetry_store.hpp"
+#include "marine_bathymetry_store/epoch.hpp"
 
 namespace marine_bathymetry_store
 {
 
-/// @brief A depth value resolved from the store, tagged with its winning layer.
+/// @brief A depth value resolved from the store, tagged with its provenance.
 ///
 /// `depth` is **ellipsoidal height** (WGS84, metres, up-positive): a seafloor
 /// below the ellipsoid has a negative value, and a *shallower* seafloor has a
@@ -44,24 +45,31 @@ struct DepthSample
   double uncertainty;    ///< 1-sigma vertical uncertainty (m).
   double timestamp;      ///< Acquisition / import time (Unix seconds).
   SourceLayer source;    ///< Which layer this value came from.
+  Epoch epoch;           ///< Which epoch within that layer (ADR-0002 A1).
 };
 
-/// @brief Highest-priority layer that has data at @p cell.
+/// @brief Highest-priority layer that has data at @p cell; within a layer, the
+///        **newest epoch** with data (ADR-0002 §A1.3 default query).
 ///
-/// Walks layers in `source_layers_by_priority` order and returns the first with
-/// usable data. `std::nullopt` means **unknown** — no layer has data here; a
-/// safety-conscious caller must treat that as not-safe (ADR-0002 §D7), not as
-/// deep water.
+/// Walks layers in `source_layers_by_priority` order; within each layer, walks
+/// epochs newest-first and takes the first with usable data. Returns the first
+/// layer that resolves. `std::nullopt` means **unknown** — no layer has data
+/// here; a safety-conscious caller must treat that as not-safe (ADR-0002 §D7),
+/// not as deep water.
 std::optional<DepthSample> bestSource(
   const BathymetryStore & store, const gggs::CellIndex & cell);
 
 /// @brief Shallowest reliable depth at @p cell (navigation-safety query).
 ///
-/// Among all layers that (a) have data and (b) have uncertainty ≤
-/// @p max_uncertainty (a NaN uncertainty is never reliable), returns the
-/// **shallowest** — i.e. the greatest ellipsoidal height, the value closest to
-/// the surface and therefore the most hazardous. `std::nullopt` means no
-/// reliable layer covers the cell; the caller must treat that as not-safe.
+/// Within each layer, walks epochs **newest-first and takes the first value
+/// passing the reliability gate** — uncertainty ≤ @p max_uncertainty (a NaN
+/// uncertainty is never reliable). This is the ADR-0002 §A1.3 walk: a fresh
+/// noisy pass fails the gate and falls through to the prior epoch's confident
+/// value, so a recently observed shoal keeps protecting navigation without any
+/// cross-epoch fusion. Among the layers that resolve, returns the
+/// **shallowest** — the greatest ellipsoidal height, the value closest to the
+/// surface and therefore the most hazardous. `std::nullopt` means no reliable
+/// data covers the cell; the caller must treat that as not-safe.
 std::optional<DepthSample> shallowestReliable(
   const BathymetryStore & store, const gggs::CellIndex & cell, double max_uncertainty);
 
@@ -77,6 +85,23 @@ void forEachCellBestSource(
   const geographic_msgs::msg::GeoPoint & maximum,
   const std::function<void(const gggs::CellIndex &,
   const std::optional<DepthSample> &)> & visitor);
+
+/// @brief Visit every cell observed in **both** epochs of @p layer (change map).
+///
+/// The reason epochs exist (ADR-0002 §A1.1): differencing two days locates
+/// change instead of averaging it away. Iterates the grids present in both
+/// epochs' tile maps and invokes @p visitor for each cell where both have
+/// usable data, passing the two records (@p epoch_a's, then @p epoch_b's).
+/// The visitor owns the significance test — e.g. comparing
+/// `|b.depth - a.depth|` against the combined uncertainty.
+/// Cells observed in only one epoch are *coverage* change, not depth change,
+/// and are not visited.
+/// @return The number of cells visited.
+std::size_t forEachChangedCell(
+  const BathymetryStore & store, SourceLayer layer,
+  const Epoch & epoch_a, const Epoch & epoch_b,
+  const std::function<void(const gggs::CellIndex &,
+  const BathyCell &, const BathyCell &)> & visitor);
 
 }  // namespace marine_bathymetry_store
 

--- a/marine_bathymetry_store/include/marine_bathymetry_store/query.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/query.hpp
@@ -34,7 +34,9 @@
 namespace marine_bathymetry_store
 {
 
-/// @brief A depth value resolved from the store, tagged with its provenance.
+/// @brief A depth value resolved from the store, tagged with its source layer
+///        and epoch. (Provenance — live-fused vs replayed — is a property of
+///        the epoch's tiles, not of an individual sample.)
 ///
 /// `depth` is **ellipsoidal height** (WGS84, metres, up-positive): a seafloor
 /// below the ellipsoid has a negative value, and a *shallower* seafloor has a

--- a/marine_bathymetry_store/include/marine_bathymetry_store/tile_io.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/tile_io.hpp
@@ -63,7 +63,7 @@ namespace marine_bathymetry_store
 /// @brief GeoTIFF filename (no directory) for a grid: `<level>_<row>_<col>.tif`.
 std::string tileFilename(const gggs::GridIndex & grid);
 
-/// @brief Subdirectory name for a source layer (`"processed"` / `"draft"`).
+/// @brief Subdirectory name for a source layer (`"processed"` / `"draft"` / `"chart"`).
 std::string layerDirName(SourceLayer layer);
 
 /// @brief Write one tile as a 3-band Float64 GeoTIFF at @p path.

--- a/marine_bathymetry_store/include/marine_bathymetry_store/tile_io.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/tile_io.hpp
@@ -29,13 +29,19 @@
 #include "marine_bathymetry_store/bathy_cell.hpp"
 #include "marine_bathymetry_store/bathymetry_store.hpp"
 #include "marine_bathymetry_store/bathymetry_tile.hpp"
+#include "marine_bathymetry_store/epoch.hpp"
 
 /// @file
-/// @brief Per-tile GeoTIFF persistence (ADR-0002 §D5).
+/// @brief Per-tile GeoTIFF persistence (ADR-0002 §D5, epochs per §A1).
 ///
 /// Each tile is one 3-band `Float64` GeoTIFF (depth, uncertainty, timestamp),
 /// WGS84-georeferenced from its GGGS grid corners. The file carries no source
-/// field — the layer is encoded as the subdirectory (`processed/`, `draft/`).
+/// or epoch field — both are encoded in the directory layout:
+/// `<dir>/<layer>/<epoch>/<tile>.tif` (e.g. `draft/2026-06-10/20_...tif`).
+/// Each epoch directory also holds a one-line `provenance` sidecar
+/// (`"live-fused"` / `"replayed"`, see `Provenance`); an epoch flagged
+/// `supersedes_disk` (a wholesale import) has its directory cleared before
+/// saving, so tiles of the surface it replaced cannot be resurrected on load.
 /// The GeoTIFF is written north-up (raster row 0 = north), so persistence flips
 /// rows relative to the in-memory GGGS cell order (row 0 = south).
 ///
@@ -76,8 +82,11 @@ BathymetryTile loadTile(const std::string & path, const gggs::Level & level);
 /// @brief Persist every **dirty** tile of @p store under @p dir, then clear
 ///        their dirty flags.
 ///
-/// Layout: `<dir>/<layer>/<level>_<row>_<col>.tif`. Creates directories as
-/// needed. Clean tiles are skipped (incremental save).
+/// Layout: `<dir>/<layer>/<epoch>/<level>_<row>_<col>.tif`, plus a
+/// `provenance` sidecar per epoch directory. Creates directories as needed.
+/// Clean tiles are skipped (incremental save) — except for an epoch flagged
+/// `supersedes_disk` (a wholesale import), whose directory is removed and
+/// rewritten in full so stale tiles of the replaced surface cannot linger.
 /// @return The number of tiles written.
 /// @throws std::runtime_error on any GDAL failure; std::filesystem::filesystem_error
 ///         (a std::runtime_error subclass) on a directory-creation failure.
@@ -85,13 +94,17 @@ std::size_t save(BathymetryStore & store, const std::string & dir);
 
 /// @brief Load every tile found under @p dir into @p store.
 ///
-/// Scans `<dir>/<layer>/*.tif` for each known layer. @p store must already be
-/// at the level the tiles were written at (loadTile enforces per-file).
-/// Loaded tiles are clean.
+/// Scans `<dir>/<layer>/<epoch>/*.tif` for each known layer, creating each
+/// epoch with the provenance read from its sidecar (a missing or unreadable
+/// sidecar is conservatively treated as `LiveFused`, the lower rank — so a
+/// later compaction can still supersede it). @p store must already be at the
+/// level the tiles were written at (loadTile enforces per-file). Loaded tiles
+/// are clean.
 /// @return The number of tiles loaded.
 /// @throws std::runtime_error on any GDAL failure or level mismatch;
-///         std::filesystem::filesystem_error (a std::runtime_error subclass) on a
-///         directory-iteration failure.
+///         std::invalid_argument on an epoch directory whose name is not a
+///         valid epoch label; std::filesystem::filesystem_error (a
+///         std::runtime_error subclass) on a directory-iteration failure.
 std::size_t load(BathymetryStore & store, const std::string & dir);
 
 }  // namespace marine_bathymetry_store

--- a/marine_bathymetry_store/src/bathymetry_store.cpp
+++ b/marine_bathymetry_store/src/bathymetry_store.cpp
@@ -21,14 +21,31 @@
 
 #include "marine_bathymetry_store/bathymetry_store.hpp"
 
+#include <map>
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 namespace marine_bathymetry_store
 {
 
-void BathymetryStore::set(
-  SourceLayer layer, const gggs::CellIndex & cell, const BathyCell & value)
+void BathymetryStore::requireGridAtLevel(
+  const gggs::GridIndex & grid, const char * who) const
+{
+  if (!grid.valid()) {
+    throw std::invalid_argument(std::string(who) + ": invalid GridIndex");
+  }
+  if (grid.level() != level_.level()) {
+    throw std::invalid_argument(
+            std::string(who) + ": GridIndex at level " +
+            std::to_string(grid.level()) + " but store is at level " +
+            std::to_string(level_.level()));
+  }
+}
+
+bool BathymetryStore::set(
+  SourceLayer layer, const Epoch & epoch, const gggs::CellIndex & cell,
+  const BathyCell & value)
 {
   if (!cell.valid()) {
     throw std::invalid_argument("BathymetryStore::set: invalid CellIndex");
@@ -39,40 +56,93 @@ void BathymetryStore::set(
             std::to_string(cell.level()) + " but store is at level " +
             std::to_string(level_.level()));
   }
-  BathymetryTile & tile = getOrCreateTile(layer, cell.grid());
-  tile.set(cell.row(), cell.column(), value);
+  EpochTiles & epoch_tiles = getOrCreateEpoch(layer, epoch, Provenance::LiveFused);
+  // A compacted (replayed) epoch is immutable: a late live snapshot must not
+  // regress it (ADR-0002 §A1.2 provenance ordering). No-op; the caller logs.
+  if (epoch_tiles.provenance == Provenance::Replayed) {
+    return false;
+  }
+  auto it = epoch_tiles.tiles.find(cell.grid());
+  if (it == epoch_tiles.tiles.end()) {
+    it = epoch_tiles.tiles.emplace(cell.grid(), BathymetryTile(cell.grid())).first;
+  }
+  it->second.set(cell.row(), cell.column(), value);
+  return true;
 }
 
 std::optional<BathyCell> BathymetryStore::get(
-  SourceLayer layer, const gggs::CellIndex & cell) const
+  SourceLayer layer, const Epoch & epoch, const gggs::CellIndex & cell) const
 {
   if (!cell.valid()) {
     return std::nullopt;
   }
-  const auto & m = layerMap(layer);
-  const auto it = m.find(cell.grid());
-  if (it == m.end()) {
+  const auto & epochs_map = layerMap(layer);
+  const auto epoch_it = epochs_map.find(epoch);
+  if (epoch_it == epochs_map.end()) {
     return std::nullopt;
   }
-  return it->second.get(cell.row(), cell.column());
+  const auto tile_it = epoch_it->second.tiles.find(cell.grid());
+  if (tile_it == epoch_it->second.tiles.end()) {
+    return std::nullopt;
+  }
+  return tile_it->second.get(cell.row(), cell.column());
+}
+
+bool BathymetryStore::importEpoch(
+  SourceLayer layer, const Epoch & epoch,
+  std::map<gggs::GridIndex, BathymetryTile> tiles, Provenance provenance)
+{
+  validateEpochLabel(epoch);
+  for (const auto & [grid, tile] : tiles) {
+    requireGridAtLevel(grid, "BathymetryStore::importEpoch");
+    static_cast<void>(tile);
+  }
+
+  auto & epochs_map = layerMap(layer);
+  const auto it = epochs_map.find(epoch);
+  // §A1.2 ordering: live-fused never replaces replayed. Equal-or-higher
+  // provenance (a re-compaction, or replayed over live) is allowed.
+  if (it != epochs_map.end() &&
+    it->second.provenance == Provenance::Replayed &&
+    provenance == Provenance::LiveFused)
+  {
+    return false;
+  }
+
+  EpochTiles replacement;
+  replacement.provenance = provenance;
+  replacement.supersedes_disk = true;
+  replacement.tiles = std::move(tiles);
+  // Everything just imported is unsaved by definition.
+  for (auto & [grid, tile] : replacement.tiles) {
+    static_cast<void>(grid);
+    tile.markDirty();
+  }
+  epochs_map[epoch] = std::move(replacement);
+  return true;
+}
+
+EpochTiles & BathymetryStore::getOrCreateEpoch(
+  SourceLayer layer, const Epoch & epoch, Provenance provenance)
+{
+  validateEpochLabel(epoch);
+  auto & epochs_map = layerMap(layer);
+  auto it = epochs_map.find(epoch);
+  if (it == epochs_map.end()) {
+    it = epochs_map.emplace(epoch, EpochTiles{}).first;
+    it->second.provenance = provenance;
+  }
+  return it->second;
 }
 
 BathymetryTile & BathymetryStore::getOrCreateTile(
-  SourceLayer layer, const gggs::GridIndex & grid)
+  SourceLayer layer, const Epoch & epoch, const gggs::GridIndex & grid)
 {
-  if (!grid.valid()) {
-    throw std::invalid_argument("BathymetryStore::getOrCreateTile: invalid GridIndex");
-  }
-  if (grid.level() != level_.level()) {
-    throw std::invalid_argument(
-            "BathymetryStore::getOrCreateTile: GridIndex at level " +
-            std::to_string(grid.level()) + " but store is at level " +
-            std::to_string(level_.level()));
-  }
-  auto & m = layerMap(layer);
-  auto it = m.find(grid);
-  if (it == m.end()) {
-    it = m.emplace(grid, BathymetryTile(grid)).first;
+  requireGridAtLevel(grid, "BathymetryStore::getOrCreateTile");
+  EpochTiles & epoch_tiles = getOrCreateEpoch(layer, epoch, Provenance::LiveFused);
+  auto it = epoch_tiles.tiles.find(grid);
+  if (it == epoch_tiles.tiles.end()) {
+    it = epoch_tiles.tiles.emplace(grid, BathymetryTile(grid)).first;
   }
   return it->second;
 }

--- a/marine_bathymetry_store/src/bathymetry_store.cpp
+++ b/marine_bathymetry_store/src/bathymetry_store.cpp
@@ -95,7 +95,13 @@ bool BathymetryStore::importEpoch(
   validateEpochLabel(epoch);
   for (const auto & [grid, tile] : tiles) {
     requireGridAtLevel(grid, "BathymetryStore::importEpoch");
-    static_cast<void>(tile);
+    // The map key and the tile's own index must agree: persistence
+    // georeferences by tile.index() but names the file by the key, so a
+    // mismatch produces a tile that load() silently re-keys elsewhere.
+    if (tile.index() != grid) {
+      throw std::invalid_argument(
+              "BathymetryStore::importEpoch: tile.index() does not match its map key");
+    }
   }
 
   auto & epochs_map = layerMap(layer);

--- a/marine_bathymetry_store/src/geotiff_import.cpp
+++ b/marine_bathymetry_store/src/geotiff_import.cpp
@@ -90,6 +90,12 @@ std::optional<std::size_t> importGeoTiff(
     throw std::runtime_error("importGeoTiff: rotated geotransform unsupported in " + path);
   }
 
+  // Honor a declared no-data value: it may be finite (e.g. -9999), which the
+  // isfinite() skip below would happily import as a 9 km depth.
+  int has_nodata = 0;
+  const double nodata =
+    in.ds->GetRasterBand(options.depth_band)->GetNoDataValue(&has_nodata);
+
   const gggs::Level & level = store.level();
   std::map<gggs::GridIndex, BathymetryTile> tiles;
   std::size_t imported = 0;
@@ -112,10 +118,11 @@ std::optional<std::size_t> importGeoTiff(
     }
     const double latitude = gt[3] + (y + 0.5) * gt[5];
     for (int x = 0; x < width; ++x) {
-      const double depth = depth_row[x];
-      if (!std::isfinite(depth)) {
+      if (!std::isfinite(depth_row[x]) || (has_nodata && depth_row[x] == nodata)) {
         continue;   // no-data pixel
       }
+      // Vertical conversion at import (§D4): pixel value -> ellipsoidal height.
+      const double depth = options.depth_scale * depth_row[x] + options.depth_offset;
       double uncertainty = options.default_uncertainty;
       if (options.uncertainty_band > 0 && std::isfinite(uncertainty_row[x])) {
         uncertainty = uncertainty_row[x];

--- a/marine_bathymetry_store/src/geotiff_import.cpp
+++ b/marine_bathymetry_store/src/geotiff_import.cpp
@@ -128,35 +128,56 @@ std::optional<std::size_t> importGeoTiff(
         uncertainty = uncertainty_row[x];
       }
       const double longitude = gt[0] + (x + 0.5) * gt[1];
-      const gggs::CellIndex cell = level.cellIndex(gggs::geoPoint(latitude, longitude));
-      if (!cell.valid()) {
-        continue;   // outside GGGS's usable envelope
-      }
-      auto tile_it = tiles.find(cell.grid());
-      if (tile_it == tiles.end()) {
-        tile_it = tiles.emplace(cell.grid(), BathymetryTile(cell.grid())).first;
-      }
-      // Several input pixels can land in one cell when the input is finer
-      // than the store level: keep the lowest-uncertainty value (a finite
-      // uncertainty always beats NaN; ties keep the first read).
-      const BathyCell existing = tile_it->second.get(cell.row(), cell.column());
-      if (existing.hasData()) {
-        const bool existing_unc_finite = std::isfinite(existing.uncertainty);
-        const bool new_unc_finite = std::isfinite(uncertainty);
-        if (!new_unc_finite && existing_unc_finite) {
-          continue;
+      // Fill the pixel's full FOOTPRINT of store cells, not just the cell
+      // under its centre — a coarser-than-store source (e.g. a 5 m contour
+      // prior into a 0.5 m store) must produce coverage, not isolated dots.
+      // The box is shrunk by a hair so adjacent pixels never contend for the
+      // cells on their shared boundary; for aligned or finer inputs it
+      // therefore covers exactly the one containing cell.
+      const double half_lon = 0.495 * std::abs(gt[1]);
+      const double half_lat = 0.495 * std::abs(gt[5]);
+      const auto box_min = gggs::geoPoint(latitude - half_lat, longitude - half_lon);
+      const auto box_max = gggs::geoPoint(latitude + half_lat, longitude + half_lon);
+      gggs::GridAreaIterator grid_it(
+        level.gridIndex(box_min.latitude, box_min.longitude),
+        level.gridIndex(box_max.latitude, box_max.longitude));
+      for (; grid_it.valid(); grid_it.next()) {
+        auto tile_it = tiles.find(*grid_it);
+        for (gggs::CellAreaIterator cell_it(*grid_it, box_min, box_max);
+          cell_it.valid(); cell_it.next())
+        {
+          const gggs::CellIndex & cell = *cell_it;
+          if (!cell.valid()) {
+            continue;   // outside GGGS's usable envelope
+          }
+          if (tile_it == tiles.end()) {
+            tile_it = tiles.emplace(cell.grid(), BathymetryTile(cell.grid())).first;
+          }
+          // Several input pixels can land in one cell when the input is finer
+          // than the store level: keep the lowest-uncertainty value (a finite
+          // uncertainty always beats NaN; ties keep the first read).
+          const BathyCell existing = tile_it->second.get(cell.row(), cell.column());
+          if (existing.hasData()) {
+            const bool existing_unc_finite = std::isfinite(existing.uncertainty);
+            const bool new_unc_finite = std::isfinite(uncertainty);
+            if (!new_unc_finite && existing_unc_finite) {
+              continue;
+            }
+            if (new_unc_finite && existing_unc_finite &&
+              uncertainty >= existing.uncertainty)
+            {
+              continue;
+            }
+            if (!new_unc_finite && !existing_unc_finite) {
+              continue;   // tie among NaNs: keep the first read
+            }
+          } else {
+            ++imported;   // a new cell (replacements don't recount)
+          }
+          tile_it->second.set(cell.row(), cell.column(), BathyCell{depth, uncertainty,
+              options.timestamp});
         }
-        if (new_unc_finite && existing_unc_finite && uncertainty >= existing.uncertainty) {
-          continue;
-        }
-        if (!new_unc_finite && !existing_unc_finite) {
-          continue;   // tie among NaNs: keep the first read
-        }
-      } else {
-        ++imported;   // a new cell (replacements don't recount)
       }
-      tile_it->second.set(cell.row(), cell.column(), BathyCell{depth, uncertainty,
-          options.timestamp});
     }
   }
 

--- a/marine_bathymetry_store/src/geotiff_import.cpp
+++ b/marine_bathymetry_store/src/geotiff_import.cpp
@@ -123,8 +123,14 @@ std::optional<std::size_t> importGeoTiff(
       }
       // Vertical conversion at import (§D4): pixel value -> ellipsoidal height.
       const double depth = options.depth_scale * depth_row[x] + options.depth_offset;
+      // A non-finite OR non-positive uncertainty is *missing*, not perfect:
+      // zero would pass every reliability gate and carry infinite weight in
+      // 1/sigma^2 fusion. Such cells get default_uncertainty (NaN by default
+      // = never reliable — conservative).
       double uncertainty = options.default_uncertainty;
-      if (options.uncertainty_band > 0 && std::isfinite(uncertainty_row[x])) {
+      if (options.uncertainty_band > 0 && std::isfinite(uncertainty_row[x]) &&
+        uncertainty_row[x] > 0.0)
+      {
         uncertainty = uncertainty_row[x];
       }
       const double longitude = gt[0] + (x + 0.5) * gt[1];

--- a/marine_bathymetry_store/src/geotiff_import.cpp
+++ b/marine_bathymetry_store/src/geotiff_import.cpp
@@ -1,0 +1,162 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "marine_bathymetry_store/geotiff_import.hpp"
+
+#include <gdal_priv.h>
+#include <ogr_spatialref.h>
+
+#include <cmath>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace marine_bathymetry_store
+{
+
+namespace
+{
+
+/// RAII wrapper so a thrown exception still closes the GDAL dataset.
+struct DatasetCloser
+{
+  GDALDataset * ds = nullptr;
+  ~DatasetCloser() {if (ds) {GDALClose(ds);}}
+};
+
+}  // namespace
+
+std::optional<std::size_t> importGeoTiff(
+  BathymetryStore & store, SourceLayer layer, const Epoch & epoch,
+  const std::string & path, Provenance provenance,
+  const GeoTiffImportOptions & options)
+{
+  validateEpochLabel(epoch);
+  if (options.depth_band < 1) {
+    throw std::invalid_argument("importGeoTiff: depth_band must be >= 1");
+  }
+  if (options.uncertainty_band < 0) {
+    throw std::invalid_argument("importGeoTiff: uncertainty_band must be >= 0 (0 = none)");
+  }
+
+  GDALAllRegister();
+  DatasetCloser in;
+  in.ds = GDALDataset::FromHandle(GDALOpen(path.c_str(), GA_ReadOnly));
+  if (in.ds == nullptr) {
+    throw std::runtime_error("importGeoTiff: could not open " + path);
+  }
+  const int width = in.ds->GetRasterXSize();
+  const int height = in.ds->GetRasterYSize();
+  const int band_count = in.ds->GetRasterCount();
+  if (options.depth_band > band_count || options.uncertainty_band > band_count) {
+    throw std::runtime_error("importGeoTiff: band index beyond raster bands in " + path);
+  }
+
+  // The pixel-center mapping below interprets the geotransform as degrees, so
+  // the file must be a geographic WGS84 raster (same guard as tile_io's load).
+  const OGRSpatialReference * srs = in.ds->GetSpatialRef();
+  OGRErr axis_error = OGRERR_NONE;
+  if (srs == nullptr || !srs->IsGeographic() ||
+    std::abs(srs->GetSemiMajor(&axis_error) - 6378137.0) > 1.0 || axis_error != OGRERR_NONE)
+  {
+    throw std::runtime_error("importGeoTiff: not a geographic WGS84 raster: " + path);
+  }
+
+  double gt[6];
+  if (in.ds->GetGeoTransform(gt) != CE_None) {
+    throw std::runtime_error("importGeoTiff: missing geotransform in " + path);
+  }
+  if (gt[2] != 0.0 || gt[4] != 0.0) {
+    throw std::runtime_error("importGeoTiff: rotated geotransform unsupported in " + path);
+  }
+
+  const gggs::Level & level = store.level();
+  std::map<gggs::GridIndex, BathymetryTile> tiles;
+  std::size_t imported = 0;
+
+  std::vector<double> depth_row(width);
+  std::vector<double> uncertainty_row(width);
+  for (int y = 0; y < height; ++y) {
+    if (in.ds->GetRasterBand(options.depth_band)->RasterIO(
+        GF_Read, 0, y, width, 1, depth_row.data(), width, 1, GDT_Float64, 0, 0) != CE_None)
+    {
+      throw std::runtime_error("importGeoTiff: depth read failed in " + path);
+    }
+    if (options.uncertainty_band > 0) {
+      if (in.ds->GetRasterBand(options.uncertainty_band)->RasterIO(
+          GF_Read, 0, y, width, 1, uncertainty_row.data(), width, 1, GDT_Float64, 0, 0) !=
+        CE_None)
+      {
+        throw std::runtime_error("importGeoTiff: uncertainty read failed in " + path);
+      }
+    }
+    const double latitude = gt[3] + (y + 0.5) * gt[5];
+    for (int x = 0; x < width; ++x) {
+      const double depth = depth_row[x];
+      if (!std::isfinite(depth)) {
+        continue;   // no-data pixel
+      }
+      double uncertainty = options.default_uncertainty;
+      if (options.uncertainty_band > 0 && std::isfinite(uncertainty_row[x])) {
+        uncertainty = uncertainty_row[x];
+      }
+      const double longitude = gt[0] + (x + 0.5) * gt[1];
+      const gggs::CellIndex cell = level.cellIndex(gggs::geoPoint(latitude, longitude));
+      if (!cell.valid()) {
+        continue;   // outside GGGS's usable envelope
+      }
+      auto tile_it = tiles.find(cell.grid());
+      if (tile_it == tiles.end()) {
+        tile_it = tiles.emplace(cell.grid(), BathymetryTile(cell.grid())).first;
+      }
+      // Several input pixels can land in one cell when the input is finer
+      // than the store level: keep the lowest-uncertainty value (a finite
+      // uncertainty always beats NaN; ties keep the first read).
+      const BathyCell existing = tile_it->second.get(cell.row(), cell.column());
+      if (existing.hasData()) {
+        const bool existing_unc_finite = std::isfinite(existing.uncertainty);
+        const bool new_unc_finite = std::isfinite(uncertainty);
+        if (!new_unc_finite && existing_unc_finite) {
+          continue;
+        }
+        if (new_unc_finite && existing_unc_finite && uncertainty >= existing.uncertainty) {
+          continue;
+        }
+        if (!new_unc_finite && !existing_unc_finite) {
+          continue;   // tie among NaNs: keep the first read
+        }
+      } else {
+        ++imported;   // a new cell (replacements don't recount)
+      }
+      tile_it->second.set(cell.row(), cell.column(), BathyCell{depth, uncertainty,
+          options.timestamp});
+    }
+  }
+
+  if (!store.importEpoch(layer, epoch, std::move(tiles), provenance)) {
+    return std::nullopt;
+  }
+  return imported;
+}
+
+}  // namespace marine_bathymetry_store

--- a/marine_bathymetry_store/src/import_geotiff_main.cpp
+++ b/marine_bathymetry_store/src/import_geotiff_main.cpp
@@ -35,6 +35,7 @@
 #include <iomanip>
 #include <iostream>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 
 #include "marine_bathymetry_store/bathymetry_store.hpp"
@@ -128,7 +129,14 @@ int main(int argc, char * argv[])
   const std::string & store_dir = positional[0];
   const auto layer = layerFromName(positional[1]);
   const std::string & epoch = positional[2];
-  const auto provenance = marine_bathymetry_store::provenanceFromToken(positional[3]);
+  marine_bathymetry_store::Provenance provenance;
+  try {
+    provenance = marine_bathymetry_store::provenanceFromToken(positional[3]);
+  } catch (const std::invalid_argument &) {
+    std::cerr << "unknown provenance '" << positional[3]
+              << "' (expected live-fused|replayed)\n";
+    return 1;
+  }
   const std::string & geotiff = positional[4];
   if (timestamp < 0.0) {
     timestamp = timestampFromEpochLabel(epoch);

--- a/marine_bathymetry_store/src/import_geotiff_main.cpp
+++ b/marine_bathymetry_store/src/import_geotiff_main.cpp
@@ -49,13 +49,20 @@ void usage()
   std::cout <<
     "usage: import_geotiff <store_dir> <layer> <epoch> <provenance> <geotiff>\n"
     "                      [--cell-size m] [--timestamp unix_seconds]\n"
-    "  layer:      processed | draft\n"
+    "                      [--uncertainty m] [--depth-scale s] [--depth-offset m]\n"
+    "  layer:      processed | draft | chart\n"
     "  epoch:      label, conventionally the acquisition date (YYYY-MM-DD)\n"
     "  provenance: live-fused | replayed\n"
     "  --cell-size: store cell size in metres (default 0.5; must match any\n"
     "               existing store under <store_dir>)\n"
     "  --timestamp: per-cell acquisition time; defaults to midnight UTC of an\n"
-    "               ISO-date epoch label, else 0\n";
+    "               ISO-date epoch label, else 0\n"
+    "  --uncertainty: ignore the file's uncertainty band and assign this\n"
+    "               constant 1-sigma value (for sources without one)\n"
+    "  --depth-scale / --depth-offset: vertical conversion at import,\n"
+    "               height = scale*pixel + offset (defaults 1, 0). A\n"
+    "               positive-down depths-below-lake-surface product imports\n"
+    "               with scale -1 and offset = lake surface ellipsoidal height\n";
   exit(1);
 }
 
@@ -67,7 +74,10 @@ marine_bathymetry_store::SourceLayer layerFromName(const std::string & name)
   if (name == "draft") {
     return marine_bathymetry_store::SourceLayer::Draft;
   }
-  std::cerr << "unknown layer '" << name << "' (expected processed|draft)\n";
+  if (name == "chart") {
+    return marine_bathymetry_store::SourceLayer::Chart;
+  }
+  std::cerr << "unknown layer '" << name << "' (expected processed|draft|chart)\n";
   exit(1);
 }
 
@@ -91,12 +101,21 @@ int main(int argc, char * argv[])
   int n_positional = 0;
   double cell_size = 0.5;
   double timestamp = -1.0;   // sentinel: derive from the epoch label
+  double constant_uncertainty = -1.0;   // sentinel: use the file's band
+  double depth_scale = 1.0;
+  double depth_offset = 0.0;
 
   for (int i = 1; i < argc; ++i) {
     if (std::strcmp(argv[i], "--cell-size") == 0 && i + 1 < argc) {
       cell_size = std::stod(argv[++i]);
     } else if (std::strcmp(argv[i], "--timestamp") == 0 && i + 1 < argc) {
       timestamp = std::stod(argv[++i]);
+    } else if (std::strcmp(argv[i], "--uncertainty") == 0 && i + 1 < argc) {
+      constant_uncertainty = std::stod(argv[++i]);
+    } else if (std::strcmp(argv[i], "--depth-scale") == 0 && i + 1 < argc) {
+      depth_scale = std::stod(argv[++i]);
+    } else if (std::strcmp(argv[i], "--depth-offset") == 0 && i + 1 < argc) {
+      depth_offset = std::stod(argv[++i]);
     } else if (n_positional < 5) {
       positional[n_positional++] = argv[i];
     } else {
@@ -124,6 +143,12 @@ int main(int argc, char * argv[])
 
   marine_bathymetry_store::GeoTiffImportOptions options;
   options.timestamp = timestamp;
+  options.depth_scale = depth_scale;
+  options.depth_offset = depth_offset;
+  if (constant_uncertainty >= 0.0) {
+    options.uncertainty_band = 0;
+    options.default_uncertainty = constant_uncertainty;
+  }
   const auto imported = marine_bathymetry_store::importGeoTiff(
     store, layer, epoch, geotiff, provenance, options);
   if (!imported) {

--- a/marine_bathymetry_store/src/import_geotiff_main.cpp
+++ b/marine_bathymetry_store/src/import_geotiff_main.cpp
@@ -1,0 +1,140 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+/// @file
+/// @brief CLI: import a depth/uncertainty GeoTIFF as one epoch of a store.
+///
+/// usage: import_geotiff <store_dir> <layer> <epoch> <provenance> <geotiff>
+///                       [--cell-size m] [--timestamp unix_seconds]
+///
+/// Loads any existing tiles under <store_dir>, imports the GeoTIFF as the
+/// whole content of <layer>/<epoch> (wholesale, ADR-0002 §A1.2), and saves.
+/// If --timestamp is omitted and <epoch> is an ISO date (YYYY-MM-DD), cells
+/// are stamped midnight UTC of that date.
+
+#include <cstring>
+#include <ctime>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include "marine_bathymetry_store/bathymetry_store.hpp"
+#include "marine_bathymetry_store/geotiff_import.hpp"
+#include "marine_bathymetry_store/tile_io.hpp"
+
+namespace
+{
+
+void usage()
+{
+  std::cout <<
+    "usage: import_geotiff <store_dir> <layer> <epoch> <provenance> <geotiff>\n"
+    "                      [--cell-size m] [--timestamp unix_seconds]\n"
+    "  layer:      processed | draft\n"
+    "  epoch:      label, conventionally the acquisition date (YYYY-MM-DD)\n"
+    "  provenance: live-fused | replayed\n"
+    "  --cell-size: store cell size in metres (default 0.5; must match any\n"
+    "               existing store under <store_dir>)\n"
+    "  --timestamp: per-cell acquisition time; defaults to midnight UTC of an\n"
+    "               ISO-date epoch label, else 0\n";
+  exit(1);
+}
+
+marine_bathymetry_store::SourceLayer layerFromName(const std::string & name)
+{
+  if (name == "processed") {
+    return marine_bathymetry_store::SourceLayer::Processed;
+  }
+  if (name == "draft") {
+    return marine_bathymetry_store::SourceLayer::Draft;
+  }
+  std::cerr << "unknown layer '" << name << "' (expected processed|draft)\n";
+  exit(1);
+}
+
+/// Midnight UTC of an ISO date label, or 0 if the label isn't one.
+double timestampFromEpochLabel(const std::string & label)
+{
+  std::tm tm = {};
+  std::istringstream in(label);
+  in >> std::get_time(&tm, "%Y-%m-%d");
+  if (in.fail() || !in.eof()) {
+    return 0.0;
+  }
+  return static_cast<double>(timegm(&tm));
+}
+
+}  // namespace
+
+int main(int argc, char * argv[])
+{
+  std::string positional[5];
+  int n_positional = 0;
+  double cell_size = 0.5;
+  double timestamp = -1.0;   // sentinel: derive from the epoch label
+
+  for (int i = 1; i < argc; ++i) {
+    if (std::strcmp(argv[i], "--cell-size") == 0 && i + 1 < argc) {
+      cell_size = std::stod(argv[++i]);
+    } else if (std::strcmp(argv[i], "--timestamp") == 0 && i + 1 < argc) {
+      timestamp = std::stod(argv[++i]);
+    } else if (n_positional < 5) {
+      positional[n_positional++] = argv[i];
+    } else {
+      usage();
+    }
+  }
+  if (n_positional != 5) {
+    usage();
+  }
+  const std::string & store_dir = positional[0];
+  const auto layer = layerFromName(positional[1]);
+  const std::string & epoch = positional[2];
+  const auto provenance = marine_bathymetry_store::provenanceFromToken(positional[3]);
+  const std::string & geotiff = positional[4];
+  if (timestamp < 0.0) {
+    timestamp = timestampFromEpochLabel(epoch);
+  }
+
+  auto store = marine_bathymetry_store::BathymetryStore::fromCellSize(
+    static_cast<float>(cell_size));
+  std::cout << "store level: " << static_cast<int>(store.level().level()) << "\n";
+
+  const std::size_t loaded = marine_bathymetry_store::load(store, store_dir);
+  std::cout << "loaded " << loaded << " existing tile(s) from " << store_dir << "\n";
+
+  marine_bathymetry_store::GeoTiffImportOptions options;
+  options.timestamp = timestamp;
+  const auto imported = marine_bathymetry_store::importGeoTiff(
+    store, layer, epoch, geotiff, provenance, options);
+  if (!imported) {
+    std::cerr << "import refused: epoch '" << epoch << "' is already replayed and the "
+      "requested provenance is live-fused (ADR-0002 A1.2 ordering)\n";
+    return 2;
+  }
+  std::cout << "imported " << *imported << " cell(s) into " << positional[1] << "/" <<
+    epoch << " (" << positional[3] << ")\n";
+
+  const std::size_t saved = marine_bathymetry_store::save(store, store_dir);
+  std::cout << "saved " << saved << " tile(s) under " << store_dir << "\n";
+  return 0;
+}

--- a/marine_bathymetry_store/src/query.cpp
+++ b/marine_bathymetry_store/src/query.cpp
@@ -29,15 +29,52 @@ namespace marine_bathymetry_store
 namespace
 {
 
-/// Resolve a single layer's sample at a cell, or nullopt if it has no usable data.
+/// Look up a cell in one epoch's tile map, or nullopt if absent.
+std::optional<BathyCell> cellIn(
+  const EpochTiles & epoch_tiles, const gggs::CellIndex & cell)
+{
+  const auto it = epoch_tiles.tiles.find(cell.grid());
+  if (it == epoch_tiles.tiles.end()) {
+    return std::nullopt;
+  }
+  return it->second.get(cell.row(), cell.column());
+}
+
+/// Resolve a single layer's sample at a cell: newest epoch with usable data
+/// (ADR-0002 §A1.3 default resolution), or nullopt if none.
 std::optional<DepthSample> sampleFor(
   const BathymetryStore & store, SourceLayer layer, const gggs::CellIndex & cell)
 {
-  const auto c = store.get(layer, cell);
-  if (!c || !c->hasData()) {
-    return std::nullopt;
+  const auto & epochs_map = store.epochs(layer);
+  for (auto it = epochs_map.rbegin(); it != epochs_map.rend(); ++it) {
+    const auto c = cellIn(it->second, cell);
+    if (c && c->hasData()) {
+      return DepthSample{c->depth, c->uncertainty, c->timestamp, layer, it->first};
+    }
   }
-  return DepthSample{c->depth, c->uncertainty, c->timestamp, layer};
+  return std::nullopt;
+}
+
+/// Resolve a single layer's *reliable* sample at a cell: newest epoch whose
+/// value passes the uncertainty gate (ADR-0002 §A1.3 safety walk) — a noisy
+/// fresh epoch is skipped, falling through to an older confident one.
+std::optional<DepthSample> reliableSampleFor(
+  const BathymetryStore & store, SourceLayer layer, const gggs::CellIndex & cell,
+  double max_uncertainty)
+{
+  const auto & epochs_map = store.epochs(layer);
+  for (auto it = epochs_map.rbegin(); it != epochs_map.rend(); ++it) {
+    const auto c = cellIn(it->second, cell);
+    if (!c || !c->hasData()) {
+      continue;
+    }
+    // A NaN uncertainty is never reliable; otherwise require it within tolerance.
+    if (std::isnan(c->uncertainty) || c->uncertainty > max_uncertainty) {
+      continue;
+    }
+    return DepthSample{c->depth, c->uncertainty, c->timestamp, layer, it->first};
+  }
+  return std::nullopt;
 }
 
 }  // namespace
@@ -58,12 +95,8 @@ std::optional<DepthSample> shallowestReliable(
 {
   std::optional<DepthSample> shallowest;
   for (const SourceLayer layer : source_layers_by_priority) {
-    const auto sample = sampleFor(store, layer, cell);
+    const auto sample = reliableSampleFor(store, layer, cell, max_uncertainty);
     if (!sample) {
-      continue;
-    }
-    // A NaN uncertainty is never reliable; otherwise require it within tolerance.
-    if (std::isnan(sample->uncertainty) || sample->uncertainty > max_uncertainty) {
       continue;
     }
     // depth is ellipsoidal height (up-positive): shallower == greater height.
@@ -92,6 +125,46 @@ void forEachCellBestSource(
       visitor(*cell_it, bestSource(store, *cell_it));
     }
   }
+}
+
+std::size_t forEachChangedCell(
+  const BathymetryStore & store, SourceLayer layer,
+  const Epoch & epoch_a, const Epoch & epoch_b,
+  const std::function<void(const gggs::CellIndex &,
+  const BathyCell &, const BathyCell &)> & visitor)
+{
+  const auto & epochs_map = store.epochs(layer);
+  const auto a_it = epochs_map.find(epoch_a);
+  const auto b_it = epochs_map.find(epoch_b);
+  if (a_it == epochs_map.end() || b_it == epochs_map.end()) {
+    return 0;
+  }
+
+  std::size_t visited = 0;
+  // Iterate grids present in both epochs; a grid covered by only one is
+  // coverage change, not depth change.
+  for (const auto & [grid, tile_a] : a_it->second.tiles) {
+    const auto tile_b_it = b_it->second.tiles.find(grid);
+    if (tile_b_it == b_it->second.tiles.end()) {
+      continue;
+    }
+    const BathymetryTile & tile_b = tile_b_it->second;
+    for (uint16_t row = 0; row < BathymetryTile::edge; ++row) {
+      for (uint16_t col = 0; col < BathymetryTile::edge; ++col) {
+        const BathyCell a = tile_a.get(row, col);
+        if (!a.hasData()) {
+          continue;
+        }
+        const BathyCell b = tile_b.get(row, col);
+        if (!b.hasData()) {
+          continue;
+        }
+        visitor(gggs::CellIndex(grid, row, col), a, b);
+        ++visited;
+      }
+    }
+  }
+  return visited;
 }
 
 }  // namespace marine_bathymetry_store

--- a/marine_bathymetry_store/src/tile_io.cpp
+++ b/marine_bathymetry_store/src/tile_io.cpp
@@ -27,6 +27,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cctype>
 #include <cmath>
 #include <cstdint>
 #include <filesystem>
@@ -270,6 +271,15 @@ Provenance readProvenance(const std::filesystem::path & epoch_dir)
   if (!in || !std::getline(in, token)) {
     return Provenance::LiveFused;
   }
+  // Trim trailing whitespace before parsing: a sidecar written with CRLF
+  // line endings (e.g. on a Windows host) leaves a '\r' on the token, which
+  // would otherwise fail the exact-match parse and silently downgrade a
+  // Replayed epoch to LiveFused — allowing live writes over replayed data.
+  token.erase(
+    std::find_if(
+      token.rbegin(), token.rend(),
+      [](unsigned char c) {return !std::isspace(c);}).base(),
+    token.end());
   try {
     return provenanceFromToken(token);
   } catch (const std::invalid_argument &) {

--- a/marine_bathymetry_store/src/tile_io.cpp
+++ b/marine_bathymetry_store/src/tile_io.cpp
@@ -91,6 +91,7 @@ std::string layerDirName(SourceLayer layer)
   switch (layer) {
     case SourceLayer::Processed: return "processed";
     case SourceLayer::Draft: return "draft";
+    case SourceLayer::Chart: return "chart";
   }
   throw std::runtime_error("layerDirName: unknown SourceLayer");
 }

--- a/marine_bathymetry_store/src/tile_io.cpp
+++ b/marine_bathymetry_store/src/tile_io.cpp
@@ -30,6 +30,7 @@
 #include <cmath>
 #include <cstdint>
 #include <filesystem>
+#include <fstream>
 #include <limits>
 #include <stdexcept>
 #include <string>
@@ -242,28 +243,80 @@ BathymetryTile loadTile(const std::string & path, const gggs::Level & level)
   return tile;
 }
 
+namespace
+{
+
+constexpr const char * kProvenanceSidecar = "provenance";
+
+/// Write the epoch's provenance sidecar (one token + newline).
+void writeProvenance(const std::filesystem::path & epoch_dir, Provenance provenance)
+{
+  const std::filesystem::path path = epoch_dir / kProvenanceSidecar;
+  std::ofstream out(path);
+  out << provenanceToken(provenance) << '\n';
+  if (!out) {
+    throw std::runtime_error("save: could not write " + path.string());
+  }
+}
+
+/// Read an epoch's provenance sidecar. A missing or unreadable sidecar is
+/// conservatively `LiveFused` — the lower rank, so a later compaction can
+/// still supersede the epoch (ADR-0002 §A1.2).
+Provenance readProvenance(const std::filesystem::path & epoch_dir)
+{
+  std::ifstream in(epoch_dir / kProvenanceSidecar);
+  std::string token;
+  if (!in || !std::getline(in, token)) {
+    return Provenance::LiveFused;
+  }
+  try {
+    return provenanceFromToken(token);
+  } catch (const std::invalid_argument &) {
+    return Provenance::LiveFused;
+  }
+}
+
+}  // namespace
+
 std::size_t save(BathymetryStore & store, const std::string & dir)
 {
   namespace fs = std::filesystem;
   std::size_t written = 0;
   for (const SourceLayer layer : source_layers_by_priority) {
     const fs::path layer_dir = fs::path(dir) / layerDirName(layer);
-    bool created_dir = false;
-    // Iterate the layer's tiles (a const view) and write each dirty one. The
-    // dirty flag is cleared via getOrCreateTile() on the same (existing) key:
-    // that's a lookup, not an insert, and clearDirty() only flips a bool on the
-    // tile value — neither mutates the map, so the iterator stays valid.
-    for (const auto & [grid, tile] : store.tiles(layer)) {
-      if (!tile.dirty()) {
-        continue;
+    // Iterate the layer's epochs (a const view) and write each epoch's dirty
+    // tiles. Flags are cleared via getOrCreateTile()/getOrCreateEpoch() on the
+    // same (existing) keys: those are lookups, not inserts, and flipping a bool
+    // on the value mutates neither map, so the iterators stay valid.
+    for (const auto & [epoch, epoch_tiles] : store.epochs(layer)) {
+      const fs::path epoch_dir = layer_dir / epoch;
+      const bool supersedes = epoch_tiles.supersedes_disk;
+      if (supersedes) {
+        // A wholesale import may cover fewer grids than the surface it
+        // replaced; clear the directory so stale tiles can't be resurrected.
+        fs::remove_all(epoch_dir);
       }
-      if (!created_dir) {
-        fs::create_directories(layer_dir);
-        created_dir = true;
+      bool wrote_any = false;
+      for (const auto & [grid, tile] : epoch_tiles.tiles) {
+        if (!supersedes && !tile.dirty()) {
+          continue;
+        }
+        if (!wrote_any) {
+          fs::create_directories(epoch_dir);
+        }
+        saveTile(tile, (epoch_dir / tileFilename(grid)).string());
+        store.getOrCreateTile(layer, epoch, grid).clearDirty();
+        ++written;
+        wrote_any = true;
       }
-      saveTile(tile, (layer_dir / tileFilename(grid)).string());
-      store.getOrCreateTile(layer, grid).clearDirty();
-      ++written;
+      if (wrote_any || supersedes) {
+        // (Re)write the sidecar — compaction changes the provenance. Ensure
+        // the directory exists even for a superseding epoch with no tiles.
+        fs::create_directories(epoch_dir);
+        writeProvenance(epoch_dir, epoch_tiles.provenance);
+        store.getOrCreateEpoch(layer, epoch, epoch_tiles.provenance)
+        .supersedes_disk = false;
+      }
     }
   }
   return written;
@@ -278,13 +331,24 @@ std::size_t load(BathymetryStore & store, const std::string & dir)
     if (!fs::is_directory(layer_dir)) {
       continue;
     }
-    for (const auto & entry : fs::directory_iterator(layer_dir)) {
-      if (!entry.is_regular_file() || entry.path().extension() != ".tif") {
-        continue;
+    for (const auto & epoch_entry : fs::directory_iterator(layer_dir)) {
+      if (!epoch_entry.is_directory()) {
+        continue;   // epochs are subdirectories; skip stray files
       }
-      BathymetryTile tile = loadTile(entry.path().string(), store.level());
-      store.getOrCreateTile(layer, tile.index()) = std::move(tile);
-      ++loaded;
+      const Epoch epoch = epoch_entry.path().filename().string();
+      validateEpochLabel(epoch);
+      const Provenance provenance = readProvenance(epoch_entry.path());
+      // Create the epoch even if it turns out to hold no tiles, so its
+      // provenance is represented in memory.
+      store.getOrCreateEpoch(layer, epoch, provenance);
+      for (const auto & entry : fs::directory_iterator(epoch_entry.path())) {
+        if (!entry.is_regular_file() || entry.path().extension() != ".tif") {
+          continue;
+        }
+        BathymetryTile tile = loadTile(entry.path().string(), store.level());
+        store.getOrCreateTile(layer, epoch, tile.index()) = std::move(tile);
+        ++loaded;
+      }
     }
   }
   return loaded;

--- a/marine_bathymetry_store/test/test_geotiff_import.cpp
+++ b/marine_bathymetry_store/test/test_geotiff_import.cpp
@@ -27,6 +27,7 @@
 #include <cmath>
 #include <filesystem>
 #include <limits>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -64,8 +65,14 @@ std::string writeTestTiff(
 
   GDALAllRegister();
   GDALDriver * driver = GetGDALDriverManager()->GetDriverByName("GTiff");
+  if (driver == nullptr) {
+    throw std::runtime_error("writeTestTiff: GTiff driver unavailable");
+  }
   GDALDataset * ds = driver->Create(path.string().c_str(), width, height, 2, GDT_Float32,
     nullptr);
+  if (ds == nullptr) {
+    throw std::runtime_error("writeTestTiff: could not create " + path.string());
+  }
   double gt[6] = {grid.westLongitude(), px, 0.0, grid.northLatitude(), 0.0, -py};
   ds->SetGeoTransform(gt);
   OGRSpatialReference srs;

--- a/marine_bathymetry_store/test/test_geotiff_import.cpp
+++ b/marine_bathymetry_store/test/test_geotiff_import.cpp
@@ -1,0 +1,222 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <gtest/gtest.h>
+
+#include <gdal_priv.h>
+#include <ogr_spatialref.h>
+
+#include <cmath>
+#include <filesystem>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "marine_autonomy/gggs.h"
+#include "marine_bathymetry_store/bathymetry_store.hpp"
+#include "marine_bathymetry_store/geotiff_import.hpp"
+
+using marine_bathymetry_store::BathymetryStore;
+using marine_bathymetry_store::GeoTiffImportOptions;
+using marine_bathymetry_store::importGeoTiff;
+using marine_bathymetry_store::Provenance;
+using marine_bathymetry_store::SourceLayer;
+
+namespace fs = std::filesystem;
+
+namespace
+{
+
+constexpr const char * kDay1 = "2026-06-09";
+
+/// Write a small north-up WGS84 GeoTIFF whose lattice starts at the
+/// north-west corner of the GGGS grid containing (43.0, -70.5) at @p level,
+/// with @p pixels_per_cell input pixels per store cell along each axis.
+/// Band 1 = depth, band 2 = uncertainty (Float32, NaN no-data).
+std::string writeTestTiff(
+  const fs::path & path, const gggs::Level & level, int width, int height,
+  const std::vector<float> & depth, const std::vector<float> & uncertainty,
+  int pixels_per_cell = 1)
+{
+  const gggs::GridIndex grid = level.gridIndex(43.0, -70.5);
+  const double cell_x = grid.longitudinalSpan() / gggs::cell_rows_per_grid;
+  const double cell_y = grid.latitudinalSpan() / gggs::cell_rows_per_grid;
+  const double px = cell_x / pixels_per_cell;
+  const double py = cell_y / pixels_per_cell;
+
+  GDALAllRegister();
+  GDALDriver * driver = GetGDALDriverManager()->GetDriverByName("GTiff");
+  GDALDataset * ds = driver->Create(path.string().c_str(), width, height, 2, GDT_Float32,
+    nullptr);
+  double gt[6] = {grid.westLongitude(), px, 0.0, grid.northLatitude(), 0.0, -py};
+  ds->SetGeoTransform(gt);
+  OGRSpatialReference srs;
+  srs.SetWellKnownGeogCS("WGS84");
+  char * wkt = nullptr;
+  srs.exportToWkt(&wkt);
+  ds->SetProjection(wkt);
+  CPLFree(wkt);
+  if (ds->GetRasterBand(1)->RasterIO(
+      GF_Write, 0, 0, width, height, const_cast<float *>(depth.data()), width, height,
+      GDT_Float32, 0, 0) != CE_None ||
+    ds->GetRasterBand(2)->RasterIO(
+      GF_Write, 0, 0, width, height, const_cast<float *>(uncertainty.data()), width, height,
+      GDT_Float32, 0, 0) != CE_None)
+  {
+    GDALClose(ds);
+    throw std::runtime_error("writeTestTiff: band write failed");
+  }
+  GDALClose(ds);
+  return path.string();
+}
+
+}  // namespace
+
+class GeoTiffImportTest : public ::testing::Test
+{
+protected:
+  fs::path dir_;
+
+  void SetUp() override
+  {
+    const std::string name = ::testing::UnitTest::GetInstance()->current_test_info()->name();
+    dir_ = fs::temp_directory_path() / ("marine_bathy_import_" + name);
+    fs::remove_all(dir_);
+    fs::create_directories(dir_);
+  }
+
+  void TearDown() override
+  {
+    fs::remove_all(dir_);
+  }
+};
+
+TEST_F(GeoTiffImportTest, AlignedImportIsCellExact)
+{
+  BathymetryStore store(11);
+  const float nan = std::numeric_limits<float>::quiet_NaN();
+  // 3x3 pixels at the grid's NW corner; centre pixel is no-data.
+  const std::vector<float> depth{
+    -30.0f, -31.0f, -32.0f,
+    -33.0f, nan, -35.0f,
+    -36.0f, -37.0f, -38.0f};
+  const std::vector<float> unc{
+    0.1f, 0.2f, 0.3f,
+    0.4f, nan, 0.6f,
+    0.7f, 0.8f, 0.9f};
+  const auto tif = writeTestTiff(dir_ / "aligned.tif", store.level(), 3, 3, depth, unc);
+
+  GeoTiffImportOptions options;
+  options.timestamp = 1.78e9;
+  const auto imported = importGeoTiff(
+    store, SourceLayer::Draft, kDay1, tif, Provenance::Replayed, options);
+  ASSERT_TRUE(imported.has_value());
+  EXPECT_EQ(*imported, 8u);   // 9 pixels minus the no-data centre
+
+  // Spot-check the NW pixel: its centre is half a cell in from the grid's
+  // NW corner.
+  const gggs::GridIndex grid = store.level().gridIndex(43.0, -70.5);
+  const double cell_x = grid.longitudinalSpan() / gggs::cell_rows_per_grid;
+  const double cell_y = grid.latitudinalSpan() / gggs::cell_rows_per_grid;
+  const auto nw_cell = store.cellIndex(
+    grid.northLatitude() - 0.5 * cell_y, grid.westLongitude() + 0.5 * cell_x);
+  const auto nw = store.get(SourceLayer::Draft, kDay1, nw_cell);
+  ASSERT_TRUE(nw.has_value());
+  EXPECT_FLOAT_EQ(static_cast<float>(nw->depth), -30.0f);
+  EXPECT_FLOAT_EQ(static_cast<float>(nw->uncertainty), 0.1f);
+  EXPECT_DOUBLE_EQ(nw->timestamp, 1.78e9);
+
+  // The epoch carries the requested provenance.
+  EXPECT_EQ(store.epochs(SourceLayer::Draft).at(kDay1).provenance, Provenance::Replayed);
+}
+
+TEST_F(GeoTiffImportTest, FinerInputKeepsLowestUncertainty)
+{
+  BathymetryStore store(11);
+  // 2x2 input pixels per store cell, covering exactly one cell: four
+  // candidate values; the lowest-uncertainty one must win.
+  const std::vector<float> depth{-30.0f, -31.0f, -32.0f, -33.0f};
+  const std::vector<float> unc{0.5f, 0.2f, 0.9f, 0.7f};
+  const auto tif = writeTestTiff(dir_ / "fine.tif", store.level(), 2, 2, depth, unc, 2);
+
+  const auto imported = importGeoTiff(
+    store, SourceLayer::Draft, kDay1, tif, Provenance::Replayed);
+  ASSERT_TRUE(imported.has_value());
+  EXPECT_EQ(*imported, 1u);   // four pixels, one cell
+
+  const gggs::GridIndex grid = store.level().gridIndex(43.0, -70.5);
+  const double cell_x = grid.longitudinalSpan() / gggs::cell_rows_per_grid;
+  const double cell_y = grid.latitudinalSpan() / gggs::cell_rows_per_grid;
+  const auto cell = store.cellIndex(
+    grid.northLatitude() - 0.5 * cell_y, grid.westLongitude() + 0.5 * cell_x);
+  const auto got = store.get(SourceLayer::Draft, kDay1, cell);
+  ASSERT_TRUE(got.has_value());
+  EXPECT_FLOAT_EQ(static_cast<float>(got->depth), -31.0f);       // unc 0.2 wins
+  EXPECT_FLOAT_EQ(static_cast<float>(got->uncertainty), 0.2f);
+}
+
+TEST_F(GeoTiffImportTest, ProvenanceOrderingRefusesLiveOverReplayed)
+{
+  BathymetryStore store(11);
+  const std::vector<float> depth{-30.0f};
+  const std::vector<float> unc{0.1f};
+  const auto tif = writeTestTiff(dir_ / "one.tif", store.level(), 1, 1, depth, unc);
+
+  ASSERT_TRUE(
+    importGeoTiff(store, SourceLayer::Draft, kDay1, tif, Provenance::Replayed).has_value());
+  // A live-fused re-import of the compacted epoch must be refused.
+  EXPECT_FALSE(
+    importGeoTiff(store, SourceLayer::Draft, kDay1, tif, Provenance::LiveFused).has_value());
+}
+
+TEST_F(GeoTiffImportTest, MissingUncertaintyBandUsesDefault)
+{
+  BathymetryStore store(11);
+  const std::vector<float> depth{-30.0f};
+  const std::vector<float> unc{0.1f};   // present in the file but ignored
+  const auto tif = writeTestTiff(dir_ / "nounc.tif", store.level(), 1, 1, depth, unc);
+
+  GeoTiffImportOptions options;
+  options.uncertainty_band = 0;
+  options.default_uncertainty = 3.5;
+  const auto imported = importGeoTiff(
+    store, SourceLayer::Processed, kDay1, tif, Provenance::Replayed, options);
+  ASSERT_TRUE(imported.has_value());
+
+  const gggs::GridIndex grid = store.level().gridIndex(43.0, -70.5);
+  const double cell_x = grid.longitudinalSpan() / gggs::cell_rows_per_grid;
+  const double cell_y = grid.latitudinalSpan() / gggs::cell_rows_per_grid;
+  const auto cell = store.cellIndex(
+    grid.northLatitude() - 0.5 * cell_y, grid.westLongitude() + 0.5 * cell_x);
+  const auto got = store.get(SourceLayer::Processed, kDay1, cell);
+  ASSERT_TRUE(got.has_value());
+  EXPECT_DOUBLE_EQ(got->uncertainty, 3.5);
+}
+
+TEST_F(GeoTiffImportTest, MissingFileThrows)
+{
+  BathymetryStore store(11);
+  EXPECT_THROW(
+    importGeoTiff(
+      store, SourceLayer::Draft, kDay1, (dir_ / "absent.tif").string(),
+      Provenance::Replayed),
+    std::runtime_error);
+}

--- a/marine_bathymetry_store/test/test_geotiff_import.cpp
+++ b/marine_bathymetry_store/test/test_geotiff_import.cpp
@@ -211,6 +211,43 @@ TEST_F(GeoTiffImportTest, MissingUncertaintyBandUsesDefault)
   EXPECT_DOUBLE_EQ(got->uncertainty, 3.5);
 }
 
+TEST_F(GeoTiffImportTest, DepthScaleOffsetAndFiniteNoData)
+{
+  // A lake-prior product: depths positive-down below the surface, with a
+  // FINITE no-data value (-9999) that must not import as a 9 km depth.
+  BathymetryStore store(11);
+  const std::vector<float> depth{4.0f, -9999.0f};   // 4 m of water; one no-data
+  const std::vector<float> unc{0.0f, 0.0f};         // source has no real band
+  const auto tif = writeTestTiff(dir_ / "lake.tif", store.level(), 2, 1, depth, unc);
+  {
+    GDALAllRegister();
+    GDALDataset * ds = GDALDataset::FromHandle(GDALOpen(tif.c_str(), GA_Update));
+    ASSERT_NE(ds, nullptr);
+    ds->GetRasterBand(1)->SetNoDataValue(-9999.0);
+    GDALClose(ds);
+  }
+
+  GeoTiffImportOptions options;
+  options.uncertainty_band = 0;
+  options.default_uncertainty = 3.0;
+  options.depth_scale = -1.0;       // positive-down -> up-positive
+  options.depth_offset = -20.0;     // lake surface ellipsoidal height
+  const auto imported = importGeoTiff(
+    store, SourceLayer::Chart, kDay1, tif, Provenance::Replayed, options);
+  ASSERT_TRUE(imported.has_value());
+  EXPECT_EQ(*imported, 1u);         // the -9999 pixel was skipped
+
+  const gggs::GridIndex grid = store.level().gridIndex(43.0, -70.5);
+  const double cell_x = grid.longitudinalSpan() / gggs::cell_rows_per_grid;
+  const double cell_y = grid.latitudinalSpan() / gggs::cell_rows_per_grid;
+  const auto cell = store.cellIndex(
+    grid.northLatitude() - 0.5 * cell_y, grid.westLongitude() + 0.5 * cell_x);
+  const auto got = store.get(SourceLayer::Chart, kDay1, cell);
+  ASSERT_TRUE(got.has_value());
+  EXPECT_DOUBLE_EQ(got->depth, -24.0);          // -1 * 4 + (-20)
+  EXPECT_DOUBLE_EQ(got->uncertainty, 3.0);
+}
+
 TEST_F(GeoTiffImportTest, MissingFileThrows)
 {
   BathymetryStore store(11);

--- a/marine_bathymetry_store/test/test_geotiff_import.cpp
+++ b/marine_bathymetry_store/test/test_geotiff_import.cpp
@@ -298,6 +298,37 @@ TEST_F(GeoTiffImportTest, CoarserInputFillsPixelFootprint)
   EXPECT_FLOAT_EQ(static_cast<float>(got->depth), -30.0f);
 }
 
+TEST_F(GeoTiffImportTest, ZeroUncertaintyIsMissingNotPerfect)
+{
+  // A source cell with uncertainty 0 must not import as "perfectly certain"
+  // — it gets default_uncertainty (NaN here), so it never passes a gate.
+  BathymetryStore store(11);
+  const std::vector<float> depth{-30.0f, -31.0f};
+  const std::vector<float> unc{0.0f, 0.4f};
+  const auto tif = writeTestTiff(dir_ / "zerounc.tif", store.level(), 2, 1, depth, unc);
+
+  const auto imported = importGeoTiff(
+    store, SourceLayer::Draft, kDay1, tif, Provenance::Replayed);
+  ASSERT_TRUE(imported.has_value());
+  EXPECT_EQ(*imported, 2u);   // both cells import (depth is real)
+
+  const gggs::GridIndex grid = store.level().gridIndex(43.0, -70.5);
+  const double cell_x = grid.longitudinalSpan() / gggs::cell_rows_per_grid;
+  const double cell_y = grid.latitudinalSpan() / gggs::cell_rows_per_grid;
+  const auto zero_cell = store.cellIndex(
+    grid.northLatitude() - 0.5 * cell_y, grid.westLongitude() + 0.5 * cell_x);
+  const auto good_cell = store.cellIndex(
+    grid.northLatitude() - 0.5 * cell_y, grid.westLongitude() + 1.5 * cell_x);
+
+  const auto zero = store.get(SourceLayer::Draft, kDay1, zero_cell);
+  ASSERT_TRUE(zero.has_value());
+  EXPECT_TRUE(std::isnan(zero->uncertainty));   // missing, not 0
+
+  const auto good = store.get(SourceLayer::Draft, kDay1, good_cell);
+  ASSERT_TRUE(good.has_value());
+  EXPECT_FLOAT_EQ(static_cast<float>(good->uncertainty), 0.4f);
+}
+
 TEST_F(GeoTiffImportTest, MissingFileThrows)
 {
   BathymetryStore store(11);

--- a/marine_bathymetry_store/test/test_geotiff_import.cpp
+++ b/marine_bathymetry_store/test/test_geotiff_import.cpp
@@ -248,6 +248,56 @@ TEST_F(GeoTiffImportTest, DepthScaleOffsetAndFiniteNoData)
   EXPECT_DOUBLE_EQ(got->uncertainty, 3.0);
 }
 
+TEST_F(GeoTiffImportTest, CoarserInputFillsPixelFootprint)
+{
+  // A 5x-coarser pixel must fill its whole footprint of store cells —
+  // coverage, not isolated dots (the contour-prior case). The helper only
+  // does integer pixels-per-cell, so build the 1x1 raster with a 5-cell
+  // pixel directly.
+  BathymetryStore store(11);
+  const std::vector<float> depth{-30.0f};
+  const std::vector<float> unc{3.0f};
+  const gggs::GridIndex grid = store.level().gridIndex(43.0, -70.5);
+  const double cell_x = grid.longitudinalSpan() / gggs::cell_rows_per_grid;
+  const double cell_y = grid.latitudinalSpan() / gggs::cell_rows_per_grid;
+  const auto path = (dir_ / "coarse.tif").string();
+  {
+    GDALAllRegister();
+    GDALDriver * driver = GetGDALDriverManager()->GetDriverByName("GTiff");
+    GDALDataset * ds = driver->Create(path.c_str(), 1, 1, 2, GDT_Float32, nullptr);
+    double gt[6] = {grid.westLongitude(), 5.0 * cell_x, 0.0,
+      grid.northLatitude(), 0.0, -5.0 * cell_y};
+    ds->SetGeoTransform(gt);
+    OGRSpatialReference srs;
+    srs.SetWellKnownGeogCS("WGS84");
+    char * wkt = nullptr;
+    srs.exportToWkt(&wkt);
+    ds->SetProjection(wkt);
+    CPLFree(wkt);
+    ASSERT_EQ(
+      ds->GetRasterBand(1)->RasterIO(
+        GF_Write, 0, 0, 1, 1, const_cast<float *>(depth.data()), 1, 1, GDT_Float32, 0, 0),
+      CE_None);
+    ASSERT_EQ(
+      ds->GetRasterBand(2)->RasterIO(
+        GF_Write, 0, 0, 1, 1, const_cast<float *>(unc.data()), 1, 1, GDT_Float32, 0, 0),
+      CE_None);
+    GDALClose(ds);
+  }
+
+  const auto imported = importGeoTiff(
+    store, SourceLayer::Chart, kDay1, path, Provenance::Replayed);
+  ASSERT_TRUE(imported.has_value());
+  EXPECT_EQ(*imported, 25u);   // 5x5 store cells under the one pixel
+
+  // Every cell of the footprint carries the value — spot-check a middle one.
+  const auto mid = store.cellIndex(
+    grid.northLatitude() - 2.5 * cell_y, grid.westLongitude() + 2.5 * cell_x);
+  const auto got = store.get(SourceLayer::Chart, kDay1, mid);
+  ASSERT_TRUE(got.has_value());
+  EXPECT_FLOAT_EQ(static_cast<float>(got->depth), -30.0f);
+}
+
 TEST_F(GeoTiffImportTest, MissingFileThrows)
 {
   BathymetryStore store(11);

--- a/marine_bathymetry_store/test/test_query.cpp
+++ b/marine_bathymetry_store/test/test_query.cpp
@@ -34,15 +34,25 @@ using marine_bathymetry_store::BathymetryStore;
 using marine_bathymetry_store::bestSource;
 using marine_bathymetry_store::DepthSample;
 using marine_bathymetry_store::forEachCellBestSource;
+using marine_bathymetry_store::forEachChangedCell;
 using marine_bathymetry_store::shallowestReliable;
 using marine_bathymetry_store::SourceLayer;
+
+namespace
+{
+
+constexpr const char * kDay1 = "2026-06-09";
+constexpr const char * kDay2 = "2026-06-10";
+constexpr const char * kDay3 = "2026-06-11";
+
+}  // namespace
 
 TEST(Query, BestSourcePrefersHigherPriorityLayer)
 {
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Draft, cell, BathyCell{-12.0, 2.0, 2.0});
-  store.set(SourceLayer::Processed, cell, BathyCell{-10.0, 0.1, 1.0});
+  store.set(SourceLayer::Draft, kDay1, cell, BathyCell{-12.0, 2.0, 2.0});
+  store.set(SourceLayer::Processed, kDay1, cell, BathyCell{-10.0, 0.1, 1.0});
 
   const auto best = bestSource(store, cell);
   ASSERT_TRUE(best.has_value());
@@ -54,11 +64,42 @@ TEST(Query, BestSourceFallsBackToLowerPriority)
 {
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Draft, cell, BathyCell{-12.0, 2.0, 2.0});
+  store.set(SourceLayer::Draft, kDay1, cell, BathyCell{-12.0, 2.0, 2.0});
 
   const auto best = bestSource(store, cell);
   ASSERT_TRUE(best.has_value());
   EXPECT_EQ(best->source, SourceLayer::Draft);
+  EXPECT_EQ(best->epoch, kDay1);
+}
+
+TEST(Query, BestSourcePicksNewestEpochWithinLayer)
+{
+  // Default resolution: latest epoch per cell (ADR-0002 §A1.3).
+  BathymetryStore store(5);
+  const auto cell = store.cellIndex(43.0, -70.5);
+  store.set(SourceLayer::Draft, kDay1, cell, BathyCell{-30.0, 0.5, 1.0});
+  store.set(SourceLayer::Draft, kDay2, cell, BathyCell{-28.0, 0.6, 2.0});
+
+  const auto best = bestSource(store, cell);
+  ASSERT_TRUE(best.has_value());
+  EXPECT_EQ(best->epoch, kDay2);
+  EXPECT_DOUBLE_EQ(best->depth, -28.0);
+}
+
+TEST(Query, BestSourceFallsThroughEpochWithoutCoverage)
+{
+  // A newer epoch that didn't cover this cell falls through to an older one —
+  // coverage gaps don't hide prior knowledge.
+  BathymetryStore store(5);
+  const auto cell = store.cellIndex(43.0, -70.5);
+  const auto elsewhere = store.cellIndex(43.2, -70.2);
+  store.set(SourceLayer::Draft, kDay1, cell, BathyCell{-30.0, 0.5, 1.0});
+  store.set(SourceLayer::Draft, kDay2, elsewhere, BathyCell{-5.0, 0.5, 2.0});
+
+  const auto best = bestSource(store, cell);
+  ASSERT_TRUE(best.has_value());
+  EXPECT_EQ(best->epoch, kDay1);
+  EXPECT_DOUBLE_EQ(best->depth, -30.0);
 }
 
 TEST(Query, UnknownCellIsNullopt)
@@ -68,7 +109,7 @@ TEST(Query, UnknownCellIsNullopt)
   EXPECT_FALSE(bestSource(store, cell).has_value());
 
   // A written-but-no-data cell is still unknown (not "deep water").
-  store.set(SourceLayer::Draft, cell, BathyCell{});
+  store.set(SourceLayer::Draft, kDay1, cell, BathyCell{});
   EXPECT_FALSE(bestSource(store, cell).has_value());
 }
 
@@ -77,8 +118,8 @@ TEST(Query, ShallowestReliablePicksGreatestHeight)
   // depth is ellipsoidal height (up-positive): shallower == greater value.
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Processed, cell, BathyCell{-30.0, 0.1, 1.0});  // deeper
-  store.set(SourceLayer::Draft, cell, BathyCell{-25.0, 0.2, 2.0});      // shallower
+  store.set(SourceLayer::Processed, kDay1, cell, BathyCell{-30.0, 0.1, 1.0});  // deeper
+  store.set(SourceLayer::Draft, kDay1, cell, BathyCell{-25.0, 0.2, 2.0});      // shallower
 
   const auto result = shallowestReliable(store, cell, 1.0);
   ASSERT_TRUE(result.has_value());
@@ -90,8 +131,10 @@ TEST(Query, ShallowestReliableExcludesOverUncertain)
 {
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Processed, cell, BathyCell{-30.0, 0.1, 1.0});  // reliable, deeper
-  store.set(SourceLayer::Draft, cell, BathyCell{-25.0, 5.0, 2.0});      // shallower, too uncertain
+  // reliable, deeper:
+  store.set(SourceLayer::Processed, kDay1, cell, BathyCell{-30.0, 0.1, 1.0});
+  // shallower, too uncertain:
+  store.set(SourceLayer::Draft, kDay1, cell, BathyCell{-25.0, 5.0, 2.0});
 
   const auto result = shallowestReliable(store, cell, 1.0);
   ASSERT_TRUE(result.has_value());
@@ -99,11 +142,34 @@ TEST(Query, ShallowestReliableExcludesOverUncertain)
   EXPECT_EQ(result->source, SourceLayer::Processed);
 }
 
+TEST(Query, ShallowestReliableFallsThroughNoisyFreshEpoch)
+{
+  // The §A1.3 safety walk: yesterday saw a confident 2 m shoal; today's first
+  // pass over the same cell is noisy. The noisy value fails the gate and the
+  // query falls through to yesterday — the shoal keeps protecting navigation.
+  BathymetryStore store(5);
+  const auto cell = store.cellIndex(43.0, -70.5);
+  store.set(SourceLayer::Draft, kDay1, cell, BathyCell{-2.0, 0.1, 1.0});   // confident shoal
+  store.set(SourceLayer::Draft, kDay2, cell, BathyCell{-4.0, 3.0, 2.0});   // noisy fresh pass
+
+  const auto result = shallowestReliable(store, cell, 1.0);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->epoch, kDay1);
+  EXPECT_DOUBLE_EQ(result->depth, -2.0);
+
+  // Once today's pass becomes confident, today governs.
+  store.set(SourceLayer::Draft, kDay2, cell, BathyCell{-4.0, 0.2, 3.0});
+  const auto later = shallowestReliable(store, cell, 1.0);
+  ASSERT_TRUE(later.has_value());
+  EXPECT_EQ(later->epoch, kDay2);
+  EXPECT_DOUBLE_EQ(later->depth, -4.0);
+}
+
 TEST(Query, ShallowestReliableTreatsNaNUncertaintyAsUnreliable)
 {
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Draft, cell, BathyCell{-25.0, std::nan(""), 2.0});
+  store.set(SourceLayer::Draft, kDay1, cell, BathyCell{-25.0, std::nan(""), 2.0});
   EXPECT_FALSE(shallowestReliable(store, cell, 1.0).has_value());
 }
 
@@ -111,7 +177,7 @@ TEST(Query, ForEachRegionVisitsCoveredCells)
 {
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Draft, cell, BathyCell{-20.0, 0.5, 1.0});
+  store.set(SourceLayer::Draft, kDay1, cell, BathyCell{-20.0, 0.5, 1.0});
 
   std::size_t visited = 0;
   std::size_t with_data = 0;
@@ -126,4 +192,42 @@ TEST(Query, ForEachRegionVisitsCoveredCells)
 
   EXPECT_GT(visited, 0u);
   EXPECT_GE(with_data, 1u);   // the written cell falls inside the box
+}
+
+TEST(Query, ChangedCellsVisitsOnlyDoublyObserved)
+{
+  // The change map (ADR-0002 §A1.1): cells observed in both epochs are
+  // visited with both records; single-epoch cells are coverage, not change.
+  BathymetryStore store(5);
+  const auto both = store.cellIndex(43.0, -70.5);
+  const auto only_day1 = store.cellIndex(43.2, -70.2);
+  store.set(SourceLayer::Draft, kDay1, both, BathyCell{-30.0, 0.5, 1.0});
+  store.set(SourceLayer::Draft, kDay1, only_day1, BathyCell{-20.0, 0.5, 1.0});
+  store.set(SourceLayer::Draft, kDay2, both, BathyCell{-28.0, 0.4, 2.0});
+
+  std::size_t visited = 0;
+  double delta = 0.0;
+  const auto count = forEachChangedCell(
+    store, SourceLayer::Draft, kDay1, kDay2,
+    [&](const gggs::CellIndex &, const BathyCell & a, const BathyCell & b) {
+      ++visited;
+      delta = b.depth - a.depth;
+    });
+
+  EXPECT_EQ(count, visited);
+  EXPECT_EQ(visited, 1u);          // only the doubly-observed cell
+  EXPECT_DOUBLE_EQ(delta, 2.0);    // shoaled by 2 m between the days
+}
+
+TEST(Query, ChangedCellsMissingEpochIsEmpty)
+{
+  BathymetryStore store(5);
+  store.set(SourceLayer::Draft, kDay1, store.cellIndex(43.0, -70.5),
+    BathyCell{-30.0, 0.5, 1.0});
+  const auto count = forEachChangedCell(
+    store, SourceLayer::Draft, kDay1, kDay3,
+    [](const gggs::CellIndex &, const BathyCell &, const BathyCell &) {
+      FAIL() << "no cells should be visited when an epoch is absent";
+    });
+  EXPECT_EQ(count, 0u);
 }

--- a/marine_bathymetry_store/test/test_query.cpp
+++ b/marine_bathymetry_store/test/test_query.cpp
@@ -219,6 +219,33 @@ TEST(Query, ChangedCellsVisitsOnlyDoublyObserved)
   EXPECT_DOUBLE_EQ(delta, 2.0);    // shoaled by 2 m between the days
 }
 
+TEST(Query, ChartLayerRanksBelowDraftAndFillsGaps)
+{
+  // The chart prior must never shadow survey data, but must answer where
+  // nothing else does.
+  BathymetryStore store(5);
+  const auto surveyed = store.cellIndex(43.0, -70.5);
+  const auto unsurveyed = store.cellIndex(43.2, -70.2);
+  store.set(SourceLayer::Chart, kDay1, surveyed, BathyCell{-10.0, 3.0, 1.0});
+  store.set(SourceLayer::Chart, kDay1, unsurveyed, BathyCell{-8.0, 3.0, 1.0});
+  store.set(SourceLayer::Draft, kDay2, surveyed, BathyCell{-12.0, 0.3, 2.0});
+
+  const auto at_surveyed = bestSource(store, surveyed);
+  ASSERT_TRUE(at_surveyed.has_value());
+  EXPECT_EQ(at_surveyed->source, SourceLayer::Draft);   // survey beats prior
+  EXPECT_DOUBLE_EQ(at_surveyed->depth, -12.0);
+
+  const auto at_unsurveyed = bestSource(store, unsurveyed);
+  ASSERT_TRUE(at_unsurveyed.has_value());
+  EXPECT_EQ(at_unsurveyed->source, SourceLayer::Chart);  // prior fills the gap
+  EXPECT_DOUBLE_EQ(at_unsurveyed->depth, -8.0);
+
+  // Under a strict gate the high-uncertainty prior is not "reliable".
+  EXPECT_FALSE(shallowestReliable(store, unsurveyed, 1.0).has_value());
+  // Under a gate that admits it, it answers.
+  EXPECT_TRUE(shallowestReliable(store, unsurveyed, 5.0).has_value());
+}
+
 TEST(Query, ChangedCellsMissingEpochIsEmpty)
 {
   BathymetryStore store(5);

--- a/marine_bathymetry_store/test/test_store.cpp
+++ b/marine_bathymetry_store/test/test_store.cpp
@@ -255,3 +255,21 @@ TEST(Store, ImportEpochWrongLevelTileThrows)
       Provenance::Replayed),
     std::invalid_argument);
 }
+
+TEST(Store, ImportEpochMismatchedTileKeyThrows)
+{
+  // The map key and the tile's own index must agree: persistence georeferences
+  // by tile.index() but names the file by the key, so a mismatch would produce
+  // a tile that load() silently re-keys elsewhere. Both grids are at the store
+  // level (so the level check passes) but key the wrong tile.
+  BathymetryStore store(5);
+  const auto cell_a = store.cellIndex(43.0, -70.5);
+  const auto cell_b = store.cellIndex(44.0, -71.0);   // a different grid
+  std::map<gggs::GridIndex, BathymetryTile> tiles;
+  BathymetryTile tile_b(cell_b.grid());
+  tile_b.set(cell_b.row(), cell_b.column(), BathyCell{-29.5, 0.2, 2.0});
+  tiles.emplace(cell_a.grid(), std::move(tile_b));   // keyed under cell_a's grid
+  EXPECT_THROW(
+    store.importEpoch(SourceLayer::Draft, kDay1, std::move(tiles), Provenance::Replayed),
+    std::invalid_argument);
+}

--- a/marine_bathymetry_store/test/test_store.cpp
+++ b/marine_bathymetry_store/test/test_store.cpp
@@ -21,22 +21,45 @@
 
 #include <gtest/gtest.h>
 
+#include <map>
 #include <stdexcept>
+#include <utility>
 
 #include "marine_autonomy/gggs.h"
 #include "marine_bathymetry_store/bathymetry_store.hpp"
 
 using marine_bathymetry_store::BathyCell;
 using marine_bathymetry_store::BathymetryStore;
+using marine_bathymetry_store::BathymetryTile;
+using marine_bathymetry_store::Provenance;
 using marine_bathymetry_store::SourceLayer;
+
+namespace
+{
+
+constexpr const char * kDay1 = "2026-06-09";
+constexpr const char * kDay2 = "2026-06-10";
+
+/// Build a single-tile map holding @p value at @p cell, for importEpoch.
+std::map<gggs::GridIndex, BathymetryTile> oneTile(
+  const gggs::CellIndex & cell, const BathyCell & value)
+{
+  std::map<gggs::GridIndex, BathymetryTile> tiles;
+  BathymetryTile tile(cell.grid());
+  tile.set(cell.row(), cell.column(), value);
+  tiles.emplace(cell.grid(), std::move(tile));
+  return tiles;
+}
+
+}  // namespace
 
 TEST(Store, SetGetRoundTrip)
 {
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Draft, cell, BathyCell{-30.0, 0.5, 1000.0});
+  EXPECT_TRUE(store.set(SourceLayer::Draft, kDay1, cell, BathyCell{-30.0, 0.5, 1000.0}));
 
-  const auto got = store.get(SourceLayer::Draft, cell);
+  const auto got = store.get(SourceLayer::Draft, kDay1, cell);
   ASSERT_TRUE(got.has_value());
   EXPECT_DOUBLE_EQ(got->depth, -30.0);
   EXPECT_DOUBLE_EQ(got->uncertainty, 0.5);
@@ -46,7 +69,8 @@ TEST(Store, SetGetRoundTrip)
 TEST(Store, GetEmptyLayerIsNullopt)
 {
   BathymetryStore store(5);
-  EXPECT_FALSE(store.get(SourceLayer::Processed, store.cellIndex(43.0, -70.5)).has_value());
+  EXPECT_FALSE(
+    store.get(SourceLayer::Processed, kDay1, store.cellIndex(43.0, -70.5)).has_value());
 }
 
 TEST(Store, LayersAreIndependent)
@@ -54,29 +78,57 @@ TEST(Store, LayersAreIndependent)
   // A draft write must not touch the processed layer at the same cell.
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Processed, cell, BathyCell{-10.0, 0.1, 1.0});
-  store.set(SourceLayer::Draft, cell, BathyCell{-12.0, 2.0, 2.0});
-  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Processed, cell)->depth, -10.0);
-  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Draft, cell)->depth, -12.0);
+  store.set(SourceLayer::Processed, kDay1, cell, BathyCell{-10.0, 0.1, 1.0});
+  store.set(SourceLayer::Draft, kDay1, cell, BathyCell{-12.0, 2.0, 2.0});
+  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Processed, kDay1, cell)->depth, -10.0);
+  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Draft, kDay1, cell)->depth, -12.0);
 }
 
-TEST(Store, TilesAllocatedLazilyPerLayer)
+TEST(Store, EpochsAreIndependent)
+{
+  // Day 2's write must not clobber day 1's value — epochs are never fused
+  // (ADR-0002 §A1.1); a cell surveyed on N days keeps N records.
+  BathymetryStore store(5);
+  const auto cell = store.cellIndex(43.0, -70.5);
+  store.set(SourceLayer::Draft, kDay1, cell, BathyCell{-30.0, 0.5, 1.0});
+  store.set(SourceLayer::Draft, kDay2, cell, BathyCell{-28.0, 0.6, 2.0});
+  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Draft, kDay1, cell)->depth, -30.0);
+  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Draft, kDay2, cell)->depth, -28.0);
+}
+
+TEST(Store, EpochsOrderChronologically)
+{
+  // ISO-date labels sort as strings, so the map's order is acquisition order
+  // and rbegin() is the newest epoch — load-bearing for query resolution.
+  BathymetryStore store(5);
+  const auto cell = store.cellIndex(43.0, -70.5);
+  store.set(SourceLayer::Draft, kDay2, cell, BathyCell{-28.0, 0.6, 2.0});
+  store.set(SourceLayer::Draft, kDay1, cell, BathyCell{-30.0, 0.5, 1.0});
+  const auto & epochs = store.epochs(SourceLayer::Draft);
+  ASSERT_EQ(epochs.size(), 2u);
+  EXPECT_EQ(epochs.begin()->first, kDay1);
+  EXPECT_EQ(epochs.rbegin()->first, kDay2);
+}
+
+TEST(Store, TilesAllocatedLazilyPerLayerAndEpoch)
 {
   BathymetryStore store(5);
-  EXPECT_TRUE(store.tiles(SourceLayer::Draft).empty());
-  EXPECT_TRUE(store.tiles(SourceLayer::Processed).empty());
+  EXPECT_TRUE(store.epochs(SourceLayer::Draft).empty());
+  EXPECT_TRUE(store.epochs(SourceLayer::Processed).empty());
 
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1.0});
-  EXPECT_EQ(store.tiles(SourceLayer::Draft).size(), 1u);
-  EXPECT_TRUE(store.tiles(SourceLayer::Processed).empty());
+  store.set(SourceLayer::Draft, kDay1, store.cellIndex(43.0, -70.5),
+    BathyCell{-30.0, 0.5, 1.0});
+  ASSERT_EQ(store.epochs(SourceLayer::Draft).size(), 1u);
+  EXPECT_EQ(store.epochs(SourceLayer::Draft).at(kDay1).tiles.size(), 1u);
+  EXPECT_TRUE(store.epochs(SourceLayer::Processed).empty());
 }
 
 TEST(Store, NoDataCellReadsBackAsNoData)
 {
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Draft, cell, BathyCell{});  // depth NaN
-  const auto got = store.get(SourceLayer::Draft, cell);
+  store.set(SourceLayer::Draft, kDay1, cell, BathyCell{});  // depth NaN
+  const auto got = store.get(SourceLayer::Draft, kDay1, cell);
   ASSERT_TRUE(got.has_value());      // tile exists
   EXPECT_FALSE(got->hasData());      // but the cell carries no usable depth
 }
@@ -86,14 +138,25 @@ TEST(Store, WrongLevelCellThrows)
   BathymetryStore store(5);
   gggs::Level other(6);
   const auto level6_cell = other.cellIndex(gggs::geoPoint(43.0, -70.5));
-  EXPECT_THROW(store.set(SourceLayer::Draft, level6_cell, BathyCell{}), std::invalid_argument);
+  EXPECT_THROW(
+    store.set(SourceLayer::Draft, kDay1, level6_cell, BathyCell{}), std::invalid_argument);
 }
 
 TEST(Store, InvalidCellThrows)
 {
   BathymetryStore store(5);
-  EXPECT_THROW(store.set(SourceLayer::Draft, gggs::CellIndex{}, BathyCell{}),
+  EXPECT_THROW(store.set(SourceLayer::Draft, kDay1, gggs::CellIndex{}, BathyCell{}),
     std::invalid_argument);
+}
+
+TEST(Store, InvalidEpochLabelThrows)
+{
+  BathymetryStore store(5);
+  const auto cell = store.cellIndex(43.0, -70.5);
+  EXPECT_THROW(store.set(SourceLayer::Draft, "", cell, BathyCell{}), std::invalid_argument);
+  EXPECT_THROW(
+    store.set(SourceLayer::Draft, "2026/06/09", cell, BathyCell{}), std::invalid_argument);
+  EXPECT_THROW(store.set(SourceLayer::Draft, "..", cell, BathyCell{}), std::invalid_argument);
 }
 
 TEST(Store, FromCellSizeChoosesAFiniteLevel)
@@ -101,4 +164,94 @@ TEST(Store, FromCellSizeChoosesAFiniteLevel)
   const auto store = BathymetryStore::fromCellSize(30.0f);
   // The chosen level must produce valid cells for a normal position.
   EXPECT_TRUE(store.cellIndex(43.0, -70.5).valid());
+}
+
+TEST(Store, ImportEpochSupersedesWholesale)
+{
+  // Compaction replaces the whole epoch (ADR-0002 §A1.2): cells of the live
+  // surface not covered by the replay product must be gone, not mixed in.
+  BathymetryStore store(5);
+  const auto cell_a = store.cellIndex(43.0, -70.5);
+  const auto cell_b = store.cellIndex(43.2, -70.2);  // far enough to be a distinct cell
+  store.set(SourceLayer::Draft, kDay1, cell_a, BathyCell{-30.0, 0.5, 1.0});
+  store.set(SourceLayer::Draft, kDay1, cell_b, BathyCell{-31.0, 0.5, 1.0});
+
+  // Replay product covers only cell_a, with a refined value.
+  EXPECT_TRUE(
+    store.importEpoch(
+      SourceLayer::Draft, kDay1, oneTile(cell_a, BathyCell{-29.5, 0.2, 2.0}),
+      Provenance::Replayed));
+
+  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Draft, kDay1, cell_a)->depth, -29.5);
+  const auto b = store.get(SourceLayer::Draft, kDay1, cell_b);
+  // cell_b is either absent (its grid wasn't imported) or no-data (same grid,
+  // fresh tile) — wholesale means the old value cannot survive either way.
+  EXPECT_TRUE(!b.has_value() || !b->hasData());
+  EXPECT_EQ(
+    store.epochs(SourceLayer::Draft).at(kDay1).provenance, Provenance::Replayed);
+}
+
+TEST(Store, LiveFusedNeverReplacesReplayed)
+{
+  // §A1.2 ordering: replayed beats live-fused, never the reverse.
+  BathymetryStore store(5);
+  const auto cell = store.cellIndex(43.0, -70.5);
+  ASSERT_TRUE(
+    store.importEpoch(
+      SourceLayer::Draft, kDay1, oneTile(cell, BathyCell{-29.5, 0.2, 2.0}),
+      Provenance::Replayed));
+
+  // A whole live import must be refused...
+  EXPECT_FALSE(
+    store.importEpoch(
+      SourceLayer::Draft, kDay1, oneTile(cell, BathyCell{-50.0, 5.0, 3.0}),
+      Provenance::LiveFused));
+  // ...and so must a stray live cell write (late snapshot after compaction).
+  EXPECT_FALSE(store.set(SourceLayer::Draft, kDay1, cell, BathyCell{-50.0, 5.0, 3.0}));
+
+  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Draft, kDay1, cell)->depth, -29.5);
+}
+
+TEST(Store, RecompactionIsAllowed)
+{
+  // Replayed-over-replayed is legitimate (a re-run compaction supersedes).
+  BathymetryStore store(5);
+  const auto cell = store.cellIndex(43.0, -70.5);
+  ASSERT_TRUE(
+    store.importEpoch(
+      SourceLayer::Draft, kDay1, oneTile(cell, BathyCell{-29.5, 0.2, 2.0}),
+      Provenance::Replayed));
+  EXPECT_TRUE(
+    store.importEpoch(
+      SourceLayer::Draft, kDay1, oneTile(cell, BathyCell{-29.6, 0.15, 3.0}),
+      Provenance::Replayed));
+  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Draft, kDay1, cell)->depth, -29.6);
+}
+
+TEST(Store, ImportEpochMarksTilesDirtyAndSupersedesDisk)
+{
+  BathymetryStore store(5);
+  const auto cell = store.cellIndex(43.0, -70.5);
+  ASSERT_TRUE(
+    store.importEpoch(
+      SourceLayer::Draft, kDay1, oneTile(cell, BathyCell{-29.5, 0.2, 2.0}),
+      Provenance::Replayed));
+  const auto & epoch = store.epochs(SourceLayer::Draft).at(kDay1);
+  EXPECT_TRUE(epoch.supersedes_disk);
+  for (const auto & [grid, tile] : epoch.tiles) {
+    static_cast<void>(grid);
+    EXPECT_TRUE(tile.dirty());
+  }
+}
+
+TEST(Store, ImportEpochWrongLevelTileThrows)
+{
+  BathymetryStore store(5);
+  gggs::Level other(6);
+  const auto level6_cell = other.cellIndex(gggs::geoPoint(43.0, -70.5));
+  EXPECT_THROW(
+    store.importEpoch(
+      SourceLayer::Draft, kDay1, oneTile(level6_cell, BathyCell{-29.5, 0.2, 2.0}),
+      Provenance::Replayed),
+    std::invalid_argument);
 }

--- a/marine_bathymetry_store/test/test_tile_io.cpp
+++ b/marine_bathymetry_store/test/test_tile_io.cpp
@@ -23,17 +23,40 @@
 
 #include <cstddef>
 #include <filesystem>
+#include <map>
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 #include "marine_bathymetry_store/bathymetry_store.hpp"
 #include "marine_bathymetry_store/tile_io.hpp"
 
 using marine_bathymetry_store::BathyCell;
 using marine_bathymetry_store::BathymetryStore;
+using marine_bathymetry_store::BathymetryTile;
+using marine_bathymetry_store::Provenance;
 using marine_bathymetry_store::SourceLayer;
 
 namespace fs = std::filesystem;
+
+namespace
+{
+
+constexpr const char * kDay1 = "2026-06-09";
+constexpr const char * kDay2 = "2026-06-10";
+
+/// Build a single-tile map holding @p value at @p cell, for importEpoch.
+std::map<gggs::GridIndex, BathymetryTile> oneTile(
+  const gggs::CellIndex & cell, const BathyCell & value)
+{
+  std::map<gggs::GridIndex, BathymetryTile> tiles;
+  BathymetryTile tile(cell.grid());
+  tile.set(cell.row(), cell.column(), value);
+  tiles.emplace(cell.grid(), std::move(tile));
+  return tiles;
+}
+
+}  // namespace
 
 class TileIoTest : public ::testing::Test
 {
@@ -56,15 +79,17 @@ protected:
 TEST_F(TileIoTest, RoundTripPreservesCells)
 {
   BathymetryStore store(5);
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.123, 0.456, 1.78e9});
-  store.set(SourceLayer::Processed, store.cellIndex(44.0, -71.0), BathyCell{-12.5, 0.2, 1.79e9});
+  store.set(SourceLayer::Draft, kDay1, store.cellIndex(43.0, -70.5),
+    BathyCell{-30.123, 0.456, 1.78e9});
+  store.set(SourceLayer::Processed, kDay1, store.cellIndex(44.0, -71.0),
+    BathyCell{-12.5, 0.2, 1.79e9});
 
   EXPECT_EQ(marine_bathymetry_store::save(store, dir_.string()), 2u);
 
   BathymetryStore reloaded(5);
   EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 2u);
 
-  const auto draft = reloaded.get(SourceLayer::Draft, reloaded.cellIndex(43.0, -70.5));
+  const auto draft = reloaded.get(SourceLayer::Draft, kDay1, reloaded.cellIndex(43.0, -70.5));
   ASSERT_TRUE(draft.has_value());
   EXPECT_DOUBLE_EQ(draft->depth, -30.123);
   EXPECT_DOUBLE_EQ(draft->uncertainty, 0.456);
@@ -72,16 +97,84 @@ TEST_F(TileIoTest, RoundTripPreservesCells)
   // (A Float32 band would lose ~128 s here — this is the precision guard.)
   EXPECT_DOUBLE_EQ(draft->timestamp, 1.78e9);
 
-  const auto processed = reloaded.get(SourceLayer::Processed, reloaded.cellIndex(44.0, -71.0));
+  const auto processed =
+    reloaded.get(SourceLayer::Processed, kDay1, reloaded.cellIndex(44.0, -71.0));
   ASSERT_TRUE(processed.has_value());
   EXPECT_DOUBLE_EQ(processed->depth, -12.5);
   EXPECT_DOUBLE_EQ(processed->timestamp, 1.79e9);
 }
 
+TEST_F(TileIoTest, RoundTripPreservesEpochsIndependently)
+{
+  // Two epochs of the same layer survive a save/load as distinct surfaces.
+  BathymetryStore store(5);
+  const auto cell = store.cellIndex(43.0, -70.5);
+  store.set(SourceLayer::Draft, kDay1, cell, BathyCell{-30.0, 0.5, 1.0});
+  store.set(SourceLayer::Draft, kDay2, cell, BathyCell{-28.0, 0.4, 2.0});
+
+  EXPECT_EQ(marine_bathymetry_store::save(store, dir_.string()), 2u);
+  EXPECT_TRUE(fs::is_directory(dir_ / "draft" / kDay1));
+  EXPECT_TRUE(fs::is_directory(dir_ / "draft" / kDay2));
+
+  BathymetryStore reloaded(5);
+  EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 2u);
+  EXPECT_DOUBLE_EQ(reloaded.get(SourceLayer::Draft, kDay1, cell)->depth, -30.0);
+  EXPECT_DOUBLE_EQ(reloaded.get(SourceLayer::Draft, kDay2, cell)->depth, -28.0);
+}
+
+TEST_F(TileIoTest, ProvenanceSurvivesRoundTrip)
+{
+  // A compacted epoch must reload as Replayed — otherwise a later live
+  // snapshot could regress it after a restart (ADR-0002 §A1.2).
+  BathymetryStore store(5);
+  const auto cell = store.cellIndex(43.0, -70.5);
+  store.set(SourceLayer::Draft, kDay1, cell, BathyCell{-30.0, 0.5, 1.0});
+  ASSERT_TRUE(
+    store.importEpoch(
+      SourceLayer::Draft, kDay2, oneTile(cell, BathyCell{-28.0, 0.2, 2.0}),
+      Provenance::Replayed));
+  marine_bathymetry_store::save(store, dir_.string());
+
+  BathymetryStore reloaded(5);
+  marine_bathymetry_store::load(reloaded, dir_.string());
+  EXPECT_EQ(
+    reloaded.epochs(SourceLayer::Draft).at(kDay1).provenance, Provenance::LiveFused);
+  EXPECT_EQ(
+    reloaded.epochs(SourceLayer::Draft).at(kDay2).provenance, Provenance::Replayed);
+  // The reloaded compacted epoch still refuses live writes.
+  EXPECT_FALSE(reloaded.set(SourceLayer::Draft, kDay2, cell, BathyCell{-50.0, 5.0, 3.0}));
+}
+
+TEST_F(TileIoTest, CompactionRemovesStaleTilesOnDisk)
+{
+  // The live surface covered two distant cells (two grids); the compaction
+  // product covers only one. After save, the stale tile file must be gone —
+  // a reload must see exactly the compacted surface (ADR-0002 §A1.2
+  // "supersedes wholesale").
+  BathymetryStore store(5);
+  const auto cell_a = store.cellIndex(43.0, -70.5);
+  const auto cell_b = store.cellIndex(44.0, -71.0);   // a different grid
+  store.set(SourceLayer::Draft, kDay1, cell_a, BathyCell{-30.0, 0.5, 1.0});
+  store.set(SourceLayer::Draft, kDay1, cell_b, BathyCell{-20.0, 0.5, 1.0});
+  EXPECT_EQ(marine_bathymetry_store::save(store, dir_.string()), 2u);
+
+  ASSERT_TRUE(
+    store.importEpoch(
+      SourceLayer::Draft, kDay1, oneTile(cell_a, BathyCell{-29.5, 0.2, 2.0}),
+      Provenance::Replayed));
+  EXPECT_EQ(marine_bathymetry_store::save(store, dir_.string()), 1u);
+
+  BathymetryStore reloaded(5);
+  EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 1u);
+  EXPECT_DOUBLE_EQ(reloaded.get(SourceLayer::Draft, kDay1, cell_a)->depth, -29.5);
+  EXPECT_FALSE(reloaded.get(SourceLayer::Draft, kDay1, cell_b).has_value());
+}
+
 TEST_F(TileIoTest, LoadedTilesAreCleanAndDontResave)
 {
   BathymetryStore store(5);
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1.0});
+  store.set(SourceLayer::Draft, kDay1, store.cellIndex(43.0, -70.5),
+    BathyCell{-30.0, 0.5, 1.0});
 
   EXPECT_EQ(marine_bathymetry_store::save(store, dir_.string()), 1u);
   // No changes since the last save -> nothing re-written (incremental save).
@@ -96,30 +189,52 @@ TEST_F(TileIoTest, LoadedTilesAreCleanAndDontResave)
 TEST_F(TileIoTest, WritingAfterSaveRedirties)
 {
   BathymetryStore store(5);
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1.0});
+  store.set(SourceLayer::Draft, kDay1, store.cellIndex(43.0, -70.5),
+    BathyCell{-30.0, 0.5, 1.0});
   EXPECT_EQ(marine_bathymetry_store::save(store, dir_.string()), 1u);
 
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-31.0, 0.4, 2.0});
+  store.set(SourceLayer::Draft, kDay1, store.cellIndex(43.0, -70.5),
+    BathyCell{-31.0, 0.4, 2.0});
   EXPECT_EQ(marine_bathymetry_store::save(store, dir_.string()), 1u);
 }
 
-TEST_F(TileIoTest, LayersWriteToSeparateSubdirectories)
+TEST_F(TileIoTest, LayersAndEpochsWriteToSeparateSubdirectories)
 {
   BathymetryStore store(5);
-  store.set(SourceLayer::Processed, store.cellIndex(43.0, -70.5), BathyCell{-10.0, 0.1, 1.0});
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-12.0, 0.5, 2.0});
+  store.set(SourceLayer::Processed, kDay1, store.cellIndex(43.0, -70.5),
+    BathyCell{-10.0, 0.1, 1.0});
+  store.set(SourceLayer::Draft, kDay1, store.cellIndex(43.0, -70.5),
+    BathyCell{-12.0, 0.5, 2.0});
   marine_bathymetry_store::save(store, dir_.string());
 
-  EXPECT_TRUE(fs::is_directory(dir_ / "processed"));
-  EXPECT_TRUE(fs::is_directory(dir_ / "draft"));
+  EXPECT_TRUE(fs::is_directory(dir_ / "processed" / kDay1));
+  EXPECT_TRUE(fs::is_directory(dir_ / "draft" / kDay1));
+  EXPECT_TRUE(fs::is_regular_file(dir_ / "draft" / kDay1 / "provenance"));
 }
 
 TEST_F(TileIoTest, LoadRejectsTilesFromAnotherLevel)
 {
   BathymetryStore store(5);
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1.0});
+  store.set(SourceLayer::Draft, kDay1, store.cellIndex(43.0, -70.5),
+    BathyCell{-30.0, 0.5, 1.0});
   marine_bathymetry_store::save(store, dir_.string());
 
   BathymetryStore wrong_level(6);
   EXPECT_THROW(marine_bathymetry_store::load(wrong_level, dir_.string()), std::runtime_error);
+}
+
+TEST_F(TileIoTest, MissingProvenanceSidecarLoadsAsLiveFused)
+{
+  // Conservative default: an epoch without a sidecar loads at the lower rank,
+  // so a later compaction can still supersede it.
+  BathymetryStore store(5);
+  store.set(SourceLayer::Draft, kDay1, store.cellIndex(43.0, -70.5),
+    BathyCell{-30.0, 0.5, 1.0});
+  marine_bathymetry_store::save(store, dir_.string());
+  fs::remove(dir_ / "draft" / kDay1 / "provenance");
+
+  BathymetryStore reloaded(5);
+  marine_bathymetry_store::load(reloaded, dir_.string());
+  EXPECT_EQ(
+    reloaded.epochs(SourceLayer::Draft).at(kDay1).provenance, Provenance::LiveFused);
 }

--- a/marine_bathymetry_store/test/test_tile_io.cpp
+++ b/marine_bathymetry_store/test/test_tile_io.cpp
@@ -23,6 +23,7 @@
 
 #include <cstddef>
 #include <filesystem>
+#include <fstream>
 #include <map>
 #include <stdexcept>
 #include <string>
@@ -237,4 +238,32 @@ TEST_F(TileIoTest, MissingProvenanceSidecarLoadsAsLiveFused)
   marine_bathymetry_store::load(reloaded, dir_.string());
   EXPECT_EQ(
     reloaded.epochs(SourceLayer::Draft).at(kDay1).provenance, Provenance::LiveFused);
+}
+
+TEST_F(TileIoTest, CrlfProvenanceSidecarStillLoadsAsReplayed)
+{
+  // A sidecar written with CRLF line endings (e.g. on a Windows host) leaves a
+  // trailing '\r' on the token. readProvenance() must trim it — otherwise the
+  // exact-match parse fails and the epoch silently downgrades to LiveFused,
+  // allowing live writes over replayed data after reload.
+  BathymetryStore store(5);
+  const auto cell = store.cellIndex(43.0, -70.5);
+  ASSERT_TRUE(
+    store.importEpoch(
+      SourceLayer::Draft, kDay1, oneTile(cell, BathyCell{-28.0, 0.2, 2.0}),
+      Provenance::Replayed));
+  marine_bathymetry_store::save(store, dir_.string());
+
+  // Rewrite the sidecar with a CRLF line ending.
+  {
+    std::ofstream out(dir_ / "draft" / kDay1 / "provenance", std::ios::binary);
+    out << "replayed\r\n";
+  }
+
+  BathymetryStore reloaded(5);
+  marine_bathymetry_store::load(reloaded, dir_.string());
+  EXPECT_EQ(
+    reloaded.epochs(SourceLayer::Draft).at(kDay1).provenance, Provenance::Replayed);
+  // Still refuses live writes after the CRLF round-trip.
+  EXPECT_FALSE(reloaded.set(SourceLayer::Draft, kDay1, cell, BathyCell{-50.0, 5.0, 3.0}));
 }


### PR DESCRIPTION
Closes #147. Part of #86.

Phase 2 of the bathymetric data store: import (bag-replay, `GeoMapSheet`, GeoTIFF) under the **per-day epoch model**.

## Status

- [x] ADR-0002 **Amendment A1** — per-day epochs: epoch instances per layer (never fused across days; differencing = change map), within-epoch rules (same-session replace / cross-session 1/σ² fusion / end-of-day compaction with wholesale supersession + `replayed`-beats-`live-fused` provenance), newest-reliable epoch walk for the D7 safety query, deliberate no-CUBE-seeding to keep change maps unbiased.
- [ ] `GeoMapSheet` → store importer (session-tagged snapshots, within-epoch rules)
- [ ] Bag-replay harness: per-day single-CUBE replay of the multi-day M3 corpus → compacted epochs
- [ ] GeoTIFF importer (processed layer; first customer: lake-contour starter GeoTIFF, CCOMJHC/ccomjhc_project11#55)
- [ ] Tests per the issue's deliverables list

Draft until the importers land; the amendment commit is reviewable now.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Fable 5`
