### PR TITLE
marine_bathymetry_store: tile-format migration — Int64 time tile + per-cell source-index band + registry (#178)

### DIFF
--- a/.agent/work-plans/issue-178/plan.md
+++ b/.agent/work-plans/issue-178/plan.md
@@ -85,6 +85,16 @@ Rationale:
    path, logged as a warning). Update `kBathyBandCount` → remove and replace with
    `kValueBandCount = 2` and `kTimeBandCount = 1`.
 
+   **Must-fix 3 (directory scan filter):** the `load()` directory scan globs
+   `*.tif` in each layer subdirectory. With three file types co-resident
+   (`<grid>.tif`, `<grid>_time.tif`, `<grid>_source.tif`), the scanner must
+   **skip the auxiliary suffixes** so it only treats the base value tile as a
+   candidate. Implement a filename-suffix filter: when iterating, skip any file
+   whose stem ends in `_time` or `_source` (i.e. names ending in `_time.tif` /
+   `_source.tif`); only the base `<level>_<row>_<col>.tif` is loaded as the value
+   tile, and the matching `_time.tif` / `_source.tif` are loaded by deriving their
+   paths from the value tile's name.
+
 ### Part 2 — Per-cell source-index band + `registry.json` sidecar
 
 6. **`bathy_cell.hpp`** — Add `uint16_t source_index = 0` to `BathyCell` (0 =
@@ -94,7 +104,11 @@ Rationale:
 7. **`bathymetry_tile.hpp`** — Add a third underlying raster:
    - `source_raster_` (`TiledRasterTile<uint16_t>`, 1 band: source index)
    Update `set()` / `get()` to read/write `source_index`. Add `sourceBand()`
-   accessors returning `std::vector<uint16_t>&`.
+   accessors returning `std::vector<uint16_t>&`. **Suggestion 5:** the dirty
+   coordination now spans **all three rasters** (value + time + source) — a single
+   tile-level dirty flag covers them (the value raster's flag is authoritative;
+   `set()` marks it, `clearDirty()`/`markDirty()` operate through it), so all
+   three are written/cleared together on `save()`.
 
 8. **`marine_bathymetry_store/tile_io.cpp`** — Add a third file per tile per layer:
    - `<level>_<row>_<col>_source.tif` — 1-band `UInt16` (source index); no-data
@@ -116,6 +130,13 @@ Rationale:
      `registry.json`. No partial-write corruption.
    - `void loadRegistry(const std::string & store_root_dir)` — load from
      `registry.json` if present; no-op if absent (fresh store).
+
+   **Suggestion 4 (registry call contract):** a source registered via
+   `registerSource()` lives only in memory until `save()` (which invokes
+   `saveRegistry()`) runs. Document on `registerSource()` that callers must call
+   `save()` (or `saveRegistry()`) to persist the entry; a registration with no
+   subsequent `save()` is lost. This is intentional — registry persistence is
+   tied to the store's `save()` lifecycle.
 
 10. **`marine_bathymetry_store/src/registry.cpp`** — Implement `SourceRegistry`.
     Use `nlohmann/json.hpp` (already a ROS 2 jazzy dependency). Index 0 is reserved
@@ -181,9 +202,13 @@ Rationale:
 | `marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_tile.hpp` | Split into value raster (2-band Float64) + time raster (1-band Int64) + source raster (1-band UInt16) |
 | `marine_bathymetry_store/include/marine_bathymetry_store/tile_io.hpp` | Update doc comment; add registry save/load declarations |
 | `marine_bathymetry_store/src/tile_io.cpp` | Rewrite to 3-file per tile; add registry save/load delegation; add missing-file fallback paths |
+| `marine_bathymetry_store/include/marine_bathymetry_store/query.hpp` | **Must-fix 1:** `DepthSample::timestamp` `double` (Unix s) → `int64_t` (ns) to match the internal store and the costmap (#164) boundary |
 | `marine_bathymetry_store/include/marine_bathymetry_store/registry.hpp` | New: `SourceRegistry` with `SourceRecord`, intern, lookup, atomic save/load |
 | `marine_bathymetry_store/src/registry.cpp` | New: implement `SourceRegistry` (nlohmann/json, atomic write-then-rename) |
+| `marine_bathymetry_store/package.xml` | **Must-fix 2:** add `<depend>nlohmann_json</depend>` (only transitive today) |
+| `marine_bathymetry_store/CMakeLists.txt` | **Must-fix 2:** `find_package(nlohmann_json REQUIRED)` + link `nlohmann_json::nlohmann_json` |
 | `marine_tiled_raster_store/src/tile_io.cpp` | Add `int64_t` explicit instantiations + `gdalType<int64_t>()` → `GDT_Int64` |
+| `marine_tiled_raster_store/test/test_tile_io.cpp` | Add an `int64_t` single-band round-trip test for the new instantiation |
 | `marine_bathymetry_store/test/test_tile_io.cpp` | Update all tests for 3-file layout; add round-trip + fallback + registry tests |
 | `marine_bathymetry_store/test/test_store.cpp` | Update timestamp values to int64_t ns; add source_index round-trip test |
 | `marine_bathymetry_store/test/test_query.cpp` | Add `ShallowestReliableUnaffectedBySourceIndex` regression test |

--- a/.agent/work-plans/issue-178/plan.md
+++ b/.agent/work-plans/issue-178/plan.md
@@ -1,0 +1,233 @@
+# Plan: marine_bathymetry_store tile-format migration — time→Int64 tile + per-cell source-index band + registry (amend ADR-0002 D5; ADR-0005 D2/D8)
+
+## Issue
+
+https://github.com/rolker/unh_marine_autonomy/issues/178
+
+## Context
+
+The bathy store currently persists each tile as a 3-band `Float64` GeoTIFF
+(depth, uncertainty, timestamp) — all `Float64` because a single GeoTIFF has one
+band dtype and the timestamp was forced to match.  Two problems: (1) `Float64`
+Unix seconds is not ROS-native (`rclcpp::Time` is int64 ns) and gives only ~0.4 µs
+resolution rather than nanosecond-exact; (2) ADR-0005 D2/D8 (merged #179)
+requires a per-cell local source-index band so multi-platform fusion can track
+which sensor contributed each cell.
+
+ADR-0005 explicitly parks the bathy adoption on this issue (#178). Both changes
+land on the same files (`bathy_cell.hpp`, `bathymetry_tile.hpp`, `tile_io.hpp`)
+so they ship as one migration.
+
+Prerequisites confirmed:
+- ADR-0005 (#179) and ADR-0006 (#180) are MERGED.
+- Phase-1 store (#141) is MERGED to `jazzy`.
+- No field data committed to the durable layer (pre-production; no persisted tiles
+  in the store directory to worry about, but implementor should verify before the
+  first commit by checking the store directory on disk).
+
+## Source-Index Encoding Decision
+
+**Chosen: parallel `uint16_t` tile (separate file, separate band dtype).**
+
+Rationale:
+
+- A source index is logically and type-distinct from depth/uncertainty (float) and
+  time (int64). Co-locating it in a `Float64` tile would require exact-in-float
+  representation (valid for uint16, but fragile under future registry growth) and
+  would force a 4-band `Float64` tile even for the hot-path costmap reader that
+  never needs the source dimension.
+- The Part 1 time-tile separation establishes the principle: separate bands of
+  different dtype → separate tile file. Source index (uint16) follows the same
+  rule consistently.
+- `uint16_t` (`GDT_UInt16`) is already an explicit instantiation in
+  `marine_tiled_raster_store/tile_io.cpp`; no new GDAL mapping is needed for the
+  source tile itself.
+- Aligns with ADR-0006 (sidescan backscatter store) which uses the same uint16
+  source band encoding — a generic "read source band" path works identically
+  across both stores.
+
+## Approach
+
+### Part 1 — Time band → separate `Int64` ns tile
+
+1. **`bathy_cell.hpp`** — Change `BathyCell::timestamp` from `double` (Unix
+   seconds) to `int64_t` (nanoseconds since epoch, ROS-native). Update the field
+   comment. Remove the `double` justification comment that no longer applies.
+
+2. **`bathymetry_tile.hpp`** — Split `BathymetryTile` into two underlying rasters:
+   - `value_raster_` (`TiledRasterTile<double>`, 2 bands: depth + uncertainty)
+   - `time_raster_` (`TiledRasterTile<int64_t>`, 1 band: timestamp ns)
+   Update `set()`, `get()`, `dirty()`/`clearDirty()`/`markDirty()` to operate on
+   both. Add typed band accessors `timestampBand()` returning `std::vector<int64_t>&`.
+   The public `using Raster = TiledRasterTile<double>` stays for the value raster;
+   add `using TimeRaster = TiledRasterTile<int64_t>`.
+
+3. **`marine_tiled_raster_store/tile_io.cpp`** — Add `int64_t` explicit
+   instantiation (all four templates: `saveTile`, `loadTile`, `saveTiles`,
+   `loadTiles`) and the corresponding `gdalType<int64_t>()` specialization
+   returning `GDT_Int64`. GDAL 3.8.4 is installed locally; this is the load-bearing
+   GDAL version constraint for this migration.
+
+4. **`marine_bathymetry_store/tile_io.hpp`** — Update the file-level doc comment:
+   remove "3-band `Float64`" / "`Float64` is deliberate" language; replace with
+   "2-band `Float64` (depth, uncertainty) + 1-band `Int64` (timestamp ns) +
+   1-band `UInt16` (source index)". Update `saveTile` / `loadTile` signatures to
+   communicate two separate files (see step 5).
+
+5. **`marine_bathymetry_store/tile_io.cpp`** — Rewrite persistence to write/read
+   two files per tile per layer:
+   - `<level>_<row>_<col>.tif` — 2-band `Float64` (depth, uncertainty); NaN
+     no-data on both bands.
+   - `<level>_<row>_<col>_time.tif` — 1-band `Int64` (timestamp ns); no no-data
+     tag (0 = unset).
+   Update `save()` / `load()` to write/read both files. On load: if the time file
+   is missing (pre-migration tile), treat timestamp as 0 for all cells (fallback
+   path, logged as a warning). Update `kBathyBandCount` → remove and replace with
+   `kValueBandCount = 2` and `kTimeBandCount = 1`.
+
+### Part 2 — Per-cell source-index band + `registry.json` sidecar
+
+6. **`bathy_cell.hpp`** — Add `uint16_t source_index = 0` to `BathyCell` (0 =
+   no-data/unset, per ADR-0005 D4: source_id 0 is the no-data sentinel). Update
+   `hasData()` to remain depth-only (source_index is not a data-presence signal).
+
+7. **`bathymetry_tile.hpp`** — Add a third underlying raster:
+   - `source_raster_` (`TiledRasterTile<uint16_t>`, 1 band: source index)
+   Update `set()` / `get()` to read/write `source_index`. Add `sourceBand()`
+   accessors returning `std::vector<uint16_t>&`.
+
+8. **`marine_bathymetry_store/tile_io.cpp`** — Add a third file per tile per layer:
+   - `<level>_<row>_<col>_source.tif` — 1-band `UInt16` (source index); no-data
+     value = 0.
+   On load: if `_source.tif` is missing, fill source_index = 0 for all cells
+   (compatible with single-platform Phase-1 data mapping to "default entry").
+   Update `save()` / `load()` accordingly.
+
+9. **New file: `marine_bathymetry_store/include/marine_bathymetry_store/registry.hpp`** —
+   Define `SourceRegistry` (a thin wrapper over `nlohmann::json` or `std::map`) with:
+   - `struct SourceRecord { std::string source_id; std::string platform;
+     std::string sensor; std::string sensor_class; std::string campaign;
+     std::string datum; };`  (ADR-0005 D3 core schema + bathy extension `datum`)
+   - `uint16_t registerSource(const SourceRecord &)` — intern a record, return its
+     local index; idempotent on `source_id`.
+   - `std::optional<SourceRecord> lookup(uint16_t index) const`
+   - `void saveRegistry(const std::string & store_root_dir)` — write-then-rename
+     atomic: write `registry.json.tmp`, then `std::filesystem::rename()` to
+     `registry.json`. No partial-write corruption.
+   - `void loadRegistry(const std::string & store_root_dir)` — load from
+     `registry.json` if present; no-op if absent (fresh store).
+
+10. **`marine_bathymetry_store/src/registry.cpp`** — Implement `SourceRegistry`.
+    Use `nlohmann/json.hpp` (already a ROS 2 jazzy dependency). Index 0 is reserved
+    as the no-data/unset sentinel and must never be assigned to a real record.
+
+11. **`marine_bathymetry_store/tile_io.hpp`** and **`tile_io.cpp`** — Add
+    `saveRegistry()` and `loadRegistry()` thin wrappers that call
+    `SourceRegistry::saveRegistry/loadRegistry` so callers of the tile_io API
+    can trigger registry persistence without touching SourceRegistry directly.
+    Registry is store-wide (not per-layer), so `save()` calls `saveRegistry()` once
+    at the end; `load()` calls `loadRegistry()` once at the start.
+
+### Part 3 — ADR-0002 documentation amendment
+
+12. **`docs/decisions/0002-bathymetric-data-store.md`** —
+    - Add an amendment header entry after the existing `#151` note:
+      `**Amended 2026-06-20 ([#178](…)):** D5 revised — time band moved to a
+      separate Int64 ns tile; per-cell source-index band (UInt16) added alongside
+      depth+uncertainty; registry sidecar added. See ADR-0005 D2/D8 and ADR-0006
+      for the cross-store alignment.`
+    - D5 body: update "3 bands … Float64" → "2-band Float64 (depth, uncertainty) +
+      1-band Int64 (timestamp ns) + 1-band UInt16 (source index)"; remove "source
+      layer is not a band" rationale sentence (it was correct for single-platform;
+      replaced by the per-cell source-index design with local-index + registry);
+      add cross-reference to ADR-0005 D2/D8 and #178.
+    - D6 content-hash section: confirm/add that the content hash covers all three
+      tile files (value + time + source) for a complete re-arbitration signal.
+
+### Tests
+
+13. **`test_tile_io.cpp`** — Update all tests for the new 3-file layout:
+    - `RoundTripPreservesCells`: use `int64_t` ns timestamp values (not
+      `1.78e9` float seconds); verify exact round-trip.
+    - `ChartRoundTripsAndLoadsIntoReadOnlyStore`: update timestamp to int64_t ns.
+    - All tests: fix any `EXPECT_DOUBLE_EQ(draft->timestamp, ...)` → use
+      integer-exact `EXPECT_EQ`.
+    - Add `RoundTripPreservesSourceIndex`: populate `source_index` in two cells,
+      save, load, verify round-trip.
+    - Add `MissingTimeTileLoadsAsZero`: save a value tile, delete the time tile,
+      load, verify timestamp == 0 for all cells (fallback for pre-migration data).
+    - Add `MissingSourceTileLoadsAsZero`: same for source_index.
+    - Add `RegistryAtomicWrite`: call `saveRegistry`, verify `registry.json` exists
+      and `registry.json.tmp` does not remain.
+
+14. **`test_store.cpp`** — Update timestamp values from float seconds to int64_t ns:
+    `1000.0` → `1'000'000'000'000LL` (1 s in ns), `1.0` → `1'000'000'000LL`, etc.
+    Add `SetGetRoundTripWithSourceIndex`: set a cell with `source_index = 3`, get
+    it back, verify.
+
+15. **`test_query.cpp`** (regression — shallowest-reliable carve-out, ADR-0005 D5) —
+    Add `ShallowestReliableUnaffectedBySourceIndex`: populate a tile with cells
+    from two different source indices; verify `shallowestReliable()` returns the
+    shallowest reliable depth regardless of `source_index` value. This directly
+    demonstrates the D5 safety carve-out: the navigation-safety query ignores the
+    registry priority axis. (The existing `ShallowestReliable*` tests continue to
+    verify the uncertainty gate and NaN behaviour.)
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `marine_bathymetry_store/include/marine_bathymetry_store/bathy_cell.hpp` | `timestamp` → `int64_t` ns; add `source_index uint16_t`; update comments |
+| `marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_tile.hpp` | Split into value raster (2-band Float64) + time raster (1-band Int64) + source raster (1-band UInt16) |
+| `marine_bathymetry_store/include/marine_bathymetry_store/tile_io.hpp` | Update doc comment; add registry save/load declarations |
+| `marine_bathymetry_store/src/tile_io.cpp` | Rewrite to 3-file per tile; add registry save/load delegation; add missing-file fallback paths |
+| `marine_bathymetry_store/include/marine_bathymetry_store/registry.hpp` | New: `SourceRegistry` with `SourceRecord`, intern, lookup, atomic save/load |
+| `marine_bathymetry_store/src/registry.cpp` | New: implement `SourceRegistry` (nlohmann/json, atomic write-then-rename) |
+| `marine_tiled_raster_store/src/tile_io.cpp` | Add `int64_t` explicit instantiations + `gdalType<int64_t>()` → `GDT_Int64` |
+| `marine_bathymetry_store/test/test_tile_io.cpp` | Update all tests for 3-file layout; add round-trip + fallback + registry tests |
+| `marine_bathymetry_store/test/test_store.cpp` | Update timestamp values to int64_t ns; add source_index round-trip test |
+| `marine_bathymetry_store/test/test_query.cpp` | Add `ShallowestReliableUnaffectedBySourceIndex` regression test |
+| `docs/decisions/0002-bathymetric-data-store.md` | Part 3: amendment header; D5 body update; D6 content-hash note |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Safety First | `shallowestReliable()` is untouched in logic; a new regression test explicitly confirms the D5 safety carve-out holds with multi-source tiles. |
+| Modularity and Decoupling | `int64_t` instantiation goes in `marine_tiled_raster_store` (generic layer); bathy-specific semantics stay in `marine_bathymetry_store`. Registry is its own header/source, not entangled with tile I/O beyond the save/load wrappers. |
+| Standards Compliance | `int64_t` ns is ROS-native; `GDT_Int64` is GDAL 3.5+ (3.8.4 installed); `nlohmann/json` is a standard ROS 2 jazzy dep. |
+| Only what's needed | No speculative features; registry schema is exactly the ADR-0005 D3 core + bathy `datum` extension. |
+| A change includes its consequences | Tests updated in this PR; downstream #164 (costmap — depth is still band-1, likely unaffected but must be verified post-merge) and #175 (CAMP layer band-layout check) flagged for follow-through. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0002 D5 | Directly amended | Part 3 updates D5 text; amendment pointer added. |
+| ADR-0005 D2/D8 | Yes — this is the bathy adopter | Part 2 implements the per-cell source-index band + registry sidecar exactly as D2/D8 specifies; source-index encoding decision (parallel uint16 tile) recorded here per D2's "left to #178". |
+| ADR-0005 D5 (safety carve-out) | Yes | `shallowestReliable()` unchanged in logic; regression test added to prove it. |
+| ADR-0002 D6 (content hash) | Watch | D6 specifies content hash covers the tile payload. With 3 files per tile, the hash must cover all three; confirmed/added in the D6 doc amendment. No Phase-1 hash implementation exists yet, so this is a doc note, not a code change. |
+| ADR-0001 (adopt ADRs) | Yes | Amendment follows the cross-reference addendum pattern from #151. |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `BathyCell::timestamp` dtype | All callers that write/read `double` seconds | Yes — test_store, test_tile_io timestamps converted to int64_t ns |
+| `BathymetryTile` now holds 3 rasters | `save()` / `load()` writes/reads 3 files | Yes |
+| New `_time.tif` / `_source.tif` files | Old pre-migration single-file tiles: load falls back gracefully | Yes — missing-file fallback with 0-fill |
+| `DepthSample::timestamp` in `query.hpp` | Still `double` for consumer API? | Yes — change to `int64_t` to be consistent; `forEachCellBestSource` callers get the correct type |
+| `registry.json` | Written atomically (write-then-rename) | Yes |
+| Post-merge: #164 costmap reader | Verify depth is still band-1 of value tile | No — follow-up (#164), depth band unchanged so likely unaffected |
+| Post-merge: #175 CAMP layer | Band-layout check post-merge | No — follow-up (#175) |
+
+## Open Questions
+
+- [ ] No open questions — plan is review-plan-ready. (Encoding decision is settled
+  above; dependency status is confirmed; no field data to migrate.)
+
+## Estimated Scope
+
+Single PR. All changes touch the same package pair
+(`marine_bathymetry_store`, `marine_tiled_raster_store`) and the same
+`docs/decisions/0002-*.md` file. No cross-repo changes required.

--- a/.agent/work-plans/issue-178/progress.md
+++ b/.agent/work-plans/issue-178/progress.md
@@ -23,3 +23,15 @@ issue: 178
 - [ ] Add atomic write (write-then-rename) for `registry.json` from the start.
 - [ ] Add a regression test verifying `shallowest-reliable` query is unaffected by the source-index/registry priority axis.
 - [ ] Flag `#164` (costmap) and `#175` (CAMP layer) for post-merge band-assumption check.
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-20 12:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet 4.6)
+
+**Plan**: `.agent/work-plans/issue-178/plan.md` at `de7e091`
+**Branch**: feature/issue-178 at `de7e091`
+**Phases**: single
+
+### Open questions
+- [ ] No open questions — plan is review-plan-ready.

--- a/.agent/work-plans/issue-178/progress.md
+++ b/.agent/work-plans/issue-178/progress.md
@@ -1,0 +1,25 @@
+---
+issue: 178
+---
+
+# Issue #178 — marine_bathymetry_store: tile-format migration — time→Int64 tile + per-cell source-index band + registry (amend ADR-0002 D5; ADR-0005 D2/D8)
+
+## Issue Review
+**Status**: complete
+**When**: 2026-06-20 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet 4.6)
+
+**Issue**: #178
+**Comment**: https://github.com/rolker/unh_marine_autonomy/issues/178#issuecomment-4759239300
+**Scope verdict**: well-scoped
+
+### Actions
+- [ ] Confirm ADR-0005 (#179) status is stable before merging (it is the registry schema contract Part 2 adopts).
+- [ ] Verify Phase 1 store (#141) is merged to main before branching for #178.
+- [ ] Confirm no persisted tiles exist in the durable layer at branch time (issue says "pre-production" — verify).
+- [ ] Update existing `test_tile_io.cpp` and `test_store.cpp` in this PR (they expect 3-band Float64; new layout breaks them).
+- [ ] Add `int64_t` explicit instantiation to `marine_tiled_raster_store/tile_io.cpp` and GDAL type mapping for `GDT_Int64`.
+- [ ] Record the source-index band encoding choice (parallel uint16 tile vs. exact-in-Float64) in the plan, not just the PR body.
+- [ ] Add atomic write (write-then-rename) for `registry.json` from the start.
+- [ ] Add a regression test verifying `shallowest-reliable` query is unaffected by the source-index/registry priority axis.
+- [ ] Flag `#164` (costmap) and `#175` (CAMP layer) for post-merge band-assumption check.

--- a/.agent/work-plans/issue-178/progress.md
+++ b/.agent/work-plans/issue-178/progress.md
@@ -183,3 +183,60 @@ Uncrustify: 2 local 0.78.1 drift failures (known environment issue, not real).
 
 ### Left / follow-ups
 None — all 4 suggestions addressed. Branch is ready to push.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-20 (focused re-confirmation of 4-suggestion delta in commit 420d189)
+**By**: Claude Code Agent (Claude Sonnet 4.6)
+
+**Verdict**: approved
+
+**Scope**: Focused re-confirmation of commit `420d189` (4 non-blocking suggestions folded
+before push). The full diff was already approved at the prior SHA. This review only
+examines the delta.
+
+### Finding summary (0 new findings)
+
+1. **registry.cpp `loadRegistry` — stored-index validation** (item 1): Correct. No false
+   positives on the normal `saveRegistry` path. `saveRegistry` writes entries in
+   `by_index_` order using `i+1` (1-based), producing a contiguous ascending sequence
+   that `loadRegistry` expects (`expected = by_index_.size() + 1` before each push).
+   A clean round-trip always matches. Index-0-reserved holds: `registerSource` uses
+   `by_index_.size() + 1` (minimum 1 on first call). `loadRegistry` only validates
+   stored vs. expected; it never synthesises index 0.
+
+2. **`tileRasterCount` helper + 3-band guard** (item 2): GDAL encapsulation intact.
+   `tileRasterCount` lives in `marine_tiled_raster_store` (which already depends on
+   GDAL); `marine_bathymetry_store` takes no new GDAL dep — it calls the helper via
+   the existing `marine_tiled_raster_store/tile_io.hpp` include. Guard fires only on
+   `band_count == 3`; a normal 2-band value tile passes through untouched. No false
+   positives on the valid post-#178 write path.
+
+3. **`saveTile` value-first ordering comment** (item 3): Accurate. The code writes
+   value→time→source in that order. The comment correctly states that `shallowestReliable`
+   reads only the value tile (confirmed: `query.cpp` is not touched by this commit and
+   accesses only `value.depth()` / `value.uncertainty()`), so a crash after writing the
+   value tile but before the companions leaves the safety query correct. The 0-fill
+   fallback on missing companions described in the comment is verified in `loadTile`
+   (the ternary zero-fill path for absent companions).
+
+4. **Companion GridIndex consistency check** (item 4): Missing-companion 0-fill fallback
+   is intact. The guard condition is `fs::is_regular_file(time_path) && !(time.index() == grid)`.
+   When the companion is ABSENT, `is_regular_file` returns false — the condition short-circuits,
+   no throw, and the previously assigned `TimeRaster(grid, ..., int64_t{0})` stands.
+   The throw only fires when the companion IS PRESENT but has a mismatched GridIndex.
+   Same logic for the source companion. This is exactly the required semantics.
+
+### ADR-0005 D5 safety carve-out
+`shallowestReliable` in `query.cpp` is untouched by commit 420d189 (confirmed by
+`git diff bf85d64 420d189 -- marine_bathymetry_store/src/query.cpp` returning empty).
+
+### Build / test
+Build: clean (both packages, 2026-06-20 re-run).
+gtest results (from XML, re-run):
+- marine_tiled_raster_store/test_tile_io: 6/6 pass
+- marine_bathymetry_store/test_store: 12/12 pass
+- marine_bathymetry_store/test_query: 10/10 pass
+- marine_bathymetry_store/test_tile_io: 17/17 pass
+Total 45/45 gtests pass.
+Uncrustify: 3 local 0.78.1 drift failures (known environment noise — ignored per task spec).

--- a/.agent/work-plans/issue-178/progress.md
+++ b/.agent/work-plans/issue-178/progress.md
@@ -112,3 +112,28 @@ a known environment issue — not real correctness; gtest is green).
   stays band-1).
 - No persisted tiles existed on disk at branch time (verified), so no data
   migration was required.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-20 18:06 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved
+
+**Branch**: feature/issue-178 at `41851c6`
+**Mode**: pre-push
+**Depth**: Deep (reason: safety-relevant data store + substantive ADR amendment + cross-package change)
+**Must-fix**: 0 | **Suggestions**: 4
+
+### Findings
+- [ ] (suggestion) `loadRegistry` discards the stored `"index"` field and re-derives index from array position — silently wrong (or diverges `by_index_`/`by_source_id_`) on a reordered/sparse/duplicate hand-edited registry.json; add a `index == size()+1` validation — `marine_bathymetry_store/src/registry.cpp:151`
+- [ ] (suggestion) Pre-migration single 3-band Float64 tile loads with band_count=2 (`GetRasterCount() < 2` passes a 3-band file) and silently drops band 3 (old Float64 seconds timestamp) instead of converting it; timestamp 0-fills via the absent `_time.tif`. Acceptable only if old acquisition times are disposable — N/A today (no on-disk data at branch) but a real migration-story decision — `marine_bathymetry_store/src/tile_io.cpp:116`
+- [ ] (suggestion) 3-file `saveTile` writes value→time→source non-atomically and registry after tiles; a crash mid-write pairs a new depth with stale/absent provenance (safety query unaffected — reads value tile only). Document the value-first ordering; consider temp-set+rename and registry-first — `marine_bathymetry_store/src/tile_io.cpp:101`
+- [ ] (suggestion) `BathymetryTile(value, time, source)` does not enforce the three rasters share a grid (doc says "must"); a mis-renamed companion would combine cell-for-cell with a different grid silently. A `grid == value.index()` check in `loadTile` after each companion load closes it cheaply — `marine_bathymetry_store/src/tile_io.cpp:134`
+
+### Notes
+- Safety carve-out VERIFIED: `shallowestReliable()` (query.cpp, unchanged) builds `DepthSample` with no `source_index` field, so it structurally cannot consult the provenance axis. The `ShallowestReliableUnaffectedBySourceIndex` regression test is non-tautological (asserts identical result with source indices swapped). Holds.
+- Backward compat VERIFIED: load() correctly excludes `_time`/`_source` companions from the value-tile scan (stem-anchored `ends_with`; no integer GridIndex filename can collide); `MissingTime/SourceTileLoadsAsZero` tests cover the 0-fill path.
+- Int64 ns round-trips bit-exact through `GDT_Int64` RasterIO (no `double` intermediary; no-data path is `std::nullopt` for the time tile). Test covers INT64_MAX.
+- Atomic registry write (write-then-rename) and uint16 interning / index-0-reserved / overflow-at-65535 / idempotency all correct.
+- ADR-0002 amendment internally consistent: D5 rewritten to three tiles, old "source layer is not a band" reasoning explicitly superseded, D6 covers all three files; remaining "3-band" mentions are correct historical context.
+- Static analysis: ament_cpplint / ament_copyright / ament_xmllint clean. cppcheck "unusedStructMember" / "useStlAlgorithm" are header-isolation false positives on unchanged lines. Local uncrustify-0.78.1 mass-fail is the known CI-drift environment issue (gtest 41/41 green is the source of truth).

--- a/.agent/work-plans/issue-178/progress.md
+++ b/.agent/work-plans/issue-178/progress.md
@@ -51,3 +51,64 @@ issue: 178
 - [ ] (must-fix) Directory scan will load `_time.tif` / `_source.tif` as value tiles — `marine_bathymetry_store/tile_io.cpp`'s `load()` calls `loadTiles` (or its own iterator) over `*.tif` in each layer subdirectory. With three file types co-resident in the same subdirectory, the scanner will pick up `<grid>_time.tif` and `<grid>_source.tif` as candidate value tiles and either fail the geotransform/band-count checks or silently load the wrong data. The plan doesn't specify a filename filter to skip the auxiliary suffixes. The implementation must filter out files matching `*_time.tif` and `*_source.tif` when scanning for value tiles. Add this to the `marine_bathymetry_store/tile_io.cpp` step (step 5 / step 8) in the plan. — `plan.md:77`
 - [ ] (suggestion) Registry save on every `save()` call regardless of dirty-tile count — Step 11 says "`save()` calls `saveRegistry()` once at the end." If `save()` is called but no tiles are dirty (incremental save skips them), a newly-registered source not yet associated with any tile cell would still have its registry entry written — which is correct. However if `registerSource()` is called in a context where `save()` is never subsequently called (e.g., an error before tiles are dirtied), the registry entry is lost. Consider documenting that registry persistence is tied to the `save()` call and that callers must ensure `save()` is invoked after registration to avoid orphaned registry entries. — `plan.md:127`
 - [ ] (suggestion) `markDirty()` language in step 7 says "both" but there are now three rasters — Step 2 correctly says "update `dirty()`/`clearDirty()`/`markDirty()` to operate on both [value + time rasters]"; step 7 adds the source raster but doesn't revisit the dirty semantics to say "all three." The implementation will need all three rasters' dirty flags coordinated; the plan text should say "all three" to avoid an implementor reading step 2 and step 7 independently missing the source raster in the dirty path. — `plan.md:57`
+
+## Implementation
+**Status**: complete
+**When**: 2026-06-20 +00:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Branch**: feature/issue-178 (6 commits on top of the plan-authored state)
+
+### What changed
+Step 0 — folded all five review-plan findings into `plan.md` (committed `debf9e6`):
+must-fix 1 (query.hpp DepthSample::timestamp int64), must-fix 2 (explicit
+nlohmann_json), must-fix 3 (directory-scan suffix filter), suggestion 4 (registry
+persistence tied to save()), suggestion 5 ("all three rasters" dirty wording).
+
+Part 1 — time → Int64 ns tile:
+- `marine_tiled_raster_store/src/tile_io.cpp`: `gdalType<int64_t>()` → `GDT_Int64`
+  + explicit instantiations for all four templates; doc/header notes updated;
+  new int64 single-band round-trip test (`edee0c6`).
+- `BathyCell::timestamp` double seconds → `int64_t` ns; `BathymetryTile` split
+  into value (2-band Float64) + time (1-band Int64) + source (1-band UInt16)
+  rasters, value raster's dirty flag authoritative; `DepthSample::timestamp` →
+  int64 ns (`481b3af`).
+
+Part 2 — source-index band + registry:
+- `BathyCell::source_index` (uint16, 0=unset); third `_source.tif` UInt16 tile;
+  `load()` skips `_time`/`_source` companions when scanning value tiles and fills
+  missing companions with 0 (pre-migration back-compat); `save()`/`load()` persist
+  the store-wide registry (`481b3af`).
+- New `SourceRegistry` (`registry.hpp`/`registry.cpp`): ADR-0005 D3 core schema +
+  bathy `datum`; intern to uint16; `registry.json` atomic write-then-rename;
+  index 0 reserved; idempotent on source_id; nlohmann_json declared explicitly
+  (`404ffb0`, wired in `481b3af`).
+
+Part 3 — ADR-0002 amendment (`7d35ef4`): amendment-pointer header (cross-ref
+ADR-0005 D2/D8 + ADR-0006); D5 rewritten to three tiles + quality vs provenance
+axes; D3 provenance-axis note + D5 carve-out pointer; D6 hash covers all three
+files. (ADR filenames verified: 0005-multi-platform-provenance-registry.md,
+0006-multi-platform-backscatter-store.md.)
+
+Tests (`fb9d19c`): all timestamps → int64 ns; added RoundTripPreservesSourceIndex,
+MissingTimeTileLoadsAsZero, MissingSourceTileLoadsAsZero, RegistryAtomicWrite,
+RegisterSourceIsIdempotent, SaveWritesRegistryWhenProvided, and the mandatory
+ShallowestReliableUnaffectedBySourceIndex (ADR-0005 D5 carve-out regression).
+
+### Build / test result
+Clean build of both packages. gtest XML (the source of truth):
+- marine_tiled_raster_store/test_tile_io: 6/6 pass
+- marine_bathymetry_store/test_store: 12/12 pass
+- marine_bathymetry_store/test_query: 10/10 pass
+- marine_bathymetry_store/test_tile_io: 13/13 pass
+Total 41/41 gtests pass. cpplint, cppcheck, copyright, lint_cmake, xmllint all
+clean. The only colcon-test failures are uncrustify (local 0.78.1 drift vs CI,
+a known environment issue — not real correctness; gtest is green).
+
+### Left / follow-ups (out of scope, flagged in plan)
+- #164 costmap reader: depth is still band-1 of the value tile (unchanged), but
+  a post-merge band-assumption check is warranted.
+- #175 CAMP layer: band-layout check post-merge (display unaffected — depth
+  stays band-1).
+- No persisted tiles existed on disk at branch time (verified), so no data
+  migration was required.

--- a/.agent/work-plans/issue-178/progress.md
+++ b/.agent/work-plans/issue-178/progress.md
@@ -35,3 +35,19 @@ issue: 178
 
 ### Open questions
 - [ ] No open questions — plan is review-plan-ready.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-06-20 18:30 +00:00
+**By**: Claude Code Agent (Claude Sonnet 4.6) (in-context — author self-review)
+
+**Plan**: `.agent/work-plans/issue-178/plan.md` at `de7e091`
+**PR**: PR-less (file-path mode)
+**Verdict**: approve-with-suggestions
+
+### Findings
+- [ ] (must-fix) `query.hpp` missing from Files to Change table — `DepthSample::timestamp` is `double` (line 45) and the Consequences table (row 4) says to change it to `int64_t`, but `query.hpp` is not listed as a file to modify. Without this change `DepthSample` callers (including the costmap #164) would receive `double` seconds from the API while the internal `BathyCell` stores `int64_t` ns, creating a type mismatch at the query boundary. Add `marine_bathymetry_store/include/marine_bathymetry_store/query.hpp` to the Files to Change table with note "change `DepthSample::timestamp` from `double` (Unix s) to `int64_t` (ns)". — `plan.md:219`
+- [ ] (must-fix) `nlohmann_json` dependency not declared — The plan relies on `nlohmann/json.hpp` for `registry.hpp`/`registry.cpp` and calls it "a standard ROS 2 jazzy dep," but `marine_bathymetry_store/package.xml` has no `<depend>nlohmann_json</depend>` and `CMakeLists.txt` has no `find_package(nlohmann_json …)`. `nlohmann-json3-dev` is installed system-wide but not via a rosdep key on this machine (rosdep lookup returns no entry). Other packages in this workspace that use nlohmann pull it transitively through `behaviortree_cpp`, not directly. Add `CMakeLists.txt` and `package.xml` to the Files to Change table with entries for the nlohmann dependency declaration. — `plan.md:186`
+- [ ] (must-fix) Directory scan will load `_time.tif` / `_source.tif` as value tiles — `marine_bathymetry_store/tile_io.cpp`'s `load()` calls `loadTiles` (or its own iterator) over `*.tif` in each layer subdirectory. With three file types co-resident in the same subdirectory, the scanner will pick up `<grid>_time.tif` and `<grid>_source.tif` as candidate value tiles and either fail the geotransform/band-count checks or silently load the wrong data. The plan doesn't specify a filename filter to skip the auxiliary suffixes. The implementation must filter out files matching `*_time.tif` and `*_source.tif` when scanning for value tiles. Add this to the `marine_bathymetry_store/tile_io.cpp` step (step 5 / step 8) in the plan. — `plan.md:77`
+- [ ] (suggestion) Registry save on every `save()` call regardless of dirty-tile count — Step 11 says "`save()` calls `saveRegistry()` once at the end." If `save()` is called but no tiles are dirty (incremental save skips them), a newly-registered source not yet associated with any tile cell would still have its registry entry written — which is correct. However if `registerSource()` is called in a context where `save()` is never subsequently called (e.g., an error before tiles are dirtied), the registry entry is lost. Consider documenting that registry persistence is tied to the `save()` call and that callers must ensure `save()` is invoked after registration to avoid orphaned registry entries. — `plan.md:127`
+- [ ] (suggestion) `markDirty()` language in step 7 says "both" but there are now three rasters — Step 2 correctly says "update `dirty()`/`clearDirty()`/`markDirty()` to operate on both [value + time rasters]"; step 7 adds the source raster but doesn't revisit the dirty semantics to say "all three." The implementation will need all three rasters' dirty flags coordinated; the plan text should say "all three" to avoid an implementor reading step 2 and step 7 independently missing the source raster in the dirty path. — `plan.md:57`

--- a/.agent/work-plans/issue-178/progress.md
+++ b/.agent/work-plans/issue-178/progress.md
@@ -137,3 +137,49 @@ a known environment issue — not real correctness; gtest is green).
 - Atomic registry write (write-then-rename) and uint16 interning / index-0-reserved / overflow-at-65535 / idempotency all correct.
 - ADR-0002 amendment internally consistent: D5 rewritten to three tiles, old "source layer is not a band" reasoning explicitly superseded, D6 covers all three files; remaining "3-band" mentions are correct historical context.
 - Static analysis: ament_cpplint / ament_copyright / ament_xmllint clean. cppcheck "unusedStructMember" / "useStlAlgorithm" are header-isolation false positives on unchanged lines. Local uncrustify-0.78.1 mass-fail is the known CI-drift environment issue (gtest 41/41 green is the source of truth).
+
+## Implementation (Pre-Push Robustness Fold-In)
+**Status**: complete
+**When**: 2026-06-20 +00:00
+**By**: Claude Code Agent (Claude Sonnet 4.6)
+
+**Commit**: `420d189` on `feature/issue-178`
+
+### What changed
+
+All 4 pre-push suggestions from the Local Review folded before push:
+
+1. **registry.cpp `loadRegistry` index validation** — validate the stored `"index"`
+   field against expected position (must be 1-based, contiguous, +1 per entry).
+   Throws `std::runtime_error` naming the offending `source_id` on mismatch or
+   missing field.  Tests: `LoadRegistryRejectsReorderedIndex`,
+   `LoadRegistryRejectsMissingIndexField`.
+
+2. **tile_io.cpp `loadTile` legacy 3-band guard** — probe via `tileRasterCount()`
+   before loading.  A value tile with exactly 3 bands is rejected with a clear
+   error explaining it is a pre-#178 tile that must be regenerated.  Keeps GDAL
+   encapsulated: `tileRasterCount(path)` is a new non-template free function added
+   to `marine_tiled_raster_store/tile_io.hpp+cpp`.  Test:
+   `LoadTileRejectsLegacyThreeBandValueTile`.
+
+3. **tile_io.cpp `saveTile` value-first ordering comment** — documents the
+   value→time→source non-atomic write order and the rationale (safety query reads
+   value tile only; 0-fill on missing companions is the correct degraded-mode
+   behaviour).  Comment-only change; no test needed.
+
+4. **tile_io.cpp `loadTile` GridIndex consistency** — after loading each companion
+   tile (time, source), check `companion.index() == grid`; throw a clear error on
+   mismatch (closes a file-tampering/mis-rename hole).  Test:
+   `LoadTileRejectsCompanionWithWrongGrid`.
+
+### Build / test result
+Clean build of both packages. gtest XML (source of truth):
+- marine_tiled_raster_store/test_tile_io: 6/6 pass
+- marine_bathymetry_store/test_store: 12/12 pass
+- marine_bathymetry_store/test_query: 10/10 pass
+- marine_bathymetry_store/test_tile_io: 17/17 pass (was 13; +4 new tests)
+Total 45/45 gtests pass.
+Uncrustify: 2 local 0.78.1 drift failures (known environment issue, not real).
+
+### Left / follow-ups
+None — all 4 suggestions addressed. Branch is ready to push.

--- a/docs/decisions/0002-bathymetric-data-store.md
+++ b/docs/decisions/0002-bathymetric-data-store.md
@@ -11,6 +11,18 @@ single-level Phase-1 implementation ([#143](https://github.com/rolker/unh_marine
 is a simplification, not a load-bearing decision; multi-level storage with a level-aware
 query is adopted now, with the refinement policy staged.
 
+**Amended 2026-06-20 ([#178](https://github.com/rolker/unh_marine_autonomy/issues/178)):**
+D5 (per-tile persistence) is revised — the timestamp moves out of the value tile
+into a **separate `Int64` nanoseconds tile** (`<grid>_time.tif`), depth and
+uncertainty stay co-located in a **2-band `Float64` value tile**, and a
+**per-cell source-index band** (`UInt16`, `<grid>_source.tif`) is re-added with a
+store-wide `registry.json` sidecar. This reconciles ADR-0002 with the now-merged
+**[ADR-0005](0005-multi-platform-provenance-registry.md) D2/D8** (multi-platform
+provenance registry) and aligns the on-disk encodings with
+**[ADR-0006](0006-multi-platform-backscatter-store.md)** (backscatter store: same
+`Int64`-ns time tile and `uint16` source band). D6 (content hash) is updated to
+cover all three tile files. See D5/D6 below.
+
 The full design is in the issue body; this ADR records the load-bearing
 architecture decisions and their rationale so they survive the issue. It is a
 **cross-cutting** decision in the sense ADR-0001 establishes for this repo's
@@ -115,6 +127,14 @@ Default query returns the highest-priority source present per cell. A separate
 draft never overwrites a trusted processed value, and a later processed import
 supersedes draft without data loss.
 
+(Amended 2026-06-20, [#178](https://github.com/rolker/unh_marine_autonomy/issues/178):
+"source layer" above is the **quality/maturity** axis. A second, orthogonal
+**platform/sensor provenance** axis — a per-cell source index into a
+`registry.json` sidecar — is added per
+[ADR-0005](0005-multi-platform-provenance-registry.md) D2/D8; see D5. The
+navigation-safety **shallowest-reliable** query deliberately ignores the
+provenance axis (ADR-0005 D5 carve-out): it selects on depth + uncertainty only.)
+
 ### D4 — All depths on the WGS84 ellipsoid; datum conversion happens at import
 
 The store holds a single vertical reference: **ellipsoidal height (WGS84)**.
@@ -134,27 +154,49 @@ stored mixed:
 Storing one datum and converting at the edge keeps every query datum-consistent
 and confines datum logic to the importers.
 
-### D5 — Persistence: one GeoTIFF per dirty GGGS tile
+### D5 — Persistence: per-tile GeoTIFFs per dirty GGGS tile
 
-Persist each dirty tile as a **multi-band GeoTIFF** named by its `GridIndex`.
-The bands are **depth, uncertainty, timestamp** (3 bands); the **source layer is
-not a band** — it is encoded as the on-disk subdirectory (`processed/`,
-`draft/`), because a tile is single-layer by construction (the store keeps one
-tile map per layer, D3), so a per-cell source band would be a constant and pure
-overhead. (As-built in the Phase-1 store, #141; this supersedes an earlier draft
-of this section that listed a 4th `source` band.) Bands are `Float64` so the
-absolute-Unix-seconds timestamp keeps usable precision — a single GeoTIFF has one
-band data type, so depth/uncertainty ride along as `Float64` too. Rationale:
-GeoTIFF I/O relies on GDAL, which the bathy-BAG / GeoTIFF importer tooling
-already uses (Phase 1 brings that dependency into the store itself); GeoTIFF
-carries its own georeferencing; per-tile files make incremental ("save only dirty
-tiles") and
-the distribution manifest (D6) fall out naturally — the manifest is
-`{GridIndex → version}`, and **version is a content hash of the tile's cell
-data** (not file mtime: mtime is unreliable across the clock-skewed robot and
-operator machines that D6 sync compares, so it cannot be the interoperability
-key). An mtime check may still be used as a cheap *local* dirty-detection
-optimization, but the hash is the authoritative sync version.
+Persist each dirty tile as **three GeoTIFFs** named by its `GridIndex`
+(amended 2026-06-20, [#178](https://github.com/rolker/unh_marine_autonomy/issues/178);
+the original [#141](https://github.com/rolker/unh_marine_autonomy/issues/141)
+form was a single 3-band `Float64` GeoTIFF):
+
+- `<level>_<row>_<col>.tif` — **2-band `Float64` value tile**: depth +
+  uncertainty. Both are float and read together on the costmap hot path (D7), so
+  they stay co-located. NaN no-data on both bands.
+- `<level>_<row>_<col>_time.tif` — **1-band `Int64` time tile**: timestamp in
+  nanoseconds since the Unix epoch. This is ROS-native (`rclcpp::Time` is int64
+  ns) and exact; the earlier `Float64` absolute-Unix-seconds band resolved 2026
+  stamps to only ~0.4 µs. Time is a different dtype and a *cold* access (not in
+  the nav loop), so it earns its own tile. 0 = unset (no no-data tag). Requires
+  GDAL >= 3.5 for `GDT_Int64` (the workspace targets >= 3.8).
+- `<level>_<row>_<col>_source.tif` — **1-band `UInt16` source-index tile**: the
+  per-cell **local source index** into the store-wide `registry.json`
+  (cross-ref [ADR-0005](0005-multi-platform-provenance-registry.md) D2/D8). 0 =
+  no-data/unset (ADR-0005 D4 sentinel).
+
+**The source layer is now two distinct axes.** The **quality/maturity** axis
+(Processed / Draft / Chart, D3) remains encoded as the on-disk subdirectory
+(`processed/`, `draft/`, `chart/`). The **platform/sensor provenance** axis is the
+per-cell source index + the `registry.json` sidecar. This re-adds a per-cell
+source band — superseding the original D5 reasoning that a tile is single-layer
+by construction so a source band would be a constant: under ADR-0005 D2,
+different platforms contribute different cells of the *same* GGGS tile, so the
+winning source is **non-constant within a tile**. (Pre-#178 single-platform data
+has no `_time.tif` / `_source.tif`; on load those bands fill with 0 — backward
+compatible.) Rationale for the file split: each band's dtype gets its native
+GeoTIFF representation (a single GeoTIFF has one band dtype), and the hot-path
+costmap reader opens only the 2-band value tile.
+
+Rationale (unchanged): GeoTIFF I/O relies on GDAL, which the bathy-BAG / GeoTIFF
+importer tooling already uses (Phase 1 brings that dependency into the store
+itself); GeoTIFF carries its own georeferencing; per-tile files make incremental
+("save only dirty tiles") and the distribution manifest (D6) fall out naturally —
+the manifest is `{GridIndex → version}`, and **version is a content hash of the
+tile's cell data** (not file mtime: mtime is unreliable across the clock-skewed
+robot and operator machines that D6 sync compares, so it cannot be the
+interoperability key). An mtime check may still be used as a cheap *local*
+dirty-detection optimization, but the hash is the authoritative sync version.
 On startup, load persisted tiles; save incrementally as data arrives. A raw
 binary tile format is the fallback **only if** GeoTIFF write amplification proves
 too costly; that change would not alter the manifest contract. This decision is
@@ -175,6 +217,15 @@ the property the monolithic `GridMap` downlink lacked. Distribution is the last
 implementation phase and stays **deferred past the June 15 survey**; `clear_grid`
 remains the agreed interim. The store core is nonetheless designed so the sync
 layer is additive.
+
+**Content hash covers all three tile files** (amended 2026-06-20,
+[#178](https://github.com/rolker/unh_marine_autonomy/issues/178)). With D5 now
+persisting a tile as a value (`<grid>.tif`), time (`<grid>_time.tif`), and source
+(`<grid>_source.tif`) file, the per-tile **version** hash must cover the cell
+data of **all three** so a re-arbitration that flips a cell's winning source (or
+updates its timestamp) flips the tile hash and re-syncs — not just a depth change.
+No Phase-1 hash implementation exists yet, so this is a forward constraint on the
+deferred D6 sync layer, not a current code change.
 
 ### D7 — Consumers depend on the store, not on sources
 

--- a/marine_bathymetry_store/CMakeLists.txt
+++ b/marine_bathymetry_store/CMakeLists.txt
@@ -75,7 +75,9 @@ if(BUILD_TESTING)
   target_link_libraries(test_query ${PROJECT_NAME})
 
   ament_add_gtest(test_tile_io test/test_tile_io.cpp)
-  target_link_libraries(test_tile_io ${PROJECT_NAME})
+  # nlohmann_json is used directly in the test (registry tamper fixtures);
+  # link it explicitly since it is PRIVATE in the library target.
+  target_link_libraries(test_tile_io ${PROJECT_NAME} nlohmann_json::nlohmann_json)
 endif()
 
 ament_package()

--- a/marine_bathymetry_store/CMakeLists.txt
+++ b/marine_bathymetry_store/CMakeLists.txt
@@ -16,10 +16,15 @@ find_package(marine_autonomy REQUIRED)
 # marine_tiled_raster_store, which carries (and re-exports) the GDAL dependency.
 find_package(marine_tiled_raster_store REQUIRED)
 find_package(geographic_msgs REQUIRED)
+# nlohmann_json backs the source registry (registry.json sidecar, #178). Declared
+# explicitly here (and in package.xml) — it was only available transitively
+# before, which is not a dependency this package may rely on.
+find_package(nlohmann_json REQUIRED)
 
 add_library(${PROJECT_NAME}
   src/bathymetry_store.cpp
   src/query.cpp
+  src/registry.cpp
   src/tile_io.cpp
 )
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
@@ -36,6 +41,11 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   marine_autonomy::marine_autonomy
   marine_tiled_raster_store::marine_tiled_raster_store
   ${geographic_msgs_TARGETS}
+)
+# nlohmann_json is header-only and used only inside registry.cpp (the public
+# registry.hpp keeps it out of its interface), so link it PRIVATE.
+target_link_libraries(${PROJECT_NAME} PRIVATE
+  nlohmann_json::nlohmann_json
 )
 
 # Headers are laid out as include/${PROJECT_NAME}/*.hpp, so install the include/

--- a/marine_bathymetry_store/include/marine_bathymetry_store/bathy_cell.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/bathy_cell.hpp
@@ -60,23 +60,32 @@ inline constexpr std::size_t source_layer_count = source_layers_by_priority.size
 
 /// @brief Per-cell bathymetric record.
 ///
-/// All fields are `double`. Depth/uncertainty don't need the range, but the
-/// **timestamp does**: an absolute Unix-seconds timestamp (~1.8e9 in 2026) in
-/// `float` resolves to ~128 s granularity, which would silently coarsen the
-/// staleness information the costmap will eventually rely on (ADR-0002 §D7).
-/// Keeping the whole record `double` (and persisting as a `Float64` GeoTIFF)
-/// avoids that trap without per-tile epoch bookkeeping. The cost is denser
-/// tiles (≈22 MB per fully-allocated 960×960 tile); see `BathymetryTile`.
+/// `depth` and `uncertainty` are `double` (a 2-band `Float64` value tile); the
+/// **timestamp is `int64_t` nanoseconds since the Unix epoch** (ROS-native:
+/// `rclcpp::Time` is int64 ns), persisted as a separate 1-band `Int64` tile so
+/// it keeps nanosecond exactness (a `Float64` seconds band resolved absolute
+/// 2026 stamps to only ~0.4 µs). The `source_index` is a small interning handle
+/// into the store-wide `registry.json` (ADR-0005 D2/D8): which platform/sensor
+/// contributed this cell. 0 = no-data/unset (ADR-0005 D4 sentinel) and is the
+/// default for pre-existing single-platform data. The on-disk layout is three
+/// tiles per grid — value (`<grid>.tif`), time (`<grid>_time.tif`), and source
+/// (`<grid>_source.tif`); see `BathymetryTile` and `tile_io`.
 struct BathyCell
 {
   /// Ellipsoidal height (WGS84), metres. NaN = no data.
   double depth = std::numeric_limits<double>::quiet_NaN();
   /// 1-sigma vertical uncertainty, metres. NaN = unknown.
   double uncertainty = std::numeric_limits<double>::quiet_NaN();
-  /// Acquisition / import time, seconds since the Unix epoch. 0 = unset.
-  double timestamp = 0.0;
+  /// Acquisition / import time, nanoseconds since the Unix epoch. 0 = unset.
+  int64_t timestamp = 0;
+  /// Local source index into the store-wide registry. 0 = no-data/unset.
+  uint16_t source_index = 0;
 
   /// @brief True if this cell carries a usable depth (depth is not NaN).
+  ///
+  /// Data presence is **depth-only**: `source_index` is provenance, not a
+  /// data-presence signal, so a cell with a registered source but NaN depth is
+  /// still no-data.
   bool hasData() const noexcept
   {
     return !std::isnan(depth);

--- a/marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_store.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_store.hpp
@@ -36,11 +36,14 @@ namespace marine_bathymetry_store
 {
 
 class BathymetryStore;
+class SourceRegistry;
 // Persistence free functions (defined in tile_io.cpp). Forward-declared here so
 // the store can friend them: `load` must populate any layer — including the
 // read-only `Chart` prior — from disk, which the public API otherwise forbids.
-std::size_t save(BathymetryStore & store, const std::string & dir);
-std::size_t load(BathymetryStore & store, const std::string & dir);
+std::size_t save(
+  BathymetryStore & store, const std::string & dir, const SourceRegistry * registry);
+std::size_t load(
+  BathymetryStore & store, const std::string & dir, SourceRegistry * registry);
 
 /// @brief In-memory, GGGS-tiled, multi-layer bathymetric store (Phase 1 core).
 ///
@@ -116,8 +119,10 @@ public:
 private:
   // Persistence needs to populate any layer (including the read-only Chart
   // prior) from disk, so the free functions in tile_io.cpp are friends.
-  friend std::size_t save(BathymetryStore & store, const std::string & dir);
-  friend std::size_t load(BathymetryStore & store, const std::string & dir);
+  friend std::size_t save(
+    BathymetryStore & store, const std::string & dir, const SourceRegistry * registry);
+  friend std::size_t load(
+    BathymetryStore & store, const std::string & dir, SourceRegistry * registry);
 
   /// @brief Find or create the tile for @p grid in @p layer.
   ///

--- a/marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_tile.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_tile.hpp
@@ -37,50 +37,74 @@ namespace marine_bathymetry_store
 
 /// @brief One GGGS grid (960×960 cells) of bathymetric data for a single layer.
 ///
-/// A thin, bathy-semantic wrapper over `marine_tiled_raster_store::
-/// TiledRasterTile<double>` (the generic GGGS-tiled raster, #172): three
-/// `Float64` bands — **depth**, **uncertainty**, **timestamp** — in that order,
-/// matching the GeoTIFF band layout (`tile_io`). The generic tile owns the
-/// storage, dirty flag, and GGGS-cell-order layout (row 0 = south); this wrapper
-/// adds the per-cell `BathyCell` record and the named band accessors the store
-/// and persistence rely on. A fully-allocated tile holds 3 × 960 × 960 doubles
-/// ≈ 22 MB (see `BathyCell` for why `double`); tiles are allocated lazily by the
-/// owning `BathymetryStore`.
+/// A bathy-semantic wrapper over **three** `marine_tiled_raster_store::
+/// TiledRasterTile<>` rasters (#172), one per on-disk tile file (#178):
+///
+/// - **value** (`TiledRasterTile<double>`, 2 bands): depth + uncertainty — both
+///   float, read together on the costmap hot path, so co-located.
+/// - **time** (`TiledRasterTile<int64_t>`, 1 band): timestamp ns — different
+///   dtype, cold access, so its own tile (ROS-native, exact).
+/// - **source** (`TiledRasterTile<uint16_t>`, 1 band): registry source index —
+///   different dtype, multi-platform provenance (ADR-0005 D2/D8).
+///
+/// Each generic tile owns its storage and GGGS-cell-order layout (row 0 = south);
+/// this wrapper adds the per-cell `BathyCell` record and the named band accessors
+/// the store and persistence rely on. The **value raster's dirty flag is
+/// authoritative** for the whole tile: `set()` marks it; `clearDirty()` /
+/// `markDirty()` operate through it; persistence writes/clears all three rasters
+/// together. Tiles are allocated lazily by the owning `BathymetryStore`.
 class BathymetryTile
 {
 public:
-  /// @brief The underlying generic raster tile type.
+  /// @brief The underlying generic raster tile type for depth + uncertainty.
   using Raster = marine_tiled_raster_store::TiledRasterTile<double>;
+  /// @brief The underlying raster type for the timestamp tile (int64 ns).
+  using TimeRaster = marine_tiled_raster_store::TiledRasterTile<int64_t>;
+  /// @brief The underlying raster type for the source-index tile (uint16).
+  using SourceRaster = marine_tiled_raster_store::TiledRasterTile<uint16_t>;
 
   /// @brief Number of cells along each grid edge (GGGS constant).
   static constexpr uint16_t edge = Raster::edge;
   /// @brief Total cells in a tile (edge × edge).
   static constexpr uint32_t cell_count = Raster::cell_count;
 
-  /// @brief Construct an empty tile for @p index (depth/uncertainty no-data, ts 0).
+  /// @brief Number of bands in each on-disk tile file.
+  /// @{
+  static constexpr std::size_t value_band_count = 2;   ///< depth + uncertainty
+  static constexpr std::size_t time_band_count = 1;    ///< timestamp ns
+  static constexpr std::size_t source_band_count = 1;  ///< source index
+  /// @}
+
+  /// @brief Construct an empty tile for @p index (depth/uncertainty no-data, ts
+  ///        and source 0 = unset).
   explicit BathymetryTile(gggs::GridIndex index)
-  : tile_(index, std::vector<double>{
+  : value_(index, std::vector<double>{
       std::numeric_limits<double>::quiet_NaN(),    // depth
-      std::numeric_limits<double>::quiet_NaN(),    // uncertainty
-      0.0})                                        // timestamp (0 = unset)
+      std::numeric_limits<double>::quiet_NaN()}),  // uncertainty
+    time_(index, time_band_count, int64_t{0}),     // timestamp (0 = unset)
+    source_(index, source_band_count, uint16_t{0})  // source index (0 = unset)
   {
   }
 
-  /// @brief Wrap a generic raster tile loaded from disk (persistence path).
-  explicit BathymetryTile(Raster tile)
-  : tile_(std::move(tile)) {}
+  /// @brief Wrap rasters loaded from disk (persistence path).
+  ///
+  /// The three rasters must cover the same grid; the value raster's grid is
+  /// authoritative for `index()`. The constructed tile is clean.
+  BathymetryTile(Raster value, TimeRaster time, SourceRaster source)
+  : value_(std::move(value)), time_(std::move(time)), source_(std::move(source)) {}
 
   /// @brief The grid this tile covers.
-  const gggs::GridIndex & index() const noexcept {return tile_.index();}
+  const gggs::GridIndex & index() const noexcept {return value_.index();}
 
   /// @brief Write a cell at (@p row, @p col) within the grid; marks the tile dirty.
   void set(uint16_t row, uint16_t col, const BathyCell & cell)
   {
     const uint32_t i = offset(row, col);
-    tile_.band(kDepth)[i] = cell.depth;
-    tile_.band(kUncertainty)[i] = cell.uncertainty;
-    tile_.band(kTimestamp)[i] = cell.timestamp;
-    tile_.markDirty();
+    value_.band(kDepth)[i] = cell.depth;
+    value_.band(kUncertainty)[i] = cell.uncertainty;
+    time_.band(0)[i] = cell.timestamp;
+    source_.band(0)[i] = cell.source_index;
+    value_.markDirty();   // value raster's dirty flag is authoritative
   }
 
   /// @brief Read the cell at (@p row, @p col) within the grid.
@@ -88,31 +112,38 @@ public:
   {
     const uint32_t i = offset(row, col);
     return BathyCell{
-      tile_.band(kDepth)[i], tile_.band(kUncertainty)[i], tile_.band(kTimestamp)[i]};
+      value_.band(kDepth)[i], value_.band(kUncertainty)[i],
+      time_.band(0)[i], source_.band(0)[i]};
   }
 
-  /// @brief Whether this tile has unsaved changes.
-  bool dirty() const noexcept {return tile_.dirty();}
+  /// @brief Whether this tile has unsaved changes (value raster is authoritative).
+  bool dirty() const noexcept {return value_.dirty();}
   /// @brief Mark all changes saved (called by persistence after a successful write).
-  void clearDirty() noexcept {tile_.clearDirty();}
+  void clearDirty() noexcept {value_.clearDirty();}
   /// @brief Force the dirty flag (used when reconstructing a tile in memory).
-  void markDirty() noexcept {tile_.markDirty();}
+  void markDirty() noexcept {value_.markDirty();}
 
   /// @brief Raw band accessors (row-major, GGGS cell order) for persistence.
   /// @{
-  const std::vector<double> & depthBand() const noexcept {return tile_.band(kDepth);}
+  const std::vector<double> & depthBand() const noexcept {return value_.band(kDepth);}
   const std::vector<double> & uncertaintyBand() const noexcept
-  {return tile_.band(kUncertainty);}
-  const std::vector<double> & timestampBand() const noexcept {return tile_.band(kTimestamp);}
-  std::vector<double> & depthBand() noexcept {return tile_.band(kDepth);}
-  std::vector<double> & uncertaintyBand() noexcept {return tile_.band(kUncertainty);}
-  std::vector<double> & timestampBand() noexcept {return tile_.band(kTimestamp);}
+  {return value_.band(kUncertainty);}
+  const std::vector<int64_t> & timestampBand() const noexcept {return time_.band(0);}
+  const std::vector<uint16_t> & sourceBand() const noexcept {return source_.band(0);}
+  std::vector<double> & depthBand() noexcept {return value_.band(kDepth);}
+  std::vector<double> & uncertaintyBand() noexcept {return value_.band(kUncertainty);}
+  std::vector<int64_t> & timestampBand() noexcept {return time_.band(0);}
+  std::vector<uint16_t> & sourceBand() noexcept {return source_.band(0);}
   /// @}
 
-  /// @brief The underlying generic raster tile (for persistence delegation).
+  /// @brief The underlying generic raster tiles (for persistence delegation).
   /// @{
-  Raster & raster() noexcept {return tile_;}
-  const Raster & raster() const noexcept {return tile_;}
+  Raster & valueRaster() noexcept {return value_;}
+  const Raster & valueRaster() const noexcept {return value_;}
+  TimeRaster & timeRaster() noexcept {return time_;}
+  const TimeRaster & timeRaster() const noexcept {return time_;}
+  SourceRaster & sourceRaster() noexcept {return source_;}
+  const SourceRaster & sourceRaster() const noexcept {return source_;}
   /// @}
 
   /// @brief Row-major offset of cell (@p row, @p col). Asserts in debug builds.
@@ -121,9 +152,10 @@ public:
 private:
   static constexpr std::size_t kDepth = 0;
   static constexpr std::size_t kUncertainty = 1;
-  static constexpr std::size_t kTimestamp = 2;
 
-  Raster tile_;
+  Raster value_;
+  TimeRaster time_;
+  SourceRaster source_;
 };
 
 }  // namespace marine_bathymetry_store

--- a/marine_bathymetry_store/include/marine_bathymetry_store/query.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/query.hpp
@@ -22,6 +22,7 @@
 #ifndef MARINE_BATHYMETRY_STORE__QUERY_HPP_
 #define MARINE_BATHYMETRY_STORE__QUERY_HPP_
 
+#include <cstdint>
 #include <functional>
 #include <optional>
 
@@ -42,7 +43,7 @@ struct DepthSample
 {
   double depth;          ///< Ellipsoidal height (WGS84, m, up-positive).
   double uncertainty;    ///< 1-sigma vertical uncertainty (m).
-  double timestamp;      ///< Acquisition / import time (Unix seconds).
+  int64_t timestamp;     ///< Acquisition / import time (ns since the Unix epoch).
   SourceLayer source;    ///< Which layer this value came from.
 };
 

--- a/marine_bathymetry_store/include/marine_bathymetry_store/registry.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/registry.hpp
@@ -1,0 +1,115 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef MARINE_BATHYMETRY_STORE__REGISTRY_HPP_
+#define MARINE_BATHYMETRY_STORE__REGISTRY_HPP_
+
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+/// @file
+/// @brief Store-wide source registry: maps each per-cell `source_index` to a
+/// provenance record (ADR-0005 D2/D8). Persisted as `registry.json` at the store
+/// root with an atomic write-then-rename.
+
+namespace marine_bathymetry_store
+{
+
+/// @brief One source's provenance record.
+///
+/// `source_id` is the origin-namespaced, never-reused wide id (ADR-0005 D4); the
+/// remaining fields are the ADR-0005 D3 core schema plus the bathy-specific
+/// `datum` extension (the converted-from vertical reference, ADR-0002 §D4). The
+/// `source_id` is the **identity** of a record — `registerSource` is idempotent
+/// on it (re-registering the same `source_id` returns the existing index).
+struct SourceRecord
+{
+  std::string source_id;     ///< Origin-namespaced wide id (ADR-0005 D4).
+  std::string platform;      ///< Contributing platform (e.g. "bizzy").
+  std::string sensor;        ///< Contributing sensor (e.g. "m3").
+  std::string sensor_class;  ///< Sensor class (e.g. "multibeam").
+  std::string campaign;      ///< Acquisition campaign / deployment.
+  std::string datum;         ///< Bathy extension: converted-from vertical datum.
+};
+
+/// @brief Interns `SourceRecord`s to small local indices and persists them.
+///
+/// Index 0 is reserved as the **no-data/unset sentinel** (ADR-0005 D4) and is
+/// never assigned to a real record; the first registered source gets index 1.
+/// Indices are assigned densely in registration order and are stable for the
+/// life of the store directory (they are the values written into the per-cell
+/// source-index tiles, so reassigning them would corrupt existing tiles).
+class SourceRegistry
+{
+public:
+  /// @brief The reserved no-data/unset source index.
+  static constexpr uint16_t kUnset = 0;
+
+  /// @brief Intern @p record, returning its local index; idempotent on `source_id`.
+  ///
+  /// If a record with the same `source_id` is already registered, its existing
+  /// index is returned (the rest of @p record is ignored). Otherwise a new index
+  /// (the next unused value, starting at 1) is assigned and returned.
+  ///
+  /// @note A registered source is held only in memory until persisted: call
+  ///   `BathymetryStore` `save()` (which invokes `saveRegistry()`), or
+  ///   `saveRegistry()` directly, to write it. A registration with no subsequent
+  ///   save is lost. Registry persistence is intentionally tied to the store's
+  ///   save lifecycle.
+  /// @throws std::overflow_error if all 65535 real indices are exhausted.
+  uint16_t registerSource(const SourceRecord & record);
+
+  /// @brief Look up the record for @p index, or `std::nullopt` if unregistered
+  ///        (including `index == kUnset`).
+  std::optional<SourceRecord> lookup(uint16_t index) const;
+
+  /// @brief Number of registered sources (excludes the reserved index 0).
+  std::size_t size() const noexcept {return by_index_.size();}
+
+  /// @brief Whether any source is registered.
+  bool empty() const noexcept {return by_index_.empty();}
+
+  /// @brief Write `registry.json` under @p store_root_dir atomically.
+  ///
+  /// Writes `registry.json.tmp` then `std::filesystem::rename()`s it over
+  /// `registry.json`, so a crash mid-write never leaves a partial file. Creates
+  /// @p store_root_dir if needed.
+  /// @throws std::runtime_error / std::filesystem::filesystem_error on failure.
+  void saveRegistry(const std::string & store_root_dir) const;
+
+  /// @brief Load `registry.json` from @p store_root_dir, replacing current
+  ///        contents. No-op (leaves the registry empty) if the file is absent.
+  /// @throws std::runtime_error on a malformed registry file.
+  void loadRegistry(const std::string & store_root_dir);
+
+private:
+  /// index (1-based) -> record. by_index_[i] is the record for index i+1.
+  std::vector<SourceRecord> by_index_;
+  /// source_id -> local index, for idempotent registration / lookup.
+  std::map<std::string, uint16_t> by_source_id_;
+};
+
+}  // namespace marine_bathymetry_store
+
+#endif  // MARINE_BATHYMETRY_STORE__REGISTRY_HPP_

--- a/marine_bathymetry_store/include/marine_bathymetry_store/tile_io.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/tile_io.hpp
@@ -29,19 +29,28 @@
 #include "marine_bathymetry_store/bathy_cell.hpp"
 #include "marine_bathymetry_store/bathymetry_store.hpp"
 #include "marine_bathymetry_store/bathymetry_tile.hpp"
+#include "marine_bathymetry_store/registry.hpp"
 
 /// @file
-/// @brief Per-tile GeoTIFF persistence (ADR-0002 §D5).
+/// @brief Per-tile GeoTIFF persistence (ADR-0002 §D5, amended by #178).
 ///
-/// Each tile is one 3-band `Float64` GeoTIFF (depth, uncertainty, timestamp),
-/// WGS84-georeferenced from its GGGS grid corners. The file carries no source
-/// field — the layer is encoded as the subdirectory (`processed/`, `draft/`).
-/// The GeoTIFF is written north-up (raster row 0 = north), so persistence flips
-/// rows relative to the in-memory GGGS cell order (row 0 = south).
+/// Each GGGS tile is persisted as **three** GeoTIFFs, all WGS84-georeferenced
+/// from the same grid corners and written north-up (raster row 0 = north), so
+/// persistence flips rows relative to the in-memory GGGS cell order
+/// (row 0 = south):
 ///
-/// `Float64` (not `Float32`) is deliberate: the timestamp band holds absolute
-/// Unix seconds, which `float` cannot represent at usable resolution. A single
-/// GeoTIFF has one band data type, so all three bands are `Float64`.
+/// - `<level>_<row>_<col>.tif` — 2-band `Float64` value tile (depth,
+///   uncertainty), NaN no-data on both.
+/// - `<level>_<row>_<col>_time.tif` — 1-band `Int64` timestamp tile
+///   (nanoseconds since epoch, ROS-native and exact; 0 = unset, no no-data tag).
+/// - `<level>_<row>_<col>_source.tif` — 1-band `UInt16` source-index tile
+///   (registry index, ADR-0005 D2/D8; 0 = no-data/unset).
+///
+/// The quality/maturity axis (Processed / Draft / Chart) is still encoded as the
+/// on-disk subdirectory (`processed/`, `draft/`, `chart/`); the platform/sensor
+/// provenance axis moves to the per-cell source index + the store-wide
+/// `registry.json` (ADR-0005 D8). On load, a missing `_time.tif` / `_source.tif`
+/// (pre-migration single-platform data) fills timestamp / source_index with 0.
 ///
 /// @note Round-trip persistence is validated for **non-polar** latitudes
 /// (|lat| < 72°), the intended lake/coastal survey envelope. Near GGGS's polar
@@ -54,45 +63,62 @@
 namespace marine_bathymetry_store
 {
 
-/// @brief GeoTIFF filename (no directory) for a grid: `<level>_<row>_<col>.tif`.
+/// @brief GeoTIFF filename (no directory) for a grid's **value** tile:
+///        `<level>_<row>_<col>.tif`.
 std::string tileFilename(const gggs::GridIndex & grid);
 
 /// @brief Subdirectory name for a source layer (`"processed"` / `"draft"`).
 std::string layerDirName(SourceLayer layer);
 
-/// @brief Write one tile as a 3-band Float64 GeoTIFF at @p path.
+/// @brief Write one tile as three GeoTIFFs derived from the value-tile @p path.
+///
+/// @p path is the value tile (`<grid>.tif`); the `_time.tif` and `_source.tif`
+/// companions are written alongside it (same directory, suffixed stem).
 /// @throws std::runtime_error on any GDAL failure.
 void saveTile(const BathymetryTile & tile, const std::string & path);
 
-/// @brief Load a tile GeoTIFF, reconstructing its GridIndex at @p level.
+/// @brief Load a tile from its three GeoTIFFs, reconstructing its GridIndex at
+///        @p level.
 ///
-/// The grid is recovered from the file's geotransform (the cell center maps
-/// back through @p level), so a file written at a different level is rejected.
-/// The returned tile is clean (not dirty).
+/// @p path is the value tile (`<grid>.tif`); the `_time.tif` and `_source.tif`
+/// companions are read from the derived paths. A **missing** companion fills the
+/// corresponding band with 0 (pre-migration backward compatibility). The grid is
+/// recovered from the value file's geotransform (the cell center maps back
+/// through @p level), so a file written at a different level is rejected. The
+/// returned tile is clean (not dirty).
 /// @throws std::runtime_error on GDAL failure, wrong dimensions, or a
 ///         geotransform that doesn't match any grid at @p level.
 BathymetryTile loadTile(const std::string & path, const gggs::Level & level);
 
 /// @brief Persist every **dirty** tile of @p store under @p dir, then clear
-///        their dirty flags.
+///        their dirty flags. Also writes the store-wide `registry.json`.
 ///
-/// Layout: `<dir>/<layer>/<level>_<row>_<col>.tif`. Creates directories as
-/// needed. Clean tiles are skipped (incremental save).
+/// Layout: `<dir>/<layer>/<level>_<row>_<col>{,_time,_source}.tif`, plus
+/// `<dir>/registry.json`. Creates directories as needed. Clean tiles are skipped
+/// (incremental save). The registry (a store-wide sidecar, not per-layer) is
+/// written once at the end via @p registry; pass `nullptr` to skip it (e.g. a
+/// caller with no registry to persist).
 /// @return The number of tiles written.
 /// @throws std::runtime_error on any GDAL failure; std::filesystem::filesystem_error
 ///         (a std::runtime_error subclass) on a directory-creation failure.
-std::size_t save(BathymetryStore & store, const std::string & dir);
+std::size_t save(
+  BathymetryStore & store, const std::string & dir,
+  const SourceRegistry * registry = nullptr);
 
-/// @brief Load every tile found under @p dir into @p store.
+/// @brief Load every tile found under @p dir into @p store, plus the registry.
 ///
-/// Scans `<dir>/<layer>/*.tif` for each known layer. @p store must already be
-/// at the level the tiles were written at (loadTile enforces per-file).
-/// Loaded tiles are clean.
+/// Scans `<dir>/<layer>/` for value tiles (`<grid>.tif`), **skipping** the
+/// `_time.tif` / `_source.tif` companions (they are loaded with their value
+/// tile). @p store must already be at the level the tiles were written at
+/// (loadTile enforces per-file). If @p registry is non-null, `registry.json` is
+/// loaded into it. Loaded tiles are clean.
 /// @return The number of tiles loaded.
 /// @throws std::runtime_error on any GDAL failure or level mismatch;
 ///         std::filesystem::filesystem_error (a std::runtime_error subclass) on a
 ///         directory-iteration failure.
-std::size_t load(BathymetryStore & store, const std::string & dir);
+std::size_t load(
+  BathymetryStore & store, const std::string & dir,
+  SourceRegistry * registry = nullptr);
 
 }  // namespace marine_bathymetry_store
 

--- a/marine_bathymetry_store/package.xml
+++ b/marine_bathymetry_store/package.xml
@@ -16,6 +16,7 @@
   <depend>marine_autonomy</depend>
   <depend>marine_tiled_raster_store</depend>
   <depend>geographic_msgs</depend>
+  <depend>nlohmann_json</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/marine_bathymetry_store/src/registry.cpp
+++ b/marine_bathymetry_store/src/registry.cpp
@@ -145,17 +145,38 @@ void SourceRegistry::loadRegistry(const std::string & store_root_dir)
   if (sources == doc.end() || !sources->is_array()) {
     return;   // empty / sourceless registry
   }
-  // Records carry an explicit "index"; assign densely in that order. Indices are
-  // expected contiguous from 1 (written that way), so push in array order and
-  // trust the stored index for the by-source-id map.
+  // Records carry an explicit "index"; validate them against the expected
+  // position (1-based, contiguous, monotonically increasing by +1).  A
+  // reordered, sparse, or duplicate hand-edited registry.json would produce
+  // mismatches between the stored index and the reconstructed by_index_ /
+  // by_source_id_ maps — silently delivering wrong provenance.  Reject early
+  // with a clear error rather than silently diverge.
   for (const auto & entry : *sources) {
     SourceRecord r{
       jsonStr(entry, "source_id"), jsonStr(entry, "platform"),
       jsonStr(entry, "sensor"), jsonStr(entry, "sensor_class"),
       jsonStr(entry, "campaign"), jsonStr(entry, "datum")};
-    const uint16_t index = static_cast<uint16_t>(by_index_.size() + 1);
+    // Expected index for this entry (1-based: position 0 → index 1, etc.).
+    const uint16_t expected = static_cast<uint16_t>(by_index_.size() + 1);
+    // Stored index field — must match.
+    const auto idx_it = entry.find("index");
+    if (idx_it == entry.end() || !idx_it->is_number_unsigned()) {
+      throw std::runtime_error(
+              "SourceRegistry::loadRegistry: entry for source_id=\"" + r.source_id +
+              "\" is missing a valid \"index\" field (expected " +
+              std::to_string(expected) + ")");
+    }
+    const uint16_t stored = idx_it->get<uint16_t>();
+    if (stored != expected) {
+      throw std::runtime_error(
+              "SourceRegistry::loadRegistry: entry for source_id=\"" + r.source_id +
+              "\" has stored index " + std::to_string(stored) +
+              " but expected " + std::to_string(expected) +
+              " (indices must be contiguous from 1; the registry may have been"
+              " reordered, has gaps, or contains duplicate entries)");
+    }
     by_index_.push_back(r);
-    by_source_id_.emplace(r.source_id, index);
+    by_source_id_.emplace(r.source_id, expected);
   }
 }
 

--- a/marine_bathymetry_store/src/registry.cpp
+++ b/marine_bathymetry_store/src/registry.cpp
@@ -1,0 +1,162 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "marine_bathymetry_store/registry.hpp"
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+/// @file
+/// @brief `SourceRegistry` implementation: in-memory interning plus atomic
+/// `registry.json` persistence (ADR-0005 D2/D8).
+
+namespace marine_bathymetry_store
+{
+
+namespace
+{
+constexpr const char * kRegistryFile = "registry.json";
+constexpr const char * kRegistryTmpFile = "registry.json.tmp";
+
+nlohmann::json recordToJson(uint16_t index, const SourceRecord & r)
+{
+  return nlohmann::json{
+    {"index", index},
+    {"source_id", r.source_id},
+    {"platform", r.platform},
+    {"sensor", r.sensor},
+    {"sensor_class", r.sensor_class},
+    {"campaign", r.campaign},
+    {"datum", r.datum},
+  };
+}
+
+/// Read a string field, defaulting to empty if absent (forward-compatible load).
+std::string jsonStr(const nlohmann::json & j, const char * key)
+{
+  const auto it = j.find(key);
+  return (it != j.end() && it->is_string()) ? it->get<std::string>() : std::string{};
+}
+}  // namespace
+
+uint16_t SourceRegistry::registerSource(const SourceRecord & record)
+{
+  const auto existing = by_source_id_.find(record.source_id);
+  if (existing != by_source_id_.end()) {
+    return existing->second;
+  }
+  // Indices are 1-based (0 reserved); the next index is size() + 1.
+  if (by_index_.size() >= std::numeric_limits<uint16_t>::max()) {
+    throw std::overflow_error("SourceRegistry: exhausted all 65535 source indices");
+  }
+  const uint16_t index = static_cast<uint16_t>(by_index_.size() + 1);
+  by_index_.push_back(record);
+  by_source_id_.emplace(record.source_id, index);
+  return index;
+}
+
+std::optional<SourceRecord> SourceRegistry::lookup(uint16_t index) const
+{
+  if (index == kUnset || index > by_index_.size()) {
+    return std::nullopt;
+  }
+  return by_index_[static_cast<std::size_t>(index) - 1];
+}
+
+void SourceRegistry::saveRegistry(const std::string & store_root_dir) const
+{
+  namespace fs = std::filesystem;
+  fs::create_directories(store_root_dir);
+
+  nlohmann::json sources = nlohmann::json::array();
+  for (std::size_t i = 0; i < by_index_.size(); ++i) {
+    sources.push_back(recordToJson(static_cast<uint16_t>(i + 1), by_index_[i]));
+  }
+  const nlohmann::json doc{
+    {"version", 1},
+    {"sources", std::move(sources)},
+  };
+
+  const fs::path tmp = fs::path(store_root_dir) / kRegistryTmpFile;
+  const fs::path final = fs::path(store_root_dir) / kRegistryFile;
+  {
+    std::ofstream out(tmp, std::ios::binary | std::ios::trunc);
+    if (!out) {
+      throw std::runtime_error("SourceRegistry::saveRegistry: could not open " + tmp.string());
+    }
+    out << doc.dump(2) << '\n';
+    out.flush();
+    if (!out) {
+      throw std::runtime_error("SourceRegistry::saveRegistry: write failed for " + tmp.string());
+    }
+  }
+  // Atomic publish: rename over the existing registry. rename() on the same
+  // filesystem is atomic, so a reader sees either the old or the new file whole.
+  fs::rename(tmp, final);
+}
+
+void SourceRegistry::loadRegistry(const std::string & store_root_dir)
+{
+  namespace fs = std::filesystem;
+  const fs::path path = fs::path(store_root_dir) / kRegistryFile;
+  if (!fs::is_regular_file(path)) {
+    return;   // fresh store: no registry yet
+  }
+
+  std::ifstream in(path, std::ios::binary);
+  if (!in) {
+    throw std::runtime_error("SourceRegistry::loadRegistry: could not open " + path.string());
+  }
+  nlohmann::json doc;
+  try {
+    in >> doc;
+  } catch (const nlohmann::json::parse_error & e) {
+    throw std::runtime_error(
+            "SourceRegistry::loadRegistry: malformed " + path.string() + ": " + e.what());
+  }
+
+  by_index_.clear();
+  by_source_id_.clear();
+  const auto sources = doc.find("sources");
+  if (sources == doc.end() || !sources->is_array()) {
+    return;   // empty / sourceless registry
+  }
+  // Records carry an explicit "index"; assign densely in that order. Indices are
+  // expected contiguous from 1 (written that way), so push in array order and
+  // trust the stored index for the by-source-id map.
+  for (const auto & entry : *sources) {
+    SourceRecord r{
+      jsonStr(entry, "source_id"), jsonStr(entry, "platform"),
+      jsonStr(entry, "sensor"), jsonStr(entry, "sensor_class"),
+      jsonStr(entry, "campaign"), jsonStr(entry, "datum")};
+    const uint16_t index = static_cast<uint16_t>(by_index_.size() + 1);
+    by_index_.push_back(r);
+    by_source_id_.emplace(r.source_id, index);
+  }
+}
+
+}  // namespace marine_bathymetry_store

--- a/marine_bathymetry_store/src/tile_io.cpp
+++ b/marine_bathymetry_store/src/tile_io.cpp
@@ -101,6 +101,14 @@ std::string layerDirName(SourceLayer layer)
 void saveTile(const BathymetryTile & tile, const std::string & path)
 {
   namespace mtrs = marine_tiled_raster_store;
+  // Write ordering: value tile first, then time, then source.  The three files
+  // are not written atomically — a crash mid-sequence leaves a partial set on
+  // disk.  Writing the value tile first is intentional: the safety query
+  // (shallowestReliable) reads only the value tile, so a crashed write that
+  // leaves an absent or stale _time / _source companion does not affect the
+  // depth/uncertainty result used by the collision monitor.  A full reload
+  // after a crash will 0-fill missing companion tiles (backward-compat path
+  // in loadTile), which is the correct degraded-mode behaviour.
   mtrs::saveTile<double>(tile.valueRaster(), path, valueBandNoData());
   mtrs::saveTile<int64_t>(
     tile.timeRaster(), companionPath(path, kTimeSuffix), timeBandNoData());
@@ -112,6 +120,28 @@ BathymetryTile loadTile(const std::string & path, const gggs::Level & level)
 {
   namespace mtrs = marine_tiled_raster_store;
   namespace fs = std::filesystem;
+
+  // Guard: reject legacy single-file 3-band Float64 tiles written before #178.
+  // The pre-migration layout (depth / uncertainty / Float64-seconds-timestamp)
+  // has exactly 3 bands in one file with no companion _time / _source tiles.
+  // Loading it with value_band_count=2 would silently discard band 3 (the old
+  // seconds timestamp) and 0-fill the new nadir Int64 time tile — losing
+  // acquisition times without warning.  There are no on-disk tiles at the time
+  // of this migration (pre-production), so this guard is a forward-safety check:
+  // if such a tile appears (e.g., from a backup or a partial manual migration),
+  // fail loudly rather than silently corrupt the provenance record.
+  // Decision: explicit rejection is preferred over silent data-drop per the
+  // workspace Quality Standard (never "good enough" when the proper fix exists).
+  {
+    const int band_count = mtrs::tileRasterCount(path);
+    if (band_count == 3) {
+      throw std::runtime_error(
+              "loadTile: rejected pre-#178 legacy 3-band Float64 tile at \"" + path +
+              "\".  This tile was written by a pre-migration store (depth/"
+              "uncertainty/Float64-seconds in one file).  Regenerate or migrate"
+              " the tile before loading it with the current store.");
+    }
+  }
 
   BathymetryTile::Raster value =
     mtrs::loadTile<double>(path, level, BathymetryTile::value_band_count);
@@ -125,11 +155,34 @@ BathymetryTile loadTile(const std::string & path, const gggs::Level & level)
     ? mtrs::loadTile<int64_t>(time_path, level, BathymetryTile::time_band_count)
     : BathymetryTile::TimeRaster(grid, BathymetryTile::time_band_count, int64_t{0});
 
+  // Enforce GridIndex consistency: the time companion must map to the same
+  // tile as the value raster.  A mis-renamed companion (e.g., from a manual
+  // store reorganisation or file tampering) would combine cell-for-cell data
+  // from different geographic tiles, silently associating wrong timestamps with
+  // depths.  The check is cheap (one comparison) and closes the tampering hole.
+  if (fs::is_regular_file(time_path) && !(time.index() == grid)) {
+    throw std::runtime_error(
+            "loadTile: companion \"" + time_path +
+            "\" has a GridIndex that does not match the value tile at \"" + path +
+            "\".  The companion file may have been mis-renamed or the store is"
+            " inconsistent.");
+  }
+
   const std::string source_path = companionPath(path, kSourceSuffix);
   BathymetryTile::SourceRaster source =
     fs::is_regular_file(source_path)
     ? mtrs::loadTile<uint16_t>(source_path, level, BathymetryTile::source_band_count)
     : BathymetryTile::SourceRaster(grid, BathymetryTile::source_band_count, uint16_t{0});
+
+  // Enforce GridIndex consistency for the source companion (same rationale as
+  // the time-companion check above).
+  if (fs::is_regular_file(source_path) && !(source.index() == grid)) {
+    throw std::runtime_error(
+            "loadTile: companion \"" + source_path +
+            "\" has a GridIndex that does not match the value tile at \"" + path +
+            "\".  The companion file may have been mis-renamed or the store is"
+            " inconsistent.");
+  }
 
   return BathymetryTile(std::move(value), std::move(time), std::move(source));
 }

--- a/marine_bathymetry_store/src/tile_io.cpp
+++ b/marine_bathymetry_store/src/tile_io.cpp
@@ -21,6 +21,7 @@
 
 #include "marine_bathymetry_store/tile_io.hpp"
 
+#include <cstdint>
 #include <filesystem>
 #include <limits>
 #include <optional>
@@ -30,27 +31,54 @@
 #include "marine_tiled_raster_store/tile_io.hpp"
 
 /// @file
-/// @brief Bathymetry persistence (ADR-0002 §D5): the multi-layer, SourceLayer
-/// subdirectory save/load, delegating each tile's GeoTIFF read/write to the
-/// generic `marine_tiled_raster_store::saveTile`/`loadTile` (#172). The bathy
-/// band semantics live here: 3 `Float64` bands (depth, uncertainty, timestamp)
-/// with a NaN no-data tag on depth/uncertainty and none on timestamp.
+/// @brief Bathymetry persistence (ADR-0002 §D5, amended by #178): the
+/// multi-layer, SourceLayer subdirectory save/load, delegating each tile's
+/// GeoTIFF read/write to the generic `marine_tiled_raster_store::saveTile` /
+/// `loadTile` (#172). Each GGGS tile persists as three files: a 2-band `Float64`
+/// value tile (depth, uncertainty; NaN no-data on both), a 1-band `Int64` time
+/// tile (`_time.tif`, timestamp ns; no no-data tag), and a 1-band `UInt16`
+/// source tile (`_source.tif`, registry index; 0 no-data). A store-wide
+/// `registry.json` sidecar maps source indices to provenance (ADR-0005 D2/D8).
 
 namespace marine_bathymetry_store
 {
 
 namespace
 {
-/// Per-band no-data for a bathy tile: NaN on depth + uncertainty, none on the
-/// timestamp band (0 = unset, never NaN). One entry per band, in band order.
-const std::vector<std::optional<double>> & bathyBandNoData()
+constexpr const char * kTimeSuffix = "_time";
+constexpr const char * kSourceSuffix = "_source";
+
+/// Per-band no-data for the 2-band Float64 value tile: NaN on both depth and
+/// uncertainty. One entry per band, in band order.
+const std::vector<std::optional<double>> & valueBandNoData()
 {
   static const double nan = std::numeric_limits<double>::quiet_NaN();
-  static const std::vector<std::optional<double>> nodata{nan, nan, std::nullopt};
+  static const std::vector<std::optional<double>> nodata{nan, nan};
   return nodata;
 }
 
-constexpr std::size_t kBathyBandCount = 3;
+/// No-data for the 1-band Int64 time tile: none (0 = unset, never tagged).
+const std::vector<std::optional<int64_t>> & timeBandNoData()
+{
+  static const std::vector<std::optional<int64_t>> nodata{std::nullopt};
+  return nodata;
+}
+
+/// No-data for the 1-band UInt16 source tile: 0 = no-data/unset.
+const std::vector<std::optional<uint16_t>> & sourceBandNoData()
+{
+  static const std::vector<std::optional<uint16_t>> nodata{std::optional<uint16_t>(0)};
+  return nodata;
+}
+
+/// Derive a companion path (`_time` / `_source`) from a value-tile path: insert
+/// @p suffix before the `.tif` extension. e.g. `5_1_2.tif` -> `5_1_2_time.tif`.
+std::string companionPath(const std::string & value_path, const char * suffix)
+{
+  namespace fs = std::filesystem;
+  const fs::path p(value_path);
+  return (p.parent_path() / (p.stem().string() + suffix + p.extension().string())).string();
+}
 }  // namespace
 
 std::string tileFilename(const gggs::GridIndex & grid)
@@ -72,16 +100,42 @@ std::string layerDirName(SourceLayer layer)
 
 void saveTile(const BathymetryTile & tile, const std::string & path)
 {
-  marine_tiled_raster_store::saveTile<double>(tile.raster(), path, bathyBandNoData());
+  namespace mtrs = marine_tiled_raster_store;
+  mtrs::saveTile<double>(tile.valueRaster(), path, valueBandNoData());
+  mtrs::saveTile<int64_t>(
+    tile.timeRaster(), companionPath(path, kTimeSuffix), timeBandNoData());
+  mtrs::saveTile<uint16_t>(
+    tile.sourceRaster(), companionPath(path, kSourceSuffix), sourceBandNoData());
 }
 
 BathymetryTile loadTile(const std::string & path, const gggs::Level & level)
 {
-  return BathymetryTile(
-    marine_tiled_raster_store::loadTile<double>(path, level, kBathyBandCount));
+  namespace mtrs = marine_tiled_raster_store;
+  namespace fs = std::filesystem;
+
+  BathymetryTile::Raster value =
+    mtrs::loadTile<double>(path, level, BathymetryTile::value_band_count);
+  const gggs::GridIndex grid = value.index();
+
+  // Companion tiles: load if present, else fill with 0 (pre-migration
+  // single-platform data has no _time / _source tile — backward compatibility).
+  const std::string time_path = companionPath(path, kTimeSuffix);
+  BathymetryTile::TimeRaster time =
+    fs::is_regular_file(time_path)
+    ? mtrs::loadTile<int64_t>(time_path, level, BathymetryTile::time_band_count)
+    : BathymetryTile::TimeRaster(grid, BathymetryTile::time_band_count, int64_t{0});
+
+  const std::string source_path = companionPath(path, kSourceSuffix);
+  BathymetryTile::SourceRaster source =
+    fs::is_regular_file(source_path)
+    ? mtrs::loadTile<uint16_t>(source_path, level, BathymetryTile::source_band_count)
+    : BathymetryTile::SourceRaster(grid, BathymetryTile::source_band_count, uint16_t{0});
+
+  return BathymetryTile(std::move(value), std::move(time), std::move(source));
 }
 
-std::size_t save(BathymetryStore & store, const std::string & dir)
+std::size_t save(
+  BathymetryStore & store, const std::string & dir, const SourceRegistry * registry)
 {
   namespace fs = std::filesystem;
   std::size_t written = 0;
@@ -105,10 +159,17 @@ std::size_t save(BathymetryStore & store, const std::string & dir)
       ++written;
     }
   }
+  // The registry is a store-wide sidecar (not per-layer): persist it once at the
+  // end. Written unconditionally when present so a freshly-registered source is
+  // saved even when no tile is dirty.
+  if (registry != nullptr) {
+    registry->saveRegistry(dir);
+  }
   return written;
 }
 
-std::size_t load(BathymetryStore & store, const std::string & dir)
+std::size_t load(
+  BathymetryStore & store, const std::string & dir, SourceRegistry * registry)
 {
   namespace fs = std::filesystem;
   std::size_t loaded = 0;
@@ -121,10 +182,25 @@ std::size_t load(BathymetryStore & store, const std::string & dir)
       if (!entry.is_regular_file() || entry.path().extension() != ".tif") {
         continue;
       }
+      // Skip the companion tiles — they are loaded alongside their value tile,
+      // not as standalone value tiles (must-fix 3: a bare *.tif glob would
+      // otherwise mis-load _time / _source as value tiles).
+      const std::string stem = entry.path().stem().string();
+      const auto ends_with = [&stem](const char * suffix) {
+          const std::string s(suffix);
+          return stem.size() >= s.size() &&
+                 stem.compare(stem.size() - s.size(), s.size(), s) == 0;
+        };
+      if (ends_with(kTimeSuffix) || ends_with(kSourceSuffix)) {
+        continue;
+      }
       BathymetryTile tile = loadTile(entry.path().string(), store.level());
       store.getOrCreateTile(layer, tile.index()) = std::move(tile);
       ++loaded;
     }
+  }
+  if (registry != nullptr) {
+    registry->loadRegistry(dir);
   }
   return loaded;
 }

--- a/marine_bathymetry_store/test/test_query.cpp
+++ b/marine_bathymetry_store/test/test_query.cpp
@@ -41,8 +41,8 @@ TEST(Query, BestSourcePrefersHigherPriorityLayer)
 {
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Draft, cell, BathyCell{-12.0, 2.0, 2.0});
-  store.set(SourceLayer::Processed, cell, BathyCell{-10.0, 0.1, 1.0});
+  store.set(SourceLayer::Draft, cell, BathyCell{-12.0, 2.0, 2LL});
+  store.set(SourceLayer::Processed, cell, BathyCell{-10.0, 0.1, 1LL});
 
   const auto best = bestSource(store, cell);
   ASSERT_TRUE(best.has_value());
@@ -54,7 +54,7 @@ TEST(Query, BestSourceFallsBackToLowerPriority)
 {
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Draft, cell, BathyCell{-12.0, 2.0, 2.0});
+  store.set(SourceLayer::Draft, cell, BathyCell{-12.0, 2.0, 2LL});
 
   const auto best = bestSource(store, cell);
   ASSERT_TRUE(best.has_value());
@@ -77,8 +77,8 @@ TEST(Query, ShallowestReliablePicksGreatestHeight)
   // depth is ellipsoidal height (up-positive): shallower == greater value.
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Processed, cell, BathyCell{-30.0, 0.1, 1.0});  // deeper
-  store.set(SourceLayer::Draft, cell, BathyCell{-25.0, 0.2, 2.0});      // shallower
+  store.set(SourceLayer::Processed, cell, BathyCell{-30.0, 0.1, 1LL});  // deeper
+  store.set(SourceLayer::Draft, cell, BathyCell{-25.0, 0.2, 2LL});      // shallower
 
   const auto result = shallowestReliable(store, cell, 1.0);
   ASSERT_TRUE(result.has_value());
@@ -90,8 +90,8 @@ TEST(Query, ShallowestReliableExcludesOverUncertain)
 {
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Processed, cell, BathyCell{-30.0, 0.1, 1.0});  // reliable, deeper
-  store.set(SourceLayer::Draft, cell, BathyCell{-25.0, 5.0, 2.0});      // shallower, too uncertain
+  store.set(SourceLayer::Processed, cell, BathyCell{-30.0, 0.1, 1LL});  // reliable, deeper
+  store.set(SourceLayer::Draft, cell, BathyCell{-25.0, 5.0, 2LL});      // shallower, too uncertain
 
   const auto result = shallowestReliable(store, cell, 1.0);
   ASSERT_TRUE(result.has_value());
@@ -103,7 +103,7 @@ TEST(Query, ShallowestReliableTreatsNaNUncertaintyAsUnreliable)
 {
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Draft, cell, BathyCell{-25.0, std::nan(""), 2.0});
+  store.set(SourceLayer::Draft, cell, BathyCell{-25.0, std::nan(""), 2LL});
   EXPECT_FALSE(shallowestReliable(store, cell, 1.0).has_value());
 }
 
@@ -111,7 +111,7 @@ TEST(Query, ForEachRegionVisitsCoveredCells)
 {
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Draft, cell, BathyCell{-20.0, 0.5, 1.0});
+  store.set(SourceLayer::Draft, cell, BathyCell{-20.0, 0.5, 1LL});
 
   std::size_t visited = 0;
   std::size_t with_data = 0;
@@ -136,9 +136,9 @@ TEST(Query, BestSourceFallsThroughToChartPrior)
   const auto unsurveyed = store.cellIndex(43.0, -70.5);
   const auto surveyed = store.cellIndex(43.0, -70.4);
 
-  store.set(SourceLayer::Chart, unsurveyed, BathyCell{38.0, 3.0, 1.0});
-  store.set(SourceLayer::Chart, surveyed, BathyCell{38.0, 3.0, 1.0});
-  store.set(SourceLayer::Draft, surveyed, BathyCell{40.0, 0.5, 2.0});
+  store.set(SourceLayer::Chart, unsurveyed, BathyCell{38.0, 3.0, 1LL});
+  store.set(SourceLayer::Chart, surveyed, BathyCell{38.0, 3.0, 1LL});
+  store.set(SourceLayer::Draft, surveyed, BathyCell{40.0, 0.5, 2LL});
 
   // Unsurveyed cell falls through to the chart prior.
   const auto a = bestSource(store, unsurveyed);
@@ -153,6 +153,36 @@ TEST(Query, BestSourceFallsThroughToChartPrior)
   EXPECT_DOUBLE_EQ(b->depth, 40.0);
 }
 
+TEST(Query, ShallowestReliableUnaffectedBySourceIndex)
+{
+  // ADR-0005 D5 safety carve-out: the navigation-safety query ignores the
+  // source-index / registry priority axis entirely. Two cells in the same layer
+  // with DIFFERENT source indices must produce exactly the same shallowest-
+  // reliable result as if source_index were unset — selection is by depth +
+  // uncertainty only, never by which platform/sensor contributed the cell.
+  BathymetryStore store(5);
+  const auto cell = store.cellIndex(43.0, -70.5);
+
+  // Deeper cell from a "high" source index; shallower from a "low" one. If the
+  // query ever consulted source_index, the answer could flip — it must not.
+  store.set(SourceLayer::Processed, cell, BathyCell{-30.0, 0.1, 1LL, 9000u});  // deeper
+  store.set(SourceLayer::Draft, cell, BathyCell{-25.0, 0.2, 2LL, 1u});         // shallower
+
+  const auto result = shallowestReliable(store, cell, 1.0);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_DOUBLE_EQ(result->depth, -25.0);          // shallowest, regardless of source
+  EXPECT_EQ(result->source, SourceLayer::Draft);
+
+  // Same geometry with source indices swapped -> identical result.
+  BathymetryStore swapped(5);
+  swapped.set(SourceLayer::Processed, cell, BathyCell{-30.0, 0.1, 1LL, 1u});
+  swapped.set(SourceLayer::Draft, cell, BathyCell{-25.0, 0.2, 2LL, 9000u});
+  const auto result2 = shallowestReliable(swapped, cell, 1.0);
+  ASSERT_TRUE(result2.has_value());
+  EXPECT_DOUBLE_EQ(result2->depth, -25.0);
+  EXPECT_EQ(result2->source, SourceLayer::Draft);
+}
+
 TEST(Query, ShallowestReliableGatesChartByUncertainty)
 {
   // The coarse Chart prior carries a fixed import uncertainty (3.0 m). It feeds
@@ -160,7 +190,7 @@ TEST(Query, ShallowestReliableGatesChartByUncertainty)
   // only when the caller's tolerance allows — both sides of the threshold.
   BathymetryStore store(5, /*chart_writable=*/true);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Chart, cell, BathyCell{38.0, 3.0, 1.0});
+  store.set(SourceLayer::Chart, cell, BathyCell{38.0, 3.0, 1LL});
 
   // Tolerance below the chart uncertainty excludes it -> cell reads as unknown.
   EXPECT_FALSE(shallowestReliable(store, cell, 2.9).has_value());

--- a/marine_bathymetry_store/test/test_store.cpp
+++ b/marine_bathymetry_store/test/test_store.cpp
@@ -34,13 +34,28 @@ TEST(Store, SetGetRoundTrip)
 {
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Draft, cell, BathyCell{-30.0, 0.5, 1000.0});
+  // timestamp is int64 nanoseconds since the epoch (1 s = 1e9 ns).
+  store.set(SourceLayer::Draft, cell, BathyCell{-30.0, 0.5, 1'000'000'000'000LL});
 
   const auto got = store.get(SourceLayer::Draft, cell);
   ASSERT_TRUE(got.has_value());
   EXPECT_DOUBLE_EQ(got->depth, -30.0);
   EXPECT_DOUBLE_EQ(got->uncertainty, 0.5);
-  EXPECT_DOUBLE_EQ(got->timestamp, 1000.0);
+  EXPECT_EQ(got->timestamp, 1'000'000'000'000LL);
+  EXPECT_EQ(got->source_index, 0u);   // default unset
+}
+
+TEST(Store, SetGetRoundTripWithSourceIndex)
+{
+  BathymetryStore store(5);
+  const auto cell = store.cellIndex(43.0, -70.5);
+  store.set(SourceLayer::Draft, cell, BathyCell{-30.0, 0.5, 2'000'000'000LL, 3u});
+
+  const auto got = store.get(SourceLayer::Draft, cell);
+  ASSERT_TRUE(got.has_value());
+  EXPECT_DOUBLE_EQ(got->depth, -30.0);
+  EXPECT_EQ(got->timestamp, 2'000'000'000LL);
+  EXPECT_EQ(got->source_index, 3u);
 }
 
 TEST(Store, GetEmptyLayerIsNullopt)
@@ -54,8 +69,8 @@ TEST(Store, LayersAreIndependent)
   // A draft write must not touch the processed layer at the same cell.
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Processed, cell, BathyCell{-10.0, 0.1, 1.0});
-  store.set(SourceLayer::Draft, cell, BathyCell{-12.0, 2.0, 2.0});
+  store.set(SourceLayer::Processed, cell, BathyCell{-10.0, 0.1, 1LL});
+  store.set(SourceLayer::Draft, cell, BathyCell{-12.0, 2.0, 2LL});
   EXPECT_DOUBLE_EQ(store.get(SourceLayer::Processed, cell)->depth, -10.0);
   EXPECT_DOUBLE_EQ(store.get(SourceLayer::Draft, cell)->depth, -12.0);
 }
@@ -66,7 +81,7 @@ TEST(Store, TilesAllocatedLazilyPerLayer)
   EXPECT_TRUE(store.tiles(SourceLayer::Draft).empty());
   EXPECT_TRUE(store.tiles(SourceLayer::Processed).empty());
 
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1.0});
+  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1LL});
   EXPECT_EQ(store.tiles(SourceLayer::Draft).size(), 1u);
   EXPECT_TRUE(store.tiles(SourceLayer::Processed).empty());
 }
