### PR TITLE
marine_sidescan_mosaic: live GGGS-tiled backscatter mosaic (L13, uint16) (#173)

### DIFF
--- a/.agent/work-plans/issue-173/plan.md
+++ b/.agent/work-plans/issue-173/plan.md
@@ -119,14 +119,15 @@ ECEF↔geodetic + `geodesics.h` `direct` Vincenty) — no hand-rolled ellipsoid 
 - **GeoTIFF no-data 0.** Untouched cells flush with a no-data tag of 0, so empty
   mosaic areas render transparent in QGIS / CAMP.
 
-## Validation status (Simulation-First — PENDING)
+## Validation status (Simulation-First — DONE, port channel)
 
 Built clean; the three pure units (`projection`, `accumulator`, `normalizer`) are
-fully unit-tested (17 gtest cases). **Runtime validation is not yet done**: this
-dev host has no rosbag with the `earth`→sensor TF chain (only `*_sidescan_raw` /
-PINGMapper output), and `unh_marine_simulation` doesn't emit sidescan
-`RawSonarImage`. The acceptance gate — replay a `bizzyboat_sonar` bag (or sim) and
-confirm the mosaic geo-registers — must run on a boat-side host (gabby/salmon) or
-once such a bag is local. The existing PINGMapper Massabesic tiles
-(`~/data/sidescan/Massabesic/.../rect_wcr`) are a ready comparison reference, and
-the `across_track_offset_deg` frame convention is the specific thing to confirm.
+fully unit-tested (17 gtest cases). **Runtime bag replay validated** against
+`~/data/logs/gabby/logs/bizzyboat_sonar/2026-06-16T14-17-37+00-00`: port pings
+georeference into WGS84 L13 tiles **centered on Lake Massabesic (42.992°N,
+71.393°W)** with real normalized backscatter — the default `across_track_offset_deg`
+frame convention is grossly correct. Caught + fixed a node-construct crash
+(double-declared `norm_*` params). **Open follow-ups:** (1) `earth→…_starboard` is
+missing from that bag's TF tree (port works) — a platform/URDF gap, all starboard
+pings dropped; (2) fine geometry accuracy vs the PINGMapper `~/data/sidescan/
+Massabesic` reference. See the `## Validation` progress entry.

--- a/.agent/work-plans/issue-173/plan.md
+++ b/.agent/work-plans/issue-173/plan.md
@@ -45,9 +45,9 @@ ECEF↔geodetic + `geodesics.h` `direct` Vincenty) — no hand-rolled ellipsoid 
 5. **Splat**: resolve **each sample's own** `GridIndex` via `Level::gridIndex(pos)`
    then `cellIndex(pos)` — do NOT reuse the origin grid (`cellIndex(grid, p)`
    clamps out-of-grid `p` to the edge, smearing across-boundary samples).
