### PR TITLE
Factor shared marine_backscatter engine (best-source + quality + registry)

### DIFF
--- a/marine_backscatter/CMakeLists.txt
+++ b/marine_backscatter/CMakeLists.txt
@@ -15,8 +15,11 @@ find_package(marine_autonomy REQUIRED)
 find_package(marine_tiled_raster_store REQUIRED)
 find_package(geographic_msgs REQUIRED)
 
-# Modality-agnostic backscatter processing core (shared by the sidescan + MBES
-# layers): best-source compositor, grazing-angle quality, provenance registry.
+# Modality-agnostic backscatter processing core. Shared by the sidescan + MBES
+# layers (ADR-0006/0007): grazing-angle quality, provenance registry, and (later)
+# the GeoCoder radiometry chain. The COMPOSITOR is per-store, not shared — this lib
+# ships the sidescan best-source ProcessedAccumulator (uint16); MBES adds its own
+# Welford mean+variance accumulator (float). See ADR-0007 D6.
 add_library(${PROJECT_NAME}
   src/processed_accumulator.cpp
   src/quality.cpp

--- a/marine_backscatter/CMakeLists.txt
+++ b/marine_backscatter/CMakeLists.txt
@@ -1,0 +1,59 @@
+cmake_minimum_required(VERSION 3.8)
+project(marine_backscatter)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(marine_autonomy REQUIRED)
+find_package(marine_tiled_raster_store REQUIRED)
+find_package(geographic_msgs REQUIRED)
+
+# Modality-agnostic backscatter processing core (shared by the sidescan + MBES
+# layers): best-source compositor, grazing-angle quality, provenance registry.
+add_library(${PROJECT_NAME}
+  src/processed_accumulator.cpp
+  src/quality.cpp
+  src/registry.cpp
+)
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include>"
+)
+ament_target_dependencies(${PROJECT_NAME}
+  marine_autonomy
+  marine_tiled_raster_store
+)
+
+install(DIRECTORY include/ DESTINATION include)
+install(TARGETS ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_dependencies(marine_autonomy marine_tiled_raster_store)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+  find_package(ament_cmake_gtest REQUIRED)
+
+  ament_add_gtest(test_processed_accumulator test/test_processed_accumulator.cpp)
+  target_link_libraries(test_processed_accumulator ${PROJECT_NAME})
+  ament_target_dependencies(test_processed_accumulator
+    geographic_msgs marine_autonomy marine_tiled_raster_store)
+
+  ament_add_gtest(test_quality test/test_quality.cpp)
+  target_link_libraries(test_quality ${PROJECT_NAME})
+endif()
+
+ament_package()

--- a/marine_backscatter/include/marine_backscatter/processed_accumulator.hpp
+++ b/marine_backscatter/include/marine_backscatter/processed_accumulator.hpp
@@ -19,8 +19,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#ifndef MARINE_SIDESCAN_MOSAIC__PROCESSED_ACCUMULATOR_HPP_
-#define MARINE_SIDESCAN_MOSAIC__PROCESSED_ACCUMULATOR_HPP_
+#ifndef MARINE_BACKSCATTER__PROCESSED_ACCUMULATOR_HPP_
+#define MARINE_BACKSCATTER__PROCESSED_ACCUMULATOR_HPP_
 
 #include <cstdint>
 #include <map>
@@ -30,18 +30,16 @@
 
 /// @file
 /// @brief Best-source compositor for the durable `processed` backscatter layer
-///   (ADR-0006 D5/D7).
+///   (ADR-0006 D5/D7) — shared by the sidescan and MBES backscatter layers.
 ///
-/// Unlike the live `MosaicAccumulator` (mean / max-hold / newest, single band),
-/// the processed layer is **best-source**: per GGGS cell it keeps the sample with
-/// the highest **quality** and stores that sample's `{intensity, quality,
-/// source-id}` — the 3-band `uint16` tile of ADR-0006 D7. Mean stays a
-/// *within-pass* concern upstream; this composites *across* passes by quality, so
-/// a poorer look never overwrites a better one. The `source-id` band is the
-/// compact per-store local index that ADR-0005's registry resolves to the global
-/// source.
+/// Per GGGS cell it keeps the sample with the highest **quality** and stores that
+/// sample's `{intensity, quality, source-id}` — the 3-band `uint16` tile of
+/// ADR-0006 D7. Mean stays a *within-pass* concern in each ingest; this
+/// composites *across* passes by quality, so a poorer look never overwrites a
+/// better one. The `source-id` band is the compact per-store local index that
+/// ADR-0005's registry resolves to the global source.
 
-namespace marine_sidescan_mosaic
+namespace marine_backscatter
 {
 
 class ProcessedAccumulator
@@ -79,6 +77,6 @@ private:
   std::map<gggs::GridIndex, Tile> output_;
 };
 
-}  // namespace marine_sidescan_mosaic
+}  // namespace marine_backscatter
 