@@ -110,11 +125,11 @@ TEST(Store, ChartIsReadOnlyByDefault)
   BathymetryStore store(5);
   EXPECT_FALSE(store.chartWritable());
   EXPECT_THROW(
-    store.set(SourceLayer::Chart, store.cellIndex(43.0, -70.5), BathyCell{-10.0, 3.0, 1.0}),
+    store.set(SourceLayer::Chart, store.cellIndex(43.0, -70.5), BathyCell{-10.0, 3.0, 1LL}),
     std::logic_error);
   // Other layers are unaffected by the guard.
   EXPECT_NO_THROW(
-    store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-12.0, 2.0, 2.0}));
+    store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-12.0, 2.0, 2LL}));
 }
 
 TEST(Store, ChartWritableStoreAllowsChartSet)
@@ -123,7 +138,7 @@ TEST(Store, ChartWritableStoreAllowsChartSet)
   BathymetryStore store(5, /*chart_writable=*/true);
   EXPECT_TRUE(store.chartWritable());
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Chart, cell, BathyCell{38.58, 3.0, 1000.0});
+  store.set(SourceLayer::Chart, cell, BathyCell{38.58, 3.0, 1000LL});
   const auto got = store.get(SourceLayer::Chart, cell);
   ASSERT_TRUE(got.has_value());
   EXPECT_DOUBLE_EQ(got->depth, 38.58);
