### PR TITLE
Generic band/dtype-parametrized tiled-GeoTIFF store core (#172)

### DIFF
--- a/.agent/work-plans/issue-172/plan.md
+++ b/.agent/work-plans/issue-172/plan.md
@@ -82,14 +82,18 @@ queries, and `BathyCell` are bathy-specific and **stay put**.
 |---|---|---|
 | Extract tile + tile_io | `marine_bathymetry_store` CMake/package.xml dep + build order | Yes |
 | New package | `.agents/README` package inventory | Yes |
-| Shared persistence substrate | Whether it merits its own ADR (cross-cutting per ADR-0001) | Open question |
+| Shared persistence substrate | Dedicated substrate ADR deferred to I3 (#86 Phase 6); I1 adds a code comment referencing ADR-0002 §D5/§D6 | Yes — code comment |
+
+## Decisions (resolved 2026-06-18)
+
+- **Parametrization**: template element type `T` + **runtime band count** (compile-time type safety, GDAL type via `gdalType<T>()` trait).
+- **GDAL linkage**: keep **PRIVATE** via explicit instantiation (`double`, `uint16_t`) in `tile_io.cpp` (mirrors bathy today).
+- **ADR**: **defer** the dedicated substrate ADR to **I3 (#86 Phase 6)**, where the shared sync contract lands; I1 only adds a code comment in the generic `tile_io` referencing ADR-0002 §D5/§D6.
+- **Package name**: `marine_tiled_raster_store` (accepted).
 
 ## Open Questions
 
-- Parametrization: template element type `T` + runtime band count (recommended) vs. a fully-runtime dtype enum?
-- Keep GDAL PRIVATE via explicit instantiation in `.cpp` (recommended) vs. header templates (GDAL becomes public)?
-- ADR now: short ADR (or amend ADR-0002 §D5) for the extracted substrate, or defer to I3 (#86 Phase 6)?
-- Package name `marine_tiled_raster_store` acceptable?
+- [ ] None — resolved above; review-plan-ready.
 
 ## Estimated Scope
 

--- a/.agent/work-plans/issue-172/plan.md
+++ b/.agent/work-plans/issue-172/plan.md
@@ -50,9 +50,8 @@ queries, and `BathyCell` are bathy-specific and **stay put**.
 |------|--------|
 | `marine_tiled_raster_store/package.xml`, `CMakeLists.txt` | New ament_cmake lib; deps `marine_autonomy`, GDAL (PRIVATE) |
 | `…/include/marine_tiled_raster_store/tiled_raster_tile.hpp` | Generic `TiledRasterTile<T>` |
-| `…/include/marine_tiled_raster_store/gdal_type.hpp` | `gdalType<T>()` trait |
-| `…/include/marine_tiled_raster_store/tile_io.hpp` | Generic `saveTile`/`loadTile`/`save`/`load` |
-| `…/src/tile_io.cpp` | GDAL impl + explicit instantiations (`double`, `uint16_t`) |
+| `…/include/marine_tiled_raster_store/tile_io.hpp` | Generic `saveTile`/`loadTile`/`saveTiles`/`loadTiles` |
+| `…/src/tile_io.cpp` | GDAL impl, internal `gdalType<T>()` trait, explicit instantiations (`double`, `uint16_t`) |
 | `…/test/test_tile_io.cpp`, `README.md` | Core tests + docs |
 | `marine_bathymetry_store/.../bathymetry_tile.hpp` | Wrap `TiledRasterTile<double>`; keep named API |
 | `marine_bathymetry_store/.../bathymetry_store.hpp` | Verify/adjust: stores `map<GridIndex, BathymetryTile>`, calls `BathymetryTile(grid)` ctor + friends `tile_io` — confirm wrapper-compatible |
@@ -100,3 +99,16 @@ queries, and `BathyCell` are bathy-specific and **stay put**.
 
 Single PR — the extraction and the bathy refactor must land together so bathy
 never builds against a removed type. Sizable but one logical change.
+
+## Implementation Notes
+
+- The `gdalType<T>()` trait lives **inside `tile_io.cpp`** (anonymous namespace),
+  not a public `gdal_type.hpp`: mapping `T`→`GDALDataType` requires the GDAL
+  header, and the whole point of the explicit-instantiation approach is to keep
+  GDAL out of the public headers. A public trait header would have leaked it.
+- `bathymetry_store.hpp` needed **no change** — `BathymetryTile` keeps the same
+  public surface (ctor, `set`/`get`, named band accessors, `index`, dirty flags,
+  `edge`/`cell_count`, `offset`), so the store's `map<GridIndex, BathymetryTile>`,
+  `getOrCreateTile`, and `friend` persistence all compile unchanged. A second
+  ctor `BathymetryTile(Raster)` + a `raster()` accessor were added for the
+  load/save delegation.

--- a/.agent/work-plans/issue-172/plan.md
+++ b/.agent/work-plans/issue-172/plan.md
@@ -1,0 +1,97 @@
+# Plan: Generic band/dtype-parametrized tiled-GeoTIFF store core (new package)
+
+## Issue
+
+https://github.com/rolker/unh_marine_autonomy/issues/172  (Part of #171; refs #86, #141)
+
+## Context
+
+`marine_bathymetry_store` (#141) holds the reusable tiled-GeoTIFF machinery a live
+sidescan mosaic (#173) needs — GGGS-keyed lazy-alloc dirty tiles, north-up
+row-flip persistence, geotransform→`GridIndex` recovery with level-match
+rejection, incremental dirty-only `save()`. But the tile (`BathymetryTile`) and
+`tile_io` are hardcoded to **3-band `Float64`** with bathy band semantics. Extract
+the format-agnostic core into a new package so bathy (3-band Float64) and sidescan
+(1-band `uint16`) share one persistence/sync contract instead of forking it.
+
+The genuinely shared, tricky nugget is **`saveTile`/`loadTile`** (corner→
+geotransform, WGS84 SRS, `flipRows`, geotransform→`GridIndex` + level-match) and
+the **tile data structure**. The multi-layer `SourceLayer` store, priority
+queries, and `BathyCell` are bathy-specific and **stay put**.
+
+## Approach
+
+1. **New package `marine_tiled_raster_store`** in `core_ws` (lib only, depends on
+   `marine_autonomy` for GGGS, GDAL for IO).
+2. **Generic tile** `TiledRasterTile<T>` — GGGS `GridIndex`-keyed, SoA one
+   `std::vector<T>` per band, runtime band count, lazy-alloc + dirty flag,
+   index-based band access. Generalized from `BathymetryTile`.
+3. **Generic single-tile IO** `saveTile`/`loadTile` parametrized over element type
+   `T`, band count, and per-band optional no-data. GDAL type chosen via a
+   `gdalType<T>()` trait (`Float64`↔`double`, `UInt16`↔`uint16_t`). Keep **GDAL a
+   PRIVATE dep** by templating in the header but providing **explicit
+   instantiations** (`double`, `uint16_t`) in `tile_io.cpp` — mirrors how bathy
+   keeps GDAL private today.
+4. **Generic directory save/load** over a single `std::map<GridIndex, Tile>` +
+   a subdirectory name (dirty-only write; `.tif` scan load; `<level>_<row>_<col>.tif`).
+5. **Refactor `marine_bathymetry_store` to compose the core, no behavior change:**
+   - `BathymetryTile` becomes a thin wrapper over `TiledRasterTile<double>` (3
+     bands) keeping named accessors (`depthBand()`→`band(0)`, etc.).
+   - Bathy `tile_io.cpp` keeps its multi-layer `save`/`load` (SourceLayer subdirs,
+     friend access, NaN-no-data on bands 0/1 only) but **delegates per-tile read/
+     write to the generic `saveTile`/`loadTile`**. Public `tile_io.hpp` signatures
+     unchanged so `test_tile_io` is untouched.
+6. **Core tests** — round-trip a **1-band `uint16`** tile and a 3-band `double`
+   tile; level-mismatch rejection; non-WGS84 rejection; dirty-only save count.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `marine_tiled_raster_store/package.xml`, `CMakeLists.txt` | New ament_cmake lib; deps `marine_autonomy`, GDAL (PRIVATE) |
+| `…/include/marine_tiled_raster_store/tiled_raster_tile.hpp` | Generic `TiledRasterTile<T>` |
+| `…/include/marine_tiled_raster_store/gdal_type.hpp` | `gdalType<T>()` trait |
+| `…/include/marine_tiled_raster_store/tile_io.hpp` | Generic `saveTile`/`loadTile`/`save`/`load` |
+| `…/src/tile_io.cpp` | GDAL impl + explicit instantiations (`double`, `uint16_t`) |
+| `…/test/test_tile_io.cpp`, `README.md` | Core tests + docs |
+| `marine_bathymetry_store/.../bathymetry_tile.hpp` | Wrap `TiledRasterTile<double>`; keep named API |
+| `marine_bathymetry_store/src/tile_io.cpp` | Delegate per-tile IO to core; keep multi-layer save/load |
+| `marine_bathymetry_store/CMakeLists.txt`, `package.xml` | `find_package` + PUBLIC dep on the new package |
+| `.agents/README.md` | Package inventory (+1), build order |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Modularity & Decoupling | ADR-0002 §D9 ("core free of consumer-specific logic") — extraction directly serves it |
+| Only what's needed | Generalize **tile + single-tile IO only**; leave multi-layer/priority store in bathy (sidescan needs neither) |
+| Safety First | Bathy feeds the nav costmap — guarded by "no behavior change + existing tests green" |
+| Standards Compliance | Pure C++ lib; preserve GDAL-PRIVATE linkage + ament export pattern |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0002 §D5 (one GeoTIFF per dirty tile, 3-band Float64) | Yes | Bathy persistence behavior unchanged; mechanism extracted, not altered |
+| 0002 §D2 (GGGS, no new tiling scheme) | Yes | Core reuses `gggs::Level/GridIndex`; no new scheme |
+| 0002 §D6 (content-hash tile sync) | Indirect | Core is where I3/Phase-6 will build the manifest/hash — note in code |
+
+## Consequences
+
+| If we change… | Also update… | In plan? |
+|---|---|---|
+| Extract tile + tile_io | `marine_bathymetry_store` CMake/package.xml dep + build order | Yes |
+| New package | `.agents/README` package inventory | Yes |
+| Shared persistence substrate | Whether it merits its own ADR (cross-cutting per ADR-0001) | Open question |
+
+## Open Questions
+
+- Parametrization: template element type `T` + runtime band count (recommended) vs. a fully-runtime dtype enum?
+- Keep GDAL PRIVATE via explicit instantiation in `.cpp` (recommended) vs. header templates (GDAL becomes public)?
+- ADR now: short ADR (or amend ADR-0002 §D5) for the extracted substrate, or defer to I3 (#86 Phase 6)?
+- Package name `marine_tiled_raster_store` acceptable?
+
+## Estimated Scope
+
+Single PR — the extraction and the bathy refactor must land together so bathy
+never builds against a removed type. Sizable but one logical change.

--- a/.agent/work-plans/issue-172/plan.md
+++ b/.agent/work-plans/issue-172/plan.md
@@ -55,9 +55,10 @@ queries, and `BathyCell` are bathy-specific and **stay put**.
 | `…/src/tile_io.cpp` | GDAL impl + explicit instantiations (`double`, `uint16_t`) |
 | `…/test/test_tile_io.cpp`, `README.md` | Core tests + docs |
 | `marine_bathymetry_store/.../bathymetry_tile.hpp` | Wrap `TiledRasterTile<double>`; keep named API |
+| `marine_bathymetry_store/.../bathymetry_store.hpp` | Verify/adjust: stores `map<GridIndex, BathymetryTile>`, calls `BathymetryTile(grid)` ctor + friends `tile_io` — confirm wrapper-compatible |
 | `marine_bathymetry_store/src/tile_io.cpp` | Delegate per-tile IO to core; keep multi-layer save/load |
 | `marine_bathymetry_store/CMakeLists.txt`, `package.xml` | `find_package` + PUBLIC dep on the new package |
-| `.agents/README.md` | Package inventory (+1), build order |
+| `.agents/README.md` | Package inventory: add `marine_tiled_raster_store` **and** the already-missing `marine_bathymetry_store` (#141) row; note build-order edge (tiled-raster core before bathy) |
 
 ## Principles Self-Check
 

--- a/.agent/work-plans/issue-172/progress.md
+++ b/.agent/work-plans/issue-172/progress.md
@@ -38,3 +38,21 @@ issue: 172
 - "NaN-no-data on bands 0/1 only" accurate (timestamp band intentionally has none) — `tile_io.cpp:139-141`.
 - Public `tile_io.hpp` signatures must stay stable so `test_tile_io` is untouched — confirmed: the test exercises `save`/`load`/`store.*`, never the per-tile helpers — `test/test_tile_io.cpp`.
 - ADR-0002 §D5 (3-band Float64) / §D2 (reuse GGGS, no new scheme) / §D9 ("store core free of consumer-specific logic") correctly cited; extraction directly serves D9. Note the store has 3 source layers (processed/draft/chart), but that is subdir-level and orthogonal to the per-tile band extraction.
+
+## Implementation
+**Status**: complete
+**When**: 2026-06-18 15:12 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Branch**: feature/issue-172 at `8ff0a23` (local, not pushed)
+**Commits**: `6368508` (new marine_tiled_raster_store package), `8ff0a23` (bathy refactor + docs)
+
+**Built**: `marine_tiled_raster_store` + `marine_bathymetry_store` — both compile clean.
+**Tests** (gtest xml, 0 failures):
+- marine_tiled_raster_store/test_tile_io: **5/5** (uint16 single-band + double 3-band round-trip, level-mismatch reject, band_nodata-size guard, dirty-only saveTiles/loadTiles).
+- marine_bathymetry_store unchanged: test_store **11/11**, test_query **9/9**, test_tile_io **7/7** — no-behavior-change confirmed.
+
+**As-built vs plan**: `gdalType<T>()` trait folded into `tile_io.cpp` (keeps GDAL out of public headers) instead of a public `gdal_type.hpp`; `bathymetry_store.hpp` needed no change (BathymetryTile public surface preserved). Plan + Implementation Notes synced.
+
+### Next
+- [ ] /review-code (pre-push) on the diff, then triage + push/PR.

--- a/.agent/work-plans/issue-172/progress.md
+++ b/.agent/work-plans/issue-172/progress.md
@@ -1,0 +1,20 @@
+---
+issue: 172
+---
+
+# Issue #172 — Generic band/dtype-parametrized tiled-GeoTIFF store core (new package)
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-18 12:11 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Plan**: `.agent/work-plans/issue-172/plan.md` at `9f7a6b1`
+**Branch**: feature/issue-172 at `9f7a6b1`
+**Phases**: single
+
+### Open questions
+- [ ] Parametrization: template element type T + runtime band count (recommended) vs. fully-runtime dtype enum?
+- [ ] Keep GDAL PRIVATE via explicit instantiation in .cpp (recommended) vs. header templates (GDAL public)?
+- [ ] ADR now (short ADR / amend ADR-0002 §D5) for the extracted substrate, or defer to I3 (#86 Phase 6)?
+- [ ] Package name `marine_tiled_raster_store` acceptable?

--- a/.agent/work-plans/issue-172/progress.md
+++ b/.agent/work-plans/issue-172/progress.md
@@ -14,7 +14,7 @@ issue: 172
 **Phases**: single
 
 ### Open questions
-- [ ] Parametrization: template element type T + runtime band count (recommended) vs. fully-runtime dtype enum?
-- [ ] Keep GDAL PRIVATE via explicit instantiation in .cpp (recommended) vs. header templates (GDAL public)?
-- [ ] ADR now (short ADR / amend ADR-0002 §D5) for the extracted substrate, or defer to I3 (#86 Phase 6)?
-- [ ] Package name `marine_tiled_raster_store` acceptable?
+- [x] Parametrization → template element type T + runtime band count (resolved 2026-06-18).
+- [x] GDAL linkage → keep PRIVATE via explicit instantiation in .cpp (resolved 2026-06-18).
+- [x] ADR → defer dedicated substrate ADR to I3 (#86 Phase 6); I1 adds a code comment referencing ADR-0002 §D5/§D6 (resolved 2026-06-18).
+- [x] Package name → `marine_tiled_raster_store` accepted (resolved 2026-06-18).

--- a/.agent/work-plans/issue-172/progress.md
+++ b/.agent/work-plans/issue-172/progress.md
@@ -56,3 +56,23 @@ issue: 172
 
 ### Next
 - [ ] /review-code (pre-push) on the diff, then triage + push/PR.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-18 17:04 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved
+
+**Branch**: feature/issue-172 at `a78e652`
+**Mode**: pre-push
+**Depth**: Standard (reason: new ~990-line C++ package + refactor of a costmap-feeding package; single repo, no security surface)
+**Must-fix**: 0 | **Suggestions**: 3 (2 addressed, 1 no-change)
+
+Static analysis (ament_cpplint): clean — "No problems found" on all 6 changed C++ files.
+Claude Adversarial: 2 passes (Lens A logic, Lens B systemic) — both 0 must-fix; independently confirmed the no-behavior-change claim (band order, NaN no-data tags, geotransform, filename mapping, load-side georeferencing guards byte-equivalent vs jazzy).
+Governance: ADR-0002 §D2 (reuse GGGS) / §D5 (bathy persistence unchanged) / §D9 (core free of consumer logic) all compliant; substrate ADR deferred to I3 by decision. Plan adherence: in sync.
+
+### Findings
+- [x] (suggestion) Drop dead GDAL declarations from marine_bathymetry_store — addressed in `a78e652`; rebuild+tests green.
+- [x] (suggestion) Document band_nodata value must be representable in T — addressed in `a78e652`.
+- [x] (suggestion) loadTile silently reads first band_count when a file has more bands — already documented + matches prior bathy behavior; no change (intended generic contract).

--- a/.agent/work-plans/issue-172/progress.md
+++ b/.agent/work-plans/issue-172/progress.md
@@ -18,3 +18,23 @@ issue: 172
 - [x] GDAL linkage → keep PRIVATE via explicit instantiation in .cpp (resolved 2026-06-18).
 - [x] ADR → defer dedicated substrate ADR to I3 (#86 Phase 6); I1 adds a code comment referencing ADR-0002 §D5/§D6 (resolved 2026-06-18).
 - [x] Package name → `marine_tiled_raster_store` accepted (resolved 2026-06-18).
+
+## Plan Review
+**Status**: complete
+**When**: 2026-06-18 12:59 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8)
+
+**Plan**: `.agent/work-plans/issue-172/plan.md` at `cf25f20`
+**PR**: PR-less (--issue / file-path mode)
+**Verdict**: approve-with-suggestions
+
+### Findings
+- [ ] (suggestion) `bathymetry_store.hpp` not in the file list, but it stores `std::map<GridIndex, BathymetryTile>`, calls the `BathymetryTile(grid)` ctor, and is the likely `friend` granting tile_io band access — making it a probable edit/verify site for the wrapper refactor. List it explicitly (even if "no change, verified"). — `plan.md:48-60`
+- [ ] (suggestion) `.agents/README.md` Package Inventory is already stale: `marine_bathymetry_store` (#141) is missing from it. When updating "package inventory (+1)", add BOTH the new `marine_tiled_raster_store` row AND the missing `marine_bathymetry_store` row, plus a build-order edge (core before bathy) in the Build/Common-Pitfalls section. — `plan.md:60`
+
+### Verification notes (code-checked, no action needed)
+- `saveTile`/`loadTile` confirmed as the shared nugget (corner→geotransform, WGS84 SRS, `flipRows`, geotransform→GridIndex + half-cell level-match, non-WGS84 rejection) — `marine_bathymetry_store/src/tile_io.cpp`.
+- GDAL-PRIVATE claim sound: PRIVATE link + `ament_export_dependencies(... GDAL)` for static-lib propagation — `marine_bathymetry_store/CMakeLists.txt:38-55`. Explicit instantiation (`double`,`uint16_t`) preserves this.
+- "NaN-no-data on bands 0/1 only" accurate (timestamp band intentionally has none) — `tile_io.cpp:139-141`.
+- Public `tile_io.hpp` signatures must stay stable so `test_tile_io` is untouched — confirmed: the test exercises `save`/`load`/`store.*`, never the per-tile helpers — `test/test_tile_io.cpp`.
+- ADR-0002 §D5 (3-band Float64) / §D2 (reuse GGGS, no new scheme) / §D9 ("store core free of consumer-specific logic") correctly cited; extraction directly serves D9. Note the store has 3 source layers (processed/draft/chart), but that is subdir-level and orthogonal to the per-tile band extraction.

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -12,7 +12,9 @@
 | `joy_to_helm` | Python | Converts joystick input to helm commands for manual piloting |
 | `marine_autonomy` | C++/Python | Meta-package with launch files, geodesic utilities, and system configuration |
 | `marine_autonomy_integration_tests` | Python (CMake) | Cross-package integration tests for mission and navigation flows |
+| `marine_bathymetry_store` | C++ | Persistent multi-source bathymetric data store: GGGS-tiled, priority source layers, best-source / shallowest-reliable queries, per-tile GeoTIFF (ADR-0002 / #86) |
 | `marine_interfaces` | C++ (IDL) | ROS 2 message definitions for helm commands, heartbeats, navigation, perception contacts, and sensor data (39 msg types) |
+| `marine_tiled_raster_store` | C++ | Generic GGGS-tiled raster store core: band/dtype-parametrized `TiledRasterTile<T>` + per-tile GeoTIFF persistence, shared by bathymetry and sidescan (#172) |
 | `mission_manager` | Python | Converts mission plans from CAMP GCS into navigation tasks and manages task execution |
 | `mission_manager_interfaces` | C++ (IDL) | Service definitions for task manipulation (3 srv types) |
 
@@ -114,6 +116,8 @@ colcon test --packages-select helm_manager && colcon test-result --verbose
 Known build requirements:
 - `marine_interfaces` must build before `helm_manager`, `mission_manager`, and
   `marine_autonomy` (provides shared message types)
+- `marine_tiled_raster_store` must build before `marine_bathymetry_store`
+  (provides the generic `TiledRasterTile<T>` + GeoTIFF persistence it wraps, #172)
 - `mission_manager_interfaces` must build before `mission_manager`
 - Integration tests depend on `command_bridge`, `mission_manager`, `marine_interfaces`,
   and `marine_nav_interfaces` (from `unh_marine_navigation`)

--- a/marine_bathymetry_store/CMakeLists.txt
+++ b/marine_bathymetry_store/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(marine_autonomy REQUIRED)
+find_package(marine_tiled_raster_store REQUIRED)
 find_package(geographic_msgs REQUIRED)
 find_package(GDAL CONFIG REQUIRED)
 
@@ -33,6 +34,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 # resolve the GDAL target via find_package(marine_bathymetry_store).
 target_link_libraries(${PROJECT_NAME} PUBLIC
   marine_autonomy::marine_autonomy
+  marine_tiled_raster_store::marine_tiled_raster_store
   ${geographic_msgs_TARGETS}
 )
 target_link_libraries(${PROJECT_NAME} PRIVATE
@@ -52,7 +54,7 @@ install(TARGETS ${PROJECT_NAME}
 )
 
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
-ament_export_dependencies(marine_autonomy geographic_msgs GDAL)
+ament_export_dependencies(marine_autonomy marine_tiled_raster_store geographic_msgs GDAL)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/marine_bathymetry_store/CMakeLists.txt
+++ b/marine_bathymetry_store/CMakeLists.txt
@@ -12,9 +12,10 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(marine_autonomy REQUIRED)
+# GDAL is no longer used directly here — tile_io delegates all GeoTIFF I/O to
+# marine_tiled_raster_store, which carries (and re-exports) the GDAL dependency.
 find_package(marine_tiled_raster_store REQUIRED)
 find_package(geographic_msgs REQUIRED)
-find_package(GDAL CONFIG REQUIRED)
 
 add_library(${PROJECT_NAME}
   src/bathymetry_store.cpp
@@ -28,17 +29,13 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   "$<INSTALL_INTERFACE:include>"
 )
 # marine_autonomy + geographic_msgs are in the public headers (GGGS / GeoPoint);
-# GDAL is used only inside tile_io.cpp, so it is PRIVATE. It is still exported as
-# a dependency below because this is a static library — CMake propagates the
-# private link to consumers as $<LINK_ONLY:GDAL::GDAL>, so they must be able to
-# resolve the GDAL target via find_package(marine_bathymetry_store).
+# marine_tiled_raster_store is public too — BathymetryTile wraps its
+# TiledRasterTile<double>. GDAL arrives transitively through that package (which
+# uses it privately in tile_io.cpp); this package no longer references GDAL.
 target_link_libraries(${PROJECT_NAME} PUBLIC
   marine_autonomy::marine_autonomy
   marine_tiled_raster_store::marine_tiled_raster_store
   ${geographic_msgs_TARGETS}
-)
-target_link_libraries(${PROJECT_NAME} PRIVATE
-  GDAL::GDAL
 )
 
 # Headers are laid out as include/${PROJECT_NAME}/*.hpp, so install the include/
@@ -54,7 +51,7 @@ install(TARGETS ${PROJECT_NAME}
 )
 
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
-ament_export_dependencies(marine_autonomy marine_tiled_raster_store geographic_msgs GDAL)
+ament_export_dependencies(marine_autonomy marine_tiled_raster_store geographic_msgs)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_tile.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_tile.hpp
@@ -22,95 +22,108 @@
 #ifndef MARINE_BATHYMETRY_STORE__BATHYMETRY_TILE_HPP_
 #define MARINE_BATHYMETRY_STORE__BATHYMETRY_TILE_HPP_
 
-#include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <utility>
 #include <vector>
 
 #include "marine_autonomy/gggs.h"
 #include "marine_bathymetry_store/bathy_cell.hpp"
+#include "marine_tiled_raster_store/tiled_raster_tile.hpp"
 
 namespace marine_bathymetry_store
 {
 
 /// @brief One GGGS grid (960×960 cells) of bathymetric data for a single layer.
 ///
-/// Stored as dense, row-major structure-of-arrays (one array each for depth,
-/// uncertainty, timestamp) in **GGGS cell coordinates**: row 0 is the southern
-/// edge and increases north; column 0 is the western edge and increases east.
-/// (Persistence flips rows to north-up GeoTIFF order — see `tile_io`.)
-///
-/// SoA mirrors the GeoTIFF band layout, making persistence a per-band copy.
-/// Arrays are allocated lazily by the owning `BathymetryStore` only when a
-/// tile is first written, so empty regions cost nothing. A fully-allocated
-/// tile holds 3 × 960 × 960 doubles ≈ 22 MB (see `BathyCell` for why double).
+/// A thin, bathy-semantic wrapper over `marine_tiled_raster_store::
+/// TiledRasterTile<double>` (the generic GGGS-tiled raster, #172): three
+/// `Float64` bands — **depth**, **uncertainty**, **timestamp** — in that order,
+/// matching the GeoTIFF band layout (`tile_io`). The generic tile owns the
+/// storage, dirty flag, and GGGS-cell-order layout (row 0 = south); this wrapper
+/// adds the per-cell `BathyCell` record and the named band accessors the store
+/// and persistence rely on. A fully-allocated tile holds 3 × 960 × 960 doubles
+/// ≈ 22 MB (see `BathyCell` for why `double`); tiles are allocated lazily by the
+/// owning `BathymetryStore`.
 class BathymetryTile
 {
 public:
-  /// @brief Number of cells along each grid edge (GGGS constant).
-  static constexpr uint16_t edge = gggs::cell_rows_per_grid;
-  /// @brief Total cells in a tile (edge × edge).
-  static constexpr uint32_t cell_count = gggs::grid_total_cell_count;
+  /// @brief The underlying generic raster tile type.
+  using Raster = marine_tiled_raster_store::TiledRasterTile<double>;
 
-  /// @brief Construct an empty tile for @p index (all cells no-data).
+  /// @brief Number of cells along each grid edge (GGGS constant).
+  static constexpr uint16_t edge = Raster::edge;
+  /// @brief Total cells in a tile (edge × edge).
+  static constexpr uint32_t cell_count = Raster::cell_count;
+
+  /// @brief Construct an empty tile for @p index (depth/uncertainty no-data, ts 0).
   explicit BathymetryTile(gggs::GridIndex index)
-  : index_(index),
-    depth_(cell_count, std::numeric_limits<double>::quiet_NaN()),
-    uncertainty_(cell_count, std::numeric_limits<double>::quiet_NaN()),
-    timestamp_(cell_count, 0.0)
+  : tile_(index, std::vector<double>{
+      std::numeric_limits<double>::quiet_NaN(),    // depth
+      std::numeric_limits<double>::quiet_NaN(),    // uncertainty
+      0.0})                                        // timestamp (0 = unset)
   {
   }
 
+  /// @brief Wrap a generic raster tile loaded from disk (persistence path).
+  explicit BathymetryTile(Raster tile)
+  : tile_(std::move(tile)) {}
+
   /// @brief The grid this tile covers.
-  const gggs::GridIndex & index() const noexcept {return index_;}
+  const gggs::GridIndex & index() const noexcept {return tile_.index();}
 
   /// @brief Write a cell at (@p row, @p col) within the grid; marks the tile dirty.
   void set(uint16_t row, uint16_t col, const BathyCell & cell)
   {
     const uint32_t i = offset(row, col);
-    depth_[i] = cell.depth;
-    uncertainty_[i] = cell.uncertainty;
-    timestamp_[i] = cell.timestamp;
-    dirty_ = true;
+    tile_.band(kDepth)[i] = cell.depth;
+    tile_.band(kUncertainty)[i] = cell.uncertainty;
+    tile_.band(kTimestamp)[i] = cell.timestamp;
+    tile_.markDirty();
   }
 
   /// @brief Read the cell at (@p row, @p col) within the grid.
   BathyCell get(uint16_t row, uint16_t col) const
   {
     const uint32_t i = offset(row, col);
-    return BathyCell{depth_[i], uncertainty_[i], timestamp_[i]};
+    return BathyCell{
+      tile_.band(kDepth)[i], tile_.band(kUncertainty)[i], tile_.band(kTimestamp)[i]};
   }
 
   /// @brief Whether this tile has unsaved changes.
-  bool dirty() const noexcept {return dirty_;}
+  bool dirty() const noexcept {return tile_.dirty();}
   /// @brief Mark all changes saved (called by persistence after a successful write).
-  void clearDirty() noexcept {dirty_ = false;}
+  void clearDirty() noexcept {tile_.clearDirty();}
   /// @brief Force the dirty flag (used when reconstructing a tile in memory).
-  void markDirty() noexcept {dirty_ = true;}
+  void markDirty() noexcept {tile_.markDirty();}
 
   /// @brief Raw band accessors (row-major, GGGS cell order) for persistence.
   /// @{
-  const std::vector<double> & depthBand() const noexcept {return depth_;}
-  const std::vector<double> & uncertaintyBand() const noexcept {return uncertainty_;}
-  const std::vector<double> & timestampBand() const noexcept {return timestamp_;}
-  std::vector<double> & depthBand() noexcept {return depth_;}
-  std::vector<double> & uncertaintyBand() noexcept {return uncertainty_;}
-  std::vector<double> & timestampBand() noexcept {return timestamp_;}
+  const std::vector<double> & depthBand() const noexcept {return tile_.band(kDepth);}
+  const std::vector<double> & uncertaintyBand() const noexcept
+  {return tile_.band(kUncertainty);}
+  const std::vector<double> & timestampBand() const noexcept {return tile_.band(kTimestamp);}
+  std::vector<double> & depthBand() noexcept {return tile_.band(kDepth);}
+  std::vector<double> & uncertaintyBand() noexcept {return tile_.band(kUncertainty);}
+  std::vector<double> & timestampBand() noexcept {return tile_.band(kTimestamp);}
+  /// @}
+
+  /// @brief The underlying generic raster tile (for persistence delegation).
+  /// @{
+  Raster & raster() noexcept {return tile_;}
+  const Raster & raster() const noexcept {return tile_;}
   /// @}
 
   /// @brief Row-major offset of cell (@p row, @p col). Asserts in debug builds.
-  static uint32_t offset(uint16_t row, uint16_t col)
-  {
-    assert(row < edge && col < edge && "BathymetryTile cell out of bounds");
-    return static_cast<uint32_t>(row) * edge + col;
-  }
+  static uint32_t offset(uint16_t row, uint16_t col) {return Raster::offset(row, col);}
 
 private:
-  gggs::GridIndex index_;
-  std::vector<double> depth_;
-  std::vector<double> uncertainty_;
-  std::vector<double> timestamp_;
-  bool dirty_ = false;
+  static constexpr std::size_t kDepth = 0;
+  static constexpr std::size_t kUncertainty = 1;
+  static constexpr std::size_t kTimestamp = 2;
+
+  Raster tile_;
 };
 
 }  // namespace marine_bathymetry_store

--- a/marine_bathymetry_store/package.xml
+++ b/marine_bathymetry_store/package.xml
@@ -14,6 +14,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>marine_autonomy</depend>
+  <depend>marine_tiled_raster_store</depend>
   <depend>geographic_msgs</depend>
   <depend>libgdal-dev</depend>
 

--- a/marine_bathymetry_store/package.xml
+++ b/marine_bathymetry_store/package.xml
@@ -16,7 +16,6 @@
   <depend>marine_autonomy</depend>
   <depend>marine_tiled_raster_store</depend>
   <depend>geographic_msgs</depend>
-  <depend>libgdal-dev</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/marine_bathymetry_store/src/tile_io.cpp
+++ b/marine_bathymetry_store/src/tile_io.cpp
@@ -21,68 +21,43 @@
 
 #include "marine_bathymetry_store/tile_io.hpp"
 
-#include <gdal_priv.h>
-#include <cpl_string.h>
-#include <ogr_spatialref.h>
-
-#include <algorithm>
-#include <array>
-#include <cmath>
-#include <cstdint>
 #include <filesystem>
 #include <limits>
-#include <stdexcept>
+#include <optional>
 #include <string>
-#include <utility>
 #include <vector>
+
+#include "marine_tiled_raster_store/tile_io.hpp"
+
+/// @file
+/// @brief Bathymetry persistence (ADR-0002 §D5): the multi-layer, SourceLayer
+/// subdirectory save/load, delegating each tile's GeoTIFF read/write to the
+/// generic `marine_tiled_raster_store::saveTile`/`loadTile` (#172). The bathy
+/// band semantics live here: 3 `Float64` bands (depth, uncertainty, timestamp)
+/// with a NaN no-data tag on depth/uncertainty and none on timestamp.
 
 namespace marine_bathymetry_store
 {
 
 namespace
 {
-
-constexpr int kEdge = BathymetryTile::edge;       // 960
-constexpr int kCellCount = kEdge * kEdge;
-constexpr int kBandCount = 3;                     // depth, uncertainty, timestamp
-constexpr int kDepthBand = 1;                     // GDAL bands are 1-indexed
-constexpr int kUncertaintyBand = 2;
-constexpr int kTimestampBand = 3;
-
-/// RAII wrapper so a thrown exception still closes the GDAL dataset.
-struct DatasetCloser
+/// Per-band no-data for a bathy tile: NaN on depth + uncertainty, none on the
+/// timestamp band (0 = unset, never NaN). One entry per band, in band order.
+const std::vector<std::optional<double>> & bathyBandNoData()
 {
-  GDALDataset * ds = nullptr;
-  ~DatasetCloser() {if (ds) {GDALClose(ds);}}
-};
-
-/// Copy a band between GGGS cell order (row 0 = south) and north-up raster
-/// order (row 0 = north) — the two differ only by a vertical row flip.
-/// Works in both directions since the flip is its own inverse mapping.
-void flipRows(const std::vector<double> & src, std::vector<double> & dst)
-{
-  for (int r = 0; r < kEdge; ++r) {
-    const std::size_t flipped = static_cast<std::size_t>(kEdge - 1 - r);
-    const std::size_t dst_row = static_cast<std::size_t>(r);
-    std::copy_n(
-      src.begin() + flipped * kEdge, kEdge,
-      dst.begin() + dst_row * kEdge);
-  }
+  static const double nan = std::numeric_limits<double>::quiet_NaN();
+  static const std::vector<std::optional<double>> nodata{nan, nan, std::nullopt};
+  return nodata;
 }
 
-void checkCE(CPLErr err, const char * what)
-{
-  if (err != CE_None) {
-    throw std::runtime_error(std::string("GDAL error: ") + what);
-  }
-}
-
+constexpr std::size_t kBathyBandCount = 3;
 }  // namespace
 
 std::string tileFilename(const gggs::GridIndex & grid)
 {
-  return std::to_string(static_cast<int>(grid.level())) + "_" +
-         std::to_string(grid.row()) + "_" + std::to_string(grid.column()) + ".tif";
+  // Delegate to the generic naming so robot/operator stores and the sync layer
+  // agree on the filename↔GridIndex mapping.
+  return marine_tiled_raster_store::tileFilename(grid);
 }
 
 std::string layerDirName(SourceLayer layer)
@@ -97,150 +72,13 @@ std::string layerDirName(SourceLayer layer)
 
 void saveTile(const BathymetryTile & tile, const std::string & path)
 {
-  GDALAllRegister();
-  GDALDriver * driver = GetGDALDriverManager()->GetDriverByName("GTiff");
-  if (driver == nullptr) {
-    throw std::runtime_error("saveTile: GTiff driver unavailable");
-  }
-
-  char ** options = nullptr;
-  options = CSLSetNameValue(options, "COMPRESS", "LZW");
-  DatasetCloser out;
-  out.ds = driver->Create(path.c_str(), kEdge, kEdge, kBandCount, GDT_Float64, options);
-  CSLDestroy(options);
-  if (out.ds == nullptr) {
-    throw std::runtime_error("saveTile: could not create " + path);
-  }
-
-  // North-up geotransform from the grid's corners.
-  const gggs::GridIndex & grid = tile.index();
-  const double west = grid.westLongitude();
-  const double north = grid.northLatitude();
-  const double pixel_x = grid.longitudinalSpan() / kEdge;
-  const double pixel_y = -grid.latitudinalSpan() / kEdge;   // negative: north-up
-  double geo_transform[6] = {west, pixel_x, 0.0, north, 0.0, pixel_y};
-  // The geotransform is load-bearing: loadTile recovers the GridIndex from it.
-  checkCE(out.ds->SetGeoTransform(geo_transform), "set geotransform");
-
-  OGRSpatialReference srs;
-  srs.SetWellKnownGeogCS("WGS84");
-  char * wkt = nullptr;
-  if (srs.exportToWkt(&wkt) != OGRERR_NONE || wkt == nullptr) {
-    CPLFree(wkt);
-    throw std::runtime_error("saveTile: could not build WGS84 WKT for " + path);
-  }
-  const CPLErr projection_result = out.ds->SetProjection(wkt);
-  CPLFree(wkt);
-  checkCE(projection_result, "set projection");
-
-  // The depth/uncertainty no-data value is metadata only — NaN round-trips
-  // through the Float64 bands regardless — so its result is intentionally not
-  // treated as fatal. The timestamp band has no no-data (0 = unset, never NaN).
-  const double nan = std::numeric_limits<double>::quiet_NaN();
-  out.ds->GetRasterBand(kDepthBand)->SetNoDataValue(nan);
-  out.ds->GetRasterBand(kUncertaintyBand)->SetNoDataValue(nan);
-
-  // Flip each band into north-up raster order, then write.
-  std::vector<double> raster(kCellCount);
-  const std::array<std::pair<int, const std::vector<double> *>, kBandCount> bands{{
-    {kDepthBand, &tile.depthBand()},
-    {kUncertaintyBand, &tile.uncertaintyBand()},
-    {kTimestampBand, &tile.timestampBand()},
-  }};
-  for (const auto & [band_index, data] : bands) {
-    flipRows(*data, raster);
-    checkCE(
-      out.ds->GetRasterBand(band_index)->RasterIO(
-        GF_Write, 0, 0, kEdge, kEdge, raster.data(), kEdge, kEdge, GDT_Float64, 0, 0),
-      "write band");
-  }
-
-  // Close explicitly and check the result. For a GTiff the (LZW-compressed)
-  // raster and directory are flushed to disk on close, so a disk-full / I/O
-  // failure surfaces only here — and saveTile must report it, because save()
-  // clears the tile's dirty flag once this returns. (The DatasetCloser stays
-  // as an exception-safety net for the error paths above; releasing the
-  // handle here prevents a double close.)
-  // GDALClose returns CPLErr since GDAL 3.7; the workspace targets GDAL >= 3.8
-  // (ROS 2 jazzy / rolling), so checking it here is well-defined.
-  GDALDataset * ds = out.ds;
-  out.ds = nullptr;
-  if (GDALClose(ds) != CE_None) {
-    throw std::runtime_error("saveTile: failed to flush/close " + path);
-  }
+  marine_tiled_raster_store::saveTile<double>(tile.raster(), path, bathyBandNoData());
 }
 
 BathymetryTile loadTile(const std::string & path, const gggs::Level & level)
 {
-  GDALAllRegister();
-  DatasetCloser in;
-  in.ds = GDALDataset::FromHandle(GDALOpen(path.c_str(), GA_ReadOnly));
-  if (in.ds == nullptr) {
-    throw std::runtime_error("loadTile: could not open " + path);
-  }
-  if (in.ds->GetRasterXSize() != kEdge || in.ds->GetRasterYSize() != kEdge ||
-    in.ds->GetRasterCount() < kBandCount)
-  {
-    throw std::runtime_error("loadTile: unexpected dimensions/bands in " + path);
-  }
-
-  // The grid recovery below interprets the geotransform as degrees, so the file
-  // must be a geographic WGS84 raster. Reject a projected (e.g. UTM, coordinates
-  // in metres) or otherwise non-WGS84 file — accidental copy, corruption — rather
-  // than silently misreading its coordinates as lat/lon.
-  const OGRSpatialReference * srs = in.ds->GetSpatialRef();
-  OGRErr axis_error = OGRERR_NONE;
-  if (srs == nullptr || !srs->IsGeographic() ||
-    std::abs(srs->GetSemiMajor(&axis_error) - 6378137.0) > 1.0 || axis_error != OGRERR_NONE)
-  {
-    throw std::runtime_error("loadTile: not a geographic WGS84 raster: " + path);
-  }
-
-  double geo_transform[6];
-  if (in.ds->GetGeoTransform(geo_transform) != CE_None) {
-    throw std::runtime_error("loadTile: missing geotransform in " + path);
-  }
-  const double west = geo_transform[0];
-  const double pixel_x = geo_transform[1];
-  const double north = geo_transform[3];
-  const double pixel_y = geo_transform[5];
-  const double east = west + pixel_x * kEdge;
-  const double south = north + pixel_y * kEdge;
-
-  // Recover the GridIndex: the cell center maps back through the level. (We
-  // cannot construct a GridIndex from raw row/col — that ctor is GGGS-private.)
-  const double center_lat = 0.5 * (north + south);
-  const double center_lon = 0.5 * (west + east);
-  const gggs::GridIndex grid = level.gridIndex(center_lat, center_lon);
-
-  // Reject a file whose grid edges don't match a grid at this level (e.g. saved
-  // at a different level): require agreement to within half a cell.
-  const double tol_lon = 0.5 * std::abs(pixel_x);
-  const double tol_lat = 0.5 * std::abs(pixel_y);
-  if (std::abs(grid.westLongitude() - west) > tol_lon ||
-    std::abs(grid.northLatitude() - north) > tol_lat)
-  {
-    throw std::runtime_error(
-            "loadTile: geotransform does not match any grid at level " +
-            std::to_string(level.level()) + " in " + path);
-  }
-
-  BathymetryTile tile(grid);
-  std::vector<double> raster(kCellCount);
-  const std::array<std::pair<int, std::vector<double> *>, kBandCount> bands{{
-    {kDepthBand, &tile.depthBand()},
-    {kUncertaintyBand, &tile.uncertaintyBand()},
-    {kTimestampBand, &tile.timestampBand()},
-  }};
-  for (const auto & [band_index, data] : bands) {
-    checkCE(
-      in.ds->GetRasterBand(band_index)->RasterIO(
-        GF_Read, 0, 0, kEdge, kEdge, raster.data(), kEdge, kEdge, GDT_Float64, 0, 0),
-      "read band");
-    flipRows(raster, *data);   // north-up raster back to GGGS cell order
-  }
-  // Filled via band accessors (not set()), so the tile stays clean.
-  return tile;
+  return BathymetryTile(
+    marine_tiled_raster_store::loadTile<double>(path, level, kBathyBandCount));
 }
 
 std::size_t save(BathymetryStore & store, const std::string & dir)

--- a/marine_tiled_raster_store/CMakeLists.txt
+++ b/marine_tiled_raster_store/CMakeLists.txt
@@ -1,0 +1,62 @@
+cmake_minimum_required(VERSION 3.8)
+project(marine_tiled_raster_store)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(marine_autonomy REQUIRED)
+find_package(GDAL CONFIG REQUIRED)
+
+add_library(${PROJECT_NAME}
+  src/tile_io.cpp
+)
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include>"
+)
+# marine_autonomy (GGGS) is in the public headers; GDAL is used only inside
+# tile_io.cpp (the templates are explicitly instantiated there), so it is
+# PRIVATE. It is still exported below because this is a static library — CMake
+# propagates the private link to consumers as $<LINK_ONLY:GDAL::GDAL>, so they
+# must be able to resolve the GDAL target via find_package(${PROJECT_NAME}).
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  marine_autonomy::marine_autonomy
+)
+target_link_libraries(${PROJECT_NAME} PRIVATE
+  GDAL::GDAL
+)
+
+# Headers are laid out as include/${PROJECT_NAME}/*.hpp, so install the include/
+# tree to `include` (not include/${PROJECT_NAME}) to avoid a doubled
+# include/${PROJECT_NAME}/${PROJECT_NAME}/ path; the INSTALL_INTERFACE above is
+# `include` to match.
+install(DIRECTORY include/ DESTINATION include)
+install(TARGETS ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_dependencies(marine_autonomy GDAL)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+  find_package(ament_cmake_gtest REQUIRED)
+
+  ament_add_gtest(test_tile_io test/test_tile_io.cpp)
+  target_link_libraries(test_tile_io ${PROJECT_NAME})
+endif()
+
+ament_package()

--- a/marine_tiled_raster_store/README.md
+++ b/marine_tiled_raster_store/README.md
@@ -1,0 +1,56 @@
+# marine_tiled_raster_store
+
+Generic, format-agnostic **GGGS-tiled raster store core**: a band/dtype-parametrized
+tile plus per-tile GeoTIFF persistence, factored out of
+[`marine_bathymetry_store`](../marine_bathymetry_store) so that multiple raster
+sources share one tiling + persistence (and, later, sync) contract instead of
+forking it.
+
+Tracked by [unh_marine_autonomy#172](https://github.com/rolker/unh_marine_autonomy/issues/172)
+(part of the sidescan-mosaic umbrella #171); the persistence/distribution contract
+originates in [ADR-0002](../docs/decisions/0002-bathymetric-data-store.md) §D5/§D6.
+
+## What it provides
+
+- **`TiledRasterTile<T>`** — one GGGS grid (960×960 cells) of an N-band raster of
+  element type `T`, GGGS-`GridIndex`-keyed, structure-of-arrays (one band per
+  `std::vector<T>`), with a dirty flag for incremental save. Per-band fills let
+  different bands carry different no-data sentinels.
+- **Per-tile GeoTIFF persistence** (`tile_io.hpp`) — `saveTile` / `loadTile` and
+  the directory-level `saveTiles` / `loadTiles`. Each tile is a GeoTIFF
+  WGS84-georeferenced from its GGGS grid corners, written north-up; `loadTile`
+  recovers the `GridIndex` from the geotransform and **rejects** a tile written
+  at a different level or a non-WGS84 raster.
+
+## Element types
+
+GDAL is kept a **private** dependency: the `tile_io` functions are templates
+**explicitly instantiated** in `tile_io.cpp` for the supported element types —
+currently `double` (bathymetry: 3-band Float64) and `std::uint16_t` (sidescan
+backscatter: 1-band, #173). To add a type, add a `gdalType<>` specialization and
+an explicit instantiation in `tile_io.cpp`; nothing in the public headers
+changes.
+
+## Consumers
+
+- `marine_bathymetry_store` — instantiates `TiledRasterTile<double>` (3 bands:
+  depth / uncertainty / timestamp) and keeps its multi-layer `SourceLayer` store,
+  priority queries, and `BathyCell` on top.
+- `marine_sidescan_mosaic` (#173) — `TiledRasterTile<std::uint16_t>` at GGGS
+  level 13.
+
+## Build & test
+
+```bash
+colcon build --symlink-install --packages-select marine_tiled_raster_store
+colcon test --packages-select marine_tiled_raster_store
+```
+
+`test_tile_io` (headless GTest) covers the uint16 single-band and double 3-band
+round-trips, level-mismatch rejection, the `band_nodata`-size guard, and
+dirty-only `saveTiles` / `loadTiles`.
+
+## Dependencies
+
+- `marine_autonomy` — the GGGS spatial index (`gggs::Level` / `GridIndex`).
+- GDAL — GeoTIFF persistence (private; in `tile_io.cpp` only).

--- a/marine_tiled_raster_store/include/marine_tiled_raster_store/tile_io.hpp
+++ b/marine_tiled_raster_store/include/marine_tiled_raster_store/tile_io.hpp
@@ -1,0 +1,112 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef MARINE_TILED_RASTER_STORE__TILE_IO_HPP_
+#define MARINE_TILED_RASTER_STORE__TILE_IO_HPP_
+
+#include <cstddef>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "marine_autonomy/gggs.h"
+#include "marine_tiled_raster_store/tiled_raster_tile.hpp"
+
+/// @file
+/// @brief Generic per-tile GeoTIFF persistence for `TiledRasterTile<T>`.
+///
+/// The format-agnostic generalization of `marine_bathymetry_store/tile_io`
+/// (ADR-0002 §D5/§D6 in `unh_marine_autonomy` is the origin and the contract
+/// the #86-Phase-6 manifest/content-hash sync will build on here). Each tile is
+/// one GeoTIFF with @c bandCount() bands of `T`, WGS84-georeferenced from its
+/// GGGS grid corners and written **north-up** (raster row 0 = north), so a row
+/// flip separates on-disk order from the in-memory GGGS cell order
+/// (row 0 = south).
+///
+/// GDAL is intentionally absent from this header: the functions are templates
+/// **explicitly instantiated** in `tile_io.cpp` for the supported element types
+/// (`double`, `std::uint16_t`), so consumers link the instantiations without
+/// taking a public GDAL dependency.
+///
+/// @note Round-trip persistence is validated for **non-polar** latitudes
+/// (|lat| < 72°), the intended lake/coastal survey envelope. Near GGGS's polar
+/// longitude-scaling boundaries the linear geotransform becomes an
+/// approximation and the level-match check on load may mis-fire. Polar tiles are
+/// out of scope for this phase.
+
+namespace marine_tiled_raster_store
+{
+
+/// @brief GeoTIFF filename (no directory) for a grid: `<level>_<row>_<col>.tif`.
+std::string tileFilename(const gggs::GridIndex & grid);
+
+/// @brief Write one tile as a `bandCount()`-band GeoTIFF (element type @p T) at @p path.
+///
+/// @param band_nodata Optional per-band no-data value, one entry per band (size
+///   must equal @p tile.bandCount()). A `std::nullopt` entry writes no no-data
+///   tag for that band (e.g. a timestamp band where every value is valid).
+/// @throws std::invalid_argument if @p band_nodata size != tile.bandCount().
+/// @throws std::runtime_error on any GDAL failure.
+template<typename T>
+void saveTile(
+  const TiledRasterTile<T> & tile, const std::string & path,
+  const std::vector<std::optional<T>> & band_nodata);
+
+/// @brief Load a tile GeoTIFF, reconstructing its GridIndex at @p level.
+///
+/// The grid is recovered from the file's geotransform (the cell center maps back
+/// through @p level), so a file written at a different level is rejected. The
+/// file must be a geographic WGS84 raster with the expected dimensions and at
+/// least @p band_count bands; the first @p band_count bands are read. The
+/// returned tile is clean (not dirty).
+/// @throws std::runtime_error on GDAL failure, wrong dimensions/bands, a
+///         non-WGS84 raster, or a geotransform that doesn't match any grid at
+///         @p level.
+template<typename T>
+TiledRasterTile<T> loadTile(
+  const std::string & path, const gggs::Level & level, std::size_t band_count);
+
+/// @brief Persist every **dirty** tile of @p tiles into @p dir, then clear their
+///        dirty flags.
+///
+/// Writes `<dir>/<level>_<row>_<col>.tif`, creating @p dir as needed. Clean
+/// tiles are skipped (incremental save). @p band_nodata is forwarded to
+/// `saveTile` for every tile.
+/// @return The number of tiles written.
+/// @throws std::runtime_error / std::filesystem::filesystem_error on failure.
+template<typename T>
+std::size_t saveTiles(
+  std::map<gggs::GridIndex, TiledRasterTile<T>> & tiles, const std::string & dir,
+  const std::vector<std::optional<T>> & band_nodata);
+
+/// @brief Load every `*.tif` under @p dir into @p tiles (insert or replace),
+///        reconstructing each tile at @p level with @p band_count bands.
+/// @return The number of tiles loaded. Loaded tiles are clean.
+/// @throws std::runtime_error / std::filesystem::filesystem_error on failure.
+template<typename T>
+std::size_t loadTiles(
+  std::map<gggs::GridIndex, TiledRasterTile<T>> & tiles, const std::string & dir,
+  const gggs::Level & level, std::size_t band_count);
+
+}  // namespace marine_tiled_raster_store
+
+#endif  // MARINE_TILED_RASTER_STORE__TILE_IO_HPP_

--- a/marine_tiled_raster_store/include/marine_tiled_raster_store/tile_io.hpp
+++ b/marine_tiled_raster_store/include/marine_tiled_raster_store/tile_io.hpp
@@ -63,7 +63,10 @@ std::string tileFilename(const gggs::GridIndex & grid);
 ///
 /// @param band_nodata Optional per-band no-data value, one entry per band (size
 ///   must equal @p tile.bandCount()). A `std::nullopt` entry writes no no-data
-///   tag for that band (e.g. a timestamp band where every value is valid).
+///   tag for that band (e.g. a timestamp band where every value is valid). A
+///   present value must be exactly representable in @p T — it is written via
+///   GDAL's `SetNoDataValue(double)`, so a sentinel outside @p T's range (or not
+///   round-tripping through `double`) would tag a value the band can never hold.
 /// @throws std::invalid_argument if @p band_nodata size != tile.bandCount().
 /// @throws std::runtime_error on any GDAL failure.
 template<typename T>

--- a/marine_tiled_raster_store/include/marine_tiled_raster_store/tiled_raster_tile.hpp
+++ b/marine_tiled_raster_store/include/marine_tiled_raster_store/tiled_raster_tile.hpp
@@ -1,0 +1,132 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef MARINE_TILED_RASTER_STORE__TILED_RASTER_TILE_HPP_
+#define MARINE_TILED_RASTER_STORE__TILED_RASTER_TILE_HPP_
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+#include "marine_autonomy/gggs.h"
+
+namespace marine_tiled_raster_store
+{
+
+/// @brief One GGGS grid (960×960 cells) of an N-band raster for a single layer.
+///
+/// The format-agnostic generalization of `marine_bathymetry_store`'s
+/// `BathymetryTile`: a GGGS-`GridIndex`-keyed tile holding @p band_count dense,
+/// row-major bands of element type @p T, in **GGGS cell coordinates** (row 0 is
+/// the southern edge and increases north; column 0 is the western edge and
+/// increases east). Persistence (`tile_io`) flips rows to north-up GeoTIFF order.
+///
+/// Structure-of-arrays (one `std::vector<T>` per band) mirrors the GeoTIFF band
+/// layout, making persistence a per-band copy. A tile is allocated whole — its
+/// owning store is what allocates tiles lazily (only when a grid is first
+/// written), so empty regions cost nothing. A tile carries a `dirty` flag so a
+/// store can persist only what changed (incremental save).
+///
+/// @tparam T Per-cell element type. `tile_io` supports the explicitly
+///   instantiated types (`double`, `std::uint16_t`); other types compile here
+///   but have no persistence backing.
+template<typename T>
+class TiledRasterTile
+{
+public:
+  /// @brief Number of cells along each grid edge (GGGS constant, 960).
+  static constexpr uint16_t edge = gggs::cell_rows_per_grid;
+  /// @brief Total cells in a tile (edge × edge).
+  static constexpr uint32_t cell_count = gggs::grid_total_cell_count;
+
+  /// @brief Construct a tile for @p index, one band per entry of @p band_fills,
+  ///        every cell of band @c b initialized to @c band_fills[b].
+  ///
+  /// Per-band fills let a consumer give different bands different no-data
+  /// sentinels (e.g. NaN for a depth band, 0 for a timestamp band).
+  /// @throws std::invalid_argument if @p band_fills is empty.
+  TiledRasterTile(gggs::GridIndex index, const std::vector<T> & band_fills)
+  : index_(index)
+  {
+    if (band_fills.empty()) {
+      throw std::invalid_argument("TiledRasterTile: band_fills must be non-empty");
+    }
+    bands_.reserve(band_fills.size());
+    for (const T fill : band_fills) {
+      bands_.emplace_back(cell_count, fill);
+    }
+  }
+
+  /// @brief Construct a tile for @p index with @p band_count bands, every cell
+  ///        of every band initialized to @p fill.
+  TiledRasterTile(gggs::GridIndex index, std::size_t band_count, T fill)
+  : TiledRasterTile(index, std::vector<T>(band_count, fill)) {}
+
+  /// @brief The grid this tile covers.
+  const gggs::GridIndex & index() const noexcept {return index_;}
+
+  /// @brief Number of bands in this tile.
+  std::size_t bandCount() const noexcept {return bands_.size();}
+
+  /// @brief Write @p value at (@p row, @p col) in band @p band; marks dirty.
+  void set(uint16_t row, uint16_t col, std::size_t band, T value)
+  {
+    bands_[band][offset(row, col)] = value;
+    dirty_ = true;
+  }
+
+  /// @brief Read the value at (@p row, @p col) in band @p band.
+  T get(uint16_t row, uint16_t col, std::size_t band) const
+  {
+    return bands_[band][offset(row, col)];
+  }
+
+  /// @brief Raw band accessors (row-major, GGGS cell order) for persistence.
+  /// @{
+  const std::vector<T> & band(std::size_t b) const {return bands_[b];}
+  std::vector<T> & band(std::size_t b) {return bands_[b];}
+  /// @}
+
+  /// @brief Whether this tile has unsaved changes.
+  bool dirty() const noexcept {return dirty_;}
+  /// @brief Mark all changes saved (called by persistence after a successful write).
+  void clearDirty() noexcept {dirty_ = false;}
+  /// @brief Force the dirty flag (used when reconstructing a tile in memory).
+  void markDirty() noexcept {dirty_ = true;}
+
+  /// @brief Row-major offset of cell (@p row, @p col). Asserts in debug builds.
+  static uint32_t offset(uint16_t row, uint16_t col)
+  {
+    assert(row < edge && col < edge && "TiledRasterTile cell out of bounds");
+    return static_cast<uint32_t>(row) * edge + col;
+  }
+
+private:
+  gggs::GridIndex index_;
+  std::vector<std::vector<T>> bands_;
+  bool dirty_ = false;
+};
+
+}  // namespace marine_tiled_raster_store
+
+#endif  // MARINE_TILED_RASTER_STORE__TILED_RASTER_TILE_HPP_

--- a/marine_tiled_raster_store/package.xml
+++ b/marine_tiled_raster_store/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>marine_tiled_raster_store</name>
+  <version>0.0.0</version>
+  <description>
+    Generic GGGS-tiled raster store core: a band/dtype-parametrized tile
+    (TiledRasterTile&lt;T&gt;) and per-tile GeoTIFF persistence, factored out of
+    marine_bathymetry_store so multiple raster sources (bathymetry, sidescan
+    backscatter) share one tiling + persistence contract. See
+    unh_marine_autonomy#172 / #171 / ADR-0002.
+  </description>
+  <maintainer email="roland.arsenault@unh.edu">Roland Arsenault</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>marine_autonomy</depend>
+  <depend>libgdal-dev</depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/marine_tiled_raster_store/src/tile_io.cpp
+++ b/marine_tiled_raster_store/src/tile_io.cpp
@@ -1,0 +1,324 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "marine_tiled_raster_store/tile_io.hpp"
+
+#include <gdal_priv.h>
+#include <cpl_string.h>
+#include <ogr_spatialref.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <map>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace marine_tiled_raster_store
+{
+
+namespace
+{
+
+constexpr int kEdge = static_cast<int>(gggs::cell_rows_per_grid);   // 960
+constexpr int kCellCount = kEdge * kEdge;
+
+/// RAII wrapper so a thrown exception still closes the GDAL dataset.
+struct DatasetCloser
+{
+  GDALDataset * ds = nullptr;
+  ~DatasetCloser() {if (ds) {GDALClose(ds);}}
+};
+
+/// Map a C++ element type to its GDAL band data type. Adding a type here (plus
+/// an explicit instantiation at the bottom of this file) is all it takes to
+/// extend the supported element types — and keeps GDAL out of the public header.
+template<typename T>
+GDALDataType gdalType();
+template<>
+GDALDataType gdalType<double>() {return GDT_Float64;}
+template<>
+GDALDataType gdalType<std::uint16_t>() {return GDT_UInt16;}
+
+/// Copy a band between GGGS cell order (row 0 = south) and north-up raster order
+/// (row 0 = north) — the two differ only by a vertical row flip. Works in both
+/// directions since the flip is its own inverse mapping.
+template<typename T>
+void flipRows(const std::vector<T> & src, std::vector<T> & dst)
+{
+  for (int r = 0; r < kEdge; ++r) {
+    const std::size_t flipped = static_cast<std::size_t>(kEdge - 1 - r);
+    const std::size_t dst_row = static_cast<std::size_t>(r);
+    std::copy_n(
+      src.begin() + flipped * kEdge, kEdge,
+      dst.begin() + dst_row * kEdge);
+  }
+}
+
+void checkCE(CPLErr err, const char * what)
+{
+  if (err != CE_None) {
+    throw std::runtime_error(std::string("GDAL error: ") + what);
+  }
+}
+
+}  // namespace
+
+std::string tileFilename(const gggs::GridIndex & grid)
+{
+  return std::to_string(static_cast<int>(grid.level())) + "_" +
+         std::to_string(grid.row()) + "_" + std::to_string(grid.column()) + ".tif";
+}
+
+template<typename T>
+void saveTile(
+  const TiledRasterTile<T> & tile, const std::string & path,
+  const std::vector<std::optional<T>> & band_nodata)
+{
+  const std::size_t band_count = tile.bandCount();
+  if (band_nodata.size() != band_count) {
+    throw std::invalid_argument("saveTile: band_nodata size must equal tile.bandCount()");
+  }
+
+  GDALAllRegister();
+  GDALDriver * driver = GetGDALDriverManager()->GetDriverByName("GTiff");
+  if (driver == nullptr) {
+    throw std::runtime_error("saveTile: GTiff driver unavailable");
+  }
+
+  char ** options = nullptr;
+  options = CSLSetNameValue(options, "COMPRESS", "LZW");
+  DatasetCloser out;
+  out.ds = driver->Create(
+    path.c_str(), kEdge, kEdge, static_cast<int>(band_count), gdalType<T>(), options);
+  CSLDestroy(options);
+  if (out.ds == nullptr) {
+    throw std::runtime_error("saveTile: could not create " + path);
+  }
+
+  // North-up geotransform from the grid's corners. It is load-bearing: loadTile
+  // recovers the GridIndex from it.
+  const gggs::GridIndex & grid = tile.index();
+  const double west = grid.westLongitude();
+  const double north = grid.northLatitude();
+  const double pixel_x = grid.longitudinalSpan() / kEdge;
+  const double pixel_y = -grid.latitudinalSpan() / kEdge;   // negative: north-up
+  double geo_transform[6] = {west, pixel_x, 0.0, north, 0.0, pixel_y};
+  checkCE(out.ds->SetGeoTransform(geo_transform), "set geotransform");
+
+  OGRSpatialReference srs;
+  srs.SetWellKnownGeogCS("WGS84");
+  char * wkt = nullptr;
+  if (srs.exportToWkt(&wkt) != OGRERR_NONE || wkt == nullptr) {
+    CPLFree(wkt);
+    throw std::runtime_error("saveTile: could not build WGS84 WKT for " + path);
+  }
+  const CPLErr projection_result = out.ds->SetProjection(wkt);
+  CPLFree(wkt);
+  checkCE(projection_result, "set projection");
+
+  // Flip each band into north-up raster order, then write. A no-data value is
+  // metadata only — the sentinel round-trips through the band regardless — so
+  // SetNoDataValue's result is intentionally not treated as fatal.
+  std::vector<T> raster(kCellCount);
+  for (std::size_t b = 0; b < band_count; ++b) {
+    const int band_index = static_cast<int>(b) + 1;   // GDAL bands are 1-indexed
+    if (band_nodata[b].has_value()) {
+      out.ds->GetRasterBand(band_index)->SetNoDataValue(
+        static_cast<double>(*band_nodata[b]));
+    }
+    flipRows<T>(tile.band(b), raster);
+    checkCE(
+      out.ds->GetRasterBand(band_index)->RasterIO(
+        GF_Write, 0, 0, kEdge, kEdge, raster.data(), kEdge, kEdge, gdalType<T>(), 0, 0),
+      "write band");
+  }
+
+  // Close explicitly and check the result: for a GTiff the (LZW-compressed)
+  // raster is flushed on close, so a disk-full / I/O failure surfaces only here,
+  // and saveTiles clears the dirty flag once this returns. (DatasetCloser stays
+  // as the exception-safety net for the error paths above; nulling out.ds here
+  // prevents a double close.) GDALClose returns CPLErr since GDAL 3.7; the
+  // workspace targets GDAL >= 3.8 (ROS 2 jazzy / rolling).
+  GDALDataset * ds = out.ds;
+  out.ds = nullptr;
+  if (GDALClose(ds) != CE_None) {
+    throw std::runtime_error("saveTile: failed to flush/close " + path);
+  }
+}
+
+template<typename T>
+TiledRasterTile<T> loadTile(
+  const std::string & path, const gggs::Level & level, std::size_t band_count)
+{
+  GDALAllRegister();
+  DatasetCloser in;
+  in.ds = GDALDataset::FromHandle(GDALOpen(path.c_str(), GA_ReadOnly));
+  if (in.ds == nullptr) {
+    throw std::runtime_error("loadTile: could not open " + path);
+  }
+  if (in.ds->GetRasterXSize() != kEdge || in.ds->GetRasterYSize() != kEdge ||
+    in.ds->GetRasterCount() < static_cast<int>(band_count))
+  {
+    throw std::runtime_error("loadTile: unexpected dimensions/bands in " + path);
+  }
+
+  // The grid recovery below interprets the geotransform as degrees, so the file
+  // must be a geographic WGS84 raster. Reject a projected or otherwise non-WGS84
+  // file rather than silently misreading its coordinates as lat/lon.
+  const OGRSpatialReference * srs = in.ds->GetSpatialRef();
+  OGRErr axis_error = OGRERR_NONE;
+  if (srs == nullptr || !srs->IsGeographic() ||
+    std::abs(srs->GetSemiMajor(&axis_error) - 6378137.0) > 1.0 || axis_error != OGRERR_NONE)
+  {
+    throw std::runtime_error("loadTile: not a geographic WGS84 raster: " + path);
+  }
+
+  double geo_transform[6];
+  if (in.ds->GetGeoTransform(geo_transform) != CE_None) {
+    throw std::runtime_error("loadTile: missing geotransform in " + path);
+  }
+  const double west = geo_transform[0];
+  const double pixel_x = geo_transform[1];
+  const double north = geo_transform[3];
+  const double pixel_y = geo_transform[5];
+  const double east = west + pixel_x * kEdge;
+  const double south = north + pixel_y * kEdge;
+
+  // Recover the GridIndex: the cell center maps back through the level.
+  const double center_lat = 0.5 * (north + south);
+  const double center_lon = 0.5 * (west + east);
+  const gggs::GridIndex grid = level.gridIndex(center_lat, center_lon);
+
+  // Reject a file whose grid edges don't match a grid at this level (e.g. saved
+  // at a different level): require agreement to within half a cell.
+  const double tol_lon = 0.5 * std::abs(pixel_x);
+  const double tol_lat = 0.5 * std::abs(pixel_y);
+  if (std::abs(grid.westLongitude() - west) > tol_lon ||
+    std::abs(grid.northLatitude() - north) > tol_lat)
+  {
+    throw std::runtime_error(
+            "loadTile: geotransform does not match any grid at level " +
+            std::to_string(level.level()) + " in " + path);
+  }
+
+  // Default-fill the bands; every cell is overwritten from the raster below, so
+  // the fill value is immaterial. Filled via band accessors (not set()), so the
+  // tile stays clean.
+  TiledRasterTile<T> tile(grid, band_count, T{});
+  std::vector<T> raster(kCellCount);
+  for (std::size_t b = 0; b < band_count; ++b) {
+    const int band_index = static_cast<int>(b) + 1;
+    checkCE(
+      in.ds->GetRasterBand(band_index)->RasterIO(
+        GF_Read, 0, 0, kEdge, kEdge, raster.data(), kEdge, kEdge, gdalType<T>(), 0, 0),
+      "read band");
+    flipRows<T>(raster, tile.band(b));
+  }
+  return tile;
+}
+
+template<typename T>
+std::size_t saveTiles(
+  std::map<gggs::GridIndex, TiledRasterTile<T>> & tiles, const std::string & dir,
+  const std::vector<std::optional<T>> & band_nodata)
+{
+  namespace fs = std::filesystem;
+  std::size_t written = 0;
+  bool created_dir = false;
+  for (auto & [grid, tile] : tiles) {
+    if (!tile.dirty()) {
+      continue;
+    }
+    if (!created_dir) {
+      fs::create_directories(dir);
+      created_dir = true;
+    }
+    saveTile<T>(tile, (fs::path(dir) / tileFilename(grid)).string(), band_nodata);
+    tile.clearDirty();
+    ++written;
+  }
+  return written;
+}
+
+template<typename T>
+std::size_t loadTiles(
+  std::map<gggs::GridIndex, TiledRasterTile<T>> & tiles, const std::string & dir,
+  const gggs::Level & level, std::size_t band_count)
+{
+  namespace fs = std::filesystem;
+  std::size_t loaded = 0;
+  if (!fs::is_directory(dir)) {
+    return 0;
+  }
+  for (const auto & entry : fs::directory_iterator(dir)) {
+    if (!entry.is_regular_file() || entry.path().extension() != ".tif") {
+      continue;
+    }
+    TiledRasterTile<T> tile = loadTile<T>(entry.path().string(), level, band_count);
+    const gggs::GridIndex index = tile.index();
+    auto it = tiles.find(index);
+    if (it == tiles.end()) {
+      tiles.emplace(index, std::move(tile));
+    } else {
+      it->second = std::move(tile);
+    }
+    ++loaded;
+  }
+  return loaded;
+}
+
+// Explicit instantiations — the element types tile_io supports. This is what
+// keeps GDAL a PRIVATE dependency: the templates are defined here, and consumers
+// (e.g. marine_bathymetry_store with double) link these symbols without ever
+// including a GDAL header. Add a type here + a gdalType<> specialization above to
+// extend (e.g. std::uint16_t for the sidescan mosaic, #173).
+template void saveTile<double>(
+  const TiledRasterTile<double> &, const std::string &,
+  const std::vector<std::optional<double>> &);
+template void saveTile<std::uint16_t>(
+  const TiledRasterTile<std::uint16_t> &, const std::string &,
+  const std::vector<std::optional<std::uint16_t>> &);
+
+template TiledRasterTile<double> loadTile<double>(
+  const std::string &, const gggs::Level &, std::size_t);
+template TiledRasterTile<std::uint16_t> loadTile<std::uint16_t>(
+  const std::string &, const gggs::Level &, std::size_t);
+
+template std::size_t saveTiles<double>(
+  std::map<gggs::GridIndex, TiledRasterTile<double>> &, const std::string &,
+  const std::vector<std::optional<double>> &);
+template std::size_t saveTiles<std::uint16_t>(
+  std::map<gggs::GridIndex, TiledRasterTile<std::uint16_t>> &, const std::string &,
+  const std::vector<std::optional<std::uint16_t>> &);
+
+template std::size_t loadTiles<double>(
+  std::map<gggs::GridIndex, TiledRasterTile<double>> &, const std::string &,
+  const gggs::Level &, std::size_t);
+template std::size_t loadTiles<std::uint16_t>(
+  std::map<gggs::GridIndex, TiledRasterTile<std::uint16_t>> &, const std::string &,
+  const gggs::Level &, std::size_t);
+
+}  // namespace marine_tiled_raster_store

--- a/marine_tiled_raster_store/test/test_tile_io.cpp
+++ b/marine_tiled_raster_store/test/test_tile_io.cpp
@@ -1,0 +1,175 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <limits>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "marine_autonomy/gggs.h"
+#include "marine_tiled_raster_store/tile_io.hpp"
+#include "marine_tiled_raster_store/tiled_raster_tile.hpp"
+
+namespace mtrs = marine_tiled_raster_store;
+
+namespace
+{
+
+// A scratch directory unique per test, removed on construction and destruction.
+class ScratchDir
+{
+public:
+  explicit ScratchDir(const std::string & name)
+  : path_(std::filesystem::path(::testing::TempDir()) / ("mtrs_" + name))
+  {
+    std::filesystem::remove_all(path_);
+    std::filesystem::create_directories(path_);
+  }
+  ~ScratchDir() {std::filesystem::remove_all(path_);}
+  const std::filesystem::path & path() const {return path_;}
+
+private:
+  std::filesystem::path path_;
+};
+
+// A grid near Lake Massabesic, away from the polar scaling boundaries.
+gggs::GridIndex sampleGrid(const gggs::Level & level)
+{
+  return level.gridIndex(43.07, -71.42);
+}
+
+}  // namespace
+
+// A single-band uint16 tile (the sidescan-mosaic shape, #173) round-trips
+// through GeoTIFF: values and recovered GridIndex survive.
+TEST(TiledRasterTileIo, RoundTripUint16SingleBand)
+{
+  ScratchDir dir("u16_single");
+  const gggs::Level level(13);                       // ~0.11 m cells
+  const gggs::GridIndex grid = sampleGrid(level);
+  const std::string path = (dir.path() / mtrs::tileFilename(grid)).string();
+
+  mtrs::TiledRasterTile<std::uint16_t> tile(grid, 1, 0);
+  tile.set(0, 0, 0, 7);
+  tile.set(100, 200, 0, 4242);
+  tile.set(tile.edge - 1, tile.edge - 1, 0, 65535);
+
+  mtrs::saveTile<std::uint16_t>(tile, path, {std::nullopt});
+  const auto loaded = mtrs::loadTile<std::uint16_t>(path, level, 1);
+
+  EXPECT_EQ(loaded.index(), grid);
+  EXPECT_EQ(loaded.bandCount(), 1u);
+  EXPECT_EQ(loaded.get(0, 0, 0), 7);
+  EXPECT_EQ(loaded.get(100, 200, 0), 4242);
+  EXPECT_EQ(loaded.get(tile.edge - 1, tile.edge - 1, 0), 65535);
+  EXPECT_FALSE(loaded.dirty());
+}
+
+// The bathymetry shape (3-band Float64, NaN no-data on two bands) round-trips,
+// confirming the generalization preserves the existing persistence behavior.
+TEST(TiledRasterTileIo, RoundTripDoubleThreeBand)
+{
+  ScratchDir dir("f64_three");
+  const gggs::Level level(11);                       // ~0.45 m cells
+  const gggs::GridIndex grid = sampleGrid(level);
+  const std::string path = (dir.path() / mtrs::tileFilename(grid)).string();
+
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  mtrs::TiledRasterTile<double> tile(grid, std::vector<double>{nan, nan, 0.0});
+  tile.set(10, 20, 0, -12.5);     // depth (ellipsoidal height)
+  tile.set(10, 20, 1, 0.3);       // uncertainty
+  tile.set(10, 20, 2, 1.78e9);    // timestamp
+
+  mtrs::saveTile<double>(tile, path, {nan, nan, std::nullopt});
+  const auto loaded = mtrs::loadTile<double>(path, level, 3);
+
+  EXPECT_EQ(loaded.index(), grid);
+  EXPECT_DOUBLE_EQ(loaded.get(10, 20, 0), -12.5);
+  EXPECT_DOUBLE_EQ(loaded.get(10, 20, 1), 0.3);
+  EXPECT_DOUBLE_EQ(loaded.get(10, 20, 2), 1.78e9);
+  EXPECT_TRUE(std::isnan(loaded.get(0, 0, 0)));     // untouched cell stays no-data
+  EXPECT_DOUBLE_EQ(loaded.get(0, 0, 2), 0.0);       // timestamp band fill
+}
+
+// A tile saved at one level is rejected when loaded at a different level (its
+// geotransform won't match any grid there).
+TEST(TiledRasterTileIo, LevelMismatchRejected)
+{
+  ScratchDir dir("level_mismatch");
+  const gggs::Level saved_level(13);
+  const gggs::GridIndex grid = sampleGrid(saved_level);
+  const std::string path = (dir.path() / mtrs::tileFilename(grid)).string();
+
+  mtrs::TiledRasterTile<std::uint16_t> tile(grid, 1, 0);
+  tile.set(0, 0, 0, 1);
+  mtrs::saveTile<std::uint16_t>(tile, path, {std::nullopt});
+
+  const gggs::Level wrong_level(12);
+  EXPECT_THROW(mtrs::loadTile<std::uint16_t>(path, wrong_level, 1), std::runtime_error);
+}
+
+// band_nodata must describe every band, or saveTile rejects the call.
+TEST(TiledRasterTileIo, BandNodataSizeMismatchThrows)
+{
+  ScratchDir dir("nodata_size");
+  const gggs::Level level(13);
+  const gggs::GridIndex grid = sampleGrid(level);
+  const std::string path = (dir.path() / mtrs::tileFilename(grid)).string();
+
+  mtrs::TiledRasterTile<double> tile(grid, 3, 0.0);
+  // Two entries for a three-band tile.
+  EXPECT_THROW(
+    mtrs::saveTile<double>(tile, path, {std::nullopt, std::nullopt}),
+    std::invalid_argument);
+}
+
+// saveTiles writes only dirty tiles and clears their flags; loadTiles recovers
+// exactly the tiles that were written.
+TEST(TiledRasterTileIo, SaveTilesWritesOnlyDirty)
+{
+  ScratchDir dir("dirty_only");
+  const gggs::Level level(13);
+  const gggs::GridIndex grid_a = level.gridIndex(43.07, -71.42);
+  const gggs::GridIndex grid_b = level.gridIndex(43.50, -71.10);
+  ASSERT_FALSE(grid_a == grid_b);
+
+  std::map<gggs::GridIndex, mtrs::TiledRasterTile<std::uint16_t>> tiles;
+  tiles.emplace(grid_a, mtrs::TiledRasterTile<std::uint16_t>(grid_a, 1, 0));
+  tiles.emplace(grid_b, mtrs::TiledRasterTile<std::uint16_t>(grid_b, 1, 0));
+  tiles.at(grid_a).set(1, 1, 0, 11);   // dirty
+  tiles.at(grid_b).set(2, 2, 0, 22);
+  tiles.at(grid_b).clearDirty();       // pretend already persisted
+
+  EXPECT_EQ(mtrs::saveTiles<std::uint16_t>(tiles, dir.path().string(), {std::nullopt}), 1u);
+  EXPECT_FALSE(tiles.at(grid_a).dirty());   // cleared by the write
+
+  std::map<gggs::GridIndex, mtrs::TiledRasterTile<std::uint16_t>> reloaded;
+  EXPECT_EQ(mtrs::loadTiles<std::uint16_t>(reloaded, dir.path().string(), level, 1), 1u);
+  ASSERT_EQ(reloaded.count(grid_a), 1u);
+  EXPECT_EQ(reloaded.at(grid_a).get(1, 1, 0), 11);
+  EXPECT_EQ(reloaded.count(grid_b), 0u);    // clean tile was never written
+}


### PR DESCRIPTION
Closes #172. Part of #171 (live sidescan mosaic).

## What

Extract a generic, format-agnostic **GGGS-tiled raster store core** out of
`marine_bathymetry_store`, so multiple raster sources (bathymetry now, sidescan
backscatter next — #173) share one tiling + persistence (and, later, #86
Phase-6 sync) contract instead of forking it.

- **New `core_ws` package `marine_tiled_raster_store`**:
  - `TiledRasterTile<T>` — GGGS-`GridIndex`-keyed, band/dtype-parametrized,
    lazy-alloc + dirty flag.
  - Templated per-tile GeoTIFF persistence (`saveTile`/`loadTile`/`saveTiles`/
    `loadTiles`): corner→geotransform, WGS84, north-up row-flip, geotransform→
    `GridIndex` recovery with half-cell level-match + non-WGS84 rejection.
  - **GDAL kept a PRIVATE dependency** via explicit template instantiation
    (`double`, `std::uint16_t`) in `tile_io.cpp` — consumers link the
    instantiations without taking a public GDAL dependency.
- **`marine_bathymetry_store` refactored onto it**: `BathymetryTile` is now a
  thin wrapper over `TiledRasterTile<double>` (identical public surface), and its
  `tile_io` delegates per-tile I/O to the generic core while keeping the
  multi-layer `SourceLayer` save/load and the NaN-no-data band policy.

## No behavior change

`marine_bathymetry_store`'s persisted format (band order, NaN no-data tags,
geotransform, LZW, `GridIndex`↔filename mapping, load-side georeferencing guards)
is byte-equivalent to `jazzy`. Confirmed independently by two fresh-context
adversarial review lenses. Its existing tests pass unchanged.

## Verification

- Both packages build clean; **112 tests, 0 failures** — generic `test_tile_io`
  **5/5** (uint16 single-band + double 3-band round-trips, level-mismatch and
  `band_nodata`-size rejection, dirty-only `saveTiles`/`loadTiles`); bathy
  `test_store` **11**, `test_query` **9**, `test_tile_io` **7**.
- `ament_cpplint` clean on all changed files.
- Local `/review-code` (Standard): **approved**, 0 must-fix; the two actionable
  suggestions (drop bathy's now-dead GDAL deps; document `band_nodata`
  representability) are applied and re-verified green.

## Governance

ADR-0002 §D2 (reuse GGGS, no new tiling), §D5 (bathy persistence unchanged),
§D9 (store core free of consumer-specific logic) — all compliant. A dedicated
ADR for the shared substrate is deferred to I3 (#86 Phase 6), where the
content-hash sync contract is actually designed.

Work plan: `.agent/work-plans/issue-172/plan.md`.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