-#endif  // MARINE_SIDESCAN_MOSAIC__PROCESSED_ACCUMULATOR_HPP_
+#endif  // MARINE_BACKSCATTER__PROCESSED_ACCUMULATOR_HPP_

--- a/marine_backscatter/include/marine_backscatter/processed_accumulator.hpp
+++ b/marine_backscatter/include/marine_backscatter/processed_accumulator.hpp
@@ -29,8 +29,10 @@
 #include "marine_tiled_raster_store/tiled_raster_tile.hpp"
 
 /// @file
-/// @brief Best-source compositor for the durable `processed` backscatter layer
-///   (ADR-0006 D5/D7) — shared by the sidescan and MBES backscatter layers.
+/// @brief Best-source compositor for the durable `processed` **sidescan**
+///   backscatter layer (ADR-0006 D5/D7). The MBES layer composites differently
+///   (Welford mean+variance, ADR-0007 D2) and does not use this — only the
+///   registry + quality helpers in this package are cross-layer shared.
 ///
 /// Per GGGS cell it keeps the sample with the highest **quality** and stores that
 /// sample's `{intensity, quality, source-id}` — the 3-band `uint16` tile of

--- a/marine_backscatter/include/marine_backscatter/quality.hpp
+++ b/marine_backscatter/include/marine_backscatter/quality.hpp
@@ -1,0 +1,42 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef MARINE_BACKSCATTER__QUALITY_HPP_
+#define MARINE_BACKSCATTER__QUALITY_HPP_
+
+#include <cstdint>
+
+/// @file
+/// @brief Per-sample best-source quality for the processed backscatter layer.
+
+namespace marine_backscatter
+{
+
+/// @brief Mid-swath grazing-angle quality in [1, 65535] from a sample's altitude
+///   above the bottom and its horizontal ground range. Peaks at 45° grazing,
+///   ~0 at nadir and far range (ADR-0006 D5), so a neighbouring line's mid-swath
+///   look wins and the nadir gap fills. Floored to 1 so a real return is never
+///   mistaken for the no-data 0.
+std::uint16_t grazingQuality(double altitude, double ground_range);
+
+}  // namespace marine_backscatter
+
+#endif  // MARINE_BACKSCATTER__QUALITY_HPP_

--- a/marine_backscatter/include/marine_backscatter/registry.hpp
+++ b/marine_backscatter/include/marine_backscatter/registry.hpp
@@ -19,39 +19,30 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include "marine_sidescan_mosaic/processed_accumulator.hpp"
+#ifndef MARINE_BACKSCATTER__REGISTRY_HPP_
+#define MARINE_BACKSCATTER__REGISTRY_HPP_
 