@@ -134,5 +149,5 @@ TEST(Store, FromCellSizePropagatesChartWritable)
   auto store = BathymetryStore::fromCellSize(30.0f, /*chart_writable=*/true);
   EXPECT_TRUE(store.chartWritable());
   EXPECT_NO_THROW(
-    store.set(SourceLayer::Chart, store.cellIndex(43.0, -70.5), BathyCell{40.0, 3.0, 1.0}));
+    store.set(SourceLayer::Chart, store.cellIndex(43.0, -70.5), BathyCell{40.0, 3.0, 1LL}));
 }

--- a/marine_bathymetry_store/test/test_tile_io.cpp
+++ b/marine_bathymetry_store/test/test_tile_io.cpp
@@ -22,16 +22,20 @@
 #include <gtest/gtest.h>
 
 #include <cstddef>
+#include <cstdint>
 #include <filesystem>
 #include <stdexcept>
 #include <string>
 
 #include "marine_bathymetry_store/bathymetry_store.hpp"
+#include "marine_bathymetry_store/registry.hpp"
 #include "marine_bathymetry_store/tile_io.hpp"
 
 using marine_bathymetry_store::BathyCell;
 using marine_bathymetry_store::BathymetryStore;
 using marine_bathymetry_store::SourceLayer;
+using marine_bathymetry_store::SourceRecord;
+using marine_bathymetry_store::SourceRegistry;
 
 namespace fs = std::filesystem;
 
