### PR TITLE
Bathy store A1: Chart source layer (read-only prior) — core

### DIFF
--- a/.agent/work-plans/issue-163/plan.md
+++ b/.agent/work-plans/issue-163/plan.md
@@ -1,0 +1,89 @@
+# Plan: Bathy store — add Chart source layer (load contour prior; lake constant-offset datum)
+
+## Issue
+https://github.com/rolker/unh_marine_autonomy/issues/163
+
+## Context
+Phase 1 (#141) shipped `SourceLayer{Processed, Draft}`; `Chart` is reserved but
+unimplemented (`bathy_cell.hpp` comment, absent from `source_layers_by_priority`,
+no `chart/` case in `tile_io`). It was gated on the mru_transform vertical-datum
+work (ADR-0002 §D4). For **Lake Massabesic that gate is a constant offset** (the
+lake-surface ellipsoidal height, 52.3 m), not the ocean VDatum path — so Chart
+lands now. The on-disk prior (`~/data/bathymetry/massabesic/store/chart/2026-06-12/`,
+142 tiles) is **raw depth-below-surface** (NH GRANIT 5-ft contours, negative-down);
+the store's `BathyCell.depth` is **ellipsoidal height**, so the prior must be
+converted *at import* (§D7) — that conversion is A2, not a raw load.
+
+## Approach (one issue, two PRs)
+
+### PR A1 — core: `SourceLayer::Chart` (datum-agnostic, `unh_marine_autonomy`)
+1. **`bathy_cell.hpp`** — add `Chart = 2`; append to `source_layers_by_priority`
+   (size 2→3; `source_layer_count`/`BathymetryStore::layers_` adapt automatically).
+   Chart is last → lowest query priority (best-source falls through to it). Update
+   the "reserved" doc comment.
+2. **`tile_io.cpp`** — add `case SourceLayer::Chart: return "chart";` in
+   `layerDirName`. `save()`/`load()` already iterate `source_layers_by_priority`,
+   so `chart/` round-trips with no further change; WGS84-validated load applies
+   as-is.
+3. **Read-only enforcement** — make Chart **read-only by default**: `set(Chart,…)`
+   throws unless the store was explicitly opened chart-writable (the A2 importer's
+   mode). This makes the prior unclobberable by live Draft/CUBE ingest everywhere
+   except the dedicated importer. (See Open Question 1 — mechanism choice.)
+4. **gtests** — `test_query`: best-source fall-through to Chart; `test_tile_io`:
+   chart tile round-trip + an existing processed/draft store still loads (chart/
+   absent → skipped); `test_store`: `set(Chart)` rejected unless chart-writable.
+
+### PR A2 — importer: contour prior → Chart layer (`cube_bathymetry`, sensors_ws)
+5. **Chart import path** (separate worktree/PR on cube_bathymetry): read the raw
+   contour tiles (depth-below-surface), add the per-tile datum offset from
+   `resolve_datum(lat, lon, entries, /*vdatum=*/nullopt)`, write ellipsoidal Chart
+   tiles via the store opened chart-writable. cube_bathymetry (sensors_ws) is above
+   `platforms_ws`, so it can link `mru_transform`'s `datum_config` and the store —
+   keeping the core datum-agnostic.
+6. **Datum entry** — add the `massabesic` polygon `DatumEntry` (`chart_datum_z:
+   52.3`) to the datum config `chart_datum_node` loads (single source of truth).
+7. **Verify** against the on-disk prior: a −13.716 m (45 ft) cell imports to 38.58 m
+   ellipsoidal; 142 tiles covered; re-import idempotent (content-hash unchanged).
+
+## Files to Change
+| File | Change |
+|------|--------|
+| `marine_bathymetry_store/include/.../bathy_cell.hpp` | add `Chart`, extend priority array, doc |
+| `marine_bathymetry_store/src/tile_io.cpp` | `layerDirName` chart case |
+| `marine_bathymetry_store/include/.../bathymetry_store.hpp` (+ src) | chart read-only mode + guarded `set` |
+| `marine_bathymetry_store/test/{test_query,test_tile_io,test_store}.cpp` | Chart coverage |
+| *(A2, cube_bathymetry repo)* | chart importer + `massabesic` datum entry |
+
+## Principles Self-Check
+| Principle | Consideration |
+|---|---|
+| Reuse over duplication | Reuses `tile_io`, `query` overlay, `resolve_datum()`; no new tile format or datum math. |
+| Layering | Core stays datum-agnostic (core_ws); conversion in the sensors_ws importer that may link platforms_ws. |
+| Do it right / completeness | Read-only guard + tests, not just the enum; idempotent import. |
+
+## ADR Compliance
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0002 §D3 (source-layer overlay) | Yes | Chart added as lowest-priority non-destructive layer. |
+| ADR-0002 §D5 (per-tile GeoTIFF) | Yes | Chart reuses the same 3-band Float64 tile_io. |
+| ADR-0002 §D7 (convert at import) | Yes | Datum offset applied in A2 importer; store stores ellipsoidal. |
+| ADR-0002 §D4 (datum gate) | Partially | Lake = constant offset, decoupled from ocean VDatum (deferred). |
+
+## Consequences
+| If we change... | Also update... | Included? |
+|---|---|---|
+| `source_layer_count` 2→3 | any code assuming exactly 2 layers | Verified: array-sized; query/tile_io iterate the array — none hardcode 2 |
+| Add Chart to save/load scan | existing processed/draft stores | Back-compatible (missing `chart/` skipped) — covered by a test |
+| Store now stores a converted prior | sim harness (#76), costmap layer (#164) consume ellipsoidal Chart | Downstream issues already assume ellipsoidal |
+
+## Open Questions
+1. **Read-only mechanism.** Recommend **Chart read-only by default**, importer
+   opts in (chart-writable store). Alternative: a runtime `setLayerReadOnly()` flag
+   (default writable). Default-read-only is the stronger guarantee; confirm at
+   review-plan.
+2. **A2 worktree** is a separate cube_bathymetry repo PR — confirm we stack it after
+   A1 lands (A1 has no cube dependency; A2 depends on A1's chart-writable API).
+
+## Estimated Scope
+Two PRs across two repos. A1 (core) is small and self-contained; A2 (importer)
+depends on A1's chart-writable API + the existing #148 import tooling patterns.

--- a/.agent/work-plans/issue-163/plan.md
+++ b/.agent/work-plans/issue-163/plan.md
@@ -77,10 +77,12 @@ converted *at import* (§D7) — that conversion is A2, not a raw load.
 | Store now stores a converted prior | sim harness (#76), costmap layer (#164) consume ellipsoidal Chart | Downstream issues already assume ellipsoidal |
 
 ## Open Questions
-1. **Read-only mechanism.** Recommend **Chart read-only by default**, importer
-   opts in (chart-writable store). Alternative: a runtime `setLayerReadOnly()` flag
-   (default writable). Default-read-only is the stronger guarantee; confirm at
-   review-plan.
+1. **Read-only mechanism — RESOLVED (implemented in A1).** Chart is read-only by
+   default: `set(Chart,…)` throws `std::logic_error` unless the store is
+   constructed `chart_writable=true` (importer only). `load()`/`getOrCreateTile`
+   stay unguarded, so the runtime loads the prior into a read-only store. The
+   alternative (runtime `setLayerReadOnly()` flag, default writable) was rejected —
+   default-read-only is the stronger guarantee.
 2. **A2 worktree** is a separate cube_bathymetry repo PR — confirm we stack it after
    A1 lands (A1 has no cube dependency; A2 depends on A1's chart-writable API).
 

--- a/.agent/work-plans/issue-163/progress.md
+++ b/.agent/work-plans/issue-163/progress.md
@@ -36,3 +36,23 @@ issue: 163
 ### Notes
 - Static analysis clean (cppcheck/cpplint/uncrustify/lint_cmake/xmllint all pass); 82 gtests, 0 failures.
 - Cross-cutting (for A2, not A1): whoever sets Chart import uncertainty holds the safety lever for shallowestReliable in unsurveyed cells.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-15 05:31 +0000
+**By**: Claude Code Agent (Claude Opus 4.8)
+**Verdict**: approved
+
+**Branch**: feature/issue-163 at `53ee921`
+**Mode**: pre-push
+**Depth**: Standard (reason: core data-model change + read-only navigation-safety guard, ADR-0002)
+**Must-fix**: 0 | **Suggestions**: 0
+
+### Findings
+- [ ] No issues found. LGTM.
+
+### Notes
+- Re-review of the final A1 state (code unchanged since `f972286`; HEAD `53ee921` adds only the prior progress entry). Confirms the earlier review's 3 fixes hold.
+- Static analysis clean: ament_cpplint, ament_uncrustify, ament_cppcheck (slow-version override) — no problems on all 7 changed C++ files.
+- Two fresh-context Claude adversarial passes (Lens A logic/correctness + Lens B systemic/safety) both returned No findings: read-only-by-construction guarantee airtight (private getOrCreateTile, friended save/load, no bypass via tiles()/get()/copy); friend signatures match across bathymetry_store.hpp / tile_io.hpp / tile_io.cpp; uncertainty-gate boundary test (3.0 m) faithful to query.cpp `>` comparison.
+- Plan adherence full; A2 (cube_bathymetry importer + massabesic datum entry) correctly deferred to a separate repo/PR.

--- a/.agent/work-plans/issue-163/progress.md
+++ b/.agent/work-plans/issue-163/progress.md
@@ -1,0 +1,18 @@
+---
+issue: 163
+---
+
+# Issue #163 — Bathy store: add Chart source layer (load contour prior; lake constant-offset datum)
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-14 23:28 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Plan**: `.agent/work-plans/issue-163/plan.md` at `ee838a5`
+**PR**: https://github.com/rolker/unh_marine_autonomy/pull/165 (`[PLAN]` prefix)
+**Phases**: two PRs (A1 core Chart layer / A2 cube_bathymetry importer)
+
+### Open questions
+- [ ] Read-only mechanism: Chart read-only by default + importer opt-in (recommended) vs runtime setLayerReadOnly() flag — confirm at review-plan.
+- [ ] A2 is a separate cube_bathymetry repo PR stacked after A1 (A2 needs A1's chart-writable API).

--- a/.agent/work-plans/issue-163/progress.md
+++ b/.agent/work-plans/issue-163/progress.md
@@ -16,3 +16,23 @@ issue: 163
 ### Open questions
 - [ ] Read-only mechanism: Chart read-only by default + importer opt-in (recommended) vs runtime setLayerReadOnly() flag — confirm at review-plan.
 - [ ] A2 is a separate cube_bathymetry repo PR stacked after A1 (A2 needs A1's chart-writable API).
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-15 00:23 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved (findings addressed in-session)
+
+**Branch**: feature/issue-163 at `f972286`
+**Mode**: pre-push
+**Depth**: Standard (reason: core data-model change + read-only safety guard, ADR-0002)
+**Must-fix**: 1 | **Suggestions**: 2
+
+### Findings
+- [x] (must-fix, cross-confirmed Lens A+B) read-only Chart guard bypassable via public `getOrCreateTile()` returning a mutable tile ref — closed by construction (made private, friended save/load) — `bathymetry_store.hpp`
+- [x] (suggestion) `set()` read-only check ran before cell validity → malformed cell reported logic_error not invalid_argument; reordered validity-first — `bathymetry_store.cpp:33`
+- [x] (suggestion) no `shallowestReliable` + Chart test across the 3.0 m import-uncertainty gate (a safety input); added boundary test — `test_query.cpp`
+
+### Notes
+- Static analysis clean (cppcheck/cpplint/uncrustify/lint_cmake/xmllint all pass); 82 gtests, 0 failures.
+- Cross-cutting (for A2, not A1): whoever sets Chart import uncertainty holds the safety lever for shallowestReliable in unsurveyed cells.

--- a/marine_bathymetry_store/include/marine_bathymetry_store/bathy_cell.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/bathy_cell.hpp
@@ -37,18 +37,23 @@ namespace marine_bathymetry_store
 /// deliberate, cleaner realization of ADR-0002 §D3's "each cell stores a
 /// source layer": the layer is the map it lives in.
 ///
-/// The numeric value is the priority rank (0 = highest). `Chart` is reserved
-/// for a later phase (it depends on the mru_transform vertical-datum work) and
-/// is intentionally not yet a member.
+/// The numeric value is the priority rank (0 = highest). `Chart` (the broad,
+/// coarse contour / S57-derived prior) is lowest priority: best-source falls
+/// through to it where no Processed/Draft data exists. Chart cells are
+/// ellipsoidal heights converted from chart datum **at import** (ADR-0002 §D7);
+/// the store treats Chart as a **read-only prior** so live Draft/CUBE ingest can
+/// never clobber it — see `BathymetryStore::set` and the `chart_writable`
+/// construction flag the importer opts into.
 enum class SourceLayer : uint8_t
 {
   Processed = 0,  ///< Externally produced grids (bathy-BAG / GeoTIFF). Highest confidence.
   Draft = 1,      ///< Real-time CUBE output. Valuable but potentially noisy.
+  Chart = 2,      ///< Contour / S57-derived prior. Broad, coarse, read-only.
 };
 
 /// @brief Source layers in descending priority order — iterate for best-source.
-inline constexpr std::array<SourceLayer, 2> source_layers_by_priority{
-  SourceLayer::Processed, SourceLayer::Draft};
+inline constexpr std::array<SourceLayer, 3> source_layers_by_priority{
+  SourceLayer::Processed, SourceLayer::Draft, SourceLayer::Chart};
 
 /// @brief Number of source layers present in this phase.
 inline constexpr std::size_t source_layer_count = source_layers_by_priority.size();

--- a/marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_store.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_store.hpp
@@ -48,16 +48,27 @@ class BathymetryStore
 {
 public:
   /// @brief Construct a store whose tiles live at GGGS quadtree @p gggs_level.
+  ///
+  /// @param chart_writable Opt in to per-cell `set()` writes on the read-only
+  ///   `Chart` prior layer. Default `false` — only the chart importer (which
+  ///   converts the contour prior to ellipsoidal at import) should pass `true`.
+  ///   Runtime consumers leave it `false` so live Draft/CUBE ingest can never
+  ///   mutate the prior. Loading Chart tiles from disk is always allowed
+  ///   (`getOrCreateTile` / `load`); only `set(Chart, …)` is gated.
   /// @throws std::out_of_range if the level is invalid (via gggs::Level).
-  explicit BathymetryStore(uint8_t gggs_level)
-  : level_(gggs_level) {}
+  explicit BathymetryStore(uint8_t gggs_level, bool chart_writable = false)
+  : level_(gggs_level), chart_writable_(chart_writable) {}
 
   /// @brief Construct a store at the coarsest GGGS level whose cells are no
   ///        larger than @p cell_size_m (clamped to the finest level, 20).
-  static BathymetryStore fromCellSize(float cell_size_m)
+  static BathymetryStore fromCellSize(float cell_size_m, bool chart_writable = false)
   {
-    return BathymetryStore(gggs::Level::fromCellSize(cell_size_m).level());
+    return BathymetryStore(
+      gggs::Level::fromCellSize(cell_size_m).level(), chart_writable);
   }
+
+  /// @brief Whether per-cell `set()` may write the read-only `Chart` layer.
+  bool chartWritable() const noexcept {return chart_writable_;}
 
   /// @brief The GGGS level all tiles in this store use.
   const gggs::Level & level() const noexcept {return level_;}
@@ -76,6 +87,8 @@ public:
   /// Creates the backing tile on first write to its grid. The cell's grid must
   /// be at this store's level.
   /// @throws std::invalid_argument if @p cell is invalid or at the wrong level.
+  /// @throws std::logic_error if @p layer is `Chart` and the store was not
+  ///   constructed `chart_writable` — the prior is read-only (ADR-0002 §D3).
   void set(SourceLayer layer, const gggs::CellIndex & cell, const BathyCell & value);
 
   /// @brief Read the raw cell in a single @p layer (no priority overlay).
@@ -104,6 +117,7 @@ private:
   }
 
   gggs::Level level_;
+  bool chart_writable_ = false;
   std::array<std::map<gggs::GridIndex, BathymetryTile>, source_layer_count> layers_;
 };
 

--- a/marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_store.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_store.hpp
@@ -23,8 +23,10 @@
 #define MARINE_BATHYMETRY_STORE__BATHYMETRY_STORE_HPP_
 
 #include <array>
+#include <cstddef>
 #include <map>
 #include <optional>
+#include <string>
 
 #include "marine_autonomy/gggs.h"
 #include "marine_bathymetry_store/bathy_cell.hpp"
@@ -32,6 +34,13 @@
 
 namespace marine_bathymetry_store
 {
+
+class BathymetryStore;
+// Persistence free functions (defined in tile_io.cpp). Forward-declared here so
+// the store can friend them: `load` must populate any layer — including the
+// read-only `Chart` prior — from disk, which the public API otherwise forbids.
+std::size_t save(BathymetryStore & store, const std::string & dir);
+std::size_t load(BathymetryStore & store, const std::string & dir);
 
 /// @brief In-memory, GGGS-tiled, multi-layer bathymetric store (Phase 1 core).
 ///
@@ -53,8 +62,10 @@ public:
   ///   `Chart` prior layer. Default `false` — only the chart importer (which
   ///   converts the contour prior to ellipsoidal at import) should pass `true`.
   ///   Runtime consumers leave it `false` so live Draft/CUBE ingest can never
-  ///   mutate the prior. Loading Chart tiles from disk is always allowed
-  ///   (`getOrCreateTile` / `load`); only `set(Chart, …)` is gated.
+  ///   mutate the prior. `load()` (a friend) may still populate Chart from disk
+  ///   regardless of this flag — the read-only gate is on per-cell mutation
+  ///   (`set`), not on loading the prior. Direct tile mutation is impossible
+  ///   from outside: `getOrCreateTile` is private (persistence-only).
   /// @throws std::out_of_range if the level is invalid (via gggs::Level).
   explicit BathymetryStore(uint8_t gggs_level, bool chart_writable = false)
   : level_(gggs_level), chart_writable_(chart_writable) {}
@@ -102,11 +113,21 @@ public:
     return layerMap(layer);
   }
 
-  /// @brief Find or create the tile for @p grid in @p layer (used by load).
+private:
+  // Persistence needs to populate any layer (including the read-only Chart
+  // prior) from disk, so the free functions in tile_io.cpp are friends.
+  friend std::size_t save(BathymetryStore & store, const std::string & dir);
+  friend std::size_t load(BathymetryStore & store, const std::string & dir);
+
+  /// @brief Find or create the tile for @p grid in @p layer.
+  ///
+  /// Private: the only mutable tile access. Public mutation goes through `set`
+  /// (which gates `Chart`); persistence reaches this via friendship. This is
+  /// what makes the Chart read-only guarantee hold by construction, not just by
+  /// convention — external code cannot obtain a mutable Chart tile.
   /// @throws std::invalid_argument if @p grid is invalid or at the wrong level.
   BathymetryTile & getOrCreateTile(SourceLayer layer, const gggs::GridIndex & grid);
 
-private:
   std::map<gggs::GridIndex, BathymetryTile> & layerMap(SourceLayer layer)
   {
     return layers_[static_cast<std::size_t>(layer)];

--- a/marine_bathymetry_store/src/bathymetry_store.cpp
+++ b/marine_bathymetry_store/src/bathymetry_store.cpp
@@ -30,6 +30,11 @@ namespace marine_bathymetry_store
 void BathymetryStore::set(
   SourceLayer layer, const gggs::CellIndex & cell, const BathyCell & value)
 {
+  if (layer == SourceLayer::Chart && !chart_writable_) {
+    throw std::logic_error(
+            "BathymetryStore::set: Chart is a read-only prior layer; construct "
+            "the store with chart_writable=true (importer only) to write it");
+  }
   if (!cell.valid()) {
     throw std::invalid_argument("BathymetryStore::set: invalid CellIndex");
   }

--- a/marine_bathymetry_store/src/bathymetry_store.cpp
+++ b/marine_bathymetry_store/src/bathymetry_store.cpp
@@ -30,11 +30,9 @@ namespace marine_bathymetry_store
 void BathymetryStore::set(
   SourceLayer layer, const gggs::CellIndex & cell, const BathyCell & value)
 {
-  if (layer == SourceLayer::Chart && !chart_writable_) {
-    throw std::logic_error(
-            "BathymetryStore::set: Chart is a read-only prior layer; construct "
-            "the store with chart_writable=true (importer only) to write it");
-  }
+  // Validate the inputs first, then the layer permission — so a malformed cell
+  // always reports invalid_argument (the more actionable error), and the
+  // read-only logic_error fires only for an otherwise-valid Chart write.
   if (!cell.valid()) {
     throw std::invalid_argument("BathymetryStore::set: invalid CellIndex");
   }
@@ -43,6 +41,11 @@ void BathymetryStore::set(
             "BathymetryStore::set: CellIndex at level " +
             std::to_string(cell.level()) + " but store is at level " +
             std::to_string(level_.level()));
+  }
+  if (layer == SourceLayer::Chart && !chart_writable_) {
+    throw std::logic_error(
+            "BathymetryStore::set: Chart is a read-only prior layer; construct "
+            "the store with chart_writable=true (importer only) to write it");
   }
   BathymetryTile & tile = getOrCreateTile(layer, cell.grid());
   tile.set(cell.row(), cell.column(), value);

--- a/marine_bathymetry_store/src/tile_io.cpp
+++ b/marine_bathymetry_store/src/tile_io.cpp
@@ -90,6 +90,7 @@ std::string layerDirName(SourceLayer layer)
   switch (layer) {
     case SourceLayer::Processed: return "processed";
     case SourceLayer::Draft: return "draft";
+    case SourceLayer::Chart: return "chart";
   }
   throw std::runtime_error("layerDirName: unknown SourceLayer");
 }

--- a/marine_bathymetry_store/test/test_query.cpp
+++ b/marine_bathymetry_store/test/test_query.cpp
@@ -152,3 +152,22 @@ TEST(Query, BestSourceFallsThroughToChartPrior)
   EXPECT_EQ(b->source, SourceLayer::Draft);
   EXPECT_DOUBLE_EQ(b->depth, 40.0);
 }
+
+TEST(Query, ShallowestReliableGatesChartByUncertainty)
+{
+  // The coarse Chart prior carries a fixed import uncertainty (3.0 m). It feeds
+  // the safety query shallowestReliable, so the uncertainty gate must admit it
+  // only when the caller's tolerance allows — both sides of the threshold.
+  BathymetryStore store(5, /*chart_writable=*/true);
+  const auto cell = store.cellIndex(43.0, -70.5);
+  store.set(SourceLayer::Chart, cell, BathyCell{38.0, 3.0, 1.0});
+
+  // Tolerance below the chart uncertainty excludes it -> cell reads as unknown.
+  EXPECT_FALSE(shallowestReliable(store, cell, 2.9).has_value());
+
+  // Tolerance at the chart uncertainty (comparison is strictly >) admits it.
+  const auto at = shallowestReliable(store, cell, 3.0);
+  ASSERT_TRUE(at.has_value());
+  EXPECT_EQ(at->source, SourceLayer::Chart);
+  EXPECT_DOUBLE_EQ(at->depth, 38.0);
+}

--- a/marine_bathymetry_store/test/test_query.cpp
+++ b/marine_bathymetry_store/test/test_query.cpp
@@ -127,3 +127,28 @@ TEST(Query, ForEachRegionVisitsCoveredCells)
   EXPECT_GT(visited, 0u);
   EXPECT_GE(with_data, 1u);   // the written cell falls inside the box
 }
+
+TEST(Query, BestSourceFallsThroughToChartPrior)
+{
+  // Chart is the lowest-priority prior: used only where nothing newer exists,
+  // and overridden by Draft/Processed where they do (ADR-0002 §D3).
+  BathymetryStore store(5, /*chart_writable=*/true);
+  const auto unsurveyed = store.cellIndex(43.0, -70.5);
+  const auto surveyed = store.cellIndex(43.0, -70.4);
+
+  store.set(SourceLayer::Chart, unsurveyed, BathyCell{38.0, 3.0, 1.0});
+  store.set(SourceLayer::Chart, surveyed, BathyCell{38.0, 3.0, 1.0});
+  store.set(SourceLayer::Draft, surveyed, BathyCell{40.0, 0.5, 2.0});
+
+  // Unsurveyed cell falls through to the chart prior.
+  const auto a = bestSource(store, unsurveyed);
+  ASSERT_TRUE(a.has_value());
+  EXPECT_EQ(a->source, SourceLayer::Chart);
+  EXPECT_DOUBLE_EQ(a->depth, 38.0);
+
+  // Surveyed cell prefers the live draft over the chart prior.
+  const auto b = bestSource(store, surveyed);
+  ASSERT_TRUE(b.has_value());
+  EXPECT_EQ(b->source, SourceLayer::Draft);
+  EXPECT_DOUBLE_EQ(b->depth, 40.0);
+}

--- a/marine_bathymetry_store/test/test_store.cpp
+++ b/marine_bathymetry_store/test/test_store.cpp
@@ -102,3 +102,37 @@ TEST(Store, FromCellSizeChoosesAFiniteLevel)
   // The chosen level must produce valid cells for a normal position.
   EXPECT_TRUE(store.cellIndex(43.0, -70.5).valid());
 }
+
+TEST(Store, ChartIsReadOnlyByDefault)
+{
+  // The contour prior must be unclobberable by live ingest: set(Chart) throws
+  // unless the store was explicitly opened chart_writable (ADR-0002 §D3).
+  BathymetryStore store(5);
+  EXPECT_FALSE(store.chartWritable());
+  EXPECT_THROW(
+    store.set(SourceLayer::Chart, store.cellIndex(43.0, -70.5), BathyCell{-10.0, 3.0, 1.0}),
+    std::logic_error);
+  // Other layers are unaffected by the guard.
+  EXPECT_NO_THROW(
+    store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-12.0, 2.0, 2.0}));
+}
+
+TEST(Store, ChartWritableStoreAllowsChartSet)
+{
+  // The importer opts in; the converted prior then writes and reads back.
+  BathymetryStore store(5, /*chart_writable=*/true);
+  EXPECT_TRUE(store.chartWritable());
+  const auto cell = store.cellIndex(43.0, -70.5);
+  store.set(SourceLayer::Chart, cell, BathyCell{38.58, 3.0, 1000.0});
+  const auto got = store.get(SourceLayer::Chart, cell);
+  ASSERT_TRUE(got.has_value());
+  EXPECT_DOUBLE_EQ(got->depth, 38.58);
+}
+
+TEST(Store, FromCellSizePropagatesChartWritable)
+{
+  auto store = BathymetryStore::fromCellSize(30.0f, /*chart_writable=*/true);
+  EXPECT_TRUE(store.chartWritable());
+  EXPECT_NO_THROW(
+    store.set(SourceLayer::Chart, store.cellIndex(43.0, -70.5), BathyCell{40.0, 3.0, 1.0}));
+}

--- a/marine_bathymetry_store/test/test_tile_io.cpp
+++ b/marine_bathymetry_store/test/test_tile_io.cpp
@@ -123,3 +123,42 @@ TEST_F(TileIoTest, LoadRejectsTilesFromAnotherLevel)
   BathymetryStore wrong_level(6);
   EXPECT_THROW(marine_bathymetry_store::load(wrong_level, dir_.string()), std::runtime_error);
 }
+
+TEST_F(TileIoTest, ChartRoundTripsAndLoadsIntoReadOnlyStore)
+{
+  // The importer writes Chart (chart_writable); the runtime loads it into a
+  // default (read-only-Chart) store. load() populates via getOrCreateTile, not
+  // set(), so the prior loads even though live set(Chart) stays forbidden.
+  BathymetryStore writer(5, /*chart_writable=*/true);
+  writer.set(SourceLayer::Chart, writer.cellIndex(43.0, -70.5), BathyCell{38.58, 3.0, 1.78e9});
+  EXPECT_EQ(marine_bathymetry_store::save(writer, dir_.string()), 1u);
+  EXPECT_TRUE(fs::is_directory(dir_ / "chart"));
+
+  BathymetryStore runtime(5);   // Chart NOT writable
+  EXPECT_FALSE(runtime.chartWritable());
+  EXPECT_EQ(marine_bathymetry_store::load(runtime, dir_.string()), 1u);
+
+  const auto got = runtime.get(SourceLayer::Chart, runtime.cellIndex(43.0, -70.5));
+  ASSERT_TRUE(got.has_value());
+  EXPECT_DOUBLE_EQ(got->depth, 38.58);
+  EXPECT_DOUBLE_EQ(got->timestamp, 1.78e9);
+
+  // The read-only guard still holds after the prior is loaded.
+  EXPECT_THROW(
+    runtime.set(SourceLayer::Chart, runtime.cellIndex(43.0, -70.5), BathyCell{1.0, 1.0, 1.0}),
+    std::logic_error);
+}
+
+TEST_F(TileIoTest, ProcessedDraftOnlyStoreLoadsWithoutChartDir)
+{
+  // Back-compat: a Phase-1 store with no chart/ subdir still saves and loads;
+  // the absent chart layer is simply skipped, not an error.
+  BathymetryStore store(5);
+  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1.0});
+  marine_bathymetry_store::save(store, dir_.string());
+  EXPECT_FALSE(fs::exists(dir_ / "chart"));   // no spurious empty chart/ dir
+
+  BathymetryStore reloaded(5);
+  EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 1u);
+  EXPECT_TRUE(reloaded.tiles(SourceLayer::Chart).empty());
+}