-namespace marine_sidescan_mosaic
+#include <cstdint>
+#include <string>
+
+/// @file
+/// @brief The ADR-0005 provenance registry sidecar (shared across backscatter layers).
+
+namespace marine_backscatter
 {
 
-ProcessedAccumulator::Tile & ProcessedAccumulator::ensureOutput(const gggs::GridIndex & grid)
-{
-  auto it = output_.find(grid);
-  if (it == output_.end()) {
-    // 3 bands {intensity, quality, source}, all no-data (0).
-    it = output_.emplace(grid, Tile(grid, kBands, 0)).first;
-  }
-  return it->second;
-}
+/// @brief Escape a string for embedding in a JSON value (operator-typed registry
+///   fields may contain quotes / backslashes / control chars).
+std::string jsonEscape(const std::string & s);
 
-void ProcessedAccumulator::add(
-  const gggs::CellIndex & cell,
-  std::uint16_t intensity, std::uint16_t quality, std::uint16_t source_id)
-{
-  if (!cell.valid()) {
-    return;
-  }
-  const std::uint16_t row = cell.row();
-  const std::uint16_t col = cell.column();
-  Tile & tile = ensureOutput(cell.grid());
-  // Best-source: keep the highest-quality look; a poorer pass never overwrites a
-  // better one. Ties (==) keep the incumbent, so the order of equally-good passes
-  // is stable.
-  if (quality > tile.get(row, col, kQuality)) {
-    tile.set(row, col, kIntensity, intensity);
-    tile.set(row, col, kQuality, quality);
-    tile.set(row, col, kSource, source_id);
-  }
-}
+/// @brief Write the `registry.json` sidecar resolving the per-cell **local source
+///   index** to its provenance record (ADR-0005). v1 is single-source, write-once.
+///   TODO(#179): multi-source / reimport over the same dir must MERGE append-only
+///   (ADR-0005 D8), not overwrite.
+void writeRegistry(
+  const std::string & path, std::uint16_t source_id, const std::string & platform,
+  const std::string & sensor, const std::string & sensor_class, const std::string & campaign);
 
-}  // namespace marine_sidescan_mosaic
+}  // namespace marine_backscatter
+
+#endif  // MARINE_BACKSCATTER__REGISTRY_HPP_

--- a/marine_backscatter/package.xml
+++ b/marine_backscatter/package.xml
@@ -3,10 +3,12 @@
   <name>marine_backscatter</name>
   <version>0.0.0</version>
   <description>
-    Modality-agnostic backscatter processing core: best-source compositor
-    (ProcessedAccumulator), grazing-angle quality, and the provenance registry,
-    shared by the sidescan (marine_sidescan_mosaic) and MBES (cube) backscatter
-    layers. Home for the GeoCoder radiometry chain. See unh_marine_autonomy#191 / #180.
+    Modality-agnostic backscatter processing core shared by the sidescan
+    (marine_sidescan_mosaic) and MBES (cube) backscatter layers: grazing-angle
+    quality, the provenance registry, and (later) the GeoCoder radiometry chain.
+    The compositor is per-store, so this package ships the sidescan best-source
+    ProcessedAccumulator (uint16); MBES adds its own Welford accumulator (float,
+    ADR-0007 D6). See unh_marine_autonomy#191 / #180.
   </description>
   <maintainer email="roland.arsenault@unh.edu">Roland Arsenault</maintainer>
   <license>MIT</license>

--- a/marine_backscatter/package.xml
+++ b/marine_backscatter/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>marine_backscatter</name>
+  <version>0.0.0</version>
+  <description>
+    Modality-agnostic backscatter processing core: best-source compositor
+    (ProcessedAccumulator), grazing-angle quality, and the provenance registry,
+    shared by the sidescan (marine_sidescan_mosaic) and MBES (cube) backscatter
+    layers. Home for the GeoCoder radiometry chain. See unh_marine_autonomy#191 / #180.
+  </description>
+  <maintainer email="roland.arsenault@unh.edu">Roland Arsenault</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>marine_autonomy</depend>
+  <depend>marine_tiled_raster_store</depend>
+  <depend>geographic_msgs</depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/marine_backscatter/src/processed_accumulator.cpp
+++ b/marine_backscatter/src/processed_accumulator.cpp
@@ -1,0 +1,57 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "marine_backscatter/processed_accumulator.hpp"
+
+namespace marine_backscatter
+{
+
+ProcessedAccumulator::Tile & ProcessedAccumulator::ensureOutput(const gggs::GridIndex & grid)
+{
+  auto it = output_.find(grid);
+  if (it == output_.end()) {
+    // 3 bands {intensity, quality, source}, all no-data (0).
+    it = output_.emplace(grid, Tile(grid, kBands, 0)).first;
+  }
+  return it->second;
+}
+
+void ProcessedAccumulator::add(
+  const gggs::CellIndex & cell,
+  std::uint16_t intensity, std::uint16_t quality, std::uint16_t source_id)
+{
+  if (!cell.valid()) {
+    return;
+  }
+  const std::uint16_t row = cell.row();
+  const std::uint16_t col = cell.column();
+  Tile & tile = ensureOutput(cell.grid());
+  // Best-source: keep the highest-quality look; a poorer pass never overwrites a
+  // better one. Ties (==) keep the incumbent, so the order of equally-good passes
+  // is stable.
+  if (quality > tile.get(row, col, kQuality)) {
+    tile.set(row, col, kIntensity, intensity);
+    tile.set(row, col, kQuality, quality);
+    tile.set(row, col, kSource, source_id);
+  }
+}
+
+}  // namespace marine_backscatter