@@ -56,8 +60,16 @@ protected:
 TEST_F(TileIoTest, RoundTripPreservesCells)
 {
   BathymetryStore store(5);
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.123, 0.456, 1.78e9});
-  store.set(SourceLayer::Processed, store.cellIndex(44.0, -71.0), BathyCell{-12.5, 0.2, 1.79e9});
+  // int64 ns stamps with sub-second precision that a Float64 seconds band could
+  // not have represented exactly — the Int64 time tile preserves them bit-exact.
+  const int64_t ts_draft = 1'780'000'000'123'456'789LL;
+  const int64_t ts_proc = 1'790'000'000'987'654'321LL;
+  store.set(
+    SourceLayer::Draft, store.cellIndex(43.0, -70.5),
+    BathyCell{-30.123, 0.456, ts_draft, 7u});
+  store.set(
+    SourceLayer::Processed, store.cellIndex(44.0, -71.0),
+    BathyCell{-12.5, 0.2, ts_proc, 0u});
 
   EXPECT_EQ(marine_bathymetry_store::save(store, dir_.string()), 2u);
 
@@ -68,20 +80,88 @@ TEST_F(TileIoTest, RoundTripPreservesCells)
   ASSERT_TRUE(draft.has_value());
   EXPECT_DOUBLE_EQ(draft->depth, -30.123);
   EXPECT_DOUBLE_EQ(draft->uncertainty, 0.456);
