### PR TITLE
fix(sidescan): default mosaic output_dir to canonical ~/data/stores/sidescan/draft

### DIFF
--- a/marine_sidescan_mosaic/launch/sidescan_mosaic.launch.py
+++ b/marine_sidescan_mosaic/launch/sidescan_mosaic.launch.py
@@ -22,6 +22,8 @@
 # Generic launch for the live sidescan mosaicker. Topics default to the Garmin
 # GCV driver's relative names; remap or namespace as needed for a platform.
 
+import os
+
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration, PythonExpression
@@ -29,9 +31,14 @@ from launch_ros.actions import Node
 
 
 def generate_launch_description():
+    # The live node writes the operator `draft` layer (splat=newest) of the
+    # sidescan store; default to the canonical split-store layout
+    # ~/data/stores/<modality>/<maturity>/ (ADR-0006). Override per platform.
+    default_output_dir = os.path.expanduser('~/data/stores/sidescan/draft')
     args = [
-        DeclareLaunchArgument('output_dir', default_value='sidescan_mosaic',
-                              description='Directory for the GGGS GeoTIFF tiles'),
+        DeclareLaunchArgument('output_dir', default_value=default_output_dir,
+                              description='GGGS GeoTIFF tile dir; default = the sidescan '
+                                          'store draft layer (~/data/stores/sidescan/draft)'),
         DeclareLaunchArgument('gggs_level', default_value='13',
                               description='GGGS level (13 ~= 0.11 m cells)'),
         DeclareLaunchArgument('splat', default_value='newest',


### PR DESCRIPTION
Closes #197. Part of #180.

The generic `sidescan_mosaic.launch.py` defaulted `output_dir` to the stale relative `'sidescan_mosaic'`. After the store split (`sidescan_backscatter/` → `sidescan/`; ADR-0006 sidescan / ADR-0007 MBES) and the canonical `~/data/stores/<modality>/<maturity>/` layout, it now defaults to **`~/data/stores/sidescan/draft`** — the live node writes the operator `draft` layer (splat default `newest`), so a deployment and CAMP find the tiles without a manual `output_dir:=…` override. Still overridable per-platform via the existing launch arg.

Verified: `ament_flake8` clean (matches baseline), `py_compile` OK, `generate_launch_description()` builds (10 entities), default expands to `~/data/stores/sidescan/draft`.

This was the operational must-do flagged after the on-disk rename — no platform bringup overrides it, so the launch default is the live store path.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