--- a/marine_backscatter/src/quality.cpp
+++ b/marine_backscatter/src/quality.cpp
@@ -1,0 +1,38 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "marine_backscatter/quality.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+namespace marine_backscatter
+{
+
+std::uint16_t grazingQuality(double altitude, double ground_range)
+{
+  const double grazing = std::atan2(altitude, ground_range);   // rad, 90deg at nadir.
+  const double q = std::sin(2.0 * grazing);                    // peak at 45 deg.
+  const double scaled = std::clamp(q, 0.0, 1.0) * 65535.0;
+  return static_cast<std::uint16_t>(std::max(1.0, scaled));    // floor 1: real return.
+}
+
+}  // namespace marine_backscatter

--- a/marine_backscatter/src/registry.cpp
+++ b/marine_backscatter/src/registry.cpp
@@ -1,0 +1,75 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "marine_backscatter/registry.hpp"
+
+#include <cstdint>
+#include <cstdio>
+#include <fstream>
+#include <string>
+
+namespace marine_backscatter
+{
+
+std::string jsonEscape(const std::string & s)
+{
+  std::string out;
+  out.reserve(s.size() + 8);
+  for (const char ch : s) {
+    switch (ch) {
+      case '"': out += "\\\""; break;
+      case '\\': out += "\\\\"; break;
+      case '\n': out += "\\n"; break;
+      case '\r': out += "\\r"; break;
+      case '\t': out += "\\t"; break;
+      default:
+        if (static_cast<unsigned char>(ch) < 0x20) {
+          char buf[8];
+          std::snprintf(buf, sizeof(buf), "\\u%04x", static_cast<unsigned char>(ch));
+          out += buf;
+        } else {
+          out += ch;
+        }
+    }
+  }
+  return out;
+}
+
+void writeRegistry(
+  const std::string & path, std::uint16_t source_id, const std::string & platform,
+  const std::string & sensor, const std::string & sensor_class, const std::string & campaign)
+{
+  // ADR-0005: per-cell band is the compact LOCAL index; the registry resolves it
+  // to the (eventually origin-namespaced, ADR-0005 D4) global source-id + record.
+  // TODO(#179): v1 writes a single-source registry write-once; multi-source / a
+  // reimport over the same out_dir must MERGE append-only (ADR-0005 D8), not
+  // overwrite — load existing + union before writing.
+  std::ofstream r(path);
+  r << "{\n  \"version\": 1,\n  \"sources\": {\n    \"" << source_id << "\": {\n"
+    << "      \"source_id\": " << source_id << ",\n"
+    << "      \"platform\": \"" << jsonEscape(platform) << "\",\n"
+    << "      \"sensor\": \"" << jsonEscape(sensor) << "\",\n"
+    << "      \"sensor_class\": \"" << jsonEscape(sensor_class) << "\",\n"
+    << "      \"campaign\": \"" << jsonEscape(campaign) << "\"\n"
+    << "    }\n  }\n}\n";
+}
+
+}  // namespace marine_backscatter

--- a/marine_backscatter/test/test_processed_accumulator.cpp
+++ b/marine_backscatter/test/test_processed_accumulator.cpp
@@ -23,9 +23,9 @@
 
 #include "geographic_msgs/msg/geo_point.hpp"
 #include "marine_autonomy/gggs.h"
-#include "marine_sidescan_mosaic/processed_accumulator.hpp"
+#include "marine_backscatter/processed_accumulator.hpp"
 