-  // Float64 timestamp band: absolute Unix seconds survive exactly.
-  // (A Float32 band would lose ~128 s here — this is the precision guard.)
-  EXPECT_DOUBLE_EQ(draft->timestamp, 1.78e9);
+  // Int64 ns timestamp band: nanosecond stamps survive exactly.
+  EXPECT_EQ(draft->timestamp, ts_draft);
+  EXPECT_EQ(draft->source_index, 7u);
 
   const auto processed = reloaded.get(SourceLayer::Processed, reloaded.cellIndex(44.0, -71.0));
   ASSERT_TRUE(processed.has_value());
   EXPECT_DOUBLE_EQ(processed->depth, -12.5);
-  EXPECT_DOUBLE_EQ(processed->timestamp, 1.79e9);
+  EXPECT_EQ(processed->timestamp, ts_proc);
+}
+
+TEST_F(TileIoTest, RoundTripPreservesSourceIndex)
+{
+  // The per-cell source index (registry handle, ADR-0005 D2/D8) round-trips
+  // through the separate UInt16 _source.tif independently of depth/time.
+  BathymetryStore store(5);
+  store.set(
+    SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 10LL, 1u});
+  store.set(
+    SourceLayer::Draft, store.cellIndex(43.0, -70.4), BathyCell{-31.0, 0.5, 11LL, 4242u});
+  EXPECT_EQ(marine_bathymetry_store::save(store, dir_.string()), 1u);
+
+  BathymetryStore reloaded(5);
+  EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 1u);
+  EXPECT_EQ(
+    reloaded.get(SourceLayer::Draft, reloaded.cellIndex(43.0, -70.5))->source_index, 1u);
+  EXPECT_EQ(
+    reloaded.get(SourceLayer::Draft, reloaded.cellIndex(43.0, -70.4))->source_index, 4242u);
+}
+
+TEST_F(TileIoTest, MissingTimeTileLoadsAsZero)
+{
+  // Pre-migration single-platform data has no _time.tif. Deleting it before load
+  // must not fail — the timestamp band fills with 0 (backward compatibility).
+  BathymetryStore store(5);
+  store.set(
+    SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 99LL, 2u});
+  marine_bathymetry_store::save(store, dir_.string());
+
+  // Remove every _time.tif under the draft layer.
+  for (const auto & e : fs::recursive_directory_iterator(dir_ / "draft")) {
+    if (e.is_regular_file() && e.path().filename().string().find("_time.tif") != std::string::npos)
+    {
+      fs::remove(e.path());
+    }
+  }
+
+  BathymetryStore reloaded(5);
+  EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 1u);
+  const auto got = reloaded.get(SourceLayer::Draft, reloaded.cellIndex(43.0, -70.5));
+  ASSERT_TRUE(got.has_value());
+  EXPECT_DOUBLE_EQ(got->depth, -30.0);   // value tile still loaded
+  EXPECT_EQ(got->timestamp, 0);          // missing time tile -> 0
+  EXPECT_EQ(got->source_index, 2u);      // source tile still loaded
+}
+
+TEST_F(TileIoTest, MissingSourceTileLoadsAsZero)
+{
+  BathymetryStore store(5);
+  store.set(
+    SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 99LL, 5u});
+  marine_bathymetry_store::save(store, dir_.string());
+
+  for (const auto & e : fs::recursive_directory_iterator(dir_ / "draft")) {
+    if (e.is_regular_file() &&
+      e.path().filename().string().find("_source.tif") != std::string::npos)
+    {
+      fs::remove(e.path());
+    }
+  }
+
+  BathymetryStore reloaded(5);
+  EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 1u);
+  const auto got = reloaded.get(SourceLayer::Draft, reloaded.cellIndex(43.0, -70.5));
+  ASSERT_TRUE(got.has_value());
+  EXPECT_EQ(got->timestamp, 99);         // time tile still loaded
+  EXPECT_EQ(got->source_index, 0u);      // missing source tile -> 0
 }
 
 TEST_F(TileIoTest, LoadedTilesAreCleanAndDontResave)
 {
   BathymetryStore store(5);
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1.0});
+  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1LL});
 
   EXPECT_EQ(marine_bathymetry_store::save(store, dir_.string()), 1u);
   // No changes since the last save -> nothing re-written (incremental save).