-   Accumulate intensity: **mean** default — per-cell **`uint32` sum + count** →
-   quantize to `uint16` on flush; policy param `splat: mean|max_hold` (mean
-   despeckles the ~5–15 samples/cell at L13; max-hold for target-cueing).
+   Accumulate intensity: **mean** default — per-cell **`uint64` sum + `uint32`
+   count** → quantize to `uint16` on flush; policy param `splat: mean|max_hold`
+   (mean despeckles the ~5–15 samples/cell at L13; max-hold for target-cueing).
 6. **Normalize** (P2): rolling/adaptive gain (TVG-like across-range + rolling
    display-scale) → `uint16`.
 7. **Flush**: dirty tiles → GeoTIFF on a timer (`marine_tiled_raster_store::
@@ -99,3 +99,34 @@ ECEF↔geodetic + `geodesics.h` `direct` Vincenty) — no hand-rolled ellipsoid 
 
 **Single PR** for #173 (P1+P2). P3 (adaptive multi-level + Req A/B) and P4
 (dirty-region) are separate follow-on sub-issues of #171, filed when reached.
+
+## Implementation Notes
+
+- **Per-side normalizers.** Port and stbd each get their own `RollingNormalizer`
+  so a sensitivity difference between channels doesn't bias the gain; the shared
+  `MosaicAccumulator` still merges both into one tile store.
+- **`uint64` sum (not `uint32`).** The mean accumulator uses a `uint64` sum so a
+  long stationary dwell can't overflow even at the `uint16` ceiling (the reviewer
+  endorsed `uint32` for 5–15 samples/cell; `uint64` removes the dwell edge case
+  for ~one extra band of scratch).
+- **`across_track_offset_deg` parameter.** The across-track azimuth is
+  `heading ± across_track_offset_deg` (default 90°), assuming the sensor
+  `frame_id` +x is vessel-forward. Made a parameter (not a hardcoded 90°) so a
+  platform whose URDF orients the sensor frame differently can correct it without
+  a rebuild — the exact value is a **validation target** (see below).
+- **Nadir-cone skip.** Samples whose ground range resolves to 0 (slant within
+  altitude) are dropped rather than piled onto the origin cell.
+- **GeoTIFF no-data 0.** Untouched cells flush with a no-data tag of 0, so empty
+  mosaic areas render transparent in QGIS / CAMP.
+
+## Validation status (Simulation-First — PENDING)
+
+Built clean; the three pure units (`projection`, `accumulator`, `normalizer`) are
+fully unit-tested (17 gtest cases). **Runtime validation is not yet done**: this
+dev host has no rosbag with the `earth`→sensor TF chain (only `*_sidescan_raw` /
+PINGMapper output), and `unh_marine_simulation` doesn't emit sidescan
+`RawSonarImage`. The acceptance gate — replay a `bizzyboat_sonar` bag (or sim) and
+confirm the mosaic geo-registers — must run on a boat-side host (gabby/salmon) or
+once such a bag is local. The existing PINGMapper Massabesic tiles
+(`~/data/sidescan/Massabesic/.../rect_wcr`) are a ready comparison reference, and
+the `across_track_offset_deg` frame convention is the specific thing to confirm.

--- a/.agent/work-plans/issue-173/plan.md
+++ b/.agent/work-plans/issue-173/plan.md
@@ -1,0 +1,102 @@
+# Plan: marine_sidescan_mosaic — live GGGS-tiled backscatter mosaic
+
+## Issue
+
+https://github.com/rolker/unh_marine_autonomy/issues/173 (Part of #171; refs #166, #86, #151, #172)
+
+## Context
+
+Build the live mosaicker node: Garmin GCV port/stbd `RawSonarImage` → georeferenced
+backscatter raster, splatted into GGGS-tiled `uint16` GeoTIFF tiles (the #172
+`marine_tiled_raster_store` core), updating live for CAMP (I4) and the #166 web
+viewer. This is the sidescan-mosaic prerequisite #166 carves out.
+
+The ping-origin georef + TF-lookup pattern is proven in `marine_tools/bag_analysis`
+`bag_to_xtf` (Python) — but that tool hands *slant* samples to PINGMapper. This
+node must georeference **each sample** (slant→ground→geodetic→GGGS cell) itself.
+Per ADR-0002 §D8, use the `geodesy` underlay package for ECEF↔geodetic + local
+tangent-plane math rather than re-porting `geo.py` by hand.
+
+## Approach — per-ping pipeline (C++ node)
+
+1. **Subscribe** port/stbd `marine_acoustic_msgs/RawSonarImage`, `~/nadir_depth`
+   (`sensor_msgs/Range`), and TF (`tf2_ros::Buffer`/`TransformListener`).
+2. **Georef ping origin**: `lookupTransform(earth, ping.frame_id, stamp)` with the
+   exact→bounded-latest→drop fallback (port `bag_to_xtf::_lookup_pose`); ECEF pose
+   → geodetic + heading via `geodesy`.
+3. **Per-sample ground projection**: range to sample `j` = `(sample0+j)·sv/(2·fs)`;
+   ground range = `sqrt(max(0, slant² − alt²))` (alt = nadir depth); place at the
+   sensor ground position offset by ground-range along the across-track azimuth
+   (`heading ± 90°`, sign per port/stbd); local-ENU offset → geodetic.
+4. **Splat**: geodetic → `gggs::CellIndex` → write normalized intensity into a
+   `TiledRasterTile<uint16_t>` (lazy-create the tile; mark dirty).
+5. **Normalization** (Phase 2): rolling/adaptive gain (TVG-like across-range + a
+   rolling display-scale) → `uint16`. Phase-1 uses a fixed linear scale to get
+   pixels on the map.
+6. **Adaptive level** (Phase 3, Req B): per-ping `gggs::Level::fromCellSize`
+   driven by the effective along-track spacing; store holds heterogeneous levels.
+7. **Effective-resolution logging** (Phase 3, Req A): along-track = speed·Δt
+   (ECEF displacement / odom), across-track = range/2000 projected; log + publish.
+8. **Flush**: dirty tiles → GeoTIFF on a timer (`marine_tiled_raster_store::
+   saveTiles`); publish a **dirty-region** topic (changed `GridIndex`).
+
+## Phasing (this is multiple PRs — see Scope)
+
+- **P1 (MVP, runnable)**: node + origin georef + per-sample projection + splat at
+  **fixed L13** + fixed-scale uint16 + tile GeoTIFF flush + unit tests. First
+  on-disk georeferenced mosaic.
+- **P2**: rolling gain normalization.
+- **P3**: adaptive multi-level (Req B) + effective-resolution logging (Req A) +
+  the #172 multi-level-load follow-up (per-tile level recovery from filename).
+- **P4**: dirty-region topic + flush tuning (CAMP consumption is I4).
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `marine_sidescan_mosaic/package.xml`, `CMakeLists.txt` | New ament_cmake node pkg; deps: rclcpp, marine_acoustic_msgs, sensor_msgs, tf2_ros, geodesy, marine_autonomy, marine_tiled_raster_store |
+| `…/src/mosaic_node.cpp` | The node (subs, TF, flush timer, dirty-region pub) |
+| `…/src/projection.{hpp,cpp}` | Pure geometry: slant→ground, across-track→geodetic→CellIndex (port from `bag_to_xtf` + geodesy) |
+| `…/src/normalizer.{hpp,cpp}` | Intensity→uint16 (fixed P1 → rolling P2) |
+| `…/launch/sidescan_mosaic.launch.py` | Generic launch (params: topics, output dir, level/cell-size, flush rate) |
+| `…/test/test_projection.cpp` | Unit tests: known pose+range → expected cell; slant/altitude edge cases |
+| `…/README.md` | Package doc |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Only what's needed | Phase the work; P1 is the runnable MVP, adaptive/normalization staged |
+| Simulation-First | Validate against a `bizzyboat_sonar` bag (has the TF chain) before field use |
+| Decoupling | Pure `projection`/`normalizer` units, node is thin glue; reuses #172 core |
+| Sensor conventions | Mounting/look-direction comes from TF/`frame_id`, not params (per prior feedback); generic launch + node defaults |
+| Safety First | Display product, not control — but tile mis-georeference would mislead a search; projection is unit-tested |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0002 §D2 (reuse GGGS) | Yes | Tiles on GGGS via #172 core; no new scheme |
+| 0002 §D8 (geodesy, not hand-rolled) | Yes | ECEF↔geodetic + ENU via `geodesy` (verify its API exposes what's needed — D8 precondition) |
+| 0002 §D5/§D6 / #151 | Indirect | Multi-level store (P3) coordinates with #151 refinement policy; #172 follow-up needed |
+
+## Consequences
+
+| If we change… | Also update… | In plan? |
+|---|---|---|
+| New package | `.agents/README` inventory + build order | Yes (per phase) |
+| Multi-level load (P3) | `marine_tiled_raster_store` `loadTile`/`loadTiles` (per-tile level recovery) | Yes — #172 follow-up |
+| Dirty-region topic | message type choice (marine_interfaces vs std_msgs) | Open question |
+
+## Open Questions
+
+- **Phasing as stacked PRs vs sub-issues of #173?** (Recommend stacked PRs; P1 first.)
+- **Splat conflict policy** when multiple samples hit one cell: last-write (P1, simplest) vs max-hold (target-friendly) vs running mean (despeckle, needs a count band)?
+- **Dirty-region message type**: reuse `std_msgs` / define in `marine_interfaces`?
+- **No-nadir fallback**: when `~/nadir_depth` is absent for a ping, assume alt≈0 (ground≈slant, OK in shallow water) or drop the ping?
+- Confirm `geodesy` exposes ECEF↔geodetic + a local-ENU/tangent helper (D8 precondition).
+
+## Estimated Scope
+
+**Multiple PRs** — too large for one. Recommend stacked PRs P1→P4 (or sub-issues
+of #173), each independently reviewable. P1 is the buildable, runnable MVP.

--- a/.agent/work-plans/issue-173/plan.md
+++ b/.agent/work-plans/issue-173/plan.md
@@ -7,96 +7,88 @@ https://github.com/rolker/unh_marine_autonomy/issues/173 (Part of #171; refs #16
 ## Context
 
 Build the live mosaicker node: Garmin GCV port/stbd `RawSonarImage` → georeferenced
-backscatter raster, splatted into GGGS-tiled `uint16` GeoTIFF tiles (the #172
-`marine_tiled_raster_store` core), updating live for CAMP (I4) and the #166 web
-viewer. This is the sidescan-mosaic prerequisite #166 carves out.
+backscatter raster, splatted into GGGS-tiled `uint16` GeoTIFF tiles (the merged
+#172 `marine_tiled_raster_store` core), updating live for CAMP (I4) and the #166
+web viewer. This is the sidescan-mosaic prerequisite #166 carves out.
 
-The ping-origin georef + TF-lookup pattern is proven in `marine_tools/bag_analysis`
-`bag_to_xtf` (Python) — but that tool hands *slant* samples to PINGMapper. This
-node must georeference **each sample** (slant→ground→geodetic→GGGS cell) itself.
-Per ADR-0002 §D8, use the `geodesy` underlay package for ECEF↔geodetic + local
-tangent-plane math rather than re-porting `geo.py` by hand.
+**This issue = P1+P2** (decided 2026-06-19): the runnable, legible MVP — per-ping
+georef + **per-sample** ground projection + splat at **fixed GGGS L13** + rolling
+normalization + tile GeoTIFF flush + tests. Two capabilities are **follow-on
+sub-issues of #171**, filed when reached: **P3** = adaptive multi-level (Req B) +
+effective-resolution logging (Req A) + the #172 multi-level-load follow-up; **P4**
+= dirty-region topic (consumed by CAMP/I4 + the Phase-6 sync).
+
+The ping-origin georef + TF-lookup pattern is proven in `bag_to_xtf`, but that
+tool hands *slant* samples to PINGMapper; this node georeferences **each sample**.
+Per ADR-0002 §D8, geometry uses the underlay `geodesy` package (verified: `ecef.h`
+ECEF↔geodetic + `geodesics.h` `direct` Vincenty) — no hand-rolled ellipsoid math.
 
 ## Approach — per-ping pipeline (C++ node)
 
 1. **Subscribe** port/stbd `marine_acoustic_msgs/RawSonarImage`, `~/nadir_depth`
-   (`sensor_msgs/Range`), and TF (`tf2_ros::Buffer`/`TransformListener`).
-2. **Georef ping origin**: `lookupTransform(earth, ping.frame_id, stamp)` with the
-   exact→bounded-latest→drop fallback (port `bag_to_xtf::_lookup_pose`); ECEF pose
-   → geodetic + heading via `geodesy`.
-3. **Per-sample ground projection**: range to sample `j` = `(sample0+j)·sv/(2·fs)`;
-   ground range = `sqrt(max(0, slant² − alt²))` (alt = nadir depth); place at the
-   sensor ground position offset by ground-range along the across-track azimuth
-   (`heading ± 90°`, sign per port/stbd); local-ENU offset → geodetic.
-4. **Splat**: geodetic → `gggs::CellIndex` → write normalized intensity into a
-   `TiledRasterTile<uint16_t>` (lazy-create the tile; mark dirty).
-5. **Normalization** (Phase 2): rolling/adaptive gain (TVG-like across-range + a
-   rolling display-scale) → `uint16`. Phase-1 uses a fixed linear scale to get
-   pixels on the map.
-6. **Adaptive level** (Phase 3, Req B): per-ping `gggs::Level::fromCellSize`
-   driven by the effective along-track spacing; store holds heterogeneous levels.
-7. **Effective-resolution logging** (Phase 3, Req A): along-track = speed·Δt
-   (ECEF displacement / odom), across-track = range/2000 projected; log + publish.
-8. **Flush**: dirty tiles → GeoTIFF on a timer (`marine_tiled_raster_store::
-   saveTiles`); publish a **dirty-region** topic (changed `GridIndex`).
-
-## Phasing (this is multiple PRs — see Scope)
-
-- **P1 (MVP, runnable)**: node + origin georef + per-sample projection + splat at
-  **fixed L13** + fixed-scale uint16 + tile GeoTIFF flush + unit tests. First
-  on-disk georeferenced mosaic.
-- **P2**: rolling gain normalization.
-- **P3**: adaptive multi-level (Req B) + effective-resolution logging (Req A) +
-  the #172 multi-level-load follow-up (per-tile level recovery from filename).
-- **P4**: dirty-region topic + flush tuning (CAMP consumption is I4).
+   (`sensor_msgs/Range`), TF (`tf2_ros::Buffer`/`TransformListener`).
+2. **Georef origin**: `lookupTransform(earth, ping.frame_id, stamp)` with exact→
+   bounded-latest→drop fallback (port `bag_to_xtf::_lookup_pose`); ECEF pose →
+   `GeoPoint` via `geodesy::ECEFPose`/`toMsg`; heading from the ECEF orientation
+   (small `geo.py`-style quaternion→ENU-azimuth extraction).
+3. **Altitude**: from `~/nadir_depth`; **hold last valid within a staleness bound**
+   (altitude varies slowly). Residual (none in window): **drop the ping**
+   (param `no_nadir_policy: drop|assume_zero`, default `drop`).
+4. **Per-sample projection**: range to sample `j` = `(sample0+j)·sv/(2·fs)`;
+   ground range = `sqrt(max(0, slant² − alt²))`; sample lat/lon =
+   `geodesy::direct(origin, heading ± 90° [sign per side], ground_range)`.
+5. **Splat**: `GeoPoint` → `gggs::CellIndex` → accumulate intensity. **Mean**
+   default (per-cell sum+count accumulator → quantize to `uint16` on flush);
+   policy param `splat: mean|max_hold` (mean despeckles oversampled data — ~5–15
+   samples/cell at L13; max-hold for target-cueing).
+6. **Normalize** (P2): rolling/adaptive gain (TVG-like across-range + rolling
+   display-scale) → `uint16`.
+7. **Flush**: dirty tiles → GeoTIFF on a timer (`marine_tiled_raster_store::
+   saveTiles`) into an output dir. (Live dirty-region *topic* is P4.)
 
 ## Files to Change
 
 | File | Change |
 |------|--------|
 | `marine_sidescan_mosaic/package.xml`, `CMakeLists.txt` | New ament_cmake node pkg; deps: rclcpp, marine_acoustic_msgs, sensor_msgs, tf2_ros, geodesy, marine_autonomy, marine_tiled_raster_store |
-| `…/src/mosaic_node.cpp` | The node (subs, TF, flush timer, dirty-region pub) |
-| `…/src/projection.{hpp,cpp}` | Pure geometry: slant→ground, across-track→geodetic→CellIndex (port from `bag_to_xtf` + geodesy) |
-| `…/src/normalizer.{hpp,cpp}` | Intensity→uint16 (fixed P1 → rolling P2) |
-| `…/launch/sidescan_mosaic.launch.py` | Generic launch (params: topics, output dir, level/cell-size, flush rate) |
-| `…/test/test_projection.cpp` | Unit tests: known pose+range → expected cell; slant/altitude edge cases |
-| `…/README.md` | Package doc |
+| `…/src/mosaic_node.cpp` | Node: subs, TF, nadir hold, flush timer |
+| `…/src/projection.{hpp,cpp}` | Pure geometry: heading extraction, slant→ground, `geodesy::direct`→`CellIndex` |
+| `…/src/accumulator.{hpp,cpp}` | Per-cell mean/max splat + uint16 quantize |
+| `…/src/normalizer.{hpp,cpp}` | Rolling gain → uint16 |
+| `…/launch/sidescan_mosaic.launch.py` | Generic launch (topics, output dir, level/cell-size, flush rate, policies) |
+| `…/test/test_projection.cpp`, `test_accumulator.cpp` | Unit tests: known pose+range → expected cell; slant/altitude edges; mean vs max splat |
+| `…/README.md`, repo `.agents/README.md` | Package doc + inventory/build-order |
 
 ## Principles Self-Check
 
 | Principle | Consideration |
 |---|---|
-| Only what's needed | Phase the work; P1 is the runnable MVP, adaptive/normalization staged |
+| Only what's needed | #173 is P1+P2 only; adaptive/Req-A/B (P3) + dirty-region (P4) are separate sub-issues |
 | Simulation-First | Validate against a `bizzyboat_sonar` bag (has the TF chain) before field use |
-| Decoupling | Pure `projection`/`normalizer` units, node is thin glue; reuses #172 core |
-| Sensor conventions | Mounting/look-direction comes from TF/`frame_id`, not params (per prior feedback); generic launch + node defaults |
-| Safety First | Display product, not control — but tile mis-georeference would mislead a search; projection is unit-tested |
+| Decoupling | Pure `projection`/`accumulator`/`normalizer` units; node is thin glue; reuses #172 core |
+| Sensor conventions | Look-direction from TF/`frame_id` (per-side sign only); generic launch + node defaults, no trademarks |
+| Safety First | Display/search aid, not control — but mis-georeference misleads a search; projection unit-tested, drop-on-no-nadir is conservative |
 
 ## ADR Compliance
 
 | ADR | Triggered | How addressed |
 |---|---|---|
 | 0002 §D2 (reuse GGGS) | Yes | Tiles on GGGS via #172 core; no new scheme |
-| 0002 §D8 (geodesy, not hand-rolled) | Yes | ECEF↔geodetic + ENU via `geodesy` (verify its API exposes what's needed — D8 precondition) |
-| 0002 §D5/§D6 / #151 | Indirect | Multi-level store (P3) coordinates with #151 refinement policy; #172 follow-up needed |
+| 0002 §D8 (geodesy, not hand-rolled) | Yes | **Verified**: `geodesy::ecef` + `geodesics::direct` cover ECEF↔geodetic + across-track |
+| 0002 §D5/§D6 / #151 | Deferred | Multi-level store is P3 (own sub-issue), coordinates with #151 + the #172 load follow-up |
 
 ## Consequences
 
 | If we change… | Also update… | In plan? |
 |---|---|---|
-| New package | `.agents/README` inventory + build order | Yes (per phase) |
-| Multi-level load (P3) | `marine_tiled_raster_store` `loadTile`/`loadTiles` (per-tile level recovery) | Yes — #172 follow-up |
-| Dirty-region topic | message type choice (marine_interfaces vs std_msgs) | Open question |
+| New package | `.agents/README` inventory + build order | Yes |
+| (P3) multi-level | `marine_tiled_raster_store` per-tile level recovery on load | Deferred to P3 sub-issue |
 
 ## Open Questions
 
-- **Phasing as stacked PRs vs sub-issues of #173?** (Recommend stacked PRs; P1 first.)
-- **Splat conflict policy** when multiple samples hit one cell: last-write (P1, simplest) vs max-hold (target-friendly) vs running mean (despeckle, needs a count band)?
-- **Dirty-region message type**: reuse `std_msgs` / define in `marine_interfaces`?
-- **No-nadir fallback**: when `~/nadir_depth` is absent for a ping, assume alt≈0 (ground≈slant, OK in shallow water) or drop the ping?
-- Confirm `geodesy` exposes ECEF↔geodetic + a local-ENU/tangent helper (D8 precondition).
+- [ ] None — Q1–Q5 resolved 2026-06-19 (see Context/Approach). Review-plan-ready.
 
 ## Estimated Scope
 
-**Multiple PRs** — too large for one. Recommend stacked PRs P1→P4 (or sub-issues
-of #173), each independently reviewable. P1 is the buildable, runnable MVP.
+**Single PR** for #173 (P1+P2). P3 (adaptive multi-level + Req A/B) and P4
+(dirty-region) are separate follow-on sub-issues of #171, filed when reached.

--- a/.agent/work-plans/issue-173/plan.md
+++ b/.agent/work-plans/issue-173/plan.md
@@ -29,18 +29,25 @@ ECEF↔geodetic + `geodesics.h` `direct` Vincenty) — no hand-rolled ellipsoid 
    (`sensor_msgs/Range`), TF (`tf2_ros::Buffer`/`TransformListener`).
 2. **Georef origin**: `lookupTransform(earth, ping.frame_id, stamp)` with exact→
    bounded-latest→drop fallback (port `bag_to_xtf::_lookup_pose`); ECEF pose →
-   `GeoPoint` via `geodesy::ECEFPose`/`toMsg`; heading from the ECEF orientation
-   (small `geo.py`-style quaternion→ENU-azimuth extraction).
+   `GeoPoint` via `geodesy::ECEFPose`/`toMsg`; **heading = sensor body x-axis
+   azimuth in local NED** at the origin — port `geo.py::ecef_pose_to_geo` /
+   `matrix_to_heading_pitch_roll` (body→NED yaw, NOT a raw ECEF-quaternion yaw).
 3. **Altitude**: from `~/nadir_depth`; **hold last valid within a staleness bound**
-   (altitude varies slowly). Residual (none in window): **drop the ping**
-   (param `no_nadir_policy: drop|assume_zero`, default `drop`).
+   (altitude varies slowly; bound is a parameter `nadir_staleness_s`). Residual
+   (none in window): **drop the ping** (param `no_nadir_policy: drop|assume_zero`,
+   default `drop`). **Throttled warning** whenever altitude is held-stale or a
+   ping is dropped, so degraded georef is visible live.
 4. **Per-sample projection**: range to sample `j` = `(sample0+j)·sv/(2·fs)`;
    ground range = `sqrt(max(0, slant² − alt²))`; sample lat/lon =
-   `geodesy::direct(origin, heading ± 90° [sign per side], ground_range)`.
-5. **Splat**: `GeoPoint` → `gggs::CellIndex` → accumulate intensity. **Mean**
-   default (per-cell sum+count accumulator → quantize to `uint16` on flush);
-   policy param `splat: mean|max_hold` (mean despeckles oversampled data — ~5–15
-   samples/cell at L13; max-hold for target-cueing).
+   `geodesy::wgs84::direct(origin0, az_rad, ground_range)` — the **non-templated**
+   wrapper (geodesics.h:387); `az_rad = heading ± 90°` (radians CW from north,
+   sign per side) and `origin0` = origin at **altitude 0** (asserted precondition).
+5. **Splat**: resolve **each sample's own** `GridIndex` via `Level::gridIndex(pos)`
+   then `cellIndex(pos)` — do NOT reuse the origin grid (`cellIndex(grid, p)`
+   clamps out-of-grid `p` to the edge, smearing across-boundary samples).
+   Accumulate intensity: **mean** default — per-cell **`uint32` sum + count** →
+   quantize to `uint16` on flush; policy param `splat: mean|max_hold` (mean
+   despeckles the ~5–15 samples/cell at L13; max-hold for target-cueing).
 6. **Normalize** (P2): rolling/adaptive gain (TVG-like across-range + rolling
    display-scale) → `uint16`.
 7. **Flush**: dirty tiles → GeoTIFF on a timer (`marine_tiled_raster_store::
@@ -56,7 +63,7 @@ ECEF↔geodetic + `geodesics.h` `direct` Vincenty) — no hand-rolled ellipsoid 
 | `…/src/accumulator.{hpp,cpp}` | Per-cell mean/max splat + uint16 quantize |
 | `…/src/normalizer.{hpp,cpp}` | Rolling gain → uint16 |
 | `…/launch/sidescan_mosaic.launch.py` | Generic launch (topics, output dir, level/cell-size, flush rate, policies) |
-| `…/test/test_projection.cpp`, `test_accumulator.cpp` | Unit tests: known pose+range → expected cell; slant/altitude edges; mean vs max splat |
+| `…/test/test_projection.cpp`, `test_accumulator.cpp` | Unit tests: known pose+range → expected cell; slant/altitude edges; **across-grid-boundary sample lands in the correct `GridIndex`** (not clamped); mean vs max splat + **quantize-on-flush boundary** |
 | `…/README.md`, repo `.agents/README.md` | Package doc + inventory/build-order |
 
 ## Principles Self-Check
@@ -64,7 +71,7 @@ ECEF↔geodetic + `geodesics.h` `direct` Vincenty) — no hand-rolled ellipsoid 
 | Principle | Consideration |
 |---|---|
 | Only what's needed | #173 is P1+P2 only; adaptive/Req-A/B (P3) + dirty-region (P4) are separate sub-issues |
-| Simulation-First | Validate against a `bizzyboat_sonar` bag (has the TF chain) before field use |
+| Simulation-First | Validate in `unh_marine_simulation` (issue Acceptance) **and** against a `bizzyboat_sonar` bag (has the TF chain) before field use |
 | Decoupling | Pure `projection`/`accumulator`/`normalizer` units; node is thin glue; reuses #172 core |
 | Sensor conventions | Look-direction from TF/`frame_id` (per-side sign only); generic launch + node defaults, no trademarks |
 | Safety First | Display/search aid, not control — but mis-georeference misleads a search; projection unit-tested, drop-on-no-nadir is conservative |