### PR DESCRIPTION
**Part of #163** — this is **PR A1 of two** (core). It does **not** close #163;
the A2 importer PR (on `cube_bathymetry`) closes it.

## What this lands (A1, core, datum-agnostic)
Adds `SourceLayer::Chart` (priority 2, lowest) to `marine_bathymetry_store` so
the store can hold the contour / S57-derived **prior**. Best-source query and
`tile_io` save/load pick it up automatically via `source_layers_by_priority`.

**Chart is a read-only prior, enforced by construction:**
- `set(Chart, …)` throws `std::logic_error` unless the store is constructed
  `chart_writable=true` (the importer's mode).
- `getOrCreateTile()` is now **private**; only `set()` (member) and the
  `save`/`load` free functions (friends) reach it — so external code cannot
  obtain a mutable Chart tile and clobber the prior. `load()` may still populate
  Chart from disk regardless of the flag (loading the prior is always allowed).
- Chart cells are **ellipsoidal heights** converted at import (ADR-0002 §D7) —
  raw depth-below-surface contour tiles are not loaded directly; that conversion
  is A2.

## Tests
82 gtests, 0 failures; full lint suite green. New coverage: read-only-by-default
guard, `chart_writable` opt-in, `fromCellSize` propagation, best-source
fall-through to Chart, chart round-trip loading into a **read-only** store, the
`shallowestReliable` uncertainty gate across the 3.0 m boundary, and back-compat
(processed/draft-only store loads, no spurious `chart/` dir).

## Pre-push review
A `/review-code` pass (two cross-confirmed adversarial lenses) caught that the
read-only guarantee was originally bypassable via the public `getOrCreateTile()`;
closed by construction (commit `f972286`). See
`.agent/work-plans/issue-163/progress.md`.

## ADRs
ADR-0002 §D3 (source-layer overlay), §D5 (tile format), §D7 (convert at import).
§D4 datum gate consciously decoupled for the lake (constant offset; ocean VDatum
deferred). Plan: `.agent/work-plans/issue-163/plan.md`.