@@ -96,18 +176,18 @@ TEST_F(TileIoTest, LoadedTilesAreCleanAndDontResave)
 TEST_F(TileIoTest, WritingAfterSaveRedirties)
 {
   BathymetryStore store(5);
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1.0});
+  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1LL});
   EXPECT_EQ(marine_bathymetry_store::save(store, dir_.string()), 1u);
 
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-31.0, 0.4, 2.0});
+  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-31.0, 0.4, 2LL});
   EXPECT_EQ(marine_bathymetry_store::save(store, dir_.string()), 1u);
 }
 
 TEST_F(TileIoTest, LayersWriteToSeparateSubdirectories)
 {
   BathymetryStore store(5);
-  store.set(SourceLayer::Processed, store.cellIndex(43.0, -70.5), BathyCell{-10.0, 0.1, 1.0});
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-12.0, 0.5, 2.0});
+  store.set(SourceLayer::Processed, store.cellIndex(43.0, -70.5), BathyCell{-10.0, 0.1, 1LL});
+  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-12.0, 0.5, 2LL});
   marine_bathymetry_store::save(store, dir_.string());
 
   EXPECT_TRUE(fs::is_directory(dir_ / "processed"));
@@ -117,7 +197,7 @@ TEST_F(TileIoTest, LayersWriteToSeparateSubdirectories)
 TEST_F(TileIoTest, LoadRejectsTilesFromAnotherLevel)
 {
   BathymetryStore store(5);
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1.0});
+  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1LL});
   marine_bathymetry_store::save(store, dir_.string());
 
   BathymetryStore wrong_level(6);