--- a/.agent/work-plans/issue-173/progress.md
+++ b/.agent/work-plans/issue-173/progress.md
@@ -1,0 +1,21 @@
+---
+issue: 173
+---
+
+# Issue #173 — marine_sidescan_mosaic: live GGGS-tiled backscatter mosaic (L13, uint16)
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-19 07:44 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Plan**: `.agent/work-plans/issue-173/plan.md` at `eaf249d`
+**Branch**: feature/issue-173 at `eaf249d`
+**Phases**: multiple (P1 MVP -> P2 normalization -> P3 adaptive multi-level + Req A/B -> P4 dirty-region); recommend stacked PRs
+
+### Open questions
+- [ ] Phasing as stacked PRs vs sub-issues of #173 (recommend stacked PRs; P1 first).
+- [ ] Splat conflict policy: last-write (P1) vs max-hold vs running mean.
+- [ ] Dirty-region message type: std_msgs vs marine_interfaces.
+- [ ] No-nadir fallback: assume alt≈0 vs drop the ping.
+- [ ] Confirm geodesy exposes ECEF↔geodetic + local-ENU helper (ADR-0002 D8 precondition).

--- a/.agent/work-plans/issue-173/progress.md
+++ b/.agent/work-plans/issue-173/progress.md
@@ -19,3 +19,21 @@ issue: 173
 - [x] No-nadir → **hold last valid nadir, then drop** on residual; selectable drop/assume_zero (resolved 2026-06-19).
 - [x] Dirty-region message type → out of #173 scope; deferred to the P4 sub-issue (resolved 2026-06-19).
 - [x] geodesy (D8) → **confirmed**: `geodesy::ecef` (ECEF↔geodetic) + `geodesics::direct` (Vincenty across-track); heading via small geo.py-style extraction (resolved 2026-06-19).
