### PR TITLE
Split backscatter ADRs: ADR-0006 sidescan + new ADR-0007 MBES (CUBE-coupled); fix ADR-0005 wording (#190)

### DIFF
--- a/.agent/work-plans/issue-190/progress.md
+++ b/.agent/work-plans/issue-190/progress.md
@@ -1,0 +1,165 @@
+# Progress — Issue #190 (ADR restructure: split backscatter store)
+
+## Local Review (Pre-Push)
+
+**Reviewer**: fresh-context sub-agent (dual-lens, docs-only)
+**Scope**: `jazzy..HEAD`, three commits, docs-only in `docs/decisions/`
+(new `0007-mbes-backscatter-store.md`; `0006` narrowed to sidescan; `0005` wording).
+**Verdict**: `approved-with-suggestions`
+
+This is an architecture-of-record change only — no code/build/static analysis.
+Both lenses applied. The split is complete and internally consistent; the design
+is sound and well-defended. All findings below are suggestions; **no must-fix**.
+
+---
+
+### Lens A — Internal coherence & completeness of the split
+
+**Result: clean. No contradictions left by the split.**
+
+- **No leftover "one store" claims.** Grep across `docs/` for `one backscatter
+  store` / `single backscatter store` / `EM2040` returns only correctly-contextualized
+  hits: the historical-note in ADR-0005 D1 (`the original wording put EM2040 and
+  Garmin in a single backscatter store`), ADR-0006's amendment banner (describing
+  what it *used* to claim), and ADR-0007's Context (`ADR-0006 was originally written
+  as the single backscatter store`). The live decision text in all three now says
+  *family of sibling stores*. ADR-0005 D1 axis-1 rewritten correctly.
+- **EM2040 / M3 no longer land in the sidescan store.** ADR-0006 D8 and its Status
+  banner now route `mbes-backscatter` to ADR-0007's store; ADR-0006 "ingests
+  `sensor_class: sidescan` sources" only. ADR-0005 D3 sensor_class table lists
+  `sidescan`, `mbes-backscatter`, `mbes-bathy` as distinct arbitration classes.
+- **ADR-0007 ↔ ADR-0006 responsibilities are cleanly disjoint and the
+  sibling/fusion relationship is stated symmetrically.** ADR-0006 D8: cross-class
+  arbitration is "across the two sibling stores at the fusion / query — or
+  central-server — layer ... *not* inside this store (ADR-0007)". ADR-0007 D8 says
+  the mirror image: "Neither store arbitrates across the other's class internally
+  (ADR-0006 D8 says the same from its side)." Both cite ADR-0005 D5/D7. Symmetric.
+- **ADR-0005 D6 re-arbitration taxonomy now covers all three stores correctly.**
+  Rewritten to three bullets: sidescan (slant Tier-1 → re-project, no bag reread),
+  MBES single-tier (bags ARE the archive → re-run CUBE pass), bathy (no in-store
+  archive → re-import). The closing sentence correctly narrows the *no-bag-reread*
+  guarantee to the sidescan Tier-1 only. This is the strongest part of the edit.
+- **No orphaned MBES text in narrowed ADR-0006.** Checked D11 (node topology:
+  gabby/salmon/dev) and D12 (package placement / phasing) — both are sidescan-only;
+  no M3/MBES/EM2040/Norbit leftovers (grep clean). Consequences "Positive" bullet
+  re-scoped to "multi-platform (sidescan-class)". D2/D7 Tier-1/slant language all
+  still coherent for a sidescan-only store.
+- **Cross-references resolve.** ADR-0007 → ADR-0002/0005/0006 all exist; issues
+  #180/#179/#178/#190/#147/#175 and cube#52/#15 all referenced consistently.
+  Verified cube#52 = **CLOSED/merged** (matches ADR-0007's "(merged)" claim, line 18).
+  cube#15 correctly described as "slope correction currently disabled". ADR-0002's
+  existing inbound link to `0006-multi-platform-backscatter-store.md` still resolves
+  (filename unchanged — see suggestion A1).
+
+**Suggestions (Lens A):**
+
+- **A1 (cosmetic).** The *file* is still named `0006-multi-platform-backscatter-store.md`
+  while the *title* is now "ADR-0006: Sidescan Backscatter Store". The mismatch is
+  harmless and arguably correct — renaming a committed ADR file breaks the stable
+  URL/anchor that ADR-0002 (and external refs) link to, and ADR convention is to keep
+  the original slug. The amendment banner already disambiguates. Recommend **leave as
+  is**; optionally note in the banner that the filename slug is retained for link
+  stability. Not a defect.
+- **A2 (minor symmetry).** ADR-0007's Status line says "Sibling to **ADR-0006**";
+  ADR-0006's *banner* names ADR-0007 but its Status header does not carry a reciprocal
+  "Sibling to ADR-0007" line. Optional one-line addition for symmetry.
+
+---
+
+### Lens B — Architectural soundness (adversarial)
+
+**Result: design is sound and the sharp edges are already acknowledged in-text.**
+
+- **"Intensity rides the winning CUBE hypothesis as a Welford passenger" (D2) — sound,
+  and the failure mode IS acknowledged.** Tying backscatter association to the depth
+  data-association is defensible: the beams that contribute a node's depth are the
+  beams whose footprints actually struck that ground cell, which is exactly the set a
+  backscatter cell estimate needs. The named failure mode — **a beam that is a valid
+  depth member but an intensity outlier** (e.g. a fish/kelp/transient specular return
+  that is geometrically on-bottom but radiometrically anomalous; or a bad-AGC ping) —
+  is real: depth-gating will *not* reject it, so it pollutes the Welford mean. ADR-0007
+  handles this honestly: D2 explicitly declines a second W&H DLM on intensity (no
+  per-beam obs-noise model for AGC dB → inverse-variance update would be false
+  precision), and D4 routes the *spread* into the **dispersion / texture band** — which
+  is exactly where an intensity outlier surfaces. So the ADR does not claim outlier
+  rejection for intensity; it claims depth-consistent association and books the residual
+  as dispersion. That is the correct disposition. **Suggestion B1**: D2's bullet
+  "outlier rejection comes free and is consistent between the two products" slightly
+  over-reads — it's free for *depth-geometry* outliers, not *intensity* outliers; worth
+  one clause cross-pointing to the D4 dispersion band so the limit isn't lost.
+- **"Deferred-settled angle correction" (D3) — sufficient stats suffice; slope
+  correctly characterized as output-stage.** Carrying per-beam `{raw intensity, grazing
+  angle}` (plus the already-present slant range / footprint geometry) on the hypothesis
+  is exactly the GeoCoder input set: footprint-area, incidence/Lambert, and residual
+  beam-pattern corrections are all functions of grazing/incidence angle + range +
+  settled depth/slope. Deferring to node-output (once depth + neighbour-derived slope
+  settle) is the right ordering — you cannot compute incidence live because slope isn't
+  known until neighbouring nodes settle. The cube#15 slope dependency is correctly
+  framed as an **output-stage** need ("the slope that feeds incidence-angle correction
+  here is the same quantity #15 must provide — at output, not in the live insert"),
+  which sidesteps re-enabling the disabled live `Node::insert` slope path. Architecturally
+  clean. One residual: D3 keeps per-beam records on the hypothesis "until output" — for
+  a long-dwell / high-overlap node that per-beam list is unbounded in principle
+  (**Suggestion B2**: note a cap / reservoir, or that draft uses live-settled and only
+  processed carries full per-beam — D7 already implies the latter; make it explicit).
+- **"Single-tier; bags are the archive" (D1) — equivalent to sidescan Tier-1 for
+  re-arbitration EXCEPT the cold-storage case, which is under-acknowledged.** For the
+  depth-refine / re-arbitrate use case D1 IS equivalent: re-running the CUBE pass over
+  the soundings bags regenerates both products against refined bathy, and the bags hold
+  strictly more than a slant Tier-1 would. The case it loses is the one the prompt
+  flags: **bags aged off to cold storage / deleted**. ADR-0006 D11 explicitly says its
+  Tier-1 archive "lets bags move to cold storage" — i.e. sidescan can *discard the bags*
+  and still re-arbitrate from Tier-1; the MBES store **cannot** — if the bags are gone,
+  the single-tier store is frozen (no re-correction, no re-arbitration). ADR-0007 D1
+  asserts "the soundings bags already are the bottom-agnostic source of truth" and the
+  Consequences lean on bag-reprocessing, but **nowhere states the dependency: the MBES
+  store's re-derivability is contingent on bag retention.** ADR-0005 D3 has the matching
+  hook ("Re-import-from-source presumes the original source is retained; source retention
+  is a ... responsibility, out of scope"), but ADR-0007 should name it locally.
+  **Suggestion B3 (strongest suggestion):** add one line to D1 or Consequences/Risk —
+  "this trades the sidescan store's bag-independence (ADR-0006 D11 cold-storage) for no
+  redundant Tier-1; the MBES store's durability/re-derivability is therefore contingent
+  on soundings-bag retention (cf. ADR-0005 D3)." It's a real asymmetry the split creates
+  and the ADR currently states only the upside.
+- **float-vs-uint16 value tile (D6) — proposed position is right.** Sidescan's `uint16`
+  intensity is detection-grade display data; MBES backscatter carries an estimate
+  *variance* band (D4) and mirrors the bathy store's `Float64` depth/uncertainty
+  semantics, so a float value tile is the consistent choice — uint16 would throw away
+  the precision the variance band exists to express. Correctly flagged "ratify in review";
+  the proposed position is defensible. (The source-index band stays `uint16` per ADR-0005,
+  unaffected.)
+- **package placement (D9) — proposed position is right.** Accumulation logic in
+  `cube_bathymetry` (where the hypothesis/grid machinery lives, sensors_ws, already feeds
+  bathy) + store/tile IO in `core_ws` reusing `marine_tiled_raster_store`, with the
+  one-way dependency `cube_bathymetry → core store` (never the reverse) is the same
+  layering ADR-0002 D9 already commits to. Sound. "new package vs thin instantiation"
+  is genuinely a code-time call; correct to defer.
+- **Safety — correct and unweakened.** ADR-0007 Consequences keeps backscatter a
+  non-autonomy product ("not a navigation or costmap input ... nothing here routes
+  backscatter into Nav2") **and** correctly carves out that the *bathy half* of the same
+  node output IS subject to ADR-0002's Safety-First costmap path ("The *bathy* half of
+  the node output is subject to ADR-0002's Safety-First costmap path; the *backscatter*
+  half is not"). It also gates any future texture/shadow→autonomy signal behind its own
+  Safety-First review. Nothing in the three diffs touches or weakens the ADR-0005 D5
+  shallowest-reliable carve-out (D5 text unchanged in this branch; ADR-0007 cites it
+  correctly as out-of-scope). Confirmed clean.
+
+**Suggestions (Lens B):** B1 (D2 outlier-claim over-reads — cross-point to D4 dispersion),
+B2 (D3 unbounded per-beam record on hypothesis — note a cap or draft/processed split),
+B3 (**strongest** — D1/Consequences should name the bag-retention dependency that the
+single-tier choice creates; ADR-0006 D11 advertises the opposite for sidescan).
+
+---
+
+### Must-fix vs suggestion
+
+- **Must-fix:** none.
+- **Suggestions:** A1 (filename/title note — recommend leave as is), A2 (reciprocal
+  sibling line in 0006 Status), B1 (qualify D2 outlier claim), B2 (bound D3 per-beam
+  carry), B3 (state the bag-retention dependency in ADR-0007 D1/Consequences — the one
+  asymmetry the split introduces that the ADR currently presents one-sided).
+
+**Recommendation:** `approved-with-suggestions`. The restructure achieves its stated
+scope completely and the new ADR-0007 is architecturally sound. B3 is the only finding
+with design substance and even it is a documentation gap, not a design flaw — safe to
+push and address in review, or fold in now.

--- a/docs/decisions/0005-multi-platform-provenance-registry.md
+++ b/docs/decisions/0005-multi-platform-provenance-registry.md
@@ -7,8 +7,9 @@ Proposed (2026-06-20). Tracked by
 
 This is a **cross-cutting** decision in the sense ADR-0001 establishes for this
 repo's `docs/decisions/`: it spans the bathymetric store (ADR-0002 / #86) and the
-backscatter store (ADR-0006 / #180), and defines the provenance contract both
-share. It is foundational to those store ADRs rather than owned by either.
+backscatter stores — **sidescan** (ADR-0006) and **MBES** (ADR-0007), both under
+#180 — and defines the provenance contract all three share. It is foundational to
+those store ADRs rather than owned by any one of them.
 
 ## Context
 
@@ -42,9 +43,18 @@ different layer of the design:
 
 1. **Modality → which store.** Bathymetry and backscatter are different value
    types, dtypes, and consumers, so they are **separate stores**. DriX EM2040
-   bathy and BizzyBoat M3 bathy both land in the bathy store; EM2040 backscatter
-   and Garmin sidescan both land in **one** backscatter store (a unified
-   "best backscatter here" surface across sensor types).
+   bathy and BizzyBoat M3 bathy both land in the bathy store. Backscatter is a
+   **family of sibling stores keyed by `sensor_class` ingest architecture** — a
+   **sidescan** store (two-tier, slant-archived: Garmin GCV; ADR-0006) and an
+   **MBES-backscatter** store (single-tier, co-estimated with bathy by the CUBE
+   pass: M3 / EM2040; ADR-0007) — because those ingest paths differ fundamentally
+   (sidescan has no bathy of its own and must archive + project later; MBES
+   backscatter is a co-registered by-product of the depth solution). The sibling
+   stores share this registry and the GGGS GridIndex, so a unified
+   "best backscatter here" surface is composed **across** them at the query /
+   central-server layer (D5/D7), not inside one monolithic store. *(Updated
+   2026-06-20, [#190](https://github.com/rolker/unh_marine_autonomy/issues/190);
+   the original wording put EM2040 and Garmin in a single backscatter store.)*
 2. **Quality / maturity → layer subdirectory** (`processed` / `draft`), exactly
    as ADR-0002 D3/D5. Unchanged.
 3. **Platform / sensor / campaign → a compact per-cell `source-id` plus a
@@ -200,19 +210,23 @@ costmap arbitration is validated in `unh_marine_simulation` before field use.
 ### D6 — Provenance is per-contribution; re-arbitration cost depends on the store
 
 Every tile cell records the **winning** `source-id`. Whether a re-arbitration (new
-platform data, or a priority change) can be done **without reimport** depends on
-whether the store keeps a per-contribution archive:
+platform data, or a priority change) can be done **without re-reading the source
+bags** depends on what archive the store keeps:
 
-- The **backscatter store keeps a Tier-1 per-ping archive** (ADR-0006), so it
-  re-projects from the retained contributions and re-arbitrates without reimport.
-- The **bathy store has no such archive today** (ADR-0002's draft layer is
+- The **sidescan backscatter store keeps a slant-indexed Tier-1 per-ping archive**
+  (ADR-0006), so it re-projects from the retained contributions and re-arbitrates
+  without re-reading bags.
+- The **MBES backscatter store is single-tier** (ADR-0007): it keeps no separate
+  per-contribution archive because the **soundings bags are its archive**, so a
+  re-arbitration / bathy-refine re-runs the CUBE + node-output pass over the bags
+  (the same offline path the bathy store uses).
+- The **bathy store likewise has no in-store archive** (ADR-0002's draft layer is
   in-memory CUBE tiles arbitrated in place), so re-arbitration there means
-  re-importing the affected sources — until/unless it grows a contribution archive
-  of its own.
+  re-importing the affected sources from their bags.
 
-The provenance contract (per-cell `source-id` + registry) is identical for both;
-only the no-reimport *guarantee* is specific to a store that archives its
-contributions.
+The provenance contract (per-cell `source-id` + registry) is identical for all
+three; only the *no-bag-reread guarantee* is specific to a store that keeps an
+in-store contribution archive (the sidescan Tier-1).
 
 ### D7 — The central server is a third sync tier
 
@@ -228,8 +242,8 @@ registry is the only addition to the existing manifest sync.
 
 ### D8 — Both stores adopt this; ADR-0002 gains it additively
 
-The backscatter store (ADR-0006) is designed against this from the start. The
-bathy store (ADR-0002) **adopts it additively**: its existing `processed` /
+Both backscatter stores (ADR-0006 sidescan, ADR-0007 MBES) are designed against
+this from the start. The bathy store (ADR-0002) **adopts it additively**: its existing `processed` /
 `draft` / `chart` remain the **quality/maturity layer** axis, while
 platform/sensor moves to `source-id` + registry. The additive change for bathy is
 the per-cell `source-id` band (D2, amending ADR-0002 D5) plus the registry;
@@ -265,7 +279,7 @@ navigation query.
 ## References
 
 - Bathymetric store: ADR-0002 / [#86](https://github.com/rolker/unh_marine_autonomy/issues/86)
-- Backscatter store: ADR-0006 (proposed) / [#180](https://github.com/rolker/unh_marine_autonomy/issues/180)
+- Backscatter stores: ADR-0006 sidescan, ADR-0007 MBES (both proposed) / [#180](https://github.com/rolker/unh_marine_autonomy/issues/180); ADR split [#190](https://github.com/rolker/unh_marine_autonomy/issues/190)
 - Sidescan mosaic umbrella: [#171](https://github.com/rolker/unh_marine_autonomy/issues/171)
 - Bathy time-band Int64 alignment: [#178](https://github.com/rolker/unh_marine_autonomy/issues/178)
 - Spatial index: `marine_autonomy` GGGS (`marine_autonomy/include/marine_autonomy/gggs/`)

--- a/docs/decisions/0006-multi-platform-backscatter-store.md
+++ b/docs/decisions/0006-multi-platform-backscatter-store.md
@@ -21,11 +21,12 @@ arbitration happens at the fusion / query (or central-server) layer across the t
 stores, not inside either one** (D8). This store ingests `sensor_class: sidescan`
 sources.
 
-Builds on **ADR-0002** (bathymetric store — tiling, layer-as-subdirectory,
-content-hash sync, datum-at-import) and **ADR-0005** (cross-store
-provenance/registry). First sensor: **BizzyBoat Garmin GCV** side-scan. A
-**cross-cutting** ADR per the ADR-0001 convention (spans `marine_sidescan_mosaic`,
-`marine_tiled_raster_store`, `marine_autonomy` GGGS, and the bathy store it reads).
+Sibling to **ADR-0007** (MBES backscatter store). Builds on **ADR-0002**
+(bathymetric store — tiling, layer-as-subdirectory, content-hash sync,
+datum-at-import) and **ADR-0005** (cross-store provenance/registry). First sensor:
+**BizzyBoat Garmin GCV** side-scan. A **cross-cutting** ADR per the ADR-0001
+convention (spans `marine_sidescan_mosaic`, `marine_tiled_raster_store`,
+`marine_autonomy` GGGS, and the bathy store it reads).
 
 ## Context
 

--- a/docs/decisions/0006-multi-platform-backscatter-store.md
+++ b/docs/decisions/0006-multi-platform-backscatter-store.md
@@ -1,4 +1,4 @@
-# ADR-0006: Multi-Platform Backscatter Store (Two-Tier, GeoCoder-Processed)
+# ADR-0006: Sidescan Backscatter Store (Two-Tier, GeoCoder-Processed)
 
 ## Status
 
@@ -7,12 +7,25 @@ Proposed (2026-06-20). Tracked by
 Part of the sidescan-mosaic umbrella
 [#171](https://github.com/rolker/unh_marine_autonomy/issues/171).
 
+**Amended 2026-06-20 ([#190](https://github.com/rolker/unh_marine_autonomy/issues/190)):
+this ADR is the *sidescan* backscatter store only.** It originally framed itself as
+the single backscatter store for *all* sensors (Garmin side-scan first, EM2040 / M3
+backscatter as later adopters into the same store). That is superseded: **MBES
+backscatter (Norbit M3, Kongsberg EM2040) has its own store** — single-tier and
+CUBE-coupled — in **ADR-0007**, because it is co-estimated with bathymetry by the
+CUBE pass and so has a fundamentally different ingest path and tiering than
+slant-archived sidescan (ADR-0007 draws the contrast). The two remain **sibling
+backscatter stores** that share the ADR-0005 registry and GGGS GridIndex, so they
+still fuse for a "best backscatter here" answer — but **cross-sensor-class
+arbitration happens at the fusion / query (or central-server) layer across the two
+stores, not inside either one** (D8). This store ingests `sensor_class: sidescan`
+sources.
+
 Builds on **ADR-0002** (bathymetric store — tiling, layer-as-subdirectory,
 content-hash sync, datum-at-import) and **ADR-0005** (cross-store
-provenance/registry). First sensor: **BizzyBoat Garmin GCV** side-scan; Kongsberg
-EM2040 / Norbit M3 backscatter are later adopters. A **cross-cutting** ADR per
-the ADR-0001 convention (spans `marine_sidescan_mosaic`, `marine_tiled_raster_store`,
-`marine_autonomy` GGGS, and the bathy store it reads).
+provenance/registry). First sensor: **BizzyBoat Garmin GCV** side-scan. A
+**cross-cutting** ADR per the ADR-0001 convention (spans `marine_sidescan_mosaic`,
+`marine_tiled_raster_store`, `marine_autonomy` GGGS, and the bathy store it reads).
 
 ## Context
 
@@ -164,13 +177,17 @@ today; CAMP consumes the tiles via the #175 GPU display-warp path.)
 The per-cell band carries a compact **local source index** (ADR-0005 D2); the
 registry resolves it to the **global, origin-namespaced `source-id`** (ADR-0005
 D2/D4). v1 ingests one source (BizzyBoat/Garmin, `sensor_class: sidescan`) but
-allocates a namespaced global id and a registry entry so the second sensor (EM2040
-`mbes-backscatter`, M3) needs no migration. Cross-source arbitration is the
-**curated-mode** rule of ADR-0005 D5 — **priority-first**: `sensor_class` is the
-primary key (calibrated `mbes-backscatter` outranks `sidescan`), quality breaks
-ties *within* a class; the numeric table is deferred with multi-sensor ingest.
-Because Tier-1 archives every ping (D1), a priority change or new source
-**re-arbitrates by a cheap Tier-2 re-projection — no reimport** (cf. ADR-0005 D6).
+allocates a namespaced global id and a registry entry so a **second sidescan-class
+platform** needs no migration. Within this store all sources are `sensor_class:
+sidescan`, so the ADR-0005 D5 **curated-mode** arbitration reduces to **quality-first**
+(the grazing-angle score of D5) across passes — there is no in-store sensor-class
+tiebreak to apply. **Cross-sensor-class arbitration** (sidescan vs MBES backscatter,
+where ADR-0005 D5 makes calibrated `mbes-backscatter` outrank `sidescan`) happens
+**across the two sibling stores at the fusion / query — or central-server — layer**
+(ADR-0007; ADR-0005 D5/D7), *not* inside this store, since MBES backscatter lives in
+its own store (ADR-0007). Because Tier-1 archives every ping (D1), a priority change
+or new sidescan source **re-arbitrates by a cheap Tier-2 re-projection — no reimport**
+(cf. ADR-0005 D6).
 
 ### D9 — Bathy coupling is a direct tile file-read, not a package dependency
 
@@ -239,9 +256,9 @@ The live `draft` recency policy is the separate, already-filed #177.
 
 ## Consequences
 
-- **Positive:** a durable, multi-survey, multi-platform backscatter product that
-  serves both detection (best-source, crisp) and a cartographic drape (feathered
-  render) from one store; bathy refinement is cheap (re-project Tier-2, no
+- **Positive:** a durable, multi-survey, multi-platform (sidescan-class) backscatter
+  product that serves both detection (best-source, crisp) and a cartographic drape
+  (feathered render) from one store; bathy refinement is cheap (re-project Tier-2, no
   reimport); reuses ADR-0002's tiling/sync and ADR-0005's provenance; GeoCoder
   preserves the reflectors/shadows that detection needs.
 - **Safety non-goal (explicit):** this is a perception / cartographic product and

--- a/docs/decisions/0007-mbes-backscatter-store.md
+++ b/docs/decisions/0007-mbes-backscatter-store.md
@@ -171,17 +171,44 @@ lookup is needed at write time.
 ### D6 — Tile schema and provenance reuse ADR-0006 / ADR-0005
 
 Persist GGGS tiles as **GeoTIFF** via the generic `marine_tiled_raster_store`
-(ADR-0002 D5 mechanism), reusing the ADR-0006 D7 schema: a compact value/quality/
-**source-index** tile plus a separate `Int64`-ns time tile (the *co-locate same-dtype,
-separate cold/differing-dtype* principle, as in [#178](https://github.com/rolker/unh_marine_autonomy/issues/178)).
+(ADR-0002 D5 mechanism), following the same *co-locate same-dtype, separate
+cold/differing-dtype* principle ADR-0006 D7 and [#178](https://github.com/rolker/unh_marine_autonomy/issues/178)
+apply. Because the value band here is **float** (next paragraph), the schema cannot
+reuse ADR-0006's single 3-band `uint16` tile — a GeoTIFF is single-dtype-per-file —
+so it separates by dtype into **three tiles**: a float **`{intensity,
+intensity_variance}` value tile**, a separate **small-int `source-index` tile**, and
+a separate **`Int64`-ns time tile**. (This is the one place the MBES schema departs
+from ADR-0006, where value/quality/source-index share a dtype and co-locate.)
 Provenance is ADR-0005: the per-cell **local source index** resolves through the
 registry to a global, origin-namespaced `source-id`; the M3 registry entry is
 `platform: bizzyboat, sensor: norbit-m3, sensor_class: mbes-backscatter`, with
 `calibration_ref` empty until a beam-pattern calibration exists (relative
-backscatter). `intensity_variance` rides as a value-band alongside intensity
-(both float, co-accessed) — the bathy and backscatter intensity precisions are
-float, so the value tile is a float tile here rather than ADR-0006's detection-grade
-`uint16` (an MBES-store divergence to ratify in review).
+backscatter).
+
+The value tile is **float** rather than ADR-0006's detection-grade `uint16` because
+`intensity_variance` (D4, the Welford estimate variance) rides as a band alongside
+intensity and both are float precisions — there is **no** integer "quality" band
+here; the variance *is* the quality/uncertainty signal (mirroring the bathy store's
+depth uncertainty). A float value tile needs a `float` instantiation of the generic
+`marine_tiled_raster_store` tile IO, mirroring the `Int64` instantiation
+[#178](https://github.com/rolker/unh_marine_autonomy/issues/178) added for the time
+band. *(Float-value tile = a position to ratify in review.)*
+
+**Shared code vs. per-store code — the `marine_backscatter` boundary.** What this
+store **shares** with the sidescan store is *library code*, not just a schema:
+[`marine_backscatter`](https://github.com/rolker/unh_marine_autonomy/issues/191)
+(#191, Part of #180) is the modality-agnostic home for the **registry writer + JSON
+escaping**, the **`grazingQuality`** helper, and — when it lands — the **GeoCoder
+radiometry chain** (footprint area + incidence/Lambert + residual beam pattern). D3's
+node-output correction *is* that shared chain, called here at MBES node-output and at
+sidescan Tier-2 — **one GeoCoder, two call sites**, not two implementations. What is
+**per-store** is the **compositor**: sidescan composites **best-source** (`uint16`,
+`marine_backscatter::ProcessedAccumulator`) because blending angle-/shadow-dependent
+sidescan degrades it; MBES composites a **Welford mean+variance** (`float`, D2)
+because its beams are angle-corrected and a running estimate is the honest treatment.
+The MBES store therefore **depends on `marine_backscatter`** for registry + quality +
+GeoCoder and adds its own Welford accumulator — it does **not** reuse the best-source
+`ProcessedAccumulator`.
 
 ### D7 — `draft` / `processed` layers (ADR-0002 D3/D5; ADR-0006 D6)
 
@@ -211,11 +238,16 @@ the cross-store composition a tile-by-tile merge, not a resample.
 The CUBE-coupled accumulation (intensity-in-`Hypothesis`, node-output correction)
 lives in **`cube_bathymetry`** (where CUBE and the hypothesis/grid machinery are; it
 sits in `sensors_ws`, above `core_ws`, and already feeds the bathy store). The
-**store/tile IO** is a `core_ws` concern reusing `marine_tiled_raster_store`; whether
-it is a new `marine_mbes_backscatter_store` package or a thin instantiation beside
-the bathy store is a placement choice to ratify. `cube_bathymetry` may depend on the
-core store package (same direction it already feeds bathy); the store package must
-**not** depend on `cube_bathymetry` (layering, ADR-0002 D9). Phases (sub-issues,
+**store/tile IO** is a `core_ws` concern reusing `marine_tiled_raster_store` and
+**depending on `marine_backscatter`** (D6: shared registry + quality + GeoCoder).
+**Recommendation: a new `marine_mbes_backscatter_store` package** (depending on
+`marine_backscatter` + `marine_tiled_raster_store`), symmetric with
+`marine_sidescan_mosaic → marine_backscatter`, rather than a thin instantiation
+beside the bathy store — the float value tile, the Welford accumulator, and the
+node-output correction stage are enough store-specific logic to warrant its own
+package. (Placement remains a position to ratify.) `cube_bathymetry` may depend on
+the core store package (same direction it already feeds bathy); the store package
+must **not** depend on `cube_bathymetry` (layering, ADR-0002 D9). Phases (sub-issues,
 Part of #180 / #190):
 
 1. This ADR.

--- a/docs/decisions/0007-mbes-backscatter-store.md
+++ b/docs/decisions/0007-mbes-backscatter-store.md
@@ -1,0 +1,250 @@
+# ADR-0007: MBES Backscatter Store (CUBE-Coupled, Single-Tier)
+
+## Status
+
+Proposed (2026-06-20). Tracked by
+[rolker/unh_marine_autonomy#190](https://github.com/rolker/unh_marine_autonomy/issues/190),
+Part of [#180](https://github.com/rolker/unh_marine_autonomy/issues/180).
+
+Sibling to **ADR-0006** (sidescan backscatter store). Builds on **ADR-0002**
+(bathymetric store — tiling, layer-as-subdirectory, content-hash sync), **ADR-0005**
+(cross-store provenance/registry), and the **CUBE** depth estimator in
+`cube_bathymetry`. A **cross-cutting** ADR per the ADR-0001 convention (spans
+`cube_bathymetry`, the bathy store, `marine_tiled_raster_store`, and
+`marine_autonomy` GGGS).
+
+First sensor: **BizzyBoat Norbit M3** (via `kongsberg_em_bridge`), whose per-beam
+reflectivity (dB) is now carried into the soundings point cloud by
+[cube_bathymetry#52](https://github.com/rolker/cube_bathymetry/issues/52) (merged).
+Kongsberg EM2040 is a later adopter of the *same* store.
+
+## Context
+
+The M3 multibeam reports **per-beam acoustic backscatter** (reflectivity, dB)
+alongside each bottom detection. This is real MBES backscatter, and it is
+**co-registered with bathymetry by construction** — both come from the same per-beam
+solution in the same CUBE pass. We want a durable, georeferenced "best MBES
+backscatter here" surface, fused (via GGGS + the ADR-0005 registry) with the
+sidescan store for a unified backscatter answer.
+
+ADR-0006 was originally written as the single backscatter store for all sensors.
+That does not fit MBES backscatter, for one decisive reason:
+
+- **Sidescan has no bathymetry of its own.** A Garmin GCV ping is a slant-range
+  time series with no per-sample bottom position; it *must* keep a slant-indexed
+  Tier-1 archive and project against an external bathy model later (ADR-0006 D1/D2).
+- **MBES backscatter already has its geometry.** Each beam's footprint position
+  *is* the sounding the CUBE pass is already estimating. There is no slant time
+  series to archive and no external-bathy projection step — the bathy is the M3's
+  own, intrinsic to the same beams.
+
+So MBES backscatter is not a slant-archived, project-later product. It is a
+**by-product of the depth estimation**, and the architecture-of-record should treat
+it that way. Two physical facts still constrain it (shared with ADR-0006):
+
+1. **Backscatter is grazing-angle-dependent.** Raw reflectivity at one ground cell
+   mixes beams that struck it at different grazing angles across passes; naive
+   averaging of *raw* dB is angle-corrupted. The angular response must be removed
+   (GeoCoder; Fonseca & Calder 2005) before cross-beam combination — and incidence
+   angle needs **local seabed slope**, i.e. the bathy.
+2. **Bathymetry refines over time.** The radiometric correction (footprint area,
+   incidence) is bathy-dependent, so a corrected value must be re-derivable when the
+   bottom model improves.
+
+The M3 is AGC/uncalibrated, so v1 yields **relative**, not absolute-ARA,
+backscatter (see Consequences) — same caveat as the Garmin GCV in ADR-0006.
+
+## Decision
+
+### D1 — Single-tier store; the soundings bags are the re-processing archive
+
+Unlike the sidescan store (ADR-0006 D1, two-tier with a slant Tier-1), the MBES
+backscatter store is **single-tier**: the CUBE node output is written straight to
+GGGS tiles. There is no separate per-ping intermediate to archive, because the
+**soundings bags already are the bottom-agnostic source of truth** — they hold the
+per-beam detections (range, angle, intensity, nav/attitude/mounting via the TF
+chain). Durable re-correction against a refined bathy model = **re-run the CUBE +
+node-output pass over the bags**, exactly the offline path the bathy store already
+uses (cf. ADR-0002 Phase-2 import; bag-read, not replay,
+[#147](https://github.com/rolker/unh_marine_autonomy/issues/147)).
+
+This is the deliberate split from ADR-0006: sidescan *needs* Tier-1 because it has
+no bathy; MBES *does not*, because its bathy and its archive (the bags) both already
+exist. Adding a slant Tier-1 here would be redundant state.
+
+### D2 — Produced by the CUBE pass: intensity rides the winning hypothesis
+
+The store is fed by the **CUBE estimator** (`cube_bathymetry`), not a standalone
+importer. CUBE's value is **data association**: at each grid node it tracks competing
+depth **hypotheses** (West & Harrison dynamic linear models;
+`cube_bathymetry/include/cube_bathymetry/hypothesis.h`), monitors for outliers /
+interventions (Bayes-factor), and disambiguates to a winning hypothesis. That
+association — *which beams belong together at this node* — is exactly what a
+backscatter cell estimate needs and would otherwise have to reinvent.
+
+**Decision: intensity is a passenger on the depth hypothesis.** When a beam's depth
+is incorporated into a hypothesis, its backscatter is accumulated on the *same*
+hypothesis. Consequences:
+
+- Beams the W&H monitor **rejects for depth** (multipath, outliers) never enter the
+  backscatter accumulator — outlier rejection comes free and is consistent between
+  the two products.
+- The winning hypothesis emits, per node, a **single enriched record**:
+  `{ depth, depth_variance, intensity, intensity_variance, n_samples }`.
+
+The intensity accumulator is a **Welford running mean + variance**, not a second
+W&H DLM. Depth has a calibrated per-beam vertical-variance from the CUBE error
+model; M3 reflectivity is AGC/relative with no comparable per-beam observation-noise
+model, so an inverse-variance Bayesian update would be false precision. A Welford
+accumulator over the associated, angle-corrected beams (D3) is the honest "similar
+statistical treatment."
+
+### D3 — Angle correction is deferred to node-output (sufficient stats in the hypothesis)
+
+Raw reflectivity cannot be accumulated directly (Context fact 1: angle-corrupted).
+The correction (GeoCoder footprint area + incidence/Lambert + residual beam pattern)
+needs the node's settled depth and **local slope**, which are not known while the
+hypothesis is still forming. Two orderings were considered (live-approximate-then-
+refine vs. deferred-settled); **the decision is deferred-settled**:
+
+- The hypothesis carries, per contributing beam, the **sufficient statistics needed
+  to correct later** — `{ raw intensity, grazing angle }` (plus the per-beam
+  geometry already present: slant range, footprint terms) — rather than a single
+  prematurely-corrected number.
+- The **radiometric correction is applied at node-output**, once the winning
+  hypothesis depth and the local slope (from neighbouring nodes) have settled. Only
+  then is the Welford mean/variance of *corrected* backscatter computed and written.
+
+This keeps the stored value radiometrically clean and re-derivable, at the cost of
+carrying a small per-beam record on the hypothesis until output. It ties directly to
+**cube_bathymetry#15** (slope correction is currently disabled in `Node::insert`):
+the slope that feeds incidence-angle correction here is the same quantity #15 must
+provide — at output, not in the live insert.
+
+### D4 — `intensity_uncertainty` = posterior estimate variance; dispersion is a candidate texture band
+
+The store's per-cell **`intensity_uncertainty`** is the **variance of the estimate**
+(the Welford mean's uncertainty, shrinking with `n_samples`), mirroring the bathy
+store's depth uncertainty (ADR-0002 D3) so the two products read symmetrically and
+the same quality/staleness logic applies.
+
+The **within-node dispersion** of corrected backscatter (the *spread* of contributing
+beams, which does **not** shrink with `n`) is a distinct quantity — a seabed
+**texture / roughness** signal (heterogeneous substrate → high spread). It is **not**
+the v1 uncertainty band, but is noted as a candidate **second band** (texture) for a
+later version; the Welford accumulator already computes it.
+
+### D5 — Node output fans out to two stores, co-registered by construction
+
+The enriched winning-hypothesis record drives **two stores** from one pass, both
+keyed by the **same GGGS `GridIndex`/`CellIndex`**:
+
+- `{ depth, depth_variance, timestamp, source-index }` → the **bathymetric store**
+  (ADR-0002, as amended by [#178](https://github.com/rolker/unh_marine_autonomy/issues/178)).
+  Unchanged — this ADR adds no bathy-store obligation beyond what the CUBE producer
+  already feeds.
+- `{ intensity, intensity_variance, timestamp, source-index }` → this **MBES
+  backscatter store**.
+
+Because both come from the same node, depth and backscatter are **co-registered with
+zero reprojection** — the property sidescan has to work for via Tier-2. No cross-store
+lookup is needed at write time.
+
+### D6 — Tile schema and provenance reuse ADR-0006 / ADR-0005
+
+Persist GGGS tiles as **GeoTIFF** via the generic `marine_tiled_raster_store`
+(ADR-0002 D5 mechanism), reusing the ADR-0006 D7 schema: a compact value/quality/
+**source-index** tile plus a separate `Int64`-ns time tile (the *co-locate same-dtype,
+separate cold/differing-dtype* principle, as in [#178](https://github.com/rolker/unh_marine_autonomy/issues/178)).
+Provenance is ADR-0005: the per-cell **local source index** resolves through the
+registry to a global, origin-namespaced `source-id`; the M3 registry entry is
+`platform: bizzyboat, sensor: norbit-m3, sensor_class: mbes-backscatter`, with
+`calibration_ref` empty until a beam-pattern calibration exists (relative
+backscatter). `intensity_variance` rides as a value-band alongside intensity
+(both float, co-accessed) — the bathy and backscatter intensity precisions are
+float, so the value tile is a float tile here rather than ADR-0006's detection-grade
+`uint16` (an MBES-store divergence to ratify in review).
+
+### D7 — `draft` / `processed` layers (ADR-0002 D3/D5; ADR-0006 D6)
+
+Same two-layer priority overlay as the sidescan store:
+
+- **`draft`** — the live operator view, written during a survey from the CUBE pass.
+  Recency/newest-valid-wins (ADR-0006 D6). For the live layer the angle correction
+  uses the *current* settled-so-far depth/slope (best available live); it is
+  superseded by the durable re-run.
+- **`processed`** — the durable product: the full deferred-settled correction (D3)
+  over the offline CUBE re-run, quality-arbitrated, re-derived when bathy refines.
+
+`draft → processed` is an overlay/promotion, mirroring ADR-0002 and ADR-0006.
+
+### D8 — Cross-sensor-class fusion with sidescan is at the query / central-server layer
+
+This store holds only `sensor_class: mbes-backscatter`. A unified "best backscatter
+here" across MBES and sidescan is composed **across the two sibling stores** at the
+fusion / query (or central-server, ADR-0005 D7) layer, by the ADR-0005 D5 curated
+rule — `sensor_class` priority (calibrated `mbes-backscatter` outranks `sidescan`),
+quality tiebreak within a class. Neither store arbitrates across the other's class
+internally (ADR-0006 D8 says the same from its side). The shared GGGS GridIndex makes
+the cross-store composition a tile-by-tile merge, not a resample.
+
+### D9 — Package placement and phasing (positions to ratify in review)
+
+The CUBE-coupled accumulation (intensity-in-`Hypothesis`, node-output correction)
+lives in **`cube_bathymetry`** (where CUBE and the hypothesis/grid machinery are; it
+sits in `sensors_ws`, above `core_ws`, and already feeds the bathy store). The
+**store/tile IO** is a `core_ws` concern reusing `marine_tiled_raster_store`; whether
+it is a new `marine_mbes_backscatter_store` package or a thin instantiation beside
+the bathy store is a placement choice to ratify. `cube_bathymetry` may depend on the
+core store package (same direction it already feeds bathy); the store package must
+**not** depend on `cube_bathymetry` (layering, ADR-0002 D9). Phases (sub-issues,
+Part of #180 / #190):
+
+1. This ADR.
+2. CUBE co-estimation in `cube_bathymetry`: extend `Hypothesis` to carry the
+   per-beam `{raw intensity, grazing angle}` sufficient stats and emit the enriched
+   node record (builds on cube#52; needs cube#15 slope at output).
+3. The MBES backscatter store package + GGGS tile IO (core_ws), `draft` live write.
+4. The deferred-settled processed build (offline CUBE re-run + GeoCoder correction +
+   quality arbitration) and CAMP consumption via the #175 GPU tile-warp.
+
+## Consequences
+
+- **Positive:** MBES backscatter is co-estimated with bathy in one pass and
+  co-registered for free; CUBE's data association gives consistent outlier rejection
+  across both products; no redundant slant Tier-1 (the bags are the archive); fuses
+  with sidescan through GGGS + the ADR-0005 registry; bathy refinement is handled by
+  the same offline re-run the bathy store already uses.
+- **Safety non-goal (explicit):** like ADR-0006, this is a perception / cartographic
+  product, **not** a navigation or costmap input — nothing here routes backscatter
+  into Nav2 or collision avoidance. The *bathy* half of the node output is subject to
+  ADR-0002's Safety-First costmap path; the *backscatter* half is not. (If shadow- or
+  texture-derived shallow-hazard signals are ever fed to autonomy, that path needs
+  its own Safety-First review — out of scope, cf. ADR-0005 D5 safety carve-out and
+  the ADR-0006 note.)
+- **Sensor caveat:** the M3 reflectivity is AGC/uncalibrated → **relative**
+  backscatter (detection and drape well served; absolute ARA characterization is
+  limited by the sensor and aspirational, as in ADR-0006).
+- **Cost:** invasive change to the CUBE hypothesis core (per-beam sufficient stats on
+  the hypothesis; node-output correction stage); a dependency on cube#15 slope; a new
+  store package / instantiation and its `draft`/`processed` build to maintain. Two
+  positions to ratify (D6 float-vs-uint16 value tile, D9 package placement).
+- **Risk if ignored:** accumulating *raw* reflectivity in the node (skipping D3)
+  would bake angle-mixing into the stored value and ruin both the detection product
+  and any later characterization; bolting MBES onto the sidescan store (the rejected
+  unification) would force a slant Tier-1 it does not need and conflate two different
+  ingest architectures.
+
+## References
+
+- Sidescan backscatter store (sibling): ADR-0006 / [#180](https://github.com/rolker/unh_marine_autonomy/issues/180)
+- Bathymetric store: ADR-0002 / [#86](https://github.com/rolker/unh_marine_autonomy/issues/86);
+  time-band Int64 / source-index migration: [#178](https://github.com/rolker/unh_marine_autonomy/issues/178)
+- Cross-store provenance/registry: ADR-0005 / [#179](https://github.com/rolker/unh_marine_autonomy/issues/179)
+- ADR split / this restructure: [#190](https://github.com/rolker/unh_marine_autonomy/issues/190)
+- Per-beam backscatter into soundings (producer prerequisite): [rolker/cube_bathymetry#52](https://github.com/rolker/cube_bathymetry/issues/52)
+- CUBE slope correction (feeds incidence at output): [rolker/cube_bathymetry#15](https://github.com/rolker/cube_bathymetry/issues/15)
+- Bag-read import path (not replay): [#147](https://github.com/rolker/unh_marine_autonomy/issues/147)
+- CUBE: B. Calder & L. Mayer, "Automatic processing of high-rate, high-density multibeam echosounder data," G-cubed, 2003
+- Backscatter processing: L. Fonseca & B. Calder, "Geocoder: An Efficient Backscatter Map Constructor," US Hydro 2005 (CCOM/UNH)
+- Spatial index: `marine_autonomy` GGGS (`marine_autonomy/include/marine_autonomy/gggs/`)

--- a/docs/decisions/0007-mbes-backscatter-store.md
+++ b/docs/decisions/0007-mbes-backscatter-store.md
@@ -72,6 +72,15 @@ This is the deliberate split from ADR-0006: sidescan *needs* Tier-1 because it h
 no bathy; MBES *does not*, because its bathy and its archive (the bags) both already
 exist. Adding a slant Tier-1 here would be redundant state.
 
+**The single-tier choice makes re-derivability contingent on soundings-bag
+retention** — an asymmetry vs sidescan, where ADR-0006 D11 lets bags move to cold
+storage *because* the slant Tier-1 survives independently. Here the bags **are** the
+archive, so they must be retained (or recallable from cold storage) for any durable
+re-correction. This is the same retention assumption ADR-0005 D3 already names for
+re-import-from-source; ADR-0007 inherits it explicitly. Bag retention is a
+producer/operational responsibility (out of scope here), but the dependency is real
+and stated.
+
 ### D2 — Produced by the CUBE pass: intensity rides the winning hypothesis
 
 The store is fed by the **CUBE estimator** (`cube_bathymetry`), not a standalone
@@ -86,9 +95,12 @@ backscatter cell estimate needs and would otherwise have to reinvent.
 is incorporated into a hypothesis, its backscatter is accumulated on the *same*
 hypothesis. Consequences:
 
-- Beams the W&H monitor **rejects for depth** (multipath, outliers) never enter the
-  backscatter accumulator — outlier rejection comes free and is consistent between
-  the two products.
+- Beams the W&H monitor **rejects for depth** (multipath, geometric outliers) never
+  enter the backscatter accumulator — *depth-geometry* outlier rejection comes free.
+  Note the limit: a beam can be a valid depth member yet an **intensity** outlier
+  (e.g. a water-column target on an otherwise-good return); the depth monitor does
+  not catch that, and it surfaces instead in the D4 within-node dispersion. So the
+  association is shared, but only depth-geometry outliers are rejected for free.
 - The winning hypothesis emits, per node, a **single enriched record**:
   `{ depth, depth_variance, intensity, intensity_variance, n_samples }`.
 
@@ -116,10 +128,16 @@ refine vs. deferred-settled); **the decision is deferred-settled**:
   then is the Welford mean/variance of *corrected* backscatter computed and written.
 
 This keeps the stored value radiometrically clean and re-derivable, at the cost of
-carrying a small per-beam record on the hypothesis until output. It ties directly to
-**cube_bathymetry#15** (slope correction is currently disabled in `Node::insert`):
-the slope that feeds incidence-angle correction here is the same quantity #15 must
-provide — at output, not in the live insert.
+carrying a small per-beam record on the hypothesis until output. That per-node state
+is **bounded by hypothesis membership** (`n_samples` beams), not unbounded; the
+`{raw intensity, grazing angle}` pair is a few bytes per contributing beam. The two
+write paths (D7) consume it differently: the live **`draft`** correction uses the
+depth/slope settled *so far* (best-available live), while the durable **`processed`**
+build re-runs the pass and applies the fully-settled correction — so "until output"
+means "until the live node emits" for draft, and "during the offline re-run" for
+processed. It ties directly to **cube_bathymetry#15** (slope correction is currently
+disabled in `Node::insert`): the slope that feeds incidence-angle correction here is
+the same quantity #15 must provide — at output, not in the live insert.
 
 ### D4 — `intensity_uncertainty` = posterior estimate variance; dispersion is a candidate texture band
 


### PR DESCRIPTION
## Summary

ADR restructure (docs-only) reflecting the decision that **MBES backscatter and Garmin side-scan are separate stores**. Closes #190. Part of #180.

- **ADR-0006 → narrowed to the *sidescan* backscatter store.** Retitle + amendment banner; two-tier / slant Tier-1 / GeoCoder / draft-processed all stand. Cross-sensor-class arbitration (mbes-backscatter vs sidescan) lifted to the ADR-0005 registry / fusion (central-server) layer; in-store arbitration is quality-first within `sensor_class: sidescan`. Filename kept stable (amend-in-place, per ADR-0002).
- **New ADR-0007 — MBES Backscatter Store (CUBE-coupled, single-tier).**
  - Fed by the CUBE pass: intensity rides the **winning hypothesis** as a Welford passenger on the depth data-association (`hypothesis.h`); depth-geometry outliers rejected for backscatter for free.
  - **Single-tier** — node output → store; the **soundings bags are the re-processing archive** (no slant Tier-1). Durable re-correction re-runs the pass.
  - **Deferred-settled** angle correction: hypothesis carries per-beam `{raw intensity, grazing angle}` sufficient stats; GeoCoder footprint+incidence+Lambert applied at **node-output** once depth+slope settle (ties cube #15).
  - Node output `{depth, depth_var, intensity, intensity_var, N}` fans to the bathy store and this one, **co-registered by GGGS GridIndex** with zero reprojection.
  - `intensity_uncertainty` = estimate variance (mirrors depth); within-node dispersion = candidate texture band. `sensor_class: mbes-backscatter`, relative (AGC) backscatter.
- **ADR-0005 wording fix** — D1: backscatter is a **family of sensor-class-specific stores** (sidescan two-tier; MBES single-tier), fused across them at the query/central-server layer — not one monolithic store. D6 re-arbitration-cost taxonomy corrected to cover all three stores (sidescan Tier-1 / MBES bags / bathy). Status, D8, References name both backscatter ADRs.

## Why separate (load-bearing)
Sidescan has **no bathy of its own** → needs a slant Tier-1 + project-later. MBES backscatter is a **co-registered by-product of the depth solution** → single-tier, bags-as-archive. Different ingest path and tiering; bolting MBES onto the sidescan store would force a Tier-1 it doesn't need.

## Review
Pre-push **dual-lens review: approved-with-suggestions, 0 must-fix** (coherence lens: split complete, no leftover "one store" claims, D6 taxonomy correct, refs resolve; adversarial lens: Welford-passenger / deferred-settled / single-tier all sound, safety carve-out untouched). The 4 cheap clarifications folded before push (bag-retention contingency, intensity-outlier limit, per-node state bound + draft/processed split, reciprocal sibling ref). Trail in `.agent/work-plans/issue-190/progress.md`.

## Positions to ratify in review (not blockers)
- ADR-0007 D6: float value tile (variance-bearing) vs ADR-0006's detection-grade `uint16`.
- ADR-0007 D9: package placement (new `marine_mbes_backscatter_store` vs instantiation beside bathy).

## Follow-ons (separate issues)
- CUBE co-estimation in `cube_bathymetry` (intensity-in-`Hypothesis` + node-output correction; builds on cube #52, needs cube #15 slope).
- The MBES backscatter store package + GGGS tile IO (core_ws).
- Does **not** touch #178 (bathy store format stands).

Closes #190

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