@@ -129,8 +209,9 @@ TEST_F(TileIoTest, ChartRoundTripsAndLoadsIntoReadOnlyStore)
   // The importer writes Chart (chart_writable); the runtime loads it into a
   // default (read-only-Chart) store. load() populates via getOrCreateTile, not
   // set(), so the prior loads even though live set(Chart) stays forbidden.
+  const int64_t ts = 1'780'000'000'000'000'000LL;
   BathymetryStore writer(5, /*chart_writable=*/true);
-  writer.set(SourceLayer::Chart, writer.cellIndex(43.0, -70.5), BathyCell{38.58, 3.0, 1.78e9});
+  writer.set(SourceLayer::Chart, writer.cellIndex(43.0, -70.5), BathyCell{38.58, 3.0, ts});
   EXPECT_EQ(marine_bathymetry_store::save(writer, dir_.string()), 1u);
   EXPECT_TRUE(fs::is_directory(dir_ / "chart"));
 
@@ -141,11 +222,11 @@ TEST_F(TileIoTest, ChartRoundTripsAndLoadsIntoReadOnlyStore)
   const auto got = runtime.get(SourceLayer::Chart, runtime.cellIndex(43.0, -70.5));
   ASSERT_TRUE(got.has_value());
   EXPECT_DOUBLE_EQ(got->depth, 38.58);
-  EXPECT_DOUBLE_EQ(got->timestamp, 1.78e9);
+  EXPECT_EQ(got->timestamp, ts);
 
   // The read-only guard still holds after the prior is loaded.
   EXPECT_THROW(
-    runtime.set(SourceLayer::Chart, runtime.cellIndex(43.0, -70.5), BathyCell{1.0, 1.0, 1.0}),
+    runtime.set(SourceLayer::Chart, runtime.cellIndex(43.0, -70.5), BathyCell{1.0, 1.0, 1LL}),
     std::logic_error);
 }
 
@@ -154,11 +235,64 @@ TEST_F(TileIoTest, ProcessedDraftOnlyStoreLoadsWithoutChartDir)
   // Back-compat: a Phase-1 store with no chart/ subdir still saves and loads;
   // the absent chart layer is simply skipped, not an error.
   BathymetryStore store(5);
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1.0});
+  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1LL});
   marine_bathymetry_store::save(store, dir_.string());
   EXPECT_FALSE(fs::exists(dir_ / "chart"));   // no spurious empty chart/ dir
 
   BathymetryStore reloaded(5);
   EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 1u);
   EXPECT_TRUE(reloaded.tiles(SourceLayer::Chart).empty());
+}
+
+TEST_F(TileIoTest, RegistryAtomicWrite)
+{
+  // saveRegistry must publish registry.json atomically: the final file exists
+  // and no .tmp scratch file is left behind.
+  fs::create_directories(dir_);
+  SourceRegistry registry;
+  const uint16_t idx = registry.registerSource(
+    SourceRecord{"bizzy:m3:0", "bizzy", "m3", "multibeam", "massabesic-2026", "ellipsoid"});
+  EXPECT_EQ(idx, 1u);                           // first real index (0 reserved)
+
+  registry.saveRegistry(dir_.string());
+  EXPECT_TRUE(fs::is_regular_file(dir_ / "registry.json"));
+  EXPECT_FALSE(fs::exists(dir_ / "registry.json.tmp"));   // no leftover scratch
+
+  SourceRegistry loaded;
+  loaded.loadRegistry(dir_.string());
+  const auto rec = loaded.lookup(1);
+  ASSERT_TRUE(rec.has_value());
+  EXPECT_EQ(rec->platform, "bizzy");
+  EXPECT_EQ(rec->datum, "ellipsoid");
+  EXPECT_FALSE(loaded.lookup(SourceRegistry::kUnset).has_value());   // index 0 is unset
+}
+
+TEST_F(TileIoTest, RegistryRegisterSourceIsIdempotent)
+{
+  SourceRegistry registry;
+  const uint16_t a = registry.registerSource(SourceRecord{"bizzy:m3:0", "bizzy", "m3", "", "", ""});
+  const uint16_t b = registry.registerSource(SourceRecord{"izzy:m3:0", "izzy", "m3", "", "", ""});
+  const uint16_t a2 = registry.registerSource(SourceRecord{"bizzy:m3:0", "x", "y", "", "", ""});
+  EXPECT_EQ(a, 1u);
+  EXPECT_EQ(b, 2u);
+  EXPECT_EQ(a2, a);                 // same source_id -> same index, no new entry
+  EXPECT_EQ(registry.size(), 2u);
+}
+
+TEST_F(TileIoTest, SaveWritesRegistryWhenProvided)
+{
+  // The store save() persists the registry sidecar once, at the store root.
+  BathymetryStore store(5);
+  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1LL, 1u});
+  SourceRegistry registry;
+  registry.registerSource(SourceRecord{"bizzy:m3:0", "bizzy", "m3", "multibeam", "", "ellipsoid"});
+
+  marine_bathymetry_store::save(store, dir_.string(), &registry);
+  EXPECT_TRUE(fs::is_regular_file(dir_ / "registry.json"));
+
+  SourceRegistry reloaded;
+  marine_bathymetry_store::load(store, dir_.string(), &reloaded);
+  EXPECT_EQ(reloaded.size(), 1u);
+  ASSERT_TRUE(reloaded.lookup(1).has_value());
+  EXPECT_EQ(reloaded.lookup(1)->platform, "bizzy");
 }

--- a/marine_bathymetry_store/test/test_tile_io.cpp
+++ b/marine_bathymetry_store/test/test_tile_io.cpp
@@ -24,12 +24,16 @@
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
+#include <fstream>
 #include <stdexcept>
 #include <string>
+
+#include <nlohmann/json.hpp>
 
 #include "marine_bathymetry_store/bathymetry_store.hpp"
 #include "marine_bathymetry_store/registry.hpp"
 #include "marine_bathymetry_store/tile_io.hpp"
+#include "marine_tiled_raster_store/tile_io.hpp"
 
 using marine_bathymetry_store::BathyCell;
 using marine_bathymetry_store::BathymetryStore;
@@ -295,4 +299,114 @@ TEST_F(TileIoTest, SaveWritesRegistryWhenProvided)
   EXPECT_EQ(reloaded.size(), 1u);
   ASSERT_TRUE(reloaded.lookup(1).has_value());
   EXPECT_EQ(reloaded.lookup(1)->platform, "bizzy");