+
+## Plan Review
+**Status**: complete
+**When**: 2026-06-19 12:18 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context)) (in-context — author self-review)
+
+**Plan**: `.agent/work-plans/issue-173/plan.md` at `223751d`
+**PR**: PR-less (file/issue mode)
+**Verdict**: approve-with-suggestions
+
+### Findings
+- [ ] (suggestion) `geodesy::direct` is templated on `EllipsoidParameters` (`geodesics.h:71`); the bare `geodesy::direct(origin, az, range)` shown in plan.md:39 won't compile. Use the non-templated convenience wrapper `geodesy::wgs84::direct(origin, azimuth_rad, distance_m)` (geodesics.h:387). Also note its preconditions: `azimuth` is **radians clockwise from north** and `p1.altitude` must be **0** (asserted) — splat origin must be projected to altitude 0 before calling. — `plan.md:39`
+- [ ] (suggestion) Heading-source asymmetry: plan step 2 extracts heading "from the ECEF orientation," but the verified `geo.py` reference derives it from a body→NED matrix (`matrix_to_heading_pitch_roll`, geo.py:118). For the across-track azimuth `heading ± 90°` to be correct, heading must be the **sensor body x-axis azimuth in the local-NED tangent plane at the ping origin**, not a raw ECEF-quaternion yaw. Plan should name the geo.py path (`ecef_pose_to_geo`/`matrix_to_heading_pitch_roll`) it is porting, so the port doesn't silently pick a different convention. — `plan.md:33`
+- [ ] (suggestion) Mean-splat in `uint16`: plan stores a per-cell sum+count accumulator and quantizes on flush (step 5), which is correct, but the accumulator's in-memory type/overflow bound isn't stated. At ~5–15 samples/cell of normalized `uint16` intensity a `uint32` sum is safe; make the accumulator type explicit in `accumulator.{hpp,cpp}` and unit-test the quantize-on-flush boundary (it's the one numeric edge most likely to regress). — `plan.md:42`
+- [ ] (suggestion) Splat origin/altitude-bug coupling: the projected sample `GeoPoint` feeds `Level(13).cellIndex(position)` — verified to exist and clamp out-of-grid p to `[0,1]` (cell_index.h:75) — so an across-grid-boundary sample is silently clamped to the grid edge rather than landing in the neighboring `GridIndex`. Confirm the splat resolves `GridIndex` from each sample's own `GeoPoint` (via `Level::gridIndex(position)`, level.h:108) rather than reusing the ping-origin's grid, or near-grid-edge pings will smear onto the boundary column/row. Worth one test. — `plan.md:42`
+- [ ] (suggestion) Nadir "hold-last-then-drop": staleness bound governs a safety-relevant input (a stale altitude biases ground range, mis-georeferencing a search aid). The bound and the `no_nadir_policy` default (`drop`) are good; make the staleness threshold a parameter (not a constant) and log a throttled warning when held/dropped, so the operator can see degraded georef live. — `plan.md:36`
+- [ ] (suggestion) Simulation-First: issue Acceptance requires validation in `unh_marine_simulation` before field use; the plan's self-check cites a `bizzyboat_sonar` bag replay but not the sim path. Note the sim-validation step (or explicitly defer it with rationale) so the acceptance criterion isn't dropped. — `plan.md:67`
+- [ ] Scope, ADR §D2/§D8, issue alignment, and the P3 (adaptive multi-level + Req A/B) / P4 (dirty-region) deferral to #171 sub-issues are all sound. The #172 store API (`loadTile`/`saveTiles`/`TiledRasterTile<T>`), `Level::cellIndex`, `Level::fromCellSize`, and `geodesy::ecef`/`toMsg` are all verified present. Ready for implementation once the suggestions above are folded in.

--- a/.agent/work-plans/issue-173/progress.md
+++ b/.agent/work-plans/issue-173/progress.md
@@ -37,3 +37,28 @@ issue: 173
 - [ ] (suggestion) Nadir "hold-last-then-drop": staleness bound governs a safety-relevant input (a stale altitude biases ground range, mis-georeferencing a search aid). The bound and the `no_nadir_policy` default (`drop`) are good; make the staleness threshold a parameter (not a constant) and log a throttled warning when held/dropped, so the operator can see degraded georef live. — `plan.md:36`
 - [ ] (suggestion) Simulation-First: issue Acceptance requires validation in `unh_marine_simulation` before field use; the plan's self-check cites a `bizzyboat_sonar` bag replay but not the sim path. Note the sim-validation step (or explicitly defer it with rationale) so the acceptance criterion isn't dropped. — `plan.md:67`
 - [ ] Scope, ADR §D2/§D8, issue alignment, and the P3 (adaptive multi-level + Req A/B) / P4 (dirty-region) deferral to #171 sub-issues are all sound. The #172 store API (`loadTile`/`saveTiles`/`TiledRasterTile<T>`), `Level::cellIndex`, `Level::fromCellSize`, and `geodesy::ecef`/`toMsg` are all verified present. Ready for implementation once the suggestions above are folded in.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-19 09:40 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved
+
+**Branch**: feature/issue-173 at `a8cbabe`
+**Mode**: pre-push
+**Depth**: Standard (reason: new ~1685-line C++ package + ROS node, single repo, no security surface)
+**Must-fix**: 2 (both addressed) | **Suggestions**: 5 (addressed)
+
+Static analysis: cpplint / copyright / flake8 clean (cppcheck skipped on version). Claude Adversarial 2 passes: Lens A (logic) 0 must-fix — independently verified heading signs, geodesy::wgs84::direct precondition, decode endianness, accumulator overflow, single-threaded safety; Lens B (systemic) 2 must-fix. Governance: ADR-0002 §D2/§D8 compliant; degraded-path safety (drop-on-no-nadir/no-TF) conservative. Plan: in sync.
+
+### Findings
+- [x] (must-fix) Multi-threaded executor data race on shared state — pinned all callbacks to one MutuallyExclusive callback group (a8cbabe). — `src/mosaic_node.cpp`
+- [x] (must-fix) Unbounded mosaic memory growth (no eviction) — throttled grid-count warning + grid_warn_count param + README limitation; full eviction deferred to P3/P4 with rationale (a8cbabe). — `src/mosaic_node.cpp` / `accumulator.hpp`
+- [x] (suggestion) Mean re-dirties tile every add — set only on value change (a8cbabe). — `src/accumulator.cpp`
+- [x] (suggestion) beam_count>1 silently mis-projected — guard + drop with warn (a8cbabe). — `src/mosaic_node.cpp`
+- [x] (suggestion) decoded length vs samples_per_beam unchecked — throttled warn (a8cbabe). — `src/mosaic_node.cpp`
+- [x] (suggestion) output_dir writability unchecked — startup check + error (a8cbabe). — `src/mosaic_node.cpp`
+- [x] (suggestion) no-data 0 collides with real dark returns — normalizer floors to >=1 (a8cbabe). — `src/normalizer.cpp`
+
+### Validation
+- [ ] Runtime bag/sim georegistration PENDING (no local bag with TF; sim has no sidescan) — boat-side gate; PINGMapper Massabesic tiles as reference; confirm across_track_offset_deg frame convention.

--- a/.agent/work-plans/issue-173/progress.md
+++ b/.agent/work-plans/issue-173/progress.md
@@ -11,11 +11,11 @@ issue: 173
 
 **Plan**: `.agent/work-plans/issue-173/plan.md` at `eaf249d`
 **Branch**: feature/issue-173 at `eaf249d`
-**Phases**: multiple (P1 MVP -> P2 normalization -> P3 adaptive multi-level + Req A/B -> P4 dirty-region); recommend stacked PRs
+**Phases**: #173 re-scoped to **P1+P2** (single PR: georef + per-sample projection + splat @ fixed L13 + rolling normalization + tests). P3 (adaptive multi-level + Req A/B) and P4 (dirty-region) = follow-on sub-issues of #171.
 
 ### Open questions
-- [ ] Phasing as stacked PRs vs sub-issues of #173 (recommend stacked PRs; P1 first).
-- [ ] Splat conflict policy: last-write (P1) vs max-hold vs running mean.
-- [ ] Dirty-region message type: std_msgs vs marine_interfaces.
-- [ ] No-nadir fallback: assume alt≈0 vs drop the ping.
-- [ ] Confirm geodesy exposes ECEF↔geodetic + local-ENU helper (ADR-0002 D8 precondition).
+- [x] Scope/phasing → Option A: #173 = P1+P2 (one PR); P3/P4 = sub-issues of #171 (resolved 2026-06-19).
+- [x] Splat conflict → **mean** default, selectable (max-hold reachable) (resolved 2026-06-19).
+- [x] No-nadir → **hold last valid nadir, then drop** on residual; selectable drop/assume_zero (resolved 2026-06-19).
+- [x] Dirty-region message type → out of #173 scope; deferred to the P4 sub-issue (resolved 2026-06-19).
+- [x] geodesy (D8) → **confirmed**: `geodesy::ecef` (ECEF↔geodetic) + `geodesics::direct` (Vincenty across-track); heading via small geo.py-style extraction (resolved 2026-06-19).

--- a/.agent/work-plans/issue-173/progress.md
+++ b/.agent/work-plans/issue-173/progress.md
@@ -62,3 +62,14 @@ Static analysis: cpplint / copyright / flake8 clean (cppcheck skipped on version
 
 ### Validation
 - [ ] Runtime bag/sim georegistration PENDING (no local bag with TF; sim has no sidescan) — boat-side gate; PINGMapper Massabesic tiles as reference; confirm across_track_offset_deg frame convention.
+
+## Validation (bag replay)
+**Status**: complete (port channel)
+**When**: 2026-06-19 09:53 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+Ran the node against a real `bizzyboat_sonar` bag (`~/data/logs/gabby/logs/bizzyboat_sonar/2026-06-16T14-17-37+00-00`, mid-survey window via `--start-offset 1200 --playback-duration 300`).
+- **Georegistration correct**: tiles are WGS84, centered **42.992°N, 71.393°W (Lake Massabesic)**, ~0.11 m pixels (L13), UInt16, NoData=0, data min=1/max=50208/mean≈24866 (normalized, floored at 1). The default `across_track_offset_deg=90` frame convention places port data at the right location.
+- **Bug found + fixed**: `makeNormalizerConfig()` called twice in the init list re-declared `norm_*` params → `ParameterAlreadyDeclaredException` crash on construct (commit 2f85591). Unit tests don't construct the node, so only runtime caught it.
+- **Platform finding (not a node bug)**: `earth→bizzy/garmin_sidescan_starboard` is **absent from the bag's TF tree** (port resolves fine) → all starboard pings dropped (correctly, with throttled warn). Likely the boat URDF is missing the starboard sidescan frame — worth a separate platform check.
+- Remaining: fine-grained geometry accuracy (compare vs the PINGMapper `~/data/sidescan/Massabesic` reference) and the starboard frame are follow-ups; gross georegistration + pipeline are validated.

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -14,6 +14,7 @@
 | `marine_autonomy_integration_tests` | Python (CMake) | Cross-package integration tests for mission and navigation flows |
 | `marine_bathymetry_store` | C++ | Persistent multi-source bathymetric data store: GGGS-tiled, priority source layers, best-source / shallowest-reliable queries, per-tile GeoTIFF (ADR-0002 / #86) |
 | `marine_interfaces` | C++ (IDL) | ROS 2 message definitions for helm commands, heartbeats, navigation, perception contacts, and sensor data (39 msg types) |
+| `marine_sidescan_mosaic` | C++ | Live georeferenced sidescan backscatter mosaicker: projects GCV port/stbd RawSonarImage samples to GGGS-tiled uint16 GeoTIFF tiles for CAMP / web display (#173 / #171 / #166) |
 | `marine_tiled_raster_store` | C++ | Generic GGGS-tiled raster store core: band/dtype-parametrized `TiledRasterTile<T>` + per-tile GeoTIFF persistence, shared by bathymetry and sidescan (#172) |
 | `mission_manager` | Python | Converts mission plans from CAMP GCS into navigation tasks and manages task execution |
 | `mission_manager_interfaces` | C++ (IDL) | Service definitions for task manipulation (3 srv types) |
@@ -116,7 +117,8 @@ colcon test --packages-select helm_manager && colcon test-result --verbose
 Known build requirements:
 - `marine_interfaces` must build before `helm_manager`, `mission_manager`, and
   `marine_autonomy` (provides shared message types)
-- `marine_tiled_raster_store` must build before `marine_bathymetry_store`
+- `marine_tiled_raster_store` must build before `marine_bathymetry_store` and
+  `marine_sidescan_mosaic` (both wrap its `TiledRasterTile` + GeoTIFF I/O)
   (provides the generic `TiledRasterTile<T>` + GeoTIFF persistence it wraps, #172)
 - `mission_manager_interfaces` must build before `mission_manager`
 - Integration tests depend on `command_bridge`, `mission_manager`, `marine_interfaces`,

--- a/marine_sidescan_mosaic/CMakeLists.txt
+++ b/marine_sidescan_mosaic/CMakeLists.txt
@@ -1,0 +1,53 @@
+cmake_minimum_required(VERSION 3.8)
+project(marine_sidescan_mosaic)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(geographic_msgs REQUIRED)
+find_package(geodesy REQUIRED)
+find_package(marine_autonomy REQUIRED)
+
+# Core library (pure logic; node executable + more units land in later slices).
+add_library(${PROJECT_NAME}
+  src/projection.cpp
+)
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include>"
+)
+ament_target_dependencies(${PROJECT_NAME}
+  geographic_msgs
+  geodesy
+  marine_autonomy
+)
+
+install(DIRECTORY include/ DESTINATION include)
+install(TARGETS ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_dependencies(geographic_msgs geodesy marine_autonomy)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+  find_package(ament_cmake_gtest REQUIRED)
+
+  ament_add_gtest(test_projection test/test_projection.cpp)
+  target_link_libraries(test_projection ${PROJECT_NAME})
+  ament_target_dependencies(test_projection geographic_msgs geodesy marine_autonomy)
+endif()
+
+ament_package()

--- a/marine_sidescan_mosaic/CMakeLists.txt
+++ b/marine_sidescan_mosaic/CMakeLists.txt
@@ -11,6 +11,11 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(marine_acoustic_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_ros REQUIRED)
 find_package(geographic_msgs REQUIRED)
 find_package(geodesy REQUIRED)
 find_package(marine_autonomy REQUIRED)
@@ -33,6 +38,20 @@ ament_target_dependencies(${PROJECT_NAME}
   marine_tiled_raster_store
 )
 
+# Node executable.
+add_executable(sidescan_mosaic_node src/mosaic_node.cpp)
+target_link_libraries(sidescan_mosaic_node ${PROJECT_NAME})
+ament_target_dependencies(sidescan_mosaic_node
+  rclcpp
+  marine_acoustic_msgs
+  sensor_msgs
+  tf2
+  tf2_ros
+  geographic_msgs
+  marine_autonomy
+  marine_tiled_raster_store
+)
+
 install(DIRECTORY include/ DESTINATION include)
 install(TARGETS ${PROJECT_NAME}
   EXPORT export_${PROJECT_NAME}
@@ -40,6 +59,8 @@ install(TARGETS ${PROJECT_NAME}
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
 )
+install(TARGETS sidescan_mosaic_node DESTINATION lib/${PROJECT_NAME})
+install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
 
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(geographic_msgs geodesy marine_autonomy marine_tiled_raster_store)

--- a/marine_sidescan_mosaic/CMakeLists.txt
+++ b/marine_sidescan_mosaic/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(marine_tiled_raster_store REQUIRED)
 add_library(${PROJECT_NAME}
   src/projection.cpp
   src/accumulator.cpp
+  src/normalizer.cpp
 )
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
@@ -55,6 +56,9 @@ if(BUILD_TESTING)
   ament_add_gtest(test_accumulator test/test_accumulator.cpp)
   target_link_libraries(test_accumulator ${PROJECT_NAME})
   ament_target_dependencies(test_accumulator marine_autonomy marine_tiled_raster_store)
+
+  ament_add_gtest(test_normalizer test/test_normalizer.cpp)
+  target_link_libraries(test_normalizer ${PROJECT_NAME})
 endif()
 
 ament_package()

--- a/marine_sidescan_mosaic/CMakeLists.txt
+++ b/marine_sidescan_mosaic/CMakeLists.txt
@@ -14,10 +14,12 @@ find_package(ament_cmake REQUIRED)
 find_package(geographic_msgs REQUIRED)
 find_package(geodesy REQUIRED)
 find_package(marine_autonomy REQUIRED)
+find_package(marine_tiled_raster_store REQUIRED)
 
 # Core library (pure logic; node executable + more units land in later slices).
 add_library(${PROJECT_NAME}
   src/projection.cpp
+  src/accumulator.cpp
 )
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
@@ -27,6 +29,7 @@ ament_target_dependencies(${PROJECT_NAME}
   geographic_msgs
   geodesy
   marine_autonomy
+  marine_tiled_raster_store
 )
 
 install(DIRECTORY include/ DESTINATION include)
@@ -38,7 +41,7 @@ install(TARGETS ${PROJECT_NAME}
 )
 
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
-ament_export_dependencies(geographic_msgs geodesy marine_autonomy)
+ament_export_dependencies(geographic_msgs geodesy marine_autonomy marine_tiled_raster_store)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -48,6 +51,10 @@ if(BUILD_TESTING)
   ament_add_gtest(test_projection test/test_projection.cpp)
   target_link_libraries(test_projection ${PROJECT_NAME})
   ament_target_dependencies(test_projection geographic_msgs geodesy marine_autonomy)
+
+  ament_add_gtest(test_accumulator test/test_accumulator.cpp)
+  target_link_libraries(test_accumulator ${PROJECT_NAME})
+  ament_target_dependencies(test_accumulator marine_autonomy marine_tiled_raster_store)
 endif()
 
 ament_package()

--- a/marine_sidescan_mosaic/README.md
+++ b/marine_sidescan_mosaic/README.md
@@ -1,0 +1,75 @@
+# marine_sidescan_mosaic
+
+Live georeferenced **sidescan backscatter mosaicker**. Subscribes the Garmin GCV
+port/stbd `RawSonarImage` channels, projects each sample to the ground, and
+splats it into **GGGS-tiled `uint16` GeoTIFF tiles** (the
+[`marine_tiled_raster_store`](../marine_tiled_raster_store) core) for live display
+in CAMP and the web viewer.
+
+Tracked by [unh_marine_autonomy#173](https://github.com/rolker/unh_marine_autonomy/issues/173)
+(part of the sidescan-mosaic umbrella #171; satisfies the sidescan prerequisite of
+the #166 web viewer). This package is **P1+P2**: a fixed-level (L13) live mosaic
+with rolling normalization. Adaptive multi-level resolution (P3, #171 follow-on)
+and the dirty-region distribution topic (P4) are separate sub-issues.
+
+## Pipeline (per ping)
+
+1. **Georeference origin** — `earth`→sensor TF lookup (exact, else bounded-latest);
+   ECEF pose → geographic origin + heading via `geodesy` + a body→NED yaw.
+2. **Altitude** — held last nadir (`~/nadir_depth`) within a staleness bound; on a
+   residual gap the `no_nadir_policy` applies (`drop` default, or `assume_zero`).
+3. **Per-sample projection** — slant range `(sample0+j)·c/2f` → ground range
+   `sqrt(slant²−alt²)` → geodetic via `geodesy::wgs84::direct` at the across-track
+   azimuth → GGGS `CellIndex` (grid resolved per sample, no edge clamp).
+4. **Normalize** — rolling AGC (`RollingNormalizer`) maps sample magnitudes to
+   `uint16` so the mosaic stays legible (live stand-in for PINGMapper's EGN).
+5. **Splat** — `MosaicAccumulator` folds into tiles (`mean` default / `max_hold`).
+6. **Flush** — dirty tiles → GeoTIFF on a timer (`saveTiles`).
+
+## Key parameters
+
+| Parameter | Default | Meaning |
+|---|---|---|
+| `gggs_level` | `13` | GGGS level (13 ≈ 0.11 m cells) |
+| `output_dir` | `sidescan_mosaic` | Where the `<level>_<row>_<col>.tif` tiles are written |
+| `splat` | `mean` | Per-cell combine: `mean` (despeckle) or `max_hold` (target-cue) |
+| `no_nadir_policy` | `drop` | On a stale/missing nadir: `drop` the ping or `assume_zero` |
+| `nadir_staleness_s` | `5.0` | How long a held nadir altitude stays valid |
+| `across_track_offset_deg` | `90` | Across-track azimuth offset from heading (see frame note) |
+| `flush_period_s` | `2.0` | Tile flush cadence |
+| `norm_*` | — | Normalizer tuning (`target_level`, `percentile`, `ema_alpha`) |
+
+## Frame convention (validate per platform)
+
+The across-track azimuth is `heading ± across_track_offset_deg`, where heading is
+the per-channel `frame_id` **+x** azimuth — i.e. this assumes the sensor frame +x
+is the **vessel-forward / along-track** direction, with the look side supplied by
+the sign. If a platform's URDF orients the sensor frame differently, set
+`across_track_offset_deg`. Verify against a real `bizzyboat_sonar` bag / sim
+(#173 validation).
+
+## Run
+
+```bash
+ros2 launch marine_sidescan_mosaic sidescan_mosaic.launch.py \
+    output_dir:=/tmp/mosaic port_topic:=/bizzy/sensors/sidescan/garmin_sidescan/sonar_image_port \
+    starboard_topic:=/bizzy/sensors/sidescan/garmin_sidescan/sonar_image_starboard \
+    nadir_topic:=/bizzy/sensors/sidescan/garmin_sidescan/nadir_depth
+```
+
+The resulting WGS84 GeoTIFF tiles load directly in QGIS / a CAMP `RasterLayer`.
+
+## Build & test
+
+```bash
+colcon build --symlink-install --packages-select marine_sidescan_mosaic
+colcon test --packages-select marine_sidescan_mosaic
+```
+
+Unit tests cover the projection geometry (`test_projection`), the splat
+accumulator (`test_accumulator`), and the normalizer (`test_normalizer`).
+
+## Dependencies
+
+`rclcpp`, `marine_acoustic_msgs`, `sensor_msgs`, `tf2_ros`, `geodesy`,
+`marine_autonomy` (GGGS), `marine_tiled_raster_store` (tiles + GeoTIFF I/O).

--- a/marine_sidescan_mosaic/README.md
+++ b/marine_sidescan_mosaic/README.md
@@ -48,6 +48,17 @@ the sign. If a platform's URDF orients the sensor frame differently, set
 `across_track_offset_deg`. Verify against a real `bizzyboat_sonar` bag / sim
 (#173 validation).
 
+## Limitations (P1)
+
+- **Memory grows with covered extent.** The accumulator holds every touched GGGS
+  grid (~12.7 MB each in `mean` mode) and never evicts — a long/large survey grows
+  unbounded. The node logs a throttled warning past `grid_warn_count` grids;
+  offload-after-flush eviction is a P3/P4 concern (ties to the Phase-6 sync).
+- **No-data = 0.** Untouched cells are 0 (transparent); real returns are floored
+  to ≥1, so "covered-but-dark" stays distinct from "never surveyed".
+- **Single-beam only.** Multi-beam `RawSonarImage` pings are dropped (warned); the
+  GCV is single-beam.
+
 ## Run
 
 ```bash

--- a/marine_sidescan_mosaic/include/marine_sidescan_mosaic/accumulator.hpp
+++ b/marine_sidescan_mosaic/include/marine_sidescan_mosaic/accumulator.hpp
@@ -1,0 +1,86 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef MARINE_SIDESCAN_MOSAIC__ACCUMULATOR_HPP_
+#define MARINE_SIDESCAN_MOSAIC__ACCUMULATOR_HPP_
+
+#include <cstdint>
+#include <map>
+#include <vector>
+
+#include "marine_autonomy/gggs.h"
+#include "marine_tiled_raster_store/tiled_raster_tile.hpp"
+
+namespace marine_sidescan_mosaic
+{
+
+/// @brief How multiple samples landing in one cell are combined.
+enum class SplatPolicy
+{
+  Mean,      ///< Mean of the samples (box-filter downsample of oversampled data).
+  MaxHold    ///< Brightest sample (target-cueing).
+};
+
+/// @brief Accumulates georeferenced sample intensities into GGGS-tiled `uint16`
+///   mosaic tiles, ready for `marine_tiled_raster_store::saveTiles`.
+///
+/// Cells are oversampled (~5–15 samples/cell at L13), so `Mean` is the default:
+/// per cell a `uint64` sum + `uint32` count is kept (the sum can't overflow even
+/// over a long stationary dwell), and the live `uint16` output cell is
+/// `sum/count`. `MaxHold` keeps the brightest sample and needs no side state.
+/// The output tiles carry the dirty flag (`set` marks dirty), so the node flushes
+/// only what changed. A cell value of 0 is "no data" (un-touched).
+class MosaicAccumulator
+{
+public:
+  using Tile = marine_tiled_raster_store::TiledRasterTile<std::uint16_t>;
+
+  MosaicAccumulator(gggs::Level level, SplatPolicy policy);
+
+  /// @brief Fold one sample @p value into @p cell (ignored if @p cell is invalid).
+  void add(const gggs::CellIndex & cell, std::uint16_t value);
+
+  /// @brief The live mosaic tiles (mutable so `saveTiles` can clear dirty flags).
+  std::map<gggs::GridIndex, Tile> & tiles() {return output_;}
+  const std::map<gggs::GridIndex, Tile> & tiles() const {return output_;}
+
+  const gggs::Level & level() const noexcept {return level_;}
+  SplatPolicy policy() const noexcept {return policy_;}
+
+private:
+  struct MeanGrid
+  {
+    std::vector<std::uint64_t> sum;
+    std::vector<std::uint32_t> count;
+  };
+
+  Tile & ensureOutput(const gggs::GridIndex & grid);
+  MeanGrid & ensureMean(const gggs::GridIndex & grid);
+
+  gggs::Level level_;
+  SplatPolicy policy_;
+  std::map<gggs::GridIndex, Tile> output_;
+  std::map<gggs::GridIndex, MeanGrid> mean_;   // only populated for SplatPolicy::Mean
+};
+
+}  // namespace marine_sidescan_mosaic
+
+#endif  // MARINE_SIDESCAN_MOSAIC__ACCUMULATOR_HPP_

--- a/marine_sidescan_mosaic/include/marine_sidescan_mosaic/normalizer.hpp
+++ b/marine_sidescan_mosaic/include/marine_sidescan_mosaic/normalizer.hpp
@@ -1,0 +1,73 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef MARINE_SIDESCAN_MOSAIC__NORMALIZER_HPP_
+#define MARINE_SIDESCAN_MOSAIC__NORMALIZER_HPP_
+
+#include <cstdint>
+#include <vector>
+
+namespace marine_sidescan_mosaic
+{
+
+/// @brief Tuning for the rolling display normalizer.
+struct NormalizerConfig
+{
+  /// The reference intensity maps to this uint16 level (mid-range leaves
+  /// headroom for bright targets).
+  double target_level = 32768.0;
+  /// Per-ping reference statistic: a high-ish quantile = "typical strong
+  /// return", robust to the dark nadir zone.
+  double percentile = 0.85;
+  /// Rolling adaptation rate (per ping) for the reference; smaller = steadier.
+  double ema_alpha = 0.05;
+  /// Floor on the reference so an all-dark ping can't blow up or divide by zero.
+  double min_reference = 1.0;
+};
+
+/// @brief Rolling automatic-gain display normalizer (P2).
+///
+/// Maps raw sidescan sample magnitudes to a `uint16` display range so the live
+/// mosaic stays legible as bottom conditions change. Per ping it takes a
+/// high-percentile reference, smooths it across pings (EMA), and scales the
+/// samples so that reference lands at `target_level`; brighter samples scale up
+/// (clamped at 65535), darker down. No per-survey statistics — this is the live
+/// stand-in for PINGMapper's whole-survey EGN (the quality product stays offline).
+class RollingNormalizer
+{
+public:
+  explicit RollingNormalizer(NormalizerConfig config = {});
+
+  /// @brief Map one ping's raw samples to `uint16`, updating the rolling
+  ///   reference from this ping. @p out is resized to @p raw.size().
+  void normalize(const std::vector<double> & raw, std::vector<std::uint16_t> & out);
+
+  /// @brief The current rolling reference level (negative before the first ping).
+  double reference() const noexcept {return reference_;}
+
+private:
+  NormalizerConfig config_;
+  double reference_ = -1.0;   ///< < 0 until the first ping initializes it.
+};
+
+}  // namespace marine_sidescan_mosaic
+
+#endif  // MARINE_SIDESCAN_MOSAIC__NORMALIZER_HPP_

--- a/marine_sidescan_mosaic/include/marine_sidescan_mosaic/projection.hpp
+++ b/marine_sidescan_mosaic/include/marine_sidescan_mosaic/projection.hpp
@@ -1,0 +1,107 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef MARINE_SIDESCAN_MOSAIC__PROJECTION_HPP_
+#define MARINE_SIDESCAN_MOSAIC__PROJECTION_HPP_
+
+#include <cmath>
+
+#include "geographic_msgs/msg/geo_point.hpp"
+#include "marine_autonomy/gggs.h"
+
+/// @file
+/// @brief Pure geometry for placing a sidescan sample on the ground.
+///
+/// No ROS/TF state — just the math the node feeds with a TF pose + ping. Ellipsoid
+/// work goes through `geodesy` (ADR-0002 §D8): ECEF↔geodetic and the Vincenty
+/// `wgs84::direct` for across-track placement. Heading extraction (ECEF
+/// orientation → local-NED azimuth) is the body→NED yaw, ported from the verified
+/// `bag_to_xtf` `geo.py` (`ecef_pose_to_geo` / `matrix_to_heading_pitch_roll`).
+
+namespace marine_sidescan_mosaic
+{
+
+/// @brief Which side of the vessel a sidescan channel images.
+enum class Side
+{
+  Port,
+  Starboard
+};
+
+/// @brief Geographic origin + sensor heading from an `earth`→sensor TF pose.
+struct GeoHeading
+{
+  double latitude_deg = 0.0;
+  double longitude_deg = 0.0;
+  double altitude_m = 0.0;     ///< Ellipsoidal height of the sensor origin (m).
+  double heading_rad = 0.0;    ///< Sensor body +x azimuth, clockwise from north.
+};
+
+/// @brief Convert an `earth`(ECEF)→sensor TF pose to geographic origin + heading.
+///
+/// @param tx,ty,tz ECEF translation of the sensor origin (metres).
+/// @param qx,qy,qz,qw Sensor orientation in ECEF (tf2 convention, `p_parent =
+///   R p_child`). A near-zero quaternion yields heading 0.
+/// @return Geographic position (via `geodesy`) plus the body +x axis azimuth in
+///   the local-NED plane at the origin.
+GeoHeading ecefPoseToGeoHeading(
+  double tx, double ty, double tz,
+  double qx, double qy, double qz, double qw);
+
+/// @brief Slant range (m) to delivered sample @p j (0-based), from the near-field
+///   gate @p sample0, sound speed (m/s) and `RawSonarImage` `sample_rate` (Hz).
+inline double slantRange(int j, int sample0, double sound_speed, double sample_rate)
+{
+  return (sample0 + j) * sound_speed / (2.0 * sample_rate);
+}
+
+/// @brief Horizontal ground range (m) from slant range and altitude above bottom.
+///   Returns 0 when the slant range is within the altitude (near-nadir cone).
+inline double groundRange(double slant_range, double altitude)
+{
+  const double d2 = slant_range * slant_range - altitude * altitude;
+  return d2 > 0.0 ? std::sqrt(d2) : 0.0;
+}
+
+/// @brief Across-track azimuth (radians, clockwise from north) for a @p side.
+///   Starboard is heading + 90°, port is heading − 90°.
+inline double acrossTrackAzimuth(double heading_rad, Side side)
+{
+  constexpr double half_pi = M_PI / 2.0;
+  return heading_rad + (side == Side::Starboard ? half_pi : -half_pi);
+}
+
+/// @brief Project one sample to its GGGS `CellIndex` at @p level.
+///
+/// @param origin Sensor ground position — **altitude must be 0** (the
+///   `geodesy::wgs84::direct` precondition); the caller zeroes it.
+/// @param azimuth_rad Across-track azimuth (radians, clockwise from north).
+/// @param ground_range Horizontal range to the sample (m).
+/// The grid is resolved from the sample's **own** position (`Level::cellIndex`),
+/// so a sample crossing into a neighbouring grid lands there rather than being
+/// clamped to the origin grid's edge.
+gggs::CellIndex projectSample(
+  const geographic_msgs::msg::GeoPoint & origin,
+  double azimuth_rad, double ground_range, const gggs::Level & level);
+
+}  // namespace marine_sidescan_mosaic
+
+#endif  // MARINE_SIDESCAN_MOSAIC__PROJECTION_HPP_

--- a/marine_sidescan_mosaic/launch/sidescan_mosaic.launch.py
+++ b/marine_sidescan_mosaic/launch/sidescan_mosaic.launch.py
@@ -1,0 +1,66 @@
+# Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+# Hydrographic Center, University of New Hampshire
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# Generic launch for the live sidescan mosaicker. Topics default to the Garmin
+# GCV driver's relative names; remap or namespace as needed for a platform.
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration, PythonExpression
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    args = [
+        DeclareLaunchArgument('output_dir', default_value='sidescan_mosaic',
+                              description='Directory for the GGGS GeoTIFF tiles'),
+        DeclareLaunchArgument('gggs_level', default_value='13',
+                              description='GGGS level (13 ~= 0.11 m cells)'),
+        DeclareLaunchArgument('splat', default_value='mean',
+                              description='Per-cell combine: mean | max_hold'),
+        DeclareLaunchArgument('no_nadir_policy', default_value='drop',
+                              description='When no fresh nadir: drop | assume_zero'),
+        DeclareLaunchArgument('flush_period_s', default_value='2.0'),
+        DeclareLaunchArgument('earth_frame', default_value='earth'),
+        DeclareLaunchArgument('port_topic', default_value='sonar_image_port'),
+        DeclareLaunchArgument('starboard_topic', default_value='sonar_image_starboard'),
+        DeclareLaunchArgument('nadir_topic', default_value='nadir_depth'),
+    ]
+
+    node = Node(
+        package='marine_sidescan_mosaic',
+        executable='sidescan_mosaic_node',
+        name='sidescan_mosaic',
+        output='screen',
+        parameters=[{
+            'output_dir': LaunchConfiguration('output_dir'),
+            'gggs_level': PythonExpression([LaunchConfiguration('gggs_level')]),
+            'splat': LaunchConfiguration('splat'),
+            'no_nadir_policy': LaunchConfiguration('no_nadir_policy'),
+            'flush_period_s': PythonExpression([LaunchConfiguration('flush_period_s')]),
+            'earth_frame': LaunchConfiguration('earth_frame'),
+            'port_topic': LaunchConfiguration('port_topic'),
+            'starboard_topic': LaunchConfiguration('starboard_topic'),
+            'nadir_topic': LaunchConfiguration('nadir_topic'),
+        }],
+    )
+
+    return LaunchDescription(args + [node])

--- a/marine_sidescan_mosaic/package.xml
+++ b/marine_sidescan_mosaic/package.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>marine_sidescan_mosaic</name>
+  <version>0.0.0</version>
+  <description>
+    Live georeferenced sidescan backscatter mosaicker: projects Garmin GCV
+    port/stbd RawSonarImage samples to the ground and splats them into GGGS-tiled
+    uint16 GeoTIFF tiles (marine_tiled_raster_store) for live display in CAMP and
+    the web viewer. See unh_marine_autonomy#173 / #171 / #166.
+  </description>
+  <maintainer email="roland.arsenault@unh.edu">Roland Arsenault</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>marine_acoustic_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>geographic_msgs</depend>
+  <depend>geodesy</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
+  <depend>marine_autonomy</depend>
+  <depend>marine_tiled_raster_store</depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/marine_sidescan_mosaic/src/accumulator.cpp
+++ b/marine_sidescan_mosaic/src/accumulator.cpp
@@ -1,0 +1,77 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "marine_sidescan_mosaic/accumulator.hpp"
+
+#include <utility>
+
+namespace marine_sidescan_mosaic
+{
+
+MosaicAccumulator::MosaicAccumulator(gggs::Level level, SplatPolicy policy)
+: level_(level), policy_(policy) {}
+
+MosaicAccumulator::Tile & MosaicAccumulator::ensureOutput(const gggs::GridIndex & grid)
+{
+  auto it = output_.find(grid);
+  if (it == output_.end()) {
+    it = output_.emplace(grid, Tile(grid, 1, 0)).first;
+  }
+  return it->second;
+}
+
+MosaicAccumulator::MeanGrid & MosaicAccumulator::ensureMean(const gggs::GridIndex & grid)
+{
+  auto it = mean_.find(grid);
+  if (it == mean_.end()) {
+    MeanGrid mg;
+    mg.sum.assign(Tile::cell_count, 0);
+    mg.count.assign(Tile::cell_count, 0);
+    it = mean_.emplace(grid, std::move(mg)).first;
+  }
+  return it->second;
+}
+
+void MosaicAccumulator::add(const gggs::CellIndex & cell, std::uint16_t value)
+{
+  if (!cell.valid()) {
+    return;
+  }
+  const gggs::GridIndex grid = cell.grid();
+  const std::uint16_t row = cell.row();
+  const std::uint16_t col = cell.column();
+  Tile & tile = ensureOutput(grid);
+
+  if (policy_ == SplatPolicy::Mean) {
+    MeanGrid & mg = ensureMean(grid);
+    const std::uint32_t i = Tile::offset(row, col);
+    mg.sum[i] += value;
+    mg.count[i] += 1;
+    tile.set(row, col, 0, static_cast<std::uint16_t>(mg.sum[i] / mg.count[i]));
+  } else {
+    // MaxHold: only write (and dirty) when the cell actually brightens.
+    if (value > tile.get(row, col, 0)) {
+      tile.set(row, col, 0, value);
+    }
+  }
+}
+
+}  // namespace marine_sidescan_mosaic

--- a/marine_sidescan_mosaic/src/accumulator.cpp
+++ b/marine_sidescan_mosaic/src/accumulator.cpp
@@ -65,7 +65,12 @@ void MosaicAccumulator::add(const gggs::CellIndex & cell, std::uint16_t value)
     const std::uint32_t i = Tile::offset(row, col);
     mg.sum[i] += value;
     mg.count[i] += 1;
-    tile.set(row, col, 0, static_cast<std::uint16_t>(mg.sum[i] / mg.count[i]));
+    // Only write (and dirty) when the rounded mean actually changes, so a dwell
+    // over stable ground doesn't re-flush the same tile every cycle.
+    const auto mean = static_cast<std::uint16_t>(mg.sum[i] / mg.count[i]);
+    if (mean != tile.get(row, col, 0)) {
+      tile.set(row, col, 0, mean);
+    }
   } else {
     // MaxHold: only write (and dirty) when the cell actually brightens.
     if (value > tile.get(row, col, 0)) {

--- a/marine_sidescan_mosaic/src/mosaic_node.cpp
+++ b/marine_sidescan_mosaic/src/mosaic_node.cpp
@@ -38,10 +38,12 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
+#include <filesystem>
 #include <limits>
 #include <memory>
 #include <optional>
 #include <string>
+#include <system_error>
 #include <vector>
 
 #include "geographic_msgs/msg/geo_point.hpp"
@@ -123,6 +125,7 @@ public:
     nadir_staleness_s_ = declare_parameter<double>("nadir_staleness_s", 5.0);
     no_nadir_policy_ = declare_parameter<std::string>("no_nadir_policy", "drop");
     max_tf_age_s_ = declare_parameter<double>("max_tf_age_s", 1.0);
+    grid_warn_count_ = declare_parameter<int>("grid_warn_count", 256);
     const double flush_period_s = declare_parameter<double>("flush_period_s", 2.0);
     const std::string splat = declare_parameter<std::string>("splat", "mean");
     accumulator_ = MosaicAccumulator(
@@ -138,20 +141,38 @@ public:
     tf_buffer_ = std::make_unique<tf2_ros::Buffer>(get_clock());
     tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
 
+    // All callbacks mutate the shared accumulator + nadir/normalizer state, so
+    // pin them to one mutually-exclusive group: serialized under the default
+    // single-threaded executor AND if the node is ever composed into a
+    // multi-threaded one (no torn std::map iteration during a flush).
+    cb_group_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+    rclcpp::SubscriptionOptions sub_opts;
+    sub_opts.callback_group = cb_group_;
+
     // Imagery is best-effort on the driver; match it or no samples arrive.
     auto qos = rclcpp::SensorDataQoS();
     port_sub_ = create_subscription<marine_acoustic_msgs::msg::RawSonarImage>(
       port_topic, qos,
-      [this](const marine_acoustic_msgs::msg::RawSonarImage & m) {onPing(m, Side::Port);});
+      [this](const marine_acoustic_msgs::msg::RawSonarImage & m) {onPing(m, Side::Port);},
+      sub_opts);
     stbd_sub_ = create_subscription<marine_acoustic_msgs::msg::RawSonarImage>(
       stbd_topic, qos,
-      [this](const marine_acoustic_msgs::msg::RawSonarImage & m) {onPing(m, Side::Starboard);});
+      [this](const marine_acoustic_msgs::msg::RawSonarImage & m) {onPing(m, Side::Starboard);},
+      sub_opts);
     nadir_sub_ = create_subscription<sensor_msgs::msg::Range>(
       nadir_topic, qos,
-      [this](const sensor_msgs::msg::Range & m) {onNadir(m);});
+      [this](const sensor_msgs::msg::Range & m) {onNadir(m);}, sub_opts);
 
     flush_timer_ = create_wall_timer(
-      std::chrono::duration<double>(flush_period_s), [this]() {flush();});
+      std::chrono::duration<double>(flush_period_s), [this]() {flush();}, cb_group_);
+
+    // Fail loudly at startup if the output directory can't be created — better
+    // than silently dropping the whole survey product on every flush.
+    if (!ensureOutputDir()) {
+      RCLCPP_ERROR(
+        get_logger(), "output_dir '%s' is not writable; tile flush will fail",
+        output_dir_.c_str());
+    }
 
     RCLCPP_INFO(
       get_logger(),
@@ -169,6 +190,14 @@ private:
     c.ema_alpha = declare_parameter<double>("norm_ema_alpha", c.ema_alpha);
     c.min_reference = declare_parameter<double>("norm_min_reference", c.min_reference);
     return c;
+  }
+
+  // Create the output directory if needed; true if it exists and is a directory.
+  bool ensureOutputDir() const
+  {
+    std::error_code ec;
+    std::filesystem::create_directories(output_dir_, ec);
+    return std::filesystem::is_directory(output_dir_, ec);
   }
 
   // Held nadir altitude valid for a ping at @p ping_ns, per the staleness bound;
@@ -223,6 +252,15 @@ private:
     if (msg.sample_rate <= 0.0) {
       return;   // can't reconstruct range without a scale
     }
+    if (msg.image.beam_count > 1) {
+      // The per-sample pipeline treats the payload as one across-track scan
+      // line; a multi-beam image would be mis-projected. The GCV is single-beam.
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), 5000,
+        "beam_count %u > 1 unsupported (single-beam sidescan only); dropping ping",
+        static_cast<unsigned>(msg.image.beam_count));
+      return;
+    }
     const int64_t ping_ns = stampNs(msg.header.stamp);
 
     // Altitude (slant→ground): held nadir, else apply the no-nadir policy.
@@ -266,6 +304,14 @@ private:
       (side == Side::Starboard ? offset_rad : -offset_rad);
 
     const std::vector<double> raw = decodeSamples(msg);
+    if (msg.samples_per_beam > 0 && raw.size() != msg.samples_per_beam) {
+      // A length mismatch points at a dtype/endianness/payload error; the scan
+      // line is still placed per-sample, but flag it so it doesn't smear silently.
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), 5000,
+        "decoded %zu samples != samples_per_beam %u; check dtype/endianness",
+        raw.size(), static_cast<unsigned>(msg.samples_per_beam));
+    }
     std::vector<std::uint16_t> norm;
     (side == Side::Port ? port_norm_ : stbd_norm_).normalize(raw, norm);
 
@@ -296,6 +342,15 @@ private:
     if (written > 0) {
       RCLCPP_INFO(get_logger(), "flushed %zu tile(s) to %s", written, output_dir_.c_str());
     }
+    // The accumulator never evicts: memory grows with covered extent. Make the
+    // ceiling visible (P1 has no eviction; offload-after-flush is a P3/P4 concern).
+    const std::size_t grids = accumulator_.tiles().size();
+    if (grid_warn_count_ > 0 && grids > static_cast<std::size_t>(grid_warn_count_)) {
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), 30000,
+        "%zu GGGS grids held in memory (~%zu MB); grows with survey extent",
+        grids, grids * 13);
+    }
   }
 
   gggs::Level level_;
@@ -310,6 +365,7 @@ private:
   double across_track_offset_deg_ = 90.0;
   double nadir_staleness_s_ = 5.0;
   double max_tf_age_s_ = 1.0;
+  int grid_warn_count_ = 256;
 
   double nadir_altitude_m_ = 0.0;
   int64_t nadir_stamp_ns_ = 0;
@@ -317,6 +373,7 @@ private:
 
   std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+  rclcpp::CallbackGroup::SharedPtr cb_group_;
   rclcpp::Subscription<marine_acoustic_msgs::msg::RawSonarImage>::SharedPtr port_sub_;
   rclcpp::Subscription<marine_acoustic_msgs::msg::RawSonarImage>::SharedPtr stbd_sub_;
   rclcpp::Subscription<sensor_msgs::msg::Range>::SharedPtr nadir_sub_;

--- a/marine_sidescan_mosaic/src/mosaic_node.cpp
+++ b/marine_sidescan_mosaic/src/mosaic_node.cpp
@@ -1,0 +1,334 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+/// @file
+/// @brief Live sidescan mosaicker node (#173 P1+P2).
+///
+/// Subscribes the Garmin GCV port/stbd RawSonarImage channels + the nadir Range,
+/// georeferences each sample (origin from the earth→sensor TF; slant→ground using
+/// the held nadir altitude; across-track placement via geodesy), normalizes the
+/// ping, splats into GGGS-tiled uint16 tiles, and flushes dirty tiles to GeoTIFF
+/// on a timer.
+///
+/// Frame convention (validate against real data, #173 slice 5): the across-track
+/// azimuth is `heading ± across_track_offset_deg`, where heading is the sensor
+/// frame +x azimuth — i.e. this assumes the per-channel `frame_id` +x is the
+/// vessel-forward / along-track direction, with the look direction (port/stbd)
+/// supplied by the sign. If a platform's URDF orients the sensor frame
+/// differently, adjust `across_track_offset_deg`.
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "geographic_msgs/msg/geo_point.hpp"
+#include "marine_acoustic_msgs/msg/raw_sonar_image.hpp"
+#include "marine_autonomy/gggs.h"
+#include "marine_tiled_raster_store/tile_io.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/range.hpp"
+#include "tf2_ros/buffer.h"
+#include "tf2_ros/transform_listener.h"
+
+#include "marine_sidescan_mosaic/accumulator.hpp"
+#include "marine_sidescan_mosaic/normalizer.hpp"
+#include "marine_sidescan_mosaic/projection.hpp"
+
+namespace marine_sidescan_mosaic
+{
+
+namespace
+{
+constexpr int64_t kNsPerS = 1000000000LL;
+
+// Decode a RawSonarImage payload (single beam) to a 1-D double array, honouring
+// the declared dtype + endianness. Handles the types the GCV emits (uint8,
+// uint16) plus a few common others; unknown dtypes fall back to uint8.
+template<typename T>
+std::vector<double> decodeAs(const std::vector<uint8_t> & data, bool big_endian)
+{
+  const std::size_t n = data.size() / sizeof(T);
+  std::vector<double> out(n);
+  for (std::size_t i = 0; i < n; ++i) {
+    T value;
+    std::memcpy(&value, data.data() + i * sizeof(T), sizeof(T));
+    if (big_endian && sizeof(T) > 1) {
+      auto * bytes = reinterpret_cast<uint8_t *>(&value);
+      std::reverse(bytes, bytes + sizeof(T));
+    }
+    out[i] = static_cast<double>(value);
+  }
+  return out;
+}
+
+std::vector<double> decodeSamples(const marine_acoustic_msgs::msg::RawSonarImage & msg)
+{
+  using SonarImageData = marine_acoustic_msgs::msg::SonarImageData;
+  const auto & data = msg.image.data;
+  const bool be = msg.image.is_bigendian;
+  switch (msg.image.dtype) {
+    case SonarImageData::DTYPE_UINT8: return decodeAs<uint8_t>(data, be);
+    case SonarImageData::DTYPE_INT8: return decodeAs<int8_t>(data, be);
+    case SonarImageData::DTYPE_UINT16: return decodeAs<uint16_t>(data, be);
+    case SonarImageData::DTYPE_INT16: return decodeAs<int16_t>(data, be);
+    case SonarImageData::DTYPE_UINT32: return decodeAs<uint32_t>(data, be);
+    case SonarImageData::DTYPE_FLOAT32: return decodeAs<float>(data, be);
+    default: return decodeAs<uint8_t>(data, be);
+  }
+}
+
+int64_t stampNs(const builtin_interfaces::msg::Time & t)
+{
+  return static_cast<int64_t>(t.sec) * kNsPerS + t.nanosec;
+}
+}  // namespace
+
+class SidescanMosaicNode : public rclcpp::Node
+{
+public:
+  SidescanMosaicNode()
+  : rclcpp::Node("sidescan_mosaic"),
+    level_(declare_parameter<int>("gggs_level", 13)),
+    accumulator_(level_, SplatPolicy::Mean),
+    port_norm_(makeNormalizerConfig()),
+    stbd_norm_(makeNormalizerConfig())
+  {
+    earth_frame_ = declare_parameter<std::string>("earth_frame", "earth");
+    output_dir_ = declare_parameter<std::string>("output_dir", "sidescan_mosaic");
+    sound_speed_ = declare_parameter<double>("sound_speed", 1500.0);
+    across_track_offset_deg_ = declare_parameter<double>("across_track_offset_deg", 90.0);
+    nadir_staleness_s_ = declare_parameter<double>("nadir_staleness_s", 5.0);
+    no_nadir_policy_ = declare_parameter<std::string>("no_nadir_policy", "drop");
+    max_tf_age_s_ = declare_parameter<double>("max_tf_age_s", 1.0);
+    const double flush_period_s = declare_parameter<double>("flush_period_s", 2.0);
+    const std::string splat = declare_parameter<std::string>("splat", "mean");
+    accumulator_ = MosaicAccumulator(
+      level_, splat == "max_hold" ? SplatPolicy::MaxHold : SplatPolicy::Mean);
+
+    const std::string port_topic = declare_parameter<std::string>(
+      "port_topic", "sonar_image_port");
+    const std::string stbd_topic = declare_parameter<std::string>(
+      "starboard_topic", "sonar_image_starboard");
+    const std::string nadir_topic = declare_parameter<std::string>(
+      "nadir_topic", "nadir_depth");
+
+    tf_buffer_ = std::make_unique<tf2_ros::Buffer>(get_clock());
+    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+
+    // Imagery is best-effort on the driver; match it or no samples arrive.
+    auto qos = rclcpp::SensorDataQoS();
+    port_sub_ = create_subscription<marine_acoustic_msgs::msg::RawSonarImage>(
+      port_topic, qos,
+      [this](const marine_acoustic_msgs::msg::RawSonarImage & m) {onPing(m, Side::Port);});
+    stbd_sub_ = create_subscription<marine_acoustic_msgs::msg::RawSonarImage>(
+      stbd_topic, qos,
+      [this](const marine_acoustic_msgs::msg::RawSonarImage & m) {onPing(m, Side::Starboard);});
+    nadir_sub_ = create_subscription<sensor_msgs::msg::Range>(
+      nadir_topic, qos,
+      [this](const sensor_msgs::msg::Range & m) {onNadir(m);});
+
+    flush_timer_ = create_wall_timer(
+      std::chrono::duration<double>(flush_period_s), [this]() {flush();});
+
+    RCLCPP_INFO(
+      get_logger(),
+      "sidescan_mosaic: level %u (~%.3f m cells), splat=%s, out=%s",
+      static_cast<unsigned>(level_.level()), level_.cellSize(), splat.c_str(),
+      output_dir_.c_str());
+  }
+
+private:
+  NormalizerConfig makeNormalizerConfig()
+  {
+    NormalizerConfig c;
+    c.target_level = declare_parameter<double>("norm_target_level", c.target_level);
+    c.percentile = declare_parameter<double>("norm_percentile", c.percentile);
+    c.ema_alpha = declare_parameter<double>("norm_ema_alpha", c.ema_alpha);
+    c.min_reference = declare_parameter<double>("norm_min_reference", c.min_reference);
+    return c;
+  }
+
+  // Held nadir altitude valid for a ping at @p ping_ns, per the staleness bound;
+  // std::nullopt when too stale / never received (caller applies no_nadir_policy).
+  std::optional<double> altitudeFor(int64_t ping_ns) const
+  {
+    if (!nadir_valid_) {
+      return std::nullopt;
+    }
+    const double age_s = std::abs(ping_ns - nadir_stamp_ns_) / 1e9;
+    if (age_s > nadir_staleness_s_) {
+      return std::nullopt;
+    }
+    return nadir_altitude_m_;
+  }
+
+  bool lookupPose(
+    const std::string & frame, const builtin_interfaces::msg::Time & stamp,
+    geometry_msgs::msg::Transform & out) const
+  {
+    try {
+      out = tf_buffer_->lookupTransform(earth_frame_, frame, tf2::TimePoint(
+          std::chrono::nanoseconds(stampNs(stamp)))).transform;
+      return true;
+    } catch (const tf2::TransformException &) {
+      // Fall back to the latest available transform, bounded by max_tf_age.
+    }
+    try {
+      const auto tf = tf_buffer_->lookupTransform(earth_frame_, frame, tf2::TimePointZero);
+      const double age_s = std::abs(stampNs(stamp) - stampNs(tf.header.stamp)) / 1e9;
+      if (age_s > max_tf_age_s_) {
+        return false;
+      }
+      out = tf.transform;
+      return true;
+    } catch (const tf2::TransformException &) {
+      return false;
+    }
+  }
+
+  void onNadir(const sensor_msgs::msg::Range & msg)
+  {
+    if (std::isfinite(msg.range) && msg.range > 0.0) {
+      nadir_altitude_m_ = msg.range;
+      nadir_stamp_ns_ = stampNs(msg.header.stamp);
+      nadir_valid_ = true;
+    }
+  }
+
+  void onPing(const marine_acoustic_msgs::msg::RawSonarImage & msg, Side side)
+  {
+    if (msg.sample_rate <= 0.0) {
+      return;   // can't reconstruct range without a scale
+    }
+    const int64_t ping_ns = stampNs(msg.header.stamp);
+
+    // Altitude (slant→ground): held nadir, else apply the no-nadir policy.
+    double altitude = 0.0;
+    if (const auto alt = altitudeFor(ping_ns)) {
+      altitude = *alt;
+    } else if (no_nadir_policy_ == "assume_zero") {
+      altitude = 0.0;
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), 5000,
+        "no fresh nadir altitude; projecting with uncorrected slant geometry");
+    } else {
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), 5000, "no fresh nadir altitude; dropping ping");
+      return;
+    }
+
+    geometry_msgs::msg::Transform pose;
+    if (!lookupPose(msg.header.frame_id, msg.header.stamp, pose)) {
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), 5000,
+        "no usable %s→%s transform; dropping ping", earth_frame_.c_str(),
+        msg.header.frame_id.c_str());
+      return;
+    }
+
+    const auto gh = ecefPoseToGeoHeading(
+      pose.translation.x, pose.translation.y, pose.translation.z,
+      pose.rotation.x, pose.rotation.y, pose.rotation.z, pose.rotation.w);
+
+    // wgs84::direct requires the origin at altitude 0 (it places on the surface).
+    geographic_msgs::msg::GeoPoint origin;
+    origin.latitude = gh.latitude_deg;
+    origin.longitude = gh.longitude_deg;
+    origin.altitude = 0.0;
+
+    const double sound_speed = msg.ping_info.sound_speed > 0.0 ?
+      msg.ping_info.sound_speed : sound_speed_;
+    const double offset_rad = across_track_offset_deg_ * M_PI / 180.0;
+    const double azimuth = gh.heading_rad +
+      (side == Side::Starboard ? offset_rad : -offset_rad);
+
+    const std::vector<double> raw = decodeSamples(msg);
+    std::vector<std::uint16_t> norm;
+    (side == Side::Port ? port_norm_ : stbd_norm_).normalize(raw, norm);
+
+    const int sample0 = static_cast<int>(msg.sample0);
+    for (std::size_t j = 0; j < norm.size(); ++j) {
+      const double slant = slantRange(
+        static_cast<int>(j), sample0, sound_speed, msg.sample_rate);
+      const double ground = groundRange(slant, altitude);
+      if (ground <= 0.0) {
+        continue;   // inside the nadir cone; nothing to place on the ground
+      }
+      accumulator_.add(projectSample(origin, azimuth, ground, level_), norm[j]);
+    }
+  }
+
+  void flush()
+  {
+    std::size_t written = 0;
+    try {
+      // Band no-data 0: untouched cells are transparent in GIS / CAMP.
+      written = marine_tiled_raster_store::saveTiles<std::uint16_t>(
+        accumulator_.tiles(), output_dir_, {std::optional<std::uint16_t>(0)});
+    } catch (const std::exception & e) {
+      RCLCPP_ERROR_THROTTLE(
+        get_logger(), *get_clock(), 5000, "tile flush failed: %s", e.what());
+      return;
+    }
+    if (written > 0) {
+      RCLCPP_INFO(get_logger(), "flushed %zu tile(s) to %s", written, output_dir_.c_str());
+    }
+  }
+
+  gggs::Level level_;
+  MosaicAccumulator accumulator_;
+  RollingNormalizer port_norm_;
+  RollingNormalizer stbd_norm_;
+
+  std::string earth_frame_;
+  std::string output_dir_;
+  std::string no_nadir_policy_;
+  double sound_speed_ = 1500.0;
+  double across_track_offset_deg_ = 90.0;
+  double nadir_staleness_s_ = 5.0;
+  double max_tf_age_s_ = 1.0;
+
+  double nadir_altitude_m_ = 0.0;
+  int64_t nadir_stamp_ns_ = 0;
+  bool nadir_valid_ = false;
+
+  std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+  rclcpp::Subscription<marine_acoustic_msgs::msg::RawSonarImage>::SharedPtr port_sub_;
+  rclcpp::Subscription<marine_acoustic_msgs::msg::RawSonarImage>::SharedPtr stbd_sub_;
+  rclcpp::Subscription<sensor_msgs::msg::Range>::SharedPtr nadir_sub_;
+  rclcpp::TimerBase::SharedPtr flush_timer_;
+};
+
+}  // namespace marine_sidescan_mosaic
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<marine_sidescan_mosaic::SidescanMosaicNode>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/marine_sidescan_mosaic/src/mosaic_node.cpp
+++ b/marine_sidescan_mosaic/src/mosaic_node.cpp
@@ -114,9 +114,7 @@ public:
   SidescanMosaicNode()
   : rclcpp::Node("sidescan_mosaic"),
     level_(declare_parameter<int>("gggs_level", 13)),
