### PR TITLE
manifest: add marine_control to core layer

### DIFF
--- a/config/repos/core.repos
+++ b/config/repos/core.repos
@@ -7,6 +7,10 @@ repositories:
     type: git
     url: https://github.com/rolker/marine_ais.git
     version: jazzy
+  marine_control:
+    type: git
+    url: https://github.com/rolker/marine_control.git
+    version: jazzy
   udp_bridge:
     type: git
     url: https://github.com/rolker/udp_bridge.git


### PR DESCRIPTION
Closes #154. Part of #140.

Adds the new `rolker/marine_control` repo to `config/repos/core.repos` so the workspace clones it.

`marine_control` holds `marine_control_interfaces` (merged) + the upcoming Qt-free device library. Placed in **core** because it's the bridge-correct device-control protocol (sibling to `udp_bridge`, already in core) and core sits below its consumers in the sensors layer (`garmin_sidescan`) and ui layer (`rqt_operator_tools`).

This unblocks the device-library work and the rqt side. YAML validated; one-entry change.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