-using marine_sidescan_mosaic::ProcessedAccumulator;
+using marine_backscatter::ProcessedAccumulator;
 
 namespace
 {

--- a/marine_backscatter/test/test_quality.cpp
+++ b/marine_backscatter/test/test_quality.cpp
@@ -1,0 +1,39 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <gtest/gtest.h>
+
+#include "marine_backscatter/quality.hpp"
+
+using marine_backscatter::grazingQuality;
+
+TEST(Quality, PeaksMidSwathFloorsAtOne)
+{
+  // 45 deg grazing (altitude == ground range) -> sin(90) = 1 -> ~full scale.
+  EXPECT_GT(grazingQuality(10.0, 10.0), 65000u);
+  // Near nadir (ground << altitude) and far range (ground >> altitude) collapse
+  // to ~0 but are floored to 1 (a real return, never no-data).
+  EXPECT_GE(grazingQuality(10.0, 0.1), 1u);
+  EXPECT_GE(grazingQuality(0.1, 100.0), 1u);
+  // Mid-swath beats both near-nadir and far.
+  EXPECT_GT(grazingQuality(10.0, 10.0), grazingQuality(10.0, 0.5));
+  EXPECT_GT(grazingQuality(10.0, 10.0), grazingQuality(10.0, 200.0));
+}

--- a/marine_sidescan_mosaic/CMakeLists.txt
+++ b/marine_sidescan_mosaic/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(geographic_msgs REQUIRED)
 find_package(geodesy REQUIRED)
 find_package(marine_autonomy REQUIRED)
 find_package(marine_tiled_raster_store REQUIRED)
+find_package(marine_backscatter REQUIRED)
 find_package(rosbag2_cpp REQUIRED)
 find_package(rosbag2_storage REQUIRED)
 find_package(geometry_msgs REQUIRED)
@@ -33,7 +34,6 @@ add_library(${PROJECT_NAME}
   src/normalizer.cpp
   src/tier1.cpp
   src/decode.cpp
-  src/processed_accumulator.cpp
 )
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
@@ -103,6 +103,7 @@ ament_target_dependencies(sidescan_tier2_processed
   geographic_msgs
   marine_autonomy
   marine_tiled_raster_store
+  marine_backscatter
 )
 install(TARGETS sidescan_tier2_processed DESTINATION lib/${PROJECT_NAME})
 
@@ -129,11 +130,6 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_tier1 test/test_tier1.cpp)
   target_link_libraries(test_tier1 ${PROJECT_NAME})
-
-  ament_add_gtest(test_processed_accumulator test/test_processed_accumulator.cpp)
-  target_link_libraries(test_processed_accumulator ${PROJECT_NAME})
-  ament_target_dependencies(test_processed_accumulator
-    geographic_msgs marine_autonomy marine_tiled_raster_store)
 endif()
 
 ament_package()

--- a/marine_sidescan_mosaic/package.xml
+++ b/marine_sidescan_mosaic/package.xml
@@ -25,6 +25,7 @@
   <depend>builtin_interfaces</depend>
   <depend>marine_autonomy</depend>
   <depend>marine_tiled_raster_store</depend>
+  <depend>marine_backscatter</depend>
   <depend>rosbag2_cpp</depend>
   <depend>rosbag2_storage</depend>
 

--- a/marine_sidescan_mosaic/src/sidescan_tier2_processed.cpp
+++ b/marine_sidescan_mosaic/src/sidescan_tier2_processed.cpp
@@ -37,7 +37,6 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
-#include <cstdio>
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
@@ -49,11 +48,14 @@
 #include "marine_autonomy/gggs.h"
 #include "marine_tiled_raster_store/tile_io.hpp"
 
-#include "marine_sidescan_mosaic/processed_accumulator.hpp"
+#include "marine_backscatter/processed_accumulator.hpp"
+#include "marine_backscatter/quality.hpp"
+#include "marine_backscatter/registry.hpp"
 #include "marine_sidescan_mosaic/projection.hpp"
 #include "marine_sidescan_mosaic/tier1.hpp"
 
-using namespace marine_sidescan_mosaic;  // NOLINT(build/namespaces) — local tool.
+using namespace marine_backscatter;       // NOLINT(build/namespaces) — shared engine.
+using namespace marine_sidescan_mosaic;   // NOLINT(build/namespaces) — local tool.
 
 namespace
 {
@@ -77,60 +79,6 @@ int toInt(const std::string & s, const std::string & flag)
   }
 }
 