-    accumulator_(level_, SplatPolicy::Mean),
-    port_norm_(makeNormalizerConfig()),
-    stbd_norm_(makeNormalizerConfig())
+    accumulator_(level_, SplatPolicy::Mean)
   {
     earth_frame_ = declare_parameter<std::string>("earth_frame", "earth");
     output_dir_ = declare_parameter<std::string>("output_dir", "sidescan_mosaic");
@@ -130,6 +128,11 @@ public:
     const std::string splat = declare_parameter<std::string>("splat", "mean");
     accumulator_ = MosaicAccumulator(
       level_, splat == "max_hold" ? SplatPolicy::MaxHold : SplatPolicy::Mean);
+    // One config (declares the norm_* params once) feeds both per-side
+    // normalizers — declaring them twice would throw ParameterAlreadyDeclared.
+    const NormalizerConfig ncfg = makeNormalizerConfig();
+    port_norm_ = RollingNormalizer(ncfg);
+    stbd_norm_ = RollingNormalizer(ncfg);
 
     const std::string port_topic = declare_parameter<std::string>(
       "port_topic", "sonar_image_port");

--- a/marine_sidescan_mosaic/src/normalizer.cpp
+++ b/marine_sidescan_mosaic/src/normalizer.cpp
@@ -70,7 +70,9 @@ void RollingNormalizer::normalize(
   const double scale = config_.target_level / reference_;
   for (std::size_t i = 0; i < raw.size(); ++i) {
     const double scaled = std::round(raw[i] * scale);
-    const double clamped = std::clamp(scaled, 0.0, 65535.0);
+    // Floor at 1: 0 is reserved as the tile no-data value (untouched cells), so
+    // even the darkest real return maps to "covered", not "no data".
+    const double clamped = std::clamp(scaled, 1.0, 65535.0);
     out[i] = static_cast<std::uint16_t>(clamped);
   }
 }

--- a/marine_sidescan_mosaic/src/normalizer.cpp
+++ b/marine_sidescan_mosaic/src/normalizer.cpp
@@ -1,0 +1,78 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "marine_sidescan_mosaic/normalizer.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+namespace marine_sidescan_mosaic
+{
+
+namespace
+{
+// The p-quantile of @p values (0..1), by partial sort. Takes a copy (mutates).
+double percentileOf(std::vector<double> values, double p)
+{
+  if (values.empty()) {
+    return 0.0;
+  }
+  p = std::clamp(p, 0.0, 1.0);
+  const std::size_t k =
+    static_cast<std::size_t>(p * static_cast<double>(values.size() - 1));
+  std::nth_element(values.begin(), values.begin() + k, values.end());
+  return values[k];
+}
+}  // namespace
+
+RollingNormalizer::RollingNormalizer(NormalizerConfig config)
+: config_(config) {}
+
+void RollingNormalizer::normalize(
+  const std::vector<double> & raw, std::vector<std::uint16_t> & out)
+{
+  out.resize(raw.size());
+  if (raw.empty()) {
+    return;
+  }
+
+  // This ping's reference, floored so an all-dark ping can't blow up the gain.
+  double ping_ref = std::max(percentileOf(raw, config_.percentile), config_.min_reference);
+
+  // Roll it into the running reference (first ping initializes directly).
+  if (reference_ < 0.0) {
+    reference_ = ping_ref;
+  } else {
+    reference_ = config_.ema_alpha * ping_ref + (1.0 - config_.ema_alpha) * reference_;
+  }
+  reference_ = std::max(reference_, config_.min_reference);
+
+  const double scale = config_.target_level / reference_;
+  for (std::size_t i = 0; i < raw.size(); ++i) {
+    const double scaled = std::round(raw[i] * scale);
+    const double clamped = std::clamp(scaled, 0.0, 65535.0);
+    out[i] = static_cast<std::uint16_t>(clamped);
+  }
+}
+
+}  // namespace marine_sidescan_mosaic

--- a/marine_sidescan_mosaic/src/projection.cpp
+++ b/marine_sidescan_mosaic/src/projection.cpp
@@ -1,0 +1,110 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "marine_sidescan_mosaic/projection.hpp"
+
+#include <array>
+#include <cmath>
+
+#include "geodesy/ecef.h"
+#include "geodesy/geodesics.h"
+
+namespace marine_sidescan_mosaic
+{
+
+namespace
+{
+// 3x3 row-major matrix multiply (a · b).
+using Mat3 = std::array<double, 9>;
+Mat3 matmul(const Mat3 & a, const Mat3 & b)
+{
+  Mat3 r{};
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      double s = 0.0;
+      for (int k = 0; k < 3; ++k) {
+        s += a[i * 3 + k] * b[k * 3 + j];
+      }
+      r[i * 3 + j] = s;
+    }
+  }
+  return r;
+}
+}  // namespace
+
+GeoHeading ecefPoseToGeoHeading(
+  double tx, double ty, double tz,
+  double qx, double qy, double qz, double qw)
+{
+  GeoHeading out;
+
+  // Position: ECEF → geodetic via geodesy (ADR-0002 §D8), not hand-rolled.
+  const auto geo = geodesy::toMsg(geodesy::ECEFPoint(tx, ty, tz));
+  out.latitude_deg = geo.latitude;
+  out.longitude_deg = geo.longitude;
+  out.altitude_m = geo.altitude;
+
+  // Heading: body→ECEF (quaternion) → body→NED (via the local ENU rotation), then
+  // the aerospace ZYX yaw. Mirrors geo.py::matrix_to_heading_pitch_roll.
+  const double norm = std::sqrt(qx * qx + qy * qy + qz * qz + qw * qw);
+  if (norm < 1e-12) {
+    out.heading_rad = 0.0;
+    return out;
+  }
+  qx /= norm; qy /= norm; qz /= norm; qw /= norm;
+
+  // body → ECEF (p_parent = R p_child), matching tf2.
+  const Mat3 r_body_ecef = {
+    1 - 2 * (qy * qy + qz * qz), 2 * (qx * qy - qz * qw), 2 * (qx * qz + qy * qw),
+    2 * (qx * qy + qz * qw), 1 - 2 * (qx * qx + qz * qz), 2 * (qy * qz - qx * qw),
+    2 * (qx * qz - qy * qw), 2 * (qy * qz + qx * qw), 1 - 2 * (qx * qx + qy * qy)};
+
+  const double lat = out.latitude_deg * M_PI / 180.0;
+  const double lon = out.longitude_deg * M_PI / 180.0;
+  const double sla = std::sin(lat), cla = std::cos(lat);
+  const double slo = std::sin(lon), clo = std::cos(lon);
+
+  // ECEF → ENU (v_enu = R v_ecef).
+  const Mat3 r_ecef_enu = {
+    -slo, clo, 0.0,
+    -sla * clo, -sla * slo, cla,
+    cla * clo, cla * slo, sla};
+  // ENU → NED.
+  const Mat3 r_enu_ned = {
+    0.0, 1.0, 0.0,
+    1.0, 0.0, 0.0,
+    0.0, 0.0, -1.0};
+
+  const Mat3 r_body_ned = matmul(r_enu_ned, matmul(r_ecef_enu, r_body_ecef));
+  out.heading_rad = std::atan2(r_body_ned[1 * 3 + 0], r_body_ned[0 * 3 + 0]);
+  return out;
+}
+
+gggs::CellIndex projectSample(
+  const geographic_msgs::msg::GeoPoint & origin,
+  double azimuth_rad, double ground_range, const gggs::Level & level)
+{
+  const auto position = geodesy::wgs84::direct(origin, azimuth_rad, ground_range);
+  // Resolve the grid from the sample's own position (no edge clamp).
+  return level.cellIndex(position);
+}
+
+}  // namespace marine_sidescan_mosaic