+}
+
+// --- Item 1: registry.cpp loadRegistry index validation ---
+
+TEST_F(TileIoTest, LoadRegistryRejectsReorderedIndex)
+{
+  // A hand-edited registry.json with a swapped/reordered "index" field must be
+  // rejected with a clear error (not silently accepted as a contiguous sequence).
+  fs::create_directories(dir_);
+  // Write a registry with two entries but with their index values swapped
+  // (entry 0 claims index=2, entry 1 claims index=1).
+  const nlohmann::json bad_registry = {
+    {"version", 1},
+    {"sources", nlohmann::json::array({
+      {{"index", 2}, {"source_id", "a"}, {"platform", "p1"}, {"sensor", "s"},
+       {"sensor_class", ""}, {"campaign", ""}, {"datum", ""}},
+      {{"index", 1}, {"source_id", "b"}, {"platform", "p2"}, {"sensor", "s"},
+       {"sensor_class", ""}, {"campaign", ""}, {"datum", ""}},
+    })}
+  };
+  {
+    std::ofstream out(dir_ / "registry.json");
+    out << bad_registry.dump(2);
+  }
+  SourceRegistry reg;
+  EXPECT_THROW(reg.loadRegistry(dir_.string()), std::runtime_error);
+}
+
+TEST_F(TileIoTest, LoadRegistryRejectsMissingIndexField)
+{
+  // An entry that lacks the "index" field entirely must also be rejected.
+  fs::create_directories(dir_);
+  const nlohmann::json bad_registry = {
+    {"version", 1},
+    {"sources", nlohmann::json::array({
+      // "index" field deliberately omitted
+      {{"source_id", "a"}, {"platform", "p1"}, {"sensor", "s"},
+       {"sensor_class", ""}, {"campaign", ""}, {"datum", ""}},
+    })}
+  };
+  {
+    std::ofstream out(dir_ / "registry.json");
+    out << bad_registry.dump(2);
+  }
+  SourceRegistry reg;
+  EXPECT_THROW(reg.loadRegistry(dir_.string()), std::runtime_error);
+}
+
+// --- Item 2: tile_io.cpp loadTile — legacy 3-band guard ---
+
+TEST_F(TileIoTest, LoadTileRejectsLegacyThreeBandValueTile)
+{
+  // A value tile with exactly 3 bands (the pre-#178 depth/uncertainty/Float64-
+  // seconds layout) must be rejected with a clear error on load rather than
+  // silently loading 2 bands and discarding the third.
+  namespace mtrs = marine_tiled_raster_store;
+  fs::create_directories(dir_ / "draft");
+
+  // Create a fake 3-band Float64 tile that mimics the old layout.
+  const gggs::Level level(5);
+  const gggs::GridIndex grid = level.gridIndex(43.0, -70.5);
+  const std::string filename = marine_bathymetry_store::tileFilename(grid);
+  const std::string path = (dir_ / "draft" / filename).string();
+
+  mtrs::TiledRasterTile<double> legacy_tile(grid, 3, 0.0);
+  legacy_tile.set(10, 20, 0, -12.5);    // depth
+  legacy_tile.set(10, 20, 1, 0.3);      // uncertainty
+  legacy_tile.set(10, 20, 2, 1.78e9);   // old Float64 seconds timestamp
+  mtrs::saveTile<double>(legacy_tile, path, {std::nullopt, std::nullopt, std::nullopt});
+
+  // loadTile must throw, not silently drop band 3.
+  BathymetryStore store(5);
+  EXPECT_THROW(marine_bathymetry_store::load(store, dir_.string()), std::runtime_error);
+}
+
+// --- Item 4: tile_io.cpp loadTile — GridIndex consistency ---
+
+TEST_F(TileIoTest, LoadTileRejectsCompanionWithWrongGrid)
+{
+  // If a _time.tif companion is manually replaced with a file from a different
+  // grid (simulating file tampering or mis-rename), loadTile must throw a clear
+  // error rather than silently combining cell-for-cell data from two different
+  // geographic locations.
+  namespace mtrs = marine_tiled_raster_store;
+  fs::create_directories(dir_ / "draft");
+
+  const gggs::Level level(5);
+  // Two grids in different locations.
+  const gggs::GridIndex grid_a = level.gridIndex(43.0, -70.5);
+  const gggs::GridIndex grid_b = level.gridIndex(44.0, -71.0);
+  ASSERT_FALSE(grid_a == grid_b);
+
+  // Save a normal tile for grid_a.
+  BathymetryStore store(5);
+  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 42LL, 1u});
+  marine_bathymetry_store::save(store, dir_.string());
+
+  // Replace grid_a's _time companion with a time tile written for grid_b.
+  // The companion filename is derived from the value tile stem (grid_a filename
+  // + "_time.tif"), but we write a file whose geotransform encodes grid_b.
+  const std::string value_filename = marine_bathymetry_store::tileFilename(grid_a);
+  const fs::path time_path =
+    dir_ / "draft" / (fs::path(value_filename).stem().string() + "_time.tif");
+  // Write a time tile for grid_b at that path (overwrites any existing companion).
+  mtrs::TiledRasterTile<int64_t> wrong_time(grid_b, 1, int64_t{0});
+  wrong_time.set(0, 0, 0, 99LL);
+  mtrs::saveTile<int64_t>(wrong_time, time_path.string(), {std::nullopt});
+
+  BathymetryStore reloaded(5);
+  EXPECT_THROW(marine_bathymetry_store::load(reloaded, dir_.string()), std::runtime_error);
 }

--- a/marine_tiled_raster_store/include/marine_tiled_raster_store/tile_io.hpp
+++ b/marine_tiled_raster_store/include/marine_tiled_raster_store/tile_io.hpp
@@ -44,8 +44,9 @@
 ///
 /// GDAL is intentionally absent from this header: the functions are templates
 /// **explicitly instantiated** in `tile_io.cpp` for the supported element types
-/// (`double`, `std::uint16_t`), so consumers link the instantiations without
-/// taking a public GDAL dependency.
+/// (`double`, `std::uint16_t`, `std::int64_t`), so consumers link the
+/// instantiations without taking a public GDAL dependency. (`std::int64_t` →
+/// `GDT_Int64` backs the bathy timestamp tile, #178; requires GDAL >= 3.5.)
 ///
 /// @note Round-trip persistence is validated for **non-polar** latitudes
 /// (|lat| < 72°), the intended lake/coastal survey envelope. Near GGGS's polar

--- a/marine_tiled_raster_store/include/marine_tiled_raster_store/tile_io.hpp
+++ b/marine_tiled_raster_store/include/marine_tiled_raster_store/tile_io.hpp
@@ -60,6 +60,14 @@ namespace marine_tiled_raster_store
 /// @brief GeoTIFF filename (no directory) for a grid: `<level>_<row>_<col>.tif`.
 std::string tileFilename(const gggs::GridIndex & grid);
 
+/// @brief Return the raster band count of a GeoTIFF file without loading its data.
+///
+/// Opens the file read-only and calls `GetRasterCount()`.  Useful for probing
+/// a tile's layout (e.g. detecting a legacy tile format) before committing to a
+/// full load.
+/// @throws std::runtime_error if the file cannot be opened or is not a raster.
+int tileRasterCount(const std::string & path);
+
 /// @brief Write one tile as a `bandCount()`-band GeoTIFF (element type @p T) at @p path.
 ///
 /// @param band_nodata Optional per-band no-data value, one entry per band (size

--- a/marine_tiled_raster_store/include/marine_tiled_raster_store/tiled_raster_tile.hpp
+++ b/marine_tiled_raster_store/include/marine_tiled_raster_store/tiled_raster_tile.hpp
@@ -48,8 +48,8 @@ namespace marine_tiled_raster_store
 /// store can persist only what changed (incremental save).
 ///
 /// @tparam T Per-cell element type. `tile_io` supports the explicitly
-///   instantiated types (`double`, `std::uint16_t`); other types compile here
-///   but have no persistence backing.
+///   instantiated types (`double`, `std::uint16_t`, `std::int64_t`); other types
+///   compile here but have no persistence backing.
 template<typename T>
 class TiledRasterTile
 {

--- a/marine_tiled_raster_store/src/tile_io.cpp
+++ b/marine_tiled_raster_store/src/tile_io.cpp
@@ -97,6 +97,17 @@ std::string tileFilename(const gggs::GridIndex & grid)
          std::to_string(grid.row()) + "_" + std::to_string(grid.column()) + ".tif";
 }
 
+int tileRasterCount(const std::string & path)
+{
+  GDALAllRegister();
+  DatasetCloser in;
+  in.ds = GDALDataset::FromHandle(GDALOpen(path.c_str(), GA_ReadOnly));
+  if (in.ds == nullptr) {
+    throw std::runtime_error("tileRasterCount: could not open " + path);
+  }
+  return in.ds->GetRasterCount();
+}
+
 template<typename T>
 void saveTile(
   const TiledRasterTile<T> & tile, const std::string & path,

--- a/marine_tiled_raster_store/src/tile_io.cpp
+++ b/marine_tiled_raster_store/src/tile_io.cpp
@@ -61,6 +61,11 @@ template<>
 GDALDataType gdalType<double>() {return GDT_Float64;}
 template<>
 GDALDataType gdalType<std::uint16_t>() {return GDT_UInt16;}
+// GDT_Int64 requires GDAL >= 3.5; the workspace targets GDAL >= 3.8 (ROS 2
+// jazzy / rolling, 3.8.4 locally). Used by the bathy timestamp tile (#178):
+// int64 nanoseconds-since-epoch is ROS-native and exact, unlike Float64 seconds.
+template<>
+GDALDataType gdalType<std::int64_t>() {return GDT_Int64;}
 
 /// Copy a band between GGGS cell order (row 0 = south) and north-up raster order
 /// (row 0 = north) — the two differ only by a vertical row flip. Works in both
@@ -301,10 +306,15 @@ template void saveTile<double>(
 template void saveTile<std::uint16_t>(
   const TiledRasterTile<std::uint16_t> &, const std::string &,
   const std::vector<std::optional<std::uint16_t>> &);
+template void saveTile<std::int64_t>(
+  const TiledRasterTile<std::int64_t> &, const std::string &,
+  const std::vector<std::optional<std::int64_t>> &);
 
 template TiledRasterTile<double> loadTile<double>(
   const std::string &, const gggs::Level &, std::size_t);
 template TiledRasterTile<std::uint16_t> loadTile<std::uint16_t>(
+  const std::string &, const gggs::Level &, std::size_t);
+template TiledRasterTile<std::int64_t> loadTile<std::int64_t>(
   const std::string &, const gggs::Level &, std::size_t);
 
 template std::size_t saveTiles<double>(
@@ -313,12 +323,18 @@ template std::size_t saveTiles<double>(
 template std::size_t saveTiles<std::uint16_t>(
   std::map<gggs::GridIndex, TiledRasterTile<std::uint16_t>> &, const std::string &,
   const std::vector<std::optional<std::uint16_t>> &);
+template std::size_t saveTiles<std::int64_t>(
+  std::map<gggs::GridIndex, TiledRasterTile<std::int64_t>> &, const std::string &,
+  const std::vector<std::optional<std::int64_t>> &);
 
 template std::size_t loadTiles<double>(
   std::map<gggs::GridIndex, TiledRasterTile<double>> &, const std::string &,
   const gggs::Level &, std::size_t);
 template std::size_t loadTiles<std::uint16_t>(
   std::map<gggs::GridIndex, TiledRasterTile<std::uint16_t>> &, const std::string &,
+  const gggs::Level &, std::size_t);
+template std::size_t loadTiles<std::int64_t>(
+  std::map<gggs::GridIndex, TiledRasterTile<std::int64_t>> &, const std::string &,
   const gggs::Level &, std::size_t);
 
 }  // namespace marine_tiled_raster_store

--- a/marine_tiled_raster_store/test/test_tile_io.cpp
+++ b/marine_tiled_raster_store/test/test_tile_io.cpp
@@ -115,6 +115,34 @@ TEST(TiledRasterTileIo, RoundTripDoubleThreeBand)
   EXPECT_DOUBLE_EQ(loaded.get(0, 0, 2), 0.0);       // timestamp band fill
 }
 
+// A single-band int64 tile (the bathy timestamp-tile shape, #178) round-trips
+// through GeoTIFF: nanosecond-since-epoch stamps survive exactly (the precision
+// guarantee Float64 seconds could not provide), and the GridIndex is recovered.
+TEST(TiledRasterTileIo, RoundTripInt64SingleBand)
+{
+  ScratchDir dir("i64_single");
+  const gggs::Level level(11);                       // ~0.45 m cells
+  const gggs::GridIndex grid = sampleGrid(level);
+  const std::string path = (dir.path() / mtrs::tileFilename(grid)).string();
+
+  // Values that a Float64 seconds band could not represent exactly.
+  const std::int64_t a = 1'780'000'000'123'456'789LL;   // ~2026, ns precision
+  const std::int64_t b = 9'223'372'036'854'775'807LL;   // INT64_MAX
+  mtrs::TiledRasterTile<std::int64_t> tile(grid, 1, 0);
+  tile.set(0, 0, 0, a);
+  tile.set(100, 200, 0, b);
+
+  mtrs::saveTile<std::int64_t>(tile, path, {std::nullopt});
+  const auto loaded = mtrs::loadTile<std::int64_t>(path, level, 1);
+
+  EXPECT_EQ(loaded.index(), grid);
+  EXPECT_EQ(loaded.bandCount(), 1u);
+  EXPECT_EQ(loaded.get(0, 0, 0), a);
+  EXPECT_EQ(loaded.get(100, 200, 0), b);
+  EXPECT_EQ(loaded.get(5, 5, 0), 0);                 // untouched cell stays fill
+  EXPECT_FALSE(loaded.dirty());
+}
+
 // A tile saved at one level is rejected when loaded at a different level (its
 // geotransform won't match any grid there).
 TEST(TiledRasterTileIo, LevelMismatchRejected)


### PR DESCRIPTION
## Summary

One-pass **tile-format migration** of `marine_bathymetry_store`, reconciling the bathy store with the sidescan-side landings that reach into it. Closes #178. Part of #86.

This absorbs **two amendments that both land on ADR-0002 D5** in a single format cut (rather than re-touching the tile format twice):

- **Part 1 — time → separate `Int64` ns tile.** `BathyCell::timestamp` `double` (Unix seconds) → `int64_t` (ns since epoch), ROS-native and bit-exact. The tile splits into a **2-band Float64** value raster (depth + uncertainty, the costmap hot path) and a separate **1-band Int64** time tile (`<grid>_time.tif`). `DepthSample::timestamp` follows suit so the query/costmap boundary matches the store. Adds the `int64_t` instantiation + `GDT_Int64` mapping to the generic `marine_tiled_raster_store` (GDAL 3.8.4).
- **Part 2 — per-cell source-index band + `registry.json` sidecar** (adopts ADR-0005 D2/D8). A per-cell **`uint16` source-index** tile (`<grid>_source.tif`) + a `SourceRegistry` writing `registry.json` (atomic write-then-rename) at the store root, schema = ADR-0005 D3 core (`platform`/`sensor`/`sensor_class`/`campaign`) + bathy `datum` extension. Index 0 = no-data/unset; existing single-platform data maps to a default registry entry (non-destructive). `nlohmann_json` declared explicitly.
- **Part 3 — ADR-0002 amendment.** Amendment-pointer header (mirrors the #151 note) + D5 rewritten to the three-tile layout (the old "source layer is not a band" / "3-band" reasoning explicitly superseded), D6 content-hash note covers all three tile files.

The existing `processed`/`draft`/`chart` subdirectories remain the **quality/maturity** axis (unchanged); platform/sensor provenance moves to source-index + registry (the orthogonal axis ADR-0005 introduces).

## Safety (load-bearing)

The **ADR-0005 D5 safety carve-out** is preserved: `shallowestReliable()` is untouched and `DepthSample` has no `source_index` field, so the navigation-safety query is *structurally* incapable of consulting the provenance/priority axis. The `ShallowestReliableUnaffectedBySourceIndex` regression test proves it non-tautologically (identical result after swapping two cells' source indices).

## Backward compatibility

Missing `_time.tif` / `_source.tif` companions on load → 0-fill (pre-migration Phase-1 compat). The `*.tif` directory scan excludes `_time`/`_source` companions so they aren't mis-loaded as value tiles. A legacy 3-band value tile is **explicitly rejected** with a clear error (no silent timestamp-band drop). No on-disk tiles existed at branch time (pre-production) — no live data migration needed.

## Review hardening (folded pre-push)

Pre-push `review-code` returned **approved (0 must-fix)**; 4 non-blocking suggestions were folded before push and re-confirmed green:
1. `loadRegistry` validates the stored `"index"` field (1-based contiguous monotonic) — rejects a reordered/tampered `registry.json`.
2. Legacy 3-band value tile rejected via a band-count probe (`tileRasterCount`, GDAL kept encapsulated in `marine_tiled_raster_store`).
3. `saveTile` value-first write ordering documented (crash mid-write never pairs a new depth with stale provenance; safety query reads only the value tile).
4. `loadTile` enforces value/time/source share a GridIndex (closes a mis-rename/tampering hole); missing-companion 0-fill preserved.

## Testing

**45/45 gtests pass** (tiled_raster 6, store 12, query 10, tile_io 17). Clean colcon build of `marine_tiled_raster_store` + `marine_bathymetry_store`. (Local uncrustify-0.78.1 lint failures are the known CI version-drift environment issue, not real findings.)

## Follow-ups (post-merge, flagged not done here)

- #164 (Phase-4 costmap) and #175 (CAMP I4 layer) need a band-assumption check — depth stays band-1, so display/costmap are likely unaffected, but confirm.
- Query-mode-specific arbitration (ADR-0005 D5: live recency-first / curated priority-first) is downstream query-layer work, not this migration.

## Lifecycle

Driven via `/run-issue 178`: review-issue → plan-task → review-plan (3 must-fix folded) → implement → review-code (approved, 4 suggestions folded) → re-review (approved). Full timeline in `.agent/work-plans/issue-178/progress.md`.

Closes #178

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