-// Escape a string for embedding in a JSON value (operator-typed registry fields
-// may contain quotes/backslashes/control chars that would otherwise corrupt the
-// ADR-0005 registry and poison downstream merges).
-std::string jsonEscape(const std::string & s)
-{
-  std::string out;
-  out.reserve(s.size() + 8);
-  for (const char ch : s) {
-    switch (ch) {
-      case '"': out += "\\\""; break;
-      case '\\': out += "\\\\"; break;
-      case '\n': out += "\\n"; break;
-      case '\r': out += "\\r"; break;
-      case '\t': out += "\\t"; break;
-      default:
-        if (static_cast<unsigned char>(ch) < 0x20) {
-          char buf[8];
-          std::snprintf(buf, sizeof(buf), "\\u%04x", static_cast<unsigned char>(ch));
-          out += buf;
-        } else {
-          out += ch;
-        }
-    }
-  }
-  return out;
-}
-
-// Mid-swath grazing-angle quality in [1, 65535]; peaks at 45 deg, ~0 at nadir/far.
-std::uint16_t gradingQuality(double altitude, double ground_range)
-{
-  const double grazing = std::atan2(altitude, ground_range);   // rad, 90deg at nadir.
-  const double q = std::sin(2.0 * grazing);                    // peak at 45 deg.
-  const double scaled = std::clamp(q, 0.0, 1.0) * 65535.0;
-  return static_cast<std::uint16_t>(std::max(1.0, scaled));    // floor 1: real return.
-}
-
-void writeRegistry(
-  const std::string & path, std::uint16_t source_id, const std::string & platform,
-  const std::string & sensor, const std::string & sensor_class, const std::string & campaign)
-{
-  // ADR-0005: per-cell band is the compact LOCAL index; the registry resolves it
-  // to the (eventually origin-namespaced, ADR-0005 D4) global source-id + record.
-  // TODO(#179): v1 writes a single-source registry write-once; multi-source / a
-  // reimport over the same out_dir must MERGE append-only (ADR-0005 D8), not
-  // overwrite — load existing + union before writing.
-  std::ofstream r(path);
-  r << "{\n  \"version\": 1,\n  \"sources\": {\n    \"" << source_id << "\": {\n"
-    << "      \"source_id\": " << source_id << ",\n"
-    << "      \"platform\": \"" << jsonEscape(platform) << "\",\n"
-    << "      \"sensor\": \"" << jsonEscape(sensor) << "\",\n"
-    << "      \"sensor_class\": \"" << jsonEscape(sensor_class) << "\",\n"
-    << "      \"campaign\": \"" << jsonEscape(campaign) << "\"\n"
-    << "    }\n  }\n}\n";
-}
 }  // namespace
 
 int main(int argc, char ** argv)
@@ -206,7 +154,7 @@ int main(int argc, char ** argv)
       }
       const auto intensity =
         static_cast<std::uint16_t>(std::clamp(static_cast<double>(p.samples[j]), 0.0, 65535.0));
-      const std::uint16_t quality = gradingQuality(altitude, ground);
+      const std::uint16_t quality = grazingQuality(altitude, ground);
       acc.add(projectSample(origin, azimuth, ground, level), intensity, quality, source_id);
       ++n_placed;
     }


### PR DESCRIPTION
Closes #191. Part of #180.

Factors the **modality-agnostic backscatter processing core** out of `marine_sidescan_mosaic` into a new **`marine_backscatter`** package, so the sidescan layer and the forthcoming MBES/cube backscatter layer share **one** compositing + provenance chain (and one home for the GeoCoder radiometry) instead of two divergent copies.

### Moved into `marine_backscatter`
- `ProcessedAccumulator` — best-source compositor → 3-band `{intensity, quality, source-id}` tile (ADR-0006 D5/D7)
- `grazingQuality` — mid-swath grazing-angle quality (was `gradingQuality`, inline)
- `registry` writer + `jsonEscape` (ADR-0005 provenance)
- their gtests, + a new quality test

`marine_sidescan_mosaic` now **depends on** `marine_backscatter`; `sidescan_tier2_processed` consumes the shared symbols. **Sidescan projection stays put** — MBES is pre-georeferenced by cube and feeds the shared core directly, so it doesn't need the slant geometry.

### Contract for the cube agent
Produce a **ground backscatter return** — `{cell, intensity, grazing inputs, source-id}` — from the chosen-hypothesis depth + accompanying intensity, and feed it into `marine_backscatter::ProcessedAccumulator` + `grazingQuality` + `writeRegistry`. One GeoCoder, not two.

### Safety
Deliberately minimal and behavior-preserving (deployment is imminent): no GeoCoder radiometry, no projection move. Both packages build; gtest all green (`marine_backscatter` 4/0, `marine_sidescan_mosaic` 26/0); the processed Tier-2 smoke-tests to identical Massabesic tiles + registry.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