--- a/marine_sidescan_mosaic/test/test_accumulator.cpp
+++ b/marine_sidescan_mosaic/test/test_accumulator.cpp
@@ -1,0 +1,121 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+#include "marine_autonomy/gggs.h"
+#include "marine_sidescan_mosaic/accumulator.hpp"
+
+namespace msm = marine_sidescan_mosaic;
+
+namespace
+{
+const gggs::Level kLevel(13);
+
+// A CellIndex at a deterministic (grid, row, col) near Lake Massabesic.
+gggs::CellIndex cellAt(uint16_t row, uint16_t col, double lat = 43.07, double lon = -71.42)
+{
+  return gggs::CellIndex(kLevel.gridIndex(lat, lon), row, col);
+}
+
+std::uint16_t valueAt(const msm::MosaicAccumulator & acc, const gggs::CellIndex & cell)
+{
+  return acc.tiles().at(cell.grid()).get(cell.row(), cell.column(), 0);
+}
+}  // namespace
+
+TEST(Accumulator, MeanOfSamples)
+{
+  msm::MosaicAccumulator acc(kLevel, msm::SplatPolicy::Mean);
+  const auto cell = cellAt(10, 20);
+  acc.add(cell, 10);
+  acc.add(cell, 20);
+  acc.add(cell, 30);
+  EXPECT_EQ(valueAt(acc, cell), 20);          // (10+20+30)/3
+  acc.add(cell, 40);
+  EXPECT_EQ(valueAt(acc, cell), 25);          // 100/4
+}
+
+TEST(Accumulator, MeanTruncates)
+{
+  msm::MosaicAccumulator acc(kLevel, msm::SplatPolicy::Mean);
+  const auto cell = cellAt(5, 5);
+  acc.add(cell, 10);
+  acc.add(cell, 15);
+  EXPECT_EQ(valueAt(acc, cell), 12);          // 25/2 = 12.5 -> 12 (integer truncation)
+}
+
+TEST(Accumulator, MaxHold)
+{
+  msm::MosaicAccumulator acc(kLevel, msm::SplatPolicy::MaxHold);
+  const auto cell = cellAt(1, 1);
+  acc.add(cell, 10);
+  acc.add(cell, 30);
+  acc.add(cell, 20);
+  EXPECT_EQ(valueAt(acc, cell), 30);          // brightest wins, order-independent
+}
+
+TEST(Accumulator, IndependentCellsAndGrids)
+{
+  msm::MosaicAccumulator acc(kLevel, msm::SplatPolicy::Mean);
+  const auto a = cellAt(1, 1);
+  const auto b = cellAt(2, 2);
+  const auto far = cellAt(1, 1, 43.50, -71.10);   // a different grid
+  acc.add(a, 100);
+  acc.add(b, 200);
+  acc.add(far, 50);
+  EXPECT_EQ(valueAt(acc, a), 100);
+  EXPECT_EQ(valueAt(acc, b), 200);
+  EXPECT_EQ(valueAt(acc, far), 50);
+  ASSERT_NE(a.grid(), far.grid());
+  EXPECT_EQ(acc.tiles().size(), 2u);              // two grids touched
+}
+
+// The uint64 sum must not overflow even at the uint16 ceiling over many samples.
+TEST(Accumulator, NoOverflowAtCeiling)
+{
+  msm::MosaicAccumulator acc(kLevel, msm::SplatPolicy::Mean);
+  const auto cell = cellAt(7, 7);
+  for (int i = 0; i < 1000; ++i) {
+    acc.add(cell, 65535);
+  }
+  EXPECT_EQ(valueAt(acc, cell), 65535);           // mean of all-max is max, no wrap
+}
+
+TEST(Accumulator, TileDirtyAfterAdd)
+{
+  msm::MosaicAccumulator acc(kLevel, msm::SplatPolicy::Mean);
+  const auto cell = cellAt(3, 3);
+  acc.add(cell, 42);
+  EXPECT_TRUE(acc.tiles().at(cell.grid()).dirty());
+}
+
+// An untouched cell reads back 0 (no-data) even once its tile exists.
+TEST(Accumulator, UntouchedCellIsZero)
+{
+  msm::MosaicAccumulator acc(kLevel, msm::SplatPolicy::Mean);
+  const auto written = cellAt(4, 4);
+  const auto untouched = cellAt(8, 9);            // same grid, different cell
+  acc.add(written, 123);
+  EXPECT_EQ(valueAt(acc, untouched), 0);
+}

--- a/marine_sidescan_mosaic/test/test_normalizer.cpp
+++ b/marine_sidescan_mosaic/test/test_normalizer.cpp
@@ -1,0 +1,86 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "marine_sidescan_mosaic/normalizer.hpp"
+
+namespace msm = marine_sidescan_mosaic;
+
+TEST(Normalizer, ConstantPingMapsToTarget)
+{
+  msm::RollingNormalizer norm;   // default target 32768
+  std::vector<double> raw(500, 100.0);
+  std::vector<std::uint16_t> out;
+  norm.normalize(raw, out);
+  EXPECT_DOUBLE_EQ(norm.reference(), 100.0);
+  for (auto v : out) {
+    EXPECT_EQ(v, 32768);
+  }
+}
+
+TEST(Normalizer, ScalesAndClamps)
+{
+  msm::RollingNormalizer norm;
+  // 90 samples at 100 then 10 at 1000: the 0.85 quantile is 100 -> reference 100.
+  std::vector<double> raw(90, 100.0);
+  raw.insert(raw.end(), 10, 1000.0);
+  std::vector<std::uint16_t> out;
+  norm.normalize(raw, out);
+  EXPECT_DOUBLE_EQ(norm.reference(), 100.0);
+  EXPECT_EQ(out.front(), 32768);     // a 100 -> target
+  EXPECT_EQ(out.back(), 65535);      // a 1000 -> 327680, clamped
+}
+
+TEST(Normalizer, AllDarkPingIsSafe)
+{
+  msm::RollingNormalizer norm;
+  std::vector<double> raw(200, 0.0);
+  std::vector<std::uint16_t> out;
+  norm.normalize(raw, out);
+  EXPECT_GE(norm.reference(), 1.0);  // floored, no divide-by-zero
+  for (auto v : out) {
+    EXPECT_EQ(v, 0);
+  }
+}
+
+TEST(Normalizer, ReferenceRollsBetweenPings)
+{
+  msm::RollingNormalizer norm;   // ema_alpha 0.05
+  std::vector<std::uint16_t> out;
+  norm.normalize(std::vector<double>(100, 100.0), out);
+  EXPECT_DOUBLE_EQ(norm.reference(), 100.0);       // first ping initializes
+  norm.normalize(std::vector<double>(100, 200.0), out);
+  EXPECT_DOUBLE_EQ(norm.reference(), 105.0);        // 0.05*200 + 0.95*100
+}
+
+TEST(Normalizer, EmptyPing)
+{
+  msm::RollingNormalizer norm;
+  std::vector<double> raw;
+  std::vector<std::uint16_t> out{1, 2, 3};
+  norm.normalize(raw, out);
+  EXPECT_TRUE(out.empty());
+  EXPECT_LT(norm.reference(), 0.0);                 // never initialized
+}

--- a/marine_sidescan_mosaic/test/test_normalizer.cpp
+++ b/marine_sidescan_mosaic/test/test_normalizer.cpp
@@ -61,7 +61,7 @@ TEST(Normalizer, AllDarkPingIsSafe)
   norm.normalize(raw, out);
   EXPECT_GE(norm.reference(), 1.0);  // floored, no divide-by-zero
   for (auto v : out) {
-    EXPECT_EQ(v, 0);
+    EXPECT_EQ(v, 1);   // floor 1: covered-but-dark, distinct from no-data 0
   }
 }
 

--- a/marine_sidescan_mosaic/test/test_projection.cpp
+++ b/marine_sidescan_mosaic/test/test_projection.cpp
@@ -1,0 +1,180 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cmath>
+
+#include "geodesy/ecef.h"
+#include "geographic_msgs/msg/geo_point.hpp"
+#include "marine_autonomy/gggs.h"
+#include "marine_sidescan_mosaic/projection.hpp"
+
+namespace msm = marine_sidescan_mosaic;
+
+namespace
+{
+using Mat3 = std::array<double, 9>;
+
+Mat3 matmul(const Mat3 & a, const Mat3 & b)
+{
+  Mat3 r{};
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      double s = 0.0;
+      for (int k = 0; k < 3; ++k) {
+        s += a[i * 3 + k] * b[k * 3 + j];
+      }
+      r[i * 3 + j] = s;
+    }
+  }
+  return r;
+}
+
+Mat3 transpose(const Mat3 & m)
+{
+  return Mat3{m[0], m[3], m[6], m[1], m[4], m[7], m[2], m[5], m[8]};
+}
+
+// Quaternion (x,y,z,w) from a proper rotation matrix (row-major), p_parent = R p_child.
+std::array<double, 4> quatFromMatrix(const Mat3 & m)
+{
+  const double t = m[0] + m[4] + m[8];
+  double x, y, z, w;
+  if (t > 0.0) {
+    double s = 0.5 / std::sqrt(t + 1.0);
+    w = 0.25 / s;
+    x = (m[7] - m[5]) * s;
+    y = (m[2] - m[6]) * s;
+    z = (m[3] - m[1]) * s;
+  } else if (m[0] > m[4] && m[0] > m[8]) {
+    double s = 2.0 * std::sqrt(1.0 + m[0] - m[4] - m[8]);
+    w = (m[7] - m[5]) / s;
+    x = 0.25 * s;
+    y = (m[1] + m[3]) / s;
+    z = (m[2] + m[6]) / s;
+  } else if (m[4] > m[8]) {
+    double s = 2.0 * std::sqrt(1.0 + m[4] - m[0] - m[8]);
+    w = (m[2] - m[6]) / s;
+    x = (m[1] + m[3]) / s;
+    y = 0.25 * s;
+    z = (m[5] + m[7]) / s;
+  } else {
+    double s = 2.0 * std::sqrt(1.0 + m[8] - m[0] - m[4]);
+    w = (m[3] - m[1]) / s;
+    x = (m[2] + m[6]) / s;
+    y = (m[5] + m[7]) / s;
+    z = 0.25 * s;
+  }
+  return {x, y, z, w};
+}
+
+// Build the body->ECEF quaternion for a vessel at (lat,lon) with the given level
+// heading (radians, CW from north), so ecefPoseToGeoHeading should recover it.
+std::array<double, 4> bodyEcefQuatForHeading(double lat_deg, double lon_deg, double heading)
+{
+  const double lat = lat_deg * M_PI / 180.0;
+  const double lon = lon_deg * M_PI / 180.0;
+  const double sla = std::sin(lat), cla = std::cos(lat);
+  const double slo = std::sin(lon), clo = std::cos(lon);
+  const Mat3 r_ecef_enu = {
+    -slo, clo, 0.0, -sla * clo, -sla * slo, cla, cla * clo, cla * slo, sla};
+  const Mat3 r_enu_ned = {0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, -1.0};
+  const Mat3 r_ecef_ned = matmul(r_enu_ned, r_ecef_enu);
+  // body->NED: yaw `heading` about Down (body x at azimuth heading).
+  const double ch = std::cos(heading), sh = std::sin(heading);
+  const Mat3 r_body_ned = {ch, -sh, 0.0, sh, ch, 0.0, 0.0, 0.0, 1.0};
+  const Mat3 r_body_ecef = matmul(transpose(r_ecef_ned), r_body_ned);
+  return quatFromMatrix(r_body_ecef);
+}
+
+geographic_msgs::msg::GeoPoint geoPoint(double lat, double lon, double alt = 0.0)
+{
+  geographic_msgs::msg::GeoPoint p;
+  p.latitude = lat;
+  p.longitude = lon;
+  p.altitude = alt;
+  return p;
+}
+}  // namespace
+
+TEST(Projection, SlantGroundAzimuth)
+{
+  // sample_rate 10 kHz, sound speed 1500 m/s, near-field gate 100.
+  EXPECT_DOUBLE_EQ(msm::slantRange(0, 100, 1500.0, 10000.0), 100.0 * 1500.0 / 20000.0);
+  EXPECT_DOUBLE_EQ(msm::slantRange(900, 100, 1500.0, 10000.0), 1000.0 * 1500.0 / 20000.0);
+  EXPECT_NEAR(msm::groundRange(15.0, 10.0), std::sqrt(125.0), 1e-9);
+  EXPECT_DOUBLE_EQ(msm::groundRange(5.0, 10.0), 0.0);   // slant within altitude
+  EXPECT_DOUBLE_EQ(msm::acrossTrackAzimuth(0.0, msm::Side::Starboard), M_PI / 2.0);
+  EXPECT_DOUBLE_EQ(msm::acrossTrackAzimuth(0.0, msm::Side::Port), -M_PI / 2.0);
+}
+
+TEST(Projection, EcefPositionRoundTrip)
+{
+  geodesy::ECEFPoint e;
+  geodesy::fromMsg(geoPoint(43.07, -71.42, 5.0), e);
+  const auto gh = msm::ecefPoseToGeoHeading(e.x, e.y, e.z, 0.0, 0.0, 0.0, 1.0);
+  EXPECT_NEAR(gh.latitude_deg, 43.07, 1e-6);
+  EXPECT_NEAR(gh.longitude_deg, -71.42, 1e-6);
+  EXPECT_NEAR(gh.altitude_m, 5.0, 1e-3);
+}
+
+TEST(Projection, HeadingRecoveredFromPose)
+{
+  geodesy::ECEFPoint e;
+  geodesy::fromMsg(geoPoint(43.07, -71.42, 0.0), e);
+  for (double h_deg : {0.0, 90.0, 200.0, 315.0}) {
+    const double h = h_deg * M_PI / 180.0;
+    const auto q = bodyEcefQuatForHeading(43.07, -71.42, h);
+    const auto gh = msm::ecefPoseToGeoHeading(e.x, e.y, e.z, q[0], q[1], q[2], q[3]);
+    // Compare on the circle (wrap-safe).
+    EXPECT_NEAR(std::cos(gh.heading_rad), std::cos(h), 1e-6) << "heading " << h_deg;
+    EXPECT_NEAR(std::sin(gh.heading_rad), std::sin(h), 1e-6) << "heading " << h_deg;
+  }
+}
+
+TEST(Projection, ProjectsEastward)
+{
+  const gggs::Level level(13);
+  const auto origin = geoPoint(43.07, -71.42, 0.0);
+  const auto cell = msm::projectSample(origin, M_PI / 2.0, 20.0, level);   // 20 m due east
+  const auto pos = cell.position();
+  EXPECT_GT(pos.longitude, origin.longitude);            // moved east
+  EXPECT_NEAR(pos.latitude, origin.latitude, 1e-4);      // ~same latitude
+}
+
+TEST(Projection, SampleCrossesGridBoundary)
+{
+  // Place the origin just west of a grid's eastern edge, then project east past
+  // it: the sample must land in the NEXT grid, not be clamped to this grid's edge.
+  const gggs::Level level(13);
+  const gggs::GridIndex grid = level.gridIndex(43.07, -71.42);
+  const double east_edge = grid.westLongitude() + grid.longitudinalSpan();
+  // ~0.5 m west of the edge (longitude degrees at ~43 N).
+  const double half_m_deg = 0.5 / (111320.0 * std::cos(43.07 * M_PI / 180.0));
+  const auto origin = geoPoint(43.07, east_edge - half_m_deg, 0.0);
+
+  const gggs::GridIndex origin_grid = level.gridIndex(origin.latitude, origin.longitude);
+  const auto cell = msm::projectSample(origin, M_PI / 2.0, 5.0, level);    // 5 m east
+  EXPECT_NE(cell.grid(), origin_grid);
+  EXPECT_EQ(cell.grid().column(), origin_grid.column() + 1);
+}


### PR DESCRIPTION
## Summary

Live **GGGS-tiled georeferenced sidescan backscatter mosaicker** (`marine_sidescan_mosaic`) — the streaming half of the umbrella effort (#171, refs #166). Garmin GCV port/stbd `RawSonarImage` → per-sample ground projection → splat into GGGS **L13 uint16** GeoTIFF tiles (built on the merged #172 `marine_tiled_raster_store` core), flushed live for CAMP (I4 #175) and the #166 web viewer.

Scope = **P1+P2** (decided 2026-06-19): per-ping georef + per-sample ground projection + fixed-L13 splat + rolling normalization + tile flush + tests. P3 (adaptive multi-level) and P4 (dirty-region topic) are follow-on sub-issues of #171.

## Pipeline (per ping)

1. Subscribe port/stbd `marine_acoustic_msgs/RawSonarImage` + `~/nadir_depth` (`sensor_msgs/Range`), `SensorDataQoS`.
2. Georef origin via `lookupTransform(earth, ping.frame_id, stamp)` (exact → bounded-latest → drop); ECEF pose → `GeoPoint` + body→NED heading (ported from `bag_to_xtf` `geo.py`).
3. Altitude from nadir Range, held within `nadir_staleness_s`; residual → `no_nadir_policy` (`drop` default).
4. Per-sample slant → ground range → `geodesy::wgs84::direct` → `Level::cellIndex` (per-sample `GridIndex`, no edge clamp).
5. Mean splat (per-cell `uint64` sum + `uint32` count → `uint16`), selectable `max_hold`.
6. Rolling per-side display normalizer (live EGN stand-in), floored to ≥1 (0 reserved for no-data).
7. Flush dirty tiles → GeoTIFF on a timer (`saveTiles`).

## Tests & validation

- **73 unit tests, 0 failures** (projection / accumulator / normalizer), incl. heading round-trip, across-grid-boundary splat, quantize-on-flush boundary.
- `review-code` **Standard approved** — both must-fix addressed (MutuallyExclusive callback group for thread-safety; throttled grid-count growth warning + param + documented memory ceiling).
- **Bag-validated** against the real Massabesic `bizzyboat_sonar` bag: port pings georeference into WGS84 L13 tiles centered on **Lake Massabesic (42.992°N, 71.393°W)** with real normalized backscatter. Running it caught a param double-declare crash (fixed) that unit tests couldn't — node isn't constructed in the unit suite.

## Known follow-ups (not blockers for this PR)

- **Starboard TF gap**: `earth→bizzy/garmin_sidescan_starboard` is absent from the bag's TF tree (port resolves fine), so all starboard pings drop correctly with a throttled warn. Platform/URDF gap — filed as rolker/unh_echoboats_project11#300.
- **Fine-geometry accuracy** vs the PINGMapper `~/data/sidescan/Massabesic` reference — gross georegistration is validated; sub-tile accuracy is a follow-up check.

Closes #173

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
