### PR TITLE
Bathymetric store Phase-2 PR-A: epoch model + multi-level query + GeoTIFF import (re-platformed; supersedes #148)

### DIFF
--- a/.agent/work-plans/issue-147/plan.md
+++ b/.agent/work-plans/issue-147/plan.md
@@ -96,10 +96,12 @@ PR boundaries.
      source-layer priority and the D7 shallowest-reliable mode, optionally bounded
      by a caller-supplied target resolution. Refinement/decimation (LOD) stays
      **staged** per D2 — query reads what's present; it does not generate overviews.
-   - `tile_io`: `loadTile` recovers each tile's level from its geotransform
-     (already does — it just currently *rejects* non-store levels); load accepts
-     mixed levels. Delete/replace `test_tile_io.cpp:LoadRejectsTilesFromAnotherLevel`
-     (it bakes in forbidden behavior).
+   - `tile_io`: mixed-level load (Plan-Review must-fix 2). `loadTile(path, level)`
+     takes the level as an INPUT (it validates the file's geotransform against the
+     supplied level), so mixed-level load needs a concrete new step: parse the
+     level prefix from the `<level>_<row>_<col>.tif` filename and pass per-file
+     level. **Implemented** as `levelFromTileFilename` + per-file load in `load()`.
+     `LoadRejectsTilesFromAnotherLevel` replaced by `LoadAcceptsMixedLevelTiles`.
 
 2. **Epoch dimension on the store.** Harvest `epoch.hpp` verbatim-as-design
    (`Epoch`, `validateEpochLabel`). For the **provenance enum**, see Open Question
@@ -132,8 +134,13 @@ PR boundaries.
 4. **Query change-map + epoch-walk.** Add `forEachChangedCell(layer, epoch_a,
    epoch_b, visitor)` (cells in both → depth Δ) and make the default/reliable
    queries walk epochs newest-first within each layer. `DepthSample` gains an
-   `epoch` field (and `source_index` is already available via the per-cell record;
-   keep the D5 carve-out — shallowest-reliable ignores provenance).
+   `epoch` field — and, per Plan-Review must-fix 5, an explicit **`source_index`**
+   field too: `source_index` lives on `BathyCell` but `DepthSample` (what queries
+   return) carried only depth/uncertainty/timestamp/source-layer, so consumers
+   needing the registry index off a query result get it via the added field
+   (`level` is added alongside for the multi-level resolve). The D5 carve-out is
+   kept — `shallowestReliable` ignores provenance. **Done** (DepthSample gains
+   `source_index` + `level` + `epoch`).
 
 5. **GeoTIFF importer.** Harvest `geotiff_import.hpp/.cpp` design onto the
    epoch+multi-level store. Key change vs #148: the importer must **register a
@@ -145,37 +152,63 @@ PR boundaries.
    import at the GGGS level matching the source resolution (or a caller-specified
    level), not a fixed store level. CLI `import_geotiff` updated for the new args.
 
-6. **Bag-replay importer (via #43).** New offline tool (cube-side or a bridge
-   package — see Open Question 2), modeled on `bag_to_geotiff.cpp -d`:
-   SequentialReader over a day's detection bags (timestamp-merged) → populate
-   `tf2::BufferCore` from `/tf`+`/tf_static` → `DetectionsProjector::project`
-   (vessel_speed NaN for detections-only bags) → `GeoMapSheet::addSoundings` →
-   one CUBE run for the whole day → iterate `GeoMapSheet::grids()` /
-   `GeoGrid::values()` → build `BathymetryTile`s keyed by the `CellIndex`'s grid →
-   `importEpoch(Draft, <date>, tiles, Replayed)`. Deterministic (direct reader,
-   no QoS cap) so content hashes are stable (D6). Registers a `SourceRecord` for
-   the contributing platform/sensor.
+6. **Bag-replay importer (via #43). — PR-B, out of PR-A scope.** New offline tool
+   (cube-side or a bridge package — see Open Question 2), modeled on
+   `bag_to_geotiff.cpp -d`: SequentialReader over a day's detection bags
+   (timestamp-merged) → populate `tf2::BufferCore` from `/tf`+`/tf_static` →
+   `DetectionsProjector::project` (vessel_speed NaN for detections-only bags) →
+   **per-sounding `Sounding`→`GeoSounding` earth-frame georeferencing**
+   (Plan-Review must-fix 3): `project()` returns `cube::Sounding` (sonar-frame
+   x/y/z), and `bag_to_geotiff.cpp -d` inserts a per-sounding
+   `lookupTransform("earth", sonar_frame, stamp)` loop converting to
+   `cube::GeoSounding` (lat/lon) **before** `addSoundings` — that loop is where
+   the bag's earth-frame TF is consumed; it must be in PR-B's chain.
+   → `GeoMapSheet::addSoundings` → one CUBE run for the whole day →
+   `GeoMapSheet::grids()` / `GeoGrid::values()`. **`GeoGrid::values()` is a flat
+   positional `std::vector<DepthAndUncertainty>` in `CellAreaIterator(index_)`
+   order (full grid, NaN-filled empties) — NOT a `CellIndex`-keyed map**
+   (Plan-Review must-fix 4): the importer walks `CellAreaIterator` in lockstep
+   with the vector to recover each cell's `CellIndex`. `values()` also mutates
+   node state (it calls `queueFlush`/`extractDepthAndUncertainty`, advancing the
+   median pre-filter), and `DepthAndUncertainty` is `float` (the store is `double`
+   — a safe widening). → build `BathymetryTile`s keyed by the `CellIndex`'s grid →
+   `importEpoch(Draft, <date>, tiles, Replayed)`. Deterministic (direct reader, no
+   QoS cap, fixed sounding-insertion order) so content hashes are stable (D6); the
+   determinism test must assert same bag + same order → byte-identical tiles.
+   Registers a `SourceRecord` for the contributing platform/sensor.
 
-7. **Tests.** Per the issue deliverables, on the new substrate:
-   - Epoch model: same-session replace vs cross-session 1/σ² fusion; compaction
-     supersession + `Replayed`-beats-`LiveFused` ordering (and the no-op reverse);
-     CRLF-safe provenance sidecar round-trip (harvest the #148 regression).
-   - Multi-level: store holds two levels, query returns best-available across them;
-     load accepts mixed-level tiles (replaces the deleted reject test).
-   - Importer round-trips: GeoTIFF in → query out (datum conversion, footprint,
-     lowest-uncertainty, non-positive-uncertainty-as-missing); registry index
-     stamped + persisted.
-   - Bag-replay determinism: same bag → byte-identical tiles across two runs
-     (content-hash stability), on a small synthetic or trimmed fixture.
-   - Change map: difference of two epochs (cells-in-both only).
-   - `importEpoch` grid/tile-index match guard (harvest #148 Copilot med-fix).
+7. **Tests.** Per the issue deliverables, on the new substrate. **PR-A** (this
+   PR) lands all of these except the bag-replay determinism test (PR-B):
+   - Epoch model (PR-A): N-epochs-never-fused; wholesale replace; compaction
+     supersession + `Replayed`-beats-`LiveFused` ordering (and the no-op reverse,
+     for both `set` and `importEpoch`); CRLF-safe provenance marker round-trip
+     (harvested #148 regression); `supersedes_disk` stale-tile cleanup. *The
+     cross-session 1/σ² live-fusion rule is a Phase-3 live-path concern (OQ3 cut)
+     and is not implemented in PR-A* — PR-A's importers each produce one wholesale
+     epoch.
+   - Multi-level (PR-A): store holds two levels, query returns best-available
+     across them (and shallowest-reliable considers all levels); load accepts
+     mixed-level tiles (replaces the deleted reject test); `levelFromTileFilename`.
+   - Importer round-trips (PR-A): GeoTIFF in → query out (datum conversion,
+     footprint, lowest-uncertainty, non-positive-uncertainty-as-missing); registry
+     index registered + stamped; caller-specified import level.
+   - Bag-replay determinism (**PR-B**): same bag + same insertion order →
+     byte-identical tiles across two runs (content-hash stability), on a small
+     synthetic or trimmed fixture.
+   - Change map (PR-A): `forEachChangedCell` difference of two epochs
+     (cells-in-both only).
+   - `importEpoch` grid/tile-index match guard (PR-A, harvested #148 Copilot med-fix).
 
-8. **ADR-0002 reconciliation.** Replace #148's pre-#153 Amendment A1 with one
-   reconciled against the merged D2 (heterogeneous levels) and D5/#178 (registry
-   provenance): epoch dirs compose with mixed-level `<GridIndex>` filenames;
-   provenance enum vs registry relationship (Open Question 1) recorded;
-   immutable-after-compaction; D7 newest-reliable epoch walk; no-CUBE-seeding
-   rationale. This is the only `docs/` change.
+8. **ADR-0002 reconciliation.** Per Plan-Review must-fix 5, the merged jazzy
+   ADR-0002 has **no** Amendment A1 / epoch content (that lived only on the #148
+   branch, never merged) — so the epoch amendment is authored **FRESH** here, not
+   "replaced". Composed against the already-merged D2 (heterogeneous levels) and
+   D5/#178 (registry provenance): epoch dirs compose with mixed-level
+   `<level>_<row>_<col>` filenames; the two orthogonal provenance axes (OQ1)
+   recorded; immutable-after-compaction; A1.3 newest-reliable epoch walk;
+   no-CUBE-seeding rationale; D6 manifest key generalized to `layer/epoch/
+   GridIndex`. **Done** — added as "Amendment A1 — Per-day epoch model" (A1.1–
+   A1.5). This is the only `docs/` change.
 
 ## Files to Change
 
@@ -227,12 +260,13 @@ PR boundaries.
 
 ## Branch Strategy
 
-The local `feature/issue-147` has been **reset to current `jazzy`** (0 behind);
-the rebuild happens here. The new PR opened from this branch will **supersede
-#148**, which stays OPEN as the harvest reference until then. **Closing #148 is a
-checkpoint decision for the operator** — recommend closing it with a comment
-pointing at the superseding PR once that PR is green, not before (the diff is the
-harvest source).
+Per Plan-Review must-fix 1 (branch strategy): the rebuild happens on a **new
+branch `feature/issue-147-replatform`** (0 behind `jazzy`), leaving
+`origin/feature/issue-147` / **PR #148 untouched** as the harvest reference — no
+force-push over #148's diff. The new PR opened from `feature/issue-147-replatform`
+**supersedes #148** by comment. **Closing #148 is a checkpoint decision for the
+operator** — recommend closing it with a comment pointing at the superseding PR
+once that PR is green, not before (the diff is the harvest source).
 
 ## Open Questions
 

--- a/.agent/work-plans/issue-147/plan.md
+++ b/.agent/work-plans/issue-147/plan.md
@@ -1,0 +1,274 @@
+# Plan: Bathymetric store Phase 2 — import (epoch model, GeoTIFF, bag-replay) on the CURRENT store
+
+## Issue
+
+https://github.com/rolker/unh_marine_autonomy/issues/147
+
+This is a **RE-PLAN**. The original PR #148 implemented Phase-2 import against the
+**pre-refactor** store. Since then `jazzy` landed three structural changes that
+re-platform the store underneath #148:
+
+- **#172** — store core re-based on a generic `marine_tiled_raster_store::TiledRasterTile<>`.
+- **#178 / ADR-0005** — tile-format migration: depth+uncertainty in a 2-band
+  `Float64` value tile, timestamp in a separate `Int64`-ns tile, **per-cell
+  `UInt16` source index** into a store-wide `SourceRegistry` (`registry.json`).
+- **#151 / #153** — ADR-0002 D2 amendment: the store holds **heterogeneous GGGS
+  levels** with a **level-aware** best-available query; single-level is now
+  forbidden as a load-bearing assumption.
+
+A merge of #148 onto current `jazzy` produced 17+ conflicts concentrated in the
+core header, `tile_io`, and every test — reconciliation is re-platforming, not a
+fix-up. So we **harvest #148's designs and rebuild on the current store.** #148
+stays open as the harvest reference until this work supersedes it.
+
+## Context
+
+### Current store (the foundation — read before coding)
+
+- `BathymetryStore` (`bathymetry_store.hpp`): per-`SourceLayer`
+  (`Processed`/`Draft`/`Chart`) map of `gggs::GridIndex → BathymetryTile`.
+  **Single level** (`gggs::Level level_;`, `requireGridAtLevel` semantics implied
+  by `set`/`get`). `set()` gates `Chart` writes behind `chart_writable`.
+  `getOrCreateTile` is private (persistence-only via `friend save/load`).
+- `BathymetryTile` (`bathymetry_tile.hpp`): three `TiledRasterTile<>` rasters
+  (value 2-band `double`, time 1-band `int64`, source 1-band `uint16`), per-cell
+  `BathyCell{depth, uncertainty, timestamp, source_index}`. Value-raster dirty
+  flag authoritative.
+- `SourceRegistry` (`registry.hpp`): interns `SourceRecord{source_id, platform,
+  sensor, sensor_class, campaign, datum}` to a `uint16` index; index 0 = unset;
+  idempotent on `source_id`; persisted as `registry.json` (atomic write+rename).
+- `query.hpp`: `bestSource` (priority overlay), `shallowestReliable`
+  (depth+uncertainty safety walk, ignores provenance per ADR-0005 D5),
+  `forEachCellBestSource`. **All single-level** (resolve within `store.level()`).
+- `tile_io.hpp`: per-tile 3-file GeoTIFF save/load, `registry.json` sidecar,
+  `processed/`/`draft/`/`chart/` subdirs. Single-level (`loadTile` pins to
+  `store.level()`).
+
+### What #148 designed (harvest these designs, not the code)
+
+- **Epoch model** (`epoch.hpp`): `Epoch = std::string` ISO-date label (sorts
+  chronologically, filesystem-safe via `validateEpochLabel`); `Provenance{LiveFused,
+  Replayed}` with `Replayed` superseding `LiveFused` and immutable-after-compaction.
+- **Store epoch API**: per-layer `std::map<Epoch, EpochTiles>` where
+  `EpochTiles{provenance, supersedes_disk, tiles}`; `set(layer,epoch,cell,value)`
+  (no-op if epoch `Replayed`); `importEpoch(layer,epoch,tiles,provenance)`
+  (wholesale replace, returns false if existing is `Replayed` and incoming is
+  `LiveFused`); `epochs(layer)` ascending.
+- **Query epoch-walk**: `bestSample`/`reliableSample` walk a layer's epochs
+  newest-first (`rbegin`), first-with-data / first-passing-gate; `forEachChangedCell`
+  differences two epochs (cells present in **both**) → change map.
+- **GeoTIFF importer** (`geotiff_import.hpp/.cpp`): `importGeoTiff(store, layer,
+  epoch, path, provenance, options)`; `GeoTiffImportOptions{depth_band,
+  uncertainty_band, default_uncertainty, timestamp, depth_scale, depth_offset}`;
+  datum conversion at import (`height = depth_scale*pixel + depth_offset`);
+  pixel-**footprint** fill (every store cell a pixel covers), lowest-uncertainty
+  wins on contention; non-positive uncertainty treated as missing; one import =
+  one wholesale epoch. CLI `import_geotiff`.
+- **Field-proven** (progress.md timeline): three replayed pier draft epochs +
+  change maps + the Massabesic chart prior all ran end-to-end on real data. The
+  *behavior* is validated; only the *substrate* changed.
+
+### The bag-replay enabler (#43, just merged in cube_bathymetry)
+
+`cube::DetectionsProjector` (`detections_projector.h`) is **rclcpp-free**:
+`project(SonarDetections, tf2::BufferCore&, vessel_speed)` → soundings.
+`bag_to_geotiff.cpp`'s `-d` path is the working reference: SequentialReader →
+populate `tf2::BufferCore` from `/tf`+`/tf_static` → `project()` → `GeoMapSheet::
+addSoundings` → `GeoMapSheet::grids()` → `GeoGrid::values()` (`DepthAndUncertainty`
+keyed by `gggs::CellIndex`, **level-bearing**). That `CellIndex`→store-cell bridge
+is the whole importer — no live ROS graph, deterministic, no QoS cap.
+
+## Approach
+
+Build in dependency order. Each numbered item is a reviewable unit; see Scope for
+PR boundaries.
+
+1. **Multi-level store + level-aware query (the old M1 blocker — do FIRST).**
+   Replace the single `level_` with per-tile levels: tiles already key by
+   `gggs::GridIndex` (which carries its level), so storage becomes level-agnostic.
+   - Store: drop the `gggs::Level level_` single-level invariant and the
+     `requireGridAtLevel` rejection; `set`/`get`/`getOrCreateTile` accept any
+     valid level. Keep `cellIndex(lat,lon)` but parameterize by a requested level
+     (default: a store-level hint retained only as a *default for writes*, not an
+     invariant). Construction keeps a default level for back-compat callers.
+   - Query: `bestSource`/`shallowestReliable`/`forEachCellBestSource` resolve the
+     **best-available cell across levels present** (ADR-0002 D2), preserving D3
+     source-layer priority and the D7 shallowest-reliable mode, optionally bounded
+     by a caller-supplied target resolution. Refinement/decimation (LOD) stays
+     **staged** per D2 — query reads what's present; it does not generate overviews.
+   - `tile_io`: `loadTile` recovers each tile's level from its geotransform
+     (already does — it just currently *rejects* non-store levels); load accepts
+     mixed levels. Delete/replace `test_tile_io.cpp:LoadRejectsTilesFromAnotherLevel`
+     (it bakes in forbidden behavior).
+
+2. **Epoch dimension on the store.** Harvest `epoch.hpp` verbatim-as-design
+   (`Epoch`, `validateEpochLabel`). For the **provenance enum**, see Open Question
+   1 — reconcile #148's `Provenance{LiveFused,Replayed}` with the now-merged
+   `SourceRegistry`. Reshape each layer to `std::map<Epoch, EpochTiles>` where
+   `EpochTiles{provenance, supersedes_disk, std::map<GridIndex,BathymetryTile>}`.
+   - `set(layer, epoch, cell, value)` — creates epoch as `LiveFused`; no-op (return
+     `false`) if epoch is `Replayed`. Still gates `Chart` via `chart_writable`.
+   - `importEpoch(layer, epoch, tiles, provenance)` — wholesale replace; returns
+     `false` if existing is `Replayed` and incoming is `LiveFused`; sets
+     `supersedes_disk` so persistence clears stale files; marks tiles dirty.
+   - `epochs(layer)` ascending; `getOrCreateEpoch`/`getOrCreateTile(layer,epoch,
+     grid)` private (load path via friends).
+   - Within-day rules (ADR-0002 A1.2): same-session = plain replace via repeated
+     `importEpoch`/`set`; cross-session (different live sessions, one day) =
+     variance-weighted 1/σ² fusion. Provide a `fuseCell` helper on import for the
+     live path; the bag-replay path produces one `Replayed` epoch per day and
+     never fuses.
+
+3. **Epoch-aware persistence.** Extend `tile_io` for the epoch directory layer:
+   `<dir>/<layer>/<epoch>/<level>_<row>_<col>{,_time,_source}.tif`, plus a
+   per-epoch provenance marker (`provenance` token file — harvest #148's
+   CRLF-safe sidecar reader, the round-1 Copilot fix). `save` honors
+   `supersedes_disk` (remove stale epoch files before writing). `registry.json`
+   stays a **store-wide** sidecar at the root (one registry spans all
+   layers/epochs — see Open Question 1). Manifest key generalizes to
+   `{layer/epoch/GridIndex → content-hash}` (D6 forward constraint; no hash impl
+   this phase).
+
+4. **Query change-map + epoch-walk.** Add `forEachChangedCell(layer, epoch_a,
+   epoch_b, visitor)` (cells in both → depth Δ) and make the default/reliable
+   queries walk epochs newest-first within each layer. `DepthSample` gains an
+   `epoch` field (and `source_index` is already available via the per-cell record;
+   keep the D5 carve-out — shallowest-reliable ignores provenance).
+
+5. **GeoTIFF importer.** Harvest `geotiff_import.hpp/.cpp` design onto the
+   epoch+multi-level store. Key change vs #148: the importer must **register a
+   `SourceRecord`** (platform/sensor/campaign/datum) in the `SourceRegistry` and
+   stamp the returned index on every imported cell (the #178 provenance axis #148
+   predated). `GeoTiffImportOptions` gains the provenance fields (or takes a
+   pre-resolved `source_index`). Footprint fill + lowest-uncertainty contention +
+   datum conversion + non-positive-uncertainty guard all carry over. Multi-level:
+   import at the GGGS level matching the source resolution (or a caller-specified
+   level), not a fixed store level. CLI `import_geotiff` updated for the new args.
+
+6. **Bag-replay importer (via #43).** New offline tool (cube-side or a bridge
+   package — see Open Question 2), modeled on `bag_to_geotiff.cpp -d`:
+   SequentialReader over a day's detection bags (timestamp-merged) → populate
+   `tf2::BufferCore` from `/tf`+`/tf_static` → `DetectionsProjector::project`
+   (vessel_speed NaN for detections-only bags) → `GeoMapSheet::addSoundings` →
+   one CUBE run for the whole day → iterate `GeoMapSheet::grids()` /
+   `GeoGrid::values()` → build `BathymetryTile`s keyed by the `CellIndex`'s grid →
+   `importEpoch(Draft, <date>, tiles, Replayed)`. Deterministic (direct reader,
+   no QoS cap) so content hashes are stable (D6). Registers a `SourceRecord` for
+   the contributing platform/sensor.
+
+7. **Tests.** Per the issue deliverables, on the new substrate:
+   - Epoch model: same-session replace vs cross-session 1/σ² fusion; compaction
+     supersession + `Replayed`-beats-`LiveFused` ordering (and the no-op reverse);
+     CRLF-safe provenance sidecar round-trip (harvest the #148 regression).
+   - Multi-level: store holds two levels, query returns best-available across them;
+     load accepts mixed-level tiles (replaces the deleted reject test).
+   - Importer round-trips: GeoTIFF in → query out (datum conversion, footprint,
+     lowest-uncertainty, non-positive-uncertainty-as-missing); registry index
+     stamped + persisted.
+   - Bag-replay determinism: same bag → byte-identical tiles across two runs
+     (content-hash stability), on a small synthetic or trimmed fixture.
+   - Change map: difference of two epochs (cells-in-both only).
+   - `importEpoch` grid/tile-index match guard (harvest #148 Copilot med-fix).
+
+8. **ADR-0002 reconciliation.** Replace #148's pre-#153 Amendment A1 with one
+   reconciled against the merged D2 (heterogeneous levels) and D5/#178 (registry
+   provenance): epoch dirs compose with mixed-level `<GridIndex>` filenames;
+   provenance enum vs registry relationship (Open Question 1) recorded;
+   immutable-after-compaction; D7 newest-reliable epoch walk; no-CUBE-seeding
+   rationale. This is the only `docs/` change.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `marine_bathymetry_store/include/.../epoch.hpp` | **New** — harvest #148 (`Epoch`, `Provenance`, `validateEpochLabel`); provenance per OQ1 |
+| `marine_bathymetry_store/include/.../bathymetry_store.hpp` | Multi-level (drop single-`level_` invariant); per-layer `map<Epoch,EpochTiles>`; epoch `set`/`importEpoch`/`epochs`/`getOrCreateEpoch` |
+| `marine_bathymetry_store/src/bathymetry_store.cpp` | Epoch + multi-level impl; within-day 1/σ² fuse helper; provenance ordering |
+| `marine_bathymetry_store/include/.../query.hpp` | Level-aware + epoch-walk queries; `DepthSample.epoch`; `forEachChangedCell` |
+| `marine_bathymetry_store/src/query.cpp` | Cross-level best-available; newest-first epoch walk; change-map |
+| `marine_bathymetry_store/include/.../tile_io.hpp` | Epoch dir layer; mixed-level load; provenance marker; `supersedes_disk` |
+| `marine_bathymetry_store/src/tile_io.cpp` | Epoch-aware save/load; CRLF-safe provenance sidecar (harvest); store-wide registry retained |
+| `marine_bathymetry_store/include/.../geotiff_import.hpp` | **New** — harvest #148; add registry/provenance args |
+| `marine_bathymetry_store/src/geotiff_import.cpp` | **New** — footprint import + datum conv + registry stamp; multi-level target |
+| `marine_bathymetry_store/src/import_geotiff_main.cpp` | **New** — CLI (epoch, provenance, source-record args), guarded parsing (harvest #148 fix) |
+| `marine_bathymetry_store/CMakeLists.txt` | `geotiff_import.cpp` into lib; `import_geotiff` exe; new gtests |
+| `marine_bathymetry_store/test/test_*.cpp` | Epoch/multi-level/importer/change-map/determinism tests; drop `LoadRejectsTilesFromAnotherLevel` |
+| `<bag-replay tool location — OQ2>` | **New** — offline bag→DetectionsProjector→GeoMapSheet→`importEpoch` harness + test |
+| `docs/decisions/0002-bathymetric-data-store.md` | Reconciled Amendment A1 (vs #153 D2 + #178 D5) |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Safety First | D7 shallowest-reliable preserved across the epoch walk + multi-level resolve; no-data/over-uncertainty stays not-safe; non-positive uncertainty = missing |
+| Robustness (complete the fix) | Multi-level (the old M1 blocker) lands **with** the importers, not deferred — no single-level assumptions reintroduced; importer registers provenance (#178) rather than ignoring it |
+| Simulation-First | Costmap consumer is Phase 4; this phase's importers are offline/in-process and unit-tested deterministically (bag-replay determinism test) |
+| Verify, don't assume | Bag-replay reads the bag's own earth-frame TF (verified present in the corpus, progress.md); importer round-trips queried back |
+| Atomic commits | One logical change per commit; multi-level, epoch, each importer, ADR land separately |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0002 (bathy store) | Yes | Implements Phase 2 (import); reconciles Amendment A1 with merged D2 (#151) + D5/#178; epoch model recorded; D6 manifest key generalized to `layer/epoch/GridIndex` (no hash impl yet) |
+| ADR-0005 (provenance registry) | Yes | GeoTIFF + bag-replay importers register `SourceRecord`s and stamp the per-cell `uint16` source index; store-wide `registry.json`; D5 carve-out kept (shallowest-reliable ignores provenance) |
+| ADR-0001 (cross-cutting decisions) | Yes | ADR-0002 lives in this repo's `docs/decisions/`; the change is the A1 reconciliation only |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| Store API → epoch+multi-level | All `query.hpp` consumers; tests | Yes |
+| `DepthSample` gains `epoch` | Phase-3 query-service / Phase-4 costmap (not yet built) | N/A — downstream consumers don't exist yet; API lands before they lock on (the M1 timing concern) |
+| Epoch directory layout | D6 sync manifest key (`layer/epoch/GridIndex`) | Documented in ADR; sync impl deferred (Phase 6) |
+| Importer registers provenance | `registry.json` schema is already #178-current | Yes — importer is the first writer of real records |
+| Bag-replay tool location | cube_bathymetry CMake or new bridge pkg (OQ2) | Flagged as Open Question |
+| PR #148 superseded | Close #148 when this supersedes it | Checkpoint decision for the operator (see Branch Strategy) |
+
+## Branch Strategy
+
+The local `feature/issue-147` has been **reset to current `jazzy`** (0 behind);
+the rebuild happens here. The new PR opened from this branch will **supersede
+#148**, which stays OPEN as the harvest reference until then. **Closing #148 is a
+checkpoint decision for the operator** — recommend closing it with a comment
+pointing at the superseding PR once that PR is green, not before (the diff is the
+harvest source).
+
+## Open Questions
+
+- [ ] **OQ1 — Provenance enum vs SourceRegistry.** #148's `Provenance{LiveFused,
+  Replayed}` is the *compaction-maturity* axis (which CUBE run produced an epoch's
+  surface); #178's `SourceRegistry` is the *platform/sensor* axis (who contributed
+  a cell). They are orthogonal and **both belong**: keep `Provenance` as a
+  per-`EpochTiles` property (governs the immutable-after-compaction ordering) and
+  the registry source-index as the per-cell property. Recommend this split;
+  confirm before coding so the ADR A1 wording is right.
+- [ ] **OQ2 — Bag-replay tool location.** Store cannot depend on cube (ADR-0002
+  layering). Options: (a) live in `cube_bathymetry` (depends on store via its
+  public API, mirrors `bag_to_geotiff`), or (b) a thin new bridge package.
+  Recommend (a) — `bag_to_geotiff` already proves cube-side offline replay and the
+  store's public import API is the only coupling. Confirm.
+- [ ] **OQ3 — GeoMapSheet live-path importer: in or out of this phase?** The issue
+  lists a `GeoMapSheet → store` importer (live path, session-tagged snapshots,
+  within-day 1/σ² fusion). Recommend **OUT** of Phase 2: it belongs with the
+  Phase-3 live node (it needs the running graph + session identity). Phase 2 ships
+  the offline bag-replay importer (which also goes through `GeoMapSheet`, so the
+  cell-extraction code is shared and ready for Phase 3). Confirm the cut.
+
+## Estimated Scope
+
+**Recommend a 2-PR split** (supersedes #148; both from `feature/issue-147` or a
+stacked pair):
+
+- **PR-A — store foundation + GeoTIFF import.** Multi-level + level-aware query
+  (M1), epoch dimension + persistence, epoch-walk + change-map query, GeoTIFF
+  importer + CLI + registry provenance, ADR-0002 A1 reconciliation, full tests.
+  This is the self-contained, in-repo half and the one downstream consumers lock
+  onto — landing the level-aware API here is the M1 timing fix.
+- **PR-B — bag-replay importer.** The cube-side (OQ2) offline harness over #43 +
+  determinism test. Separable because it lives in a different repo/package and
+  depends only on PR-A's public import API.
+
+One-PR is viable but PR-A is already large (the re-platform) and PR-B crosses a
+repo boundary — the split keeps each reviewable and lets PR-A supersede #148
+promptly. GeoMapSheet live-path importer (OQ3) is **out** (Phase 3).

--- a/.agent/work-plans/issue-147/progress.md
+++ b/.agent/work-plans/issue-147/progress.md
@@ -350,3 +350,28 @@ cross-repo/internal API claims (loadTile level recovery, the Sounding→GeoSound
 mutation/determinism) are mis-described against the actual code and must be corrected so the implementer builds the right
 thing. Fix those five and it's ready.
 
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-21 09:24 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved
+**Round**: 1
+**Ship**: recommended
+
+**Branch**: feature/issue-147-replatform at `9465564` (PR-A; supersedes PR #148)
+**Mode**: pre-push
+**Depth**: Deep (reason: ~2260-line store change — multi-level query + epoch model + persistence + GeoTIFF importer + ADR)
+**Must-fix**: 1 (resolved) | **Suggestions**: 2 (resolved)
+
+Two disjoint-lens Claude adversarial passes. Lens A: epoch never-fused, Replayed-immutable,
+multi-level resolution, persistence round-trip, importer math all VERIFIED correct; 2 low-sev
+suggestions. Lens B: 1 must-fix (Chart read-only gate bypass in importEpoch). All resolved.
+68 gtests pass (the 3 test.sh "failures" are the known local uncrustify-0.78.1 drift on
+unmodified base files — cpplint+uncrustify clean on all changed files).
+
+### Findings
+- [x] (must-fix) importEpoch bypassed the read-only-Chart gate set() enforces (CLI could overwrite the Chart prior) — gated; CLI opts into chart_writable only for Chart — `bathymetry_store.cpp:83`, `import_geotiff_main.cpp:178`
+- [x] (suggestion) empty-tiles import created a phantom epoch that vanished on reload — importEpoch rejects empty — `bathymetry_store.cpp`
+- [x] (suggestion) importer honored depth no-data but not uncertainty no-data — symmetric guard added — `geotiff_import.cpp`
+- [ ] (PR-B, deferred) bag-replay importer needs Sounding→GeoSounding georef + GeoGrid::values() is positional float — recorded in plan §6 for PR-B

--- a/.agent/work-plans/issue-147/progress.md
+++ b/.agent/work-plans/issue-147/progress.md
@@ -1,0 +1,236 @@
+---
+issue: 147
+---
+
+# Issue #147 — Bathymetric store Phase 2: import (bag-replay, GeoMapSheet, GeoTIFF) with per-day epoch model
+
+## Corpus Inventory
+**Status**: complete
+**When**: 2026-06-11 21:55 -0400
+**By**: Claude Code Agent (Fable 5)
+
+Surveyed `~/data/logs` (144 GB) for ROS-bag M3 multibeam coverage to drive the
+Phase-2 bag-replay importer.
+
+### M3 detection coverage (ROS bags)
+
+| Day | Source | Sessions | M3 det msgs | Hours |
+|-----|--------|----------|-------------|-------|
+| 2026-06-09 | `gabby/logs/bizzy_m3/bag_2026-06-09T14.51.50_m3_detections` | 1 | 55,100 | 1.6 |
+| 2026-06-10 | `gabby/logs/bizzyboat_sonar/2026-06-10T17-57-25+00-00` | 1 | 104,979 | 2.4 |
+| 2026-06-11 | `gabby/logs/bizzyboat_sonar/2026-06-11T{16-30-24,19-29-20}+00-00` | 2 | 253,044 | 3.7 |
+
+Total: **3 days / 4 sessions / 413k SonarDetections messages**. June 11's two
+same-day sessions are a natural test case for the within-epoch cross-session
+fusion rule (ADR-0002 A1.2); the three days exercise the multi-day epoch model.
+
+### Replayability
+
+- June-9 standalone bag is self-contained: `/bizzy/sensors/m3/detections`
+  (SonarDetections) **and** `/bizzy/sensors/m3/soundings` (PointCloud2),
+  `/bizzy/odom`, `/tf` (188k msgs), `/tf_static`, sound speed.
+- June-10/11 sonar-recorder bags carry detections + `/bizzy/odom` + `/tf` +
+  `/tf_static` (no pre-projected soundings topic).
+- 98 of 101 sonar-recorder sessions (Apr 6 – Jun 8) contain **no** M3 topics —
+  M3 recording in bags begins 2026-06-09. Earlier M3 data lives in QINSy
+  projects on mercat (`mercat/QPS-Projects`, not ROS bags) and would enter the
+  store as processed-layer products (BAG/GeoTIFF export), not via bag replay.
+
+### Verification items — both PASS (2026-06-11)
+
+- [x] **Earth-frame chain present in bags.** June-10 bag's `/tf` carries
+  `earth -> bizzy/map` plus the full cube pose chain
+  (`bizzy/map -> bizzy/base_link_north_up` level frame,
+  `bizzy/odom -> bizzy/map_tide` tide frame) and `/tf_static` has the sensor
+  mounts (`bizzy/base_link -> bizzy/m3`). A cold replay georeferences from the
+  bag alone. (Boat config: `map_frame: bizzy/map`; georeferencing goes through
+  the ECEF `earth` frame — same pattern `bag_to_geotiff.cpp:280,314` uses.)
+- [x] **Pipeline inputs confirmed.** `detections_to_pointcloud` consumes
+  `SonarDetections` + `Odometry` and produces PointCloud2 `soundings`;
+  `cube_bathymetry_node` consumes `soundings` and transforms into `map_frame`.
+  Sound speed is embedded per-ping (`ping_info.sound_speed` in
+  `SonarDetections`) — no external sound-speed feed needed at replay. June-9
+  bag also recorded the pre-projected `soundings` topic; June-10/11 bags need
+  the detections→soundings stage re-run.
+
+### Boat layout decision (Roland, 2026-06-12)
+
+Store root is a **sibling of the log root, not nested in it** — bags are the
+append-only raw record, the store is derived working knowledge (re-derivable
+from bags, so no special backup discipline):
+
+```
+<data root>/logs/...                 # existing per-session bags, untouched
+<data root>/bathymetry/store/        # persists across sessions & reboots
+    draft/<date>/                    # today live-fused; past dates compacted
+    processed/<date>/
+```
+
+Flow: underway, live importer (Phase 3) writes `draft/<today>/` incrementally;
+evenings, dev replays the day's bags → compacted epoch → copied back (Phase-6
+sync later). The concrete path + `store_dir` parameter land in `bizzyboat.yaml`
+with the Phase-3 node — record it as a config item in that sub-issue.
+
+### Distribution transport decision (Roland, 2026-06-12) — for the Phase-6 sub-issue
+
+Per ADR-0002 §D6, robot and operator each hold a **full independent store**;
+sync is manifest-diff (`{layer/epoch/GridIndex → content-hash}`), single-writer
+per epoch (draft = boat-produced, processed = operator/dev-produced — no merge
+case), and epochs are immutable after compaction so only today's live-fused
+epoch is ever hot. Transport in two stages:
+
+- **Interim / dockside: rsync (or plain cp).** The store is directories of
+  immutable files — rsync is already a correct sync protocol for it, zero
+  code. Compacted epochs ride the evening bag-offload, copy back the same way.
+- **Phase 6 / underway: ROS-msg protocol over udp_bridge.** During ops
+  udp_bridge is the managed link (rate-limited, prioritized); a node pair does
+  manifest exchange + tile chunks as messages, idempotent by content-hash.
+  "rsync semantics, udp_bridge transport." This is the bounded, change-only
+  payload that durably fixes the unh_echoboats_project11#250 monolithic-grid
+  downlink failure (`clear_grid` stays the interim until then).
+
+Nothing in the tile format, layout, or epoch rules changes for Phase 6 — the
+sync layer is additive, and camp#90's directory watcher works identically
+whichever transport filled the operator store.
+
+### Tooling gotchas found driving the corpus (2026-06-12)
+
+- `detections_to_pointcloud` is a **lifecycle node**: replay harnesses must
+  configure+activate it or it records nothing, silently (cost a 25-min no-op).
+  Conversion script fixed; durable fix is the projection-refactor
+  (rolker/cube_bathymetry#43) which removes the live-replay step entirely.
+- Replay rate is capped (~5x) by the node's best-effort `SensorDataQoS` — no
+  backpressure, silent drops. Same refactor removes the cap (direct bag
+  reader, in-process, deterministic — required for content-hash-stable
+  compaction per ADR-0002 §D6).
+
+### First end-to-end run (2026-06-12, overnight)
+
+Bags → per-day CUBE replay → `import_geotiff` → epoch store → change maps,
+all real data:
+
+- **Pier store** (`~/data/logs/analysis/2026-06-11_pier_grid/store`): three
+  replayed draft epochs — 2026-06-09 (133,406 cells), -10 (274,573), -11
+  (215,228; both sessions through ONE CUBE run = A1.2 compaction), 8 tiles,
+  15 MB. Conversions ran ≥99.9% faithful at 5x replay.
+- **Change maps**: 09→10 = 59k doubly-observed cells, median +0.08 m,
+  95th |Δ| 0.39 m. 10→11 = 134k cells, median +0.14 m, 95th |Δ| 2.26 m
+  (June-11 includes the sidescan/range-experiment sessions — noisier).
+  Small positive medians look like day-to-day datum/tide residual — exactly
+  the systematic signal the epoch model is meant to expose.
+- **No cross-day combined CUBE run was made — deliberately**: the "all data
+  combined" view is the store's newest-epoch composite (369k cells), per
+  A1.1; fusing days in CUBE would violate the model.
+- **Lake Massabesic store** (`~/data/bathymetry/massabesic/store`):
+  chart/2026-06-12 prior from the CCOMJHC/ccomjhc_project11#55 contour
+  GeoTIFF — 69,157,035 cells, 142 tiles, 242 MB, uncertainty 3.0 m const,
+  `--depth-scale -1`. **OPEN: --depth-offset 0** — chart heights are
+  lake-surface-relative until day-1 M3-vs-prior change-map calibration
+  measures the surface's ellipsoidal height; then re-import (one command).
+- Import guard added en route: non-positive uncertainty = missing (real
+  June-9 product had 5,971 cells with uncertainty 0).
+
+Renders: `pier_epochs_and_change.png`, `june09_pier_0.5m.png` (analysis dir),
+`store_chart_preview.png` (massabesic dir).
+
+### Key discovery
+
+`cube_bathymetry` already ships **`bag_to_geotiff`** — an offline multi-bag
+reader (merges bags by timestamp, builds a `GeoMapSheet` via the bag's
+earth-frame TF, exports GeoTIFF). The boat config comment confirms the intent:
+"Logging detections lets soundings + grid be re-derived offline by replaying
+through the pipeline." The Phase-2 replay harness should extend or mirror this
+tool (adding epoch-tagged store import per ADR-0002 A1) rather than starting
+from scratch. Note layering: the store cannot depend on cube (ADR-0002), so the
+harness lives cube-side or as a bridge package, importing into the store via
+its public API.
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-13 05:17 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**PR**: #148 at `a5a2824`
+**Sources**: 1 (Copilot @ `a5a2824`)
+**Cross-source confirmations**: 0 (no prior Local Review entries on the timeline)
+**CI**: all-pass (build success)
+
+### Findings
+- [x] (high, Copilot) `readProvenance()` treated a CRLF sidecar (`\r`) as a parse
+  failure → silently downgraded a Replayed epoch to LiveFused, allowing live writes
+  over replayed data after reload — `src/tile_io.cpp`. Fixed: trim trailing
+  whitespace + CRLF round-trip regression test.
+- [x] (med, Copilot) `importEpoch()` validated the map key grid but not that the
+  tile was built for the same grid → file-name/georef mismatch corruption on
+  `load()` — `src/bathymetry_store.cpp`. Fixed: explicit `tile.index() == grid`
+  check (throws) + test.
+- [x] (med, Copilot) `import_geotiff` called `provenanceFromToken()` unguarded →
+  uncaught `std::invalid_argument` on bad CLI input — `src/import_geotiff_main.cpp`.
+  Fixed: guard parse, print expected values, exit 1 (matches `layerFromName`).
+- [x] (med, Copilot) `writeTestTiff()` dereferenced GDAL driver/dataset with no
+  null-check → test-runner crash on GDAL failure; also missing `<stdexcept>` —
+  `test/test_geotiff_import.cpp`. Fixed: null-checks that throw + explicit include.
+- [x] (low, Copilot) `DepthSample` doc said "tagged with its provenance" but the
+  struct carries source + epoch — `include/marine_bathymetry_store/query.hpp`.
+  Fixed: reworded comment.
+
+### False positives
+- (none)
+
+## Post-PR Review — PR #148 @ 75528a4fd — 2026-06-14 (coordinator-dispatched reviewer; Copilot quota out)
+
+**Verdict: CHANGES NEEDED.** The epoch model, GeoTIFF importer, error handling, and provenance immutability are high quality and well-tested. Blockers are timing/contract:
+
+- **M1 (must-fix): single-level store/query contradicts the now-merged multi-level ADR (#151 / ADR amendment #153).** Hard-coded single level throughout: `requireGridAtLevel` throws on off-level tiles (set/importEpoch/getOrCreateTile); `forEachCellBestSource`/`bestSource`/`shallowestReliable` resolve within one `store.level()` only; `tile_io::loadTile` + `importGeoTiff` pin to `store.level()` and the test `LoadRejectsTilesFromAnotherLevel` bakes in behavior the ADR now forbids. Per #151 this is "mostly removing the single-`level_` assumption + single-level query iteration" — must land the level-aware best-available query before A2/B2 consumers lock onto it this week.
+- **M2 (must-fix): in-PR ADR copy (Amendment A1) predates #153** and still says single-level; merge `jazzy` and reconcile A1 with the D2 heterogeneous-levels paragraph (epoch dirs compose with mixed-level `<GridIndex>` filenames — state it).
+- **M3 (must-fix): PR marked Ready but body says "Draft until importers land";** GeoMapSheet (live path) + bag-replay importers and the cross-session 1/σ² fusion rule are unimplemented (CMakeLists builds only geotiff_import). Split to "epoch + GeoTIFF import" with follow-on issues, or finish — and fix the stale body so scope is legible.
+- Nits: signature Model says `Fable 5` (cosmetic); consider a coverage-change iterator (cells in exactly one epoch) as a follow-on for survey QC.
+
+Full strengths confirmed: datum-at-import (depth_scale/offset before write), zero/neg-uncertainty guard, GDAL error surfacing before clearing dirty, CRLF-safe provenance sidecar, supersedes_disk stale-tile cleanup — all tested.
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-14 10:42 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**PR**: #148 at `5922b7b`
+**Sources**: 3 (Copilot R1 @ `a5a2824`, Post-PR Review @ `75528a4`, CI rollup @ `5922b7b`)
+**Cross-source confirmations**: 0 (Copilot's code-hardening set and the Post-PR contract/timing set do not overlap)
+**CI**: all-pass (build success @ `5922b7b`)
+
+Round 2 of triage. Copilot R1's 6 inline comments were already integrated and
+fixed in the prior `## Integrated Review` (@ `a5a2824`, commits `0d25fef`..`99c03ca`);
+re-verified addressed at current head. Copilot R2 @ `75528a4` returned no comments
+(reviewer quota exhausted). The live open items are the local Post-PR Review's
+three must-fix blockers (contract/timing, not code-quality), verified against
+current code below.
+
+### Findings
+- [ ] (M1, high, Post-PR Review) Store/query are hard-coded single-level, contradicting
+  the now-merged multi-level ADR amendment (jazzy `0d27447` "store holds heterogeneous
+  GGGS levels", #151/#153). `requireGridAtLevel` throws on off-level grids
+  (`set`/`importEpoch`/`getOrCreateTile`); `bestSource`/`shallowestReliable`/
+  `forEachCellBestSource` resolve within one `store.level()`; `tile_io::loadTile`
+  + `importGeoTiff` pin to `store.level()`; `test_tile_io.cpp:216
+  LoadRejectsTilesFromAnotherLevel` bakes in the forbidden behavior. Land the
+  level-aware best-available query before A2/B2 consumers lock onto the API —
+  `src/bathymetry_store.cpp`, `src/query.cpp`, `src/geotiff_import.cpp`,
+  `src/tile_io.cpp`, `test/test_tile_io.cpp`.
+- [ ] (M2, high, Post-PR Review) In-PR `docs/decisions/0002-bathymetric-data-store.md`
+  predates the merged heterogeneous-levels amendment — branch is 7 behind jazzy and
+  the ADR copy still carries only the single-level Amendment A1. Merge `jazzy` and
+  reconcile A1 with the D2 heterogeneous-levels paragraph (epoch dirs compose with
+  mixed-level `<GridIndex>` filenames) — `docs/decisions/0002-bathymetric-data-store.md`.
+- [ ] (M3, med, Post-PR Review) PR marked Ready but body says "Draft until the importers
+  land"; CMake builds only `import_geotiff` (no GeoMapSheet live-path or bag-replay
+  importer, no cross-session 1/σ² fusion rule). Either split scope to "epoch + GeoTIFF
+  import" with follow-on issues for the remaining importers, or finish them — and fix
+  the stale PR body so scope is legible — `marine_bathymetry_store/CMakeLists.txt`, PR body.
+- [ ] (nit, low, Post-PR Review) Follow-on: a coverage-change iterator (cells observed in
+  exactly one epoch) would aid survey QC — enhancement, not a blocker.
+- [ ] (nit, cosmetic, Post-PR Review) Corpus Inventory entry signature says model `Fable 5`
+  — cosmetic, no action required.
+
+### False positives
+- (none) — all Copilot R1 findings were valid and are fixed; the Post-PR blockers all
+  reproduce against current code.

--- a/.agent/work-plans/issue-147/progress.md
+++ b/.agent/work-plans/issue-147/progress.md
@@ -259,3 +259,94 @@ rebuilt via the just-merged #43 DetectionsProjector (offline, no live ROS graph)
 - [ ] OQ2 — Bag-replay tool location: recommend cube_bathymetry-side (mirrors bag_to_geotiff, depends on store via public API) — confirm.
 - [ ] OQ3 — GeoMapSheet live-path importer: recommend OUT of Phase 2 (belongs with Phase-3 live node) — confirm the cut.
 - [ ] Checkpoint — close #148 when the superseding PR is green (it stays the harvest reference until then) — operator decision.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-06-21 02:10 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context)) (in-context — author self-review)
+<!-- Fresh-context independent review pass per host dispatch; the `## Plan Authored`
+     entry shares the same agent-name string, so the name-based independence detection
+     annotates it as author self-review per the skill. Weight accordingly. -->
+
+**Plan**: `.agent/work-plans/issue-147/plan.md` at `71bc52c`
+**PR**: PR-less (`--issue`/file-path mode; PR #148 is the prior Phase-2 PR on this same branch, not this plan's PR)
+**Verdict**: changes-requested
+
+### Verification against current code
+- **Store API read is accurate.** `BathymetryStore` per-`SourceLayer` `map<GridIndex,BathymetryTile>`,
+  single `gggs::Level level_`, private `getOrCreateTile`, `chart_writable` gate, `set`/`get`
+  level-checks — all as the plan's Context says (`bathymetry_store.hpp/.cpp` confirmed). `BathymetryTile`
+  3-raster value(2-band double)/time(int64)/source(uint16) + `BathyCell{depth,uncertainty,timestamp,source_index}`
+  confirmed. `SourceRegistry` idempotent-on-`source_id`, index-0 sentinel, `registry.json` atomic — confirmed.
+  `query.hpp` `bestSource`/`shallowestReliable`/`forEachCellBestSource` all single-level (`store.level()`) — confirmed.
+  ADR-0002 already carries the merged heterogeneous-levels D2 amendment (the store body lags the ADR) — confirmed.
+- **Minor naming drift (not blocking):** the plan calls the off-level rejection `requireGridAtLevel`; the actual
+  mechanism is inline `cell.level() != level_.level()` checks in `set`/`getOrCreateTile` (#148-era name). The plan
+  also names harvested query fns `bestSample`/`reliableSample`; current jazzy fns are `bestSource`/`shallowestReliable`.
+  Substance is right; names should track current code when implemented.
+
+### Findings
+- [ ] (must-fix) **Branch strategy is internally inconsistent and risks destroying PR #148's diff.** PR #148's
+  `headRefName` IS `feature/issue-147` — the exact branch this plan reset to jazzy. Local has diverged from
+  `origin/feature/issue-147` (local 79 ahead / 20 behind; only 3 ahead of jazzy). Pushing this re-plan requires a
+  force-push that overwrites `origin/feature/issue-147` and erases #148's harvest diff — contradicting "keep #148
+  OPEN as the harvest reference." You cannot both reset this branch and preserve #148. Fix: open the new PR from a
+  NEW branch (e.g. `feature/issue-147-replatform`), leaving `origin/feature/issue-147`/#148 untouched as the
+  reference; supersede by comment, not by force-push. — `plan.md:228-235`
+- [ ] (must-fix) **Multi-level load mechanism is mis-described and under-specified (the M1 core).** Plan says
+  `tile_io::loadTile` "recovers each tile's level from its geotransform (already does — it just currently rejects
+  non-store levels)." It does NOT: `loadTile(path, level)` takes the level as an INPUT and `mtrs::loadTile<T>(path,
+  level, bands)` validates the geotransform against that supplied level. `load()` passes `store.level()` to every
+  tile. Mixed-level load therefore needs a concrete new step the plan omits: parse the level prefix from the
+  `<level>_<row>_<col>.tif` filename and pass per-file level (the filename already encodes it — small, but it must
+  be stated). Spell this out in M1. — `plan.md:99-102`
+- [ ] (must-fix) **Bag-replay chain omits the Sounding→GeoSounding earth-frame georeferencing step.** Plan's chain
+  is `project() → GeoMapSheet::addSoundings → grids() → values()`. The actual `bag_to_geotiff.cpp -d` path inserts a
+  per-sounding `lookupTransform("earth", sonar_frame, stamp)` loop (lines ~517-559) that converts `cube::Sounding`
+  (sonar-frame x/y/z) into `cube::GeoSounding` (lat/lon) BEFORE `addSoundings`. `project()` returns `cube::Sounding`,
+  not `GeoSounding`. State this intermediate; it's where earth-frame TF is consumed. — `plan.md:148-157,75-79`
+- [ ] (must-fix) **`GeoGrid::values()` is a flat positional vector, not "keyed by CellIndex," and it mutates node
+  state.** `values()` returns `std::vector<DepthAndUncertainty>` in `CellAreaIterator(index_)` order (full grid,
+  NaN-filled empties) — the CellIndex association is positional, not a map. The plan's "`DepthAndUncertainty` keyed
+  by `gggs::CellIndex`" is wrong; the importer must walk `CellAreaIterator` in lockstep with the vector. Also
+  `values()` calls `queueFlush`/`extractDepthAndUncertainty` (mutates the median pre-filter), and `DepthAndUncertainty`
+  is `float` (store is `double` — widening, fine). The determinism claim (D6 byte-identical) hinges on CUBE +
+  `values()` being deterministic for a fixed sounding-insertion order; make the determinism test assert that explicitly
+  (same bag, same order → identical tiles) and note the float→double widening. — `plan.md:75-79,168-169`
+- [ ] (suggestion) **ADR-0002 "replace #148's Amendment A1" overstates the docs delta.** Current jazzy ADR-0002 has
+  NO Amendment A1 / epoch content (that lived only on the #148 branch, never merged). The epoch amendment is authored
+  FRESH here, composed against the already-merged D2/D5. Reword to "author the epoch Amendment A1 against merged
+  D2/D5," not "replace." — `plan.md:173-178,213`
+- [ ] (suggestion) **`DepthSample` has no `source_index` today.** Plan §4 says "`source_index` is already available
+  via the per-cell record" — true at `BathyCell`, but `DepthSample` (what queries return) carries only depth/uncertainty/
+  timestamp/source-LAYER. If consumers need the registry index off a query result, `DepthSample` must gain it
+  explicitly alongside the planned `epoch` field. — `plan.md:135-136`
+
+### Open-question recommendations (independent)
+- [ ] **OQ1 (dual provenance axes) — AGREE, genuinely orthogonal.** `Provenance{LiveFused,Replayed}` is the
+  per-epoch compaction-maturity axis (governs immutable-after-compaction ordering); the `SourceRegistry` uint16 is the
+  per-cell platform/sensor axis. They never alias (one is epoch-scoped, one cell-scoped) and the store already holds
+  both substrates. Keep both; the plan treats them so. Lock the ADR-A1 wording to this split before coding.
+- [ ] **OQ2 (bag-replay tool location) — AGREE, cube-side (option a).** Store can't depend on cube (ADR-0002 D-layering);
+  cube already depends on the store's public API path is the only coupling, and `bag_to_geotiff` proves cube-side
+  offline replay end-to-end. A separate bridge package adds a repo/CMake surface for zero isolation benefit. Caveat:
+  this makes PR-B genuinely cross-repo (cube_bathymetry), so PR-B depends on PR-A's public import API being released
+  first — sequence accordingly (see PR-split note).
+- [ ] **OQ3 (GeoMapSheet live-path importer) — AGREE, OUT of Phase 2.** It needs the running graph + session identity
+  (Phase-3 live node). The offline bag-replay importer already exercises the GeoMapSheet→store cell-extraction code, so
+  Phase 3 inherits it. Clean cut.
+
+### PR-split assessment
+Sound in principle: PR-A is the self-contained in-repo foundation downstream consumers lock onto; PR-B is cross-repo and
+depends only on PR-A's public import API. One API-timing risk to record: PR-B (cube-side) cannot build until PR-A's
+import API is merged+released into the layer, so the split is a hard dependency order, not parallelizable. No dependency
+inversion (store never depends on cube). PR-A is large (re-platform); acceptable given it supersedes #148.
+
+### Summary
+Strong, well-grounded re-plan: the harvest-vs-rebuild call is correct (17+ conflict merge = re-platform), the store-API
+reading is accurate, multi-level-from-the-start correctly resolves the old M1 blocker, and all three OQ recommendations
+are sound. Not ready as written: the branch strategy will destroy #148's reference diff on push (must-fix), and three
+cross-repo/internal API claims (loadTile level recovery, the Sounding→GeoSounding step, GeoGrid::values() shape +
+mutation/determinism) are mis-described against the actual code and must be corrected so the implementer builds the right
+thing. Fix those five and it's ready.
+

--- a/.agent/work-plans/issue-147/progress.md
+++ b/.agent/work-plans/issue-147/progress.md
@@ -234,3 +234,28 @@ current code below.
 ### False positives
 - (none) — all Copilot R1 findings were valid and are fixed; the Post-PR blockers all
   reproduce against current code.
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-21 00:46 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Plan**: `.agent/work-plans/issue-147/plan.md` at `71bc52c`
+**Branch**: feature/issue-147 at `71bc52c` (reset to current jazzy; new PR will SUPERSEDE #148)
+**Phases**: 2-PR split recommended (PR-A store foundation + GeoTIFF import; PR-B bag-replay importer)
+
+**Re-plan rationale**: PR #148's Phase-2 code was written against the pre-refactor
+store. Since then jazzy landed #172 (generic tiled-raster core), #178/ADR-0005
+(Int64-time + UInt16 source-tile + SourceRegistry provenance), and #151/#153
+(heterogeneous levels + read-only Chart). A merge = 17+ conflicts = re-platforming.
+This plan HARVESTS #148's designs (epoch model, GeoTIFF footprint importer,
+change-map, end-to-end-validated behavior) and REBUILDS them on the current store:
+multi-level / level-aware from the start (the old M1 blocker) and SourceRegistry
+provenance integrated (the #178/#179 axis #148 predated). Bag-replay importer
+rebuilt via the just-merged #43 DetectionsProjector (offline, no live ROS graph).
+
+### Open questions
+- [ ] OQ1 — Provenance enum (LiveFused/Replayed, compaction-maturity) vs SourceRegistry (platform/sensor): recommend keeping both, orthogonal — confirm before coding so ADR A1 wording is right.
+- [ ] OQ2 — Bag-replay tool location: recommend cube_bathymetry-side (mirrors bag_to_geotiff, depends on store via public API) — confirm.
+- [ ] OQ3 — GeoMapSheet live-path importer: recommend OUT of Phase 2 (belongs with Phase-3 live node) — confirm the cut.
+- [ ] Checkpoint — close #148 when the superseding PR is green (it stays the harvest reference until then) — operator decision.

--- a/docs/decisions/0002-bathymetric-data-store.md
+++ b/docs/decisions/0002-bathymetric-data-store.md
@@ -23,6 +23,14 @@ provenance registry) and aligns the on-disk encodings with
 `Int64`-ns time tile and `uint16` source band). D6 (content hash) is updated to
 cover all three tile files. See D5/D6 below.
 
+**Amendment A1 — per-day epoch model (2026-06-21,
+[#147](https://github.com/rolker/unh_marine_autonomy/issues/147)):** Phase 2
+(import) adds an **epoch dimension** to each source layer — a layer holds dated
+instances, never fused across days, so repeat surveys *locate* change instead of
+averaging it away. Composed against the already-merged D2 (heterogeneous levels)
+and D5/#178 (registry provenance); it does **not** replace D2 — epoch directories
+compose with mixed-level `<level>_<row>_<col>` tile filenames. See **A1** below.
+
 The full design is in the issue body; this ADR records the load-bearing
 architecture decisions and their rationale so they survive the issue. It is a
 **cross-cutting** decision in the sense ADR-0001 establishes for this repo's
@@ -286,6 +294,88 @@ each as its own sub-issue and PR (`Part of #86`):
 
 Phase 1 is decoupled from the mru_transform datum work (D4); only the chart layer
 waits on it.
+
+## Amendment A1 — Per-day epoch model (Phase 2, #147)
+
+Phase 2 introduces import. Imports raised a question the Phase-1 core did not
+answer: when the **same area is surveyed on multiple days**, what does the store
+hold? Fusing all observations into one surface (a single CUBE estimate over all
+days) averages real change — siltation, scour, a newly-deposited object — into
+the mean, which is exactly the signal a repeat survey exists to find. So the
+store keeps observations **separated by day**, not fused across days.
+
+### A1.1 — A layer is a map of epochs; differencing locates change
+
+Each `SourceLayer` (Processed / Draft / Chart) becomes a map of **epochs**. An
+epoch is a labeled instance of the layer, by convention the local acquisition
+date in ISO-8601 (`"2026-06-10"`) — labels must sort chronologically as plain
+strings (ISO dates do) and be filesystem-safe (single path component,
+`[0-9A-Za-z._-]`, never `.`/`..`), because they are also on-disk directory
+names. A cell surveyed on N days keeps N records; **differencing two epochs**
+(cells observed in *both*) yields a change map. Cells observed in only one epoch
+are *coverage* change, not depth change, and are not part of the difference.
+This composes with **D2**: an epoch holds tiles at heterogeneous levels, and the
+on-disk path is `<layer>/<epoch>/<level>_<row>_<col>{,_time,_source}.tif`.
+
+### A1.2 — Provenance ordering: replayed supersedes live-fused, then immutable
+
+Within a day there are two ways an epoch's surface is produced, captured by a
+per-epoch **`Provenance`** (orthogonal to the per-cell `SourceRegistry` index of
+D5/#178 — see A1.4):
+
+- **`LiveFused`** — built incrementally underway from live session snapshots
+  (the Phase-3 live node writes today's `draft/<today>/` epoch as it goes).
+- **`Replayed`** — the authoritative end-of-day **compaction**: one CUBE run over
+  the whole day's bags (deterministic, no live-graph QoS cap), replacing the live
+  surface.
+
+Ordering rule: **`Replayed` supersedes `LiveFused` for the same epoch, never the
+reverse.** Once compacted, an epoch is **immutable** — a later live write or a
+live-fused re-import is a refused no-op. A re-compaction (`Replayed` over
+`Replayed`) is allowed. This is enforced in the store: `set` and `importEpoch`
+return `false` rather than regress a `Replayed` epoch. Persistence records the
+provenance in a per-epoch `provenance` marker file (CRLF-safe on load — a marker
+that round-tripped through a Windows/mixed checkout must not be mis-read and
+silently downgrade a compacted epoch to live-fused).
+
+A wholesale import flags the epoch `supersedes_disk`: persistence clears the
+epoch's stale tile files before writing, so a compacted epoch covering *fewer*
+grids than the live surface it replaces never resurrects a removed tile on the
+next load.
+
+### A1.3 — Query walks epochs newest-first; no cross-epoch fusion
+
+Best-available and shallowest-reliable resolve a layer by walking its epochs
+**newest-first** and taking the first that has data (best-available) or the first
+that passes the reliability gate (shallowest-reliable). A fresh-but-noisy epoch
+that fails the uncertainty gate falls through to the prior epoch's confident
+value — a recently observed shoal keeps protecting navigation — **with no
+cross-epoch fusion**. This walk is *inside* the existing D2 multi-level and D3
+source-priority resolution: layer priority first, then newest epoch within the
+winning layer, then best level within that epoch.
+
+### A1.4 — Two orthogonal provenance axes, both retained
+
+`Provenance{LiveFused, Replayed}` (this amendment) is the **compaction-maturity**
+axis — which CUBE run produced an epoch's surface, governing the
+immutable-after-compaction ordering. The **`SourceRegistry`** `uint16` index
+(D5/#178, ADR-0005 D2/D8) is the **platform/sensor** axis — who contributed a
+cell. They are orthogonal (one epoch-scoped, one cell-scoped) and never alias;
+the store carries both. The Phase-2 importers (GeoTIFF here; bag-replay in the
+follow-on) register a `SourceRecord` and stamp its index on every imported cell,
+making them the first writers of real registry records. The **D5 safety
+carve-out** is unchanged: `shallowestReliable` ignores both provenance axes and
+selects by depth + uncertainty only.
+
+### A1.5 — D6 manifest key generalizes; no CUBE seeding
+
+The D6 sync manifest key generalizes from `layer/GridIndex → content-hash` to
+**`layer/epoch/GridIndex → content-hash`** (single-writer per epoch — draft =
+boat-produced, processed = operator/dev-produced — and epochs immutable after
+compaction, so only today's live-fused epoch is ever hot). No hash implementation
+lands this phase (Phase 6). The store is **never seeded from CUBE state**: the
+bag-replay path produces one `Replayed` epoch per day from the raw bags, so the
+store is always re-derivable from the append-only bag record.
 
 ## Consequences
 

--- a/marine_bathymetry_store/CMakeLists.txt
+++ b/marine_bathymetry_store/CMakeLists.txt
@@ -12,17 +12,21 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(marine_autonomy REQUIRED)
-# GDAL is no longer used directly here — tile_io delegates all GeoTIFF I/O to
-# marine_tiled_raster_store, which carries (and re-exports) the GDAL dependency.
 find_package(marine_tiled_raster_store REQUIRED)
 find_package(geographic_msgs REQUIRED)
 # nlohmann_json backs the source registry (registry.json sidecar, #178). Declared
 # explicitly here (and in package.xml) — it was only available transitively
 # before, which is not a dependency this package may rely on.
 find_package(nlohmann_json REQUIRED)
+# GDAL is used directly by the GeoTIFF importer (geotiff_import.cpp): it opens
+# the source raster and reads bands/geotransform/SRS. tile_io still delegates its
+# GeoTIFF I/O to marine_tiled_raster_store; the importer needs GDAL directly, so
+# declare it explicitly (also in package.xml).
+find_package(GDAL REQUIRED)
 
 add_library(${PROJECT_NAME}
   src/bathymetry_store.cpp
+  src/geotiff_import.cpp
   src/query.cpp
   src/registry.cpp
   src/tile_io.cpp
@@ -43,10 +47,14 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   ${geographic_msgs_TARGETS}
 )
 # nlohmann_json is header-only and used only inside registry.cpp (the public
-# registry.hpp keeps it out of its interface), so link it PRIVATE.
+# registry.hpp keeps it out of its interface); GDAL is used only inside
+# geotiff_import.cpp (the public geotiff_import.hpp keeps it out of its
+# interface). Both are PRIVATE.
 target_link_libraries(${PROJECT_NAME} PRIVATE
   nlohmann_json::nlohmann_json
+  ${GDAL_LIBRARIES}
 )
+target_include_directories(${PROJECT_NAME} PRIVATE ${GDAL_INCLUDE_DIRS})
 
 # Headers are laid out as include/${PROJECT_NAME}/*.hpp, so install the include/
 # tree to `include` (not include/${PROJECT_NAME}) to avoid a doubled
@@ -60,8 +68,14 @@ install(TARGETS ${PROJECT_NAME}
   RUNTIME DESTINATION bin
 )
 
+# The `import_geotiff` CLI: import a GeoTIFF as one epoch of a store.
+add_executable(import_geotiff src/import_geotiff_main.cpp)
+target_link_libraries(import_geotiff ${PROJECT_NAME})
+
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(marine_autonomy marine_tiled_raster_store geographic_msgs)
+
+install(TARGETS import_geotiff RUNTIME DESTINATION lib/${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -78,6 +92,12 @@ if(BUILD_TESTING)
   # nlohmann_json is used directly in the test (registry tamper fixtures);
   # link it explicitly since it is PRIVATE in the library target.
   target_link_libraries(test_tile_io ${PROJECT_NAME} nlohmann_json::nlohmann_json)
+
+  # The GeoTIFF importer test writes fixture rasters with GDAL directly, so it
+  # links GDAL (PRIVATE in the library target).
+  ament_add_gtest(test_geotiff_import test/test_geotiff_import.cpp)
+  target_link_libraries(test_geotiff_import ${PROJECT_NAME} ${GDAL_LIBRARIES})
+  target_include_directories(test_geotiff_import PRIVATE ${GDAL_INCLUDE_DIRS})
 endif()
 
 ament_package()

--- a/marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_store.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_store.hpp
@@ -27,10 +27,12 @@
 #include <map>
 #include <optional>
 #include <string>
+#include <utility>
 
 #include "marine_autonomy/gggs.h"
 #include "marine_bathymetry_store/bathy_cell.hpp"
 #include "marine_bathymetry_store/bathymetry_tile.hpp"
+#include "marine_bathymetry_store/epoch.hpp"
 
 namespace marine_bathymetry_store
 {
@@ -38,28 +40,45 @@ namespace marine_bathymetry_store
 class BathymetryStore;
 class SourceRegistry;
 // Persistence free functions (defined in tile_io.cpp). Forward-declared here so
-// the store can friend them: `load` must populate any layer — including the
-// read-only `Chart` prior — from disk, which the public API otherwise forbids.
+// the store can friend them: `load` must reach getOrCreateEpoch /
+// getOrCreateTile on any layer — including the read-only `Chart` prior — which
+// the public API otherwise forbids.
 std::size_t save(
   BathymetryStore & store, const std::string & dir, const SourceRegistry * registry);
 std::size_t load(
   BathymetryStore & store, const std::string & dir, SourceRegistry * registry);
 
-/// @brief In-memory, GGGS-tiled, multi-layer, **multi-level** bathymetric store.
+/// @brief One epoch's tile set within a layer, with its provenance.
 ///
-/// Holds one tile map per `SourceLayer`, keyed by `gggs::GridIndex` (which
-/// itself carries its level). The store is **level-agnostic**: tiles at
-/// heterogeneous GGGS levels coexist in the same layer (ADR-0002 §D2,
-/// amendment #151/#153). The constructor's `gggs_level` is retained only as a
-/// **default for `cellIndex(lat,lon)`** (the write/query convenience that turns
-/// coordinates into a cell) — it is *not* an invariant on stored tiles, so a
-/// coarse chart prior and a fine survey grid can live in the same store and the
-/// query resolves the best-available level per cell.
+/// `supersedes_disk` is set by a wholesale import (`BathymetryStore::importEpoch`)
+/// and tells persistence that any files previously written for this epoch are
+/// stale and must be removed before saving — a compacted epoch may legitimately
+/// cover fewer grids than the live surface it replaces, and a leftover tile
+/// file would otherwise be silently resurrected on the next load.
+struct EpochTiles
+{
+  Provenance provenance = Provenance::LiveFused;
+  bool supersedes_disk = false;
+  std::map<gggs::GridIndex, BathymetryTile> tiles;
+};
+
+/// @brief In-memory, GGGS-tiled, multi-layer, multi-level, **multi-epoch**
+///        bathymetric store.
+///
+/// Holds, per `SourceLayer`, a map of **epochs** (dated layer instances,
+/// ADR-0002 Amendment A1) each holding a tile map keyed by `gggs::GridIndex`
+/// (which itself carries its level). The store is **level-agnostic**: tiles at
+/// heterogeneous GGGS levels coexist within an epoch (ADR-0002 §D2, amendment
+/// #151/#153). The constructor's `gggs_level` is retained only as a **default
+/// for `cellIndex(lat,lon)`** (the write/query convenience that turns
+/// coordinates into a cell) — it is *not* an invariant on stored tiles.
 ///
 /// Source priority is a **non-destructive query-time overlay** (see
 /// `query.hpp`): the layers are independent, so a noisy draft write never
-/// clobbers a trusted processed cell and a later processed import never has to
-/// merge with draft (ADR-0002 §D3).
+/// clobbers a trusted processed cell. Epochs are **never fused across days** —
+/// queries resolve a layer by walking its epochs newest-first (epoch labels
+/// sort chronologically; see `Epoch`), and differencing two epochs yields a
+/// change map (ADR-0002 §A1.1).
 ///
 /// This phase has no ROS interface or distribution — just storage, in-process
 /// queries (`query.hpp`), per-tile GeoTIFF persistence (`tile_io.hpp`), and the
@@ -113,57 +132,97 @@ public:
     return level_.cellIndex(gggs::geoPoint(latitude, longitude));
   }
 
-  /// @brief Write @p value into @p layer at @p cell.
+  /// @brief Write @p value into @p layer's @p epoch at @p cell (live path).
   ///
-  /// Creates the backing tile on first write to its grid. The cell may be at
-  /// **any** valid GGGS level — the store is multi-level (ADR-0002 §D2).
-  /// @throws std::invalid_argument if @p cell is invalid.
+  /// Creates the epoch (as `LiveFused`) and the backing tile on first write. The
+  /// cell may be at **any** valid GGGS level — the store is multi-level
+  /// (ADR-0002 §D2).
+  /// @return `false` (a no-op) if the epoch is already `Replayed`: a compacted
+  ///         epoch is immutable, and a live write must never regress it
+  ///         (ADR-0002 §A1.2 provenance ordering). The caller should log this —
+  ///         it means a live snapshot arrived after the day was compacted.
+  /// @throws std::invalid_argument if @p cell is invalid or @p epoch is not a
+  ///         valid label (`validateEpochLabel`).
   /// @throws std::logic_error if @p layer is `Chart` and the store was not
   ///   constructed `chart_writable` — the prior is read-only (ADR-0002 §D3).
-  void set(SourceLayer layer, const gggs::CellIndex & cell, const BathyCell & value);
+  bool set(
+    SourceLayer layer, const Epoch & epoch, const gggs::CellIndex & cell,
+    const BathyCell & value);
 
-  /// @brief Read the raw cell in a single @p layer (no priority overlay).
-  /// @return The cell, or `std::nullopt` if @p layer has no tile for that grid.
+  /// @brief Read the raw cell of one @p epoch in one @p layer (no overlay).
+  /// @return The cell, or `std::nullopt` if the epoch or its tile is absent.
   ///         A returned cell may still be no-data (`!hasData()`).
-  std::optional<BathyCell> get(SourceLayer layer, const gggs::CellIndex & cell) const;
+  std::optional<BathyCell> get(
+    SourceLayer layer, const Epoch & epoch, const gggs::CellIndex & cell) const;
 
-  /// @brief The tiles of a layer (for persistence / iteration). Tiles may be at
-  ///        heterogeneous levels (multi-level, ADR-0002 §D2).
-  const std::map<gggs::GridIndex, BathymetryTile> & tiles(SourceLayer layer) const
+  /// @brief Replace @p layer's @p epoch wholesale with @p tiles (import path).
+  ///
+  /// Used both for compaction products (@p provenance = `Replayed`: a full-day
+  /// replay superseding the live surface) and for whole-epoch imports such as
+  /// processed GeoTIFFs. All imported tiles are marked dirty and the epoch is
+  /// flagged `supersedes_disk` so persistence removes any stale files first.
+  /// Tiles may be at heterogeneous levels (multi-level, ADR-0002 §D2).
+  /// @return `false` (a no-op) if the existing epoch is `Replayed` and
+  ///         @p provenance is `LiveFused` — the §A1.2 ordering: live-fused
+  ///         never replaces replayed. Re-importing at equal-or-higher
+  ///         provenance (e.g. a re-compaction) is allowed.
+  /// @throws std::invalid_argument if @p epoch is not a valid label, or any
+  ///         tile is keyed at an invalid grid.
+  bool importEpoch(
+    SourceLayer layer, const Epoch & epoch,
+    std::map<gggs::GridIndex, BathymetryTile> tiles, Provenance provenance);
+
+  /// @brief A layer's epochs, ascending by label (oldest first; `rbegin()` =
+  ///        newest). Empty map if the layer holds no data.
+  const std::map<Epoch, EpochTiles> & epochs(SourceLayer layer) const
   {
     return layerMap(layer);
   }
 
 private:
-  // Persistence needs to populate any layer (including the read-only Chart
-  // prior) from disk, so the free functions in tile_io.cpp are friends.
+  // Persistence must reach getOrCreateEpoch / getOrCreateTile to populate any
+  // layer (including the read-only `Chart` prior) from disk and to clear dirty
+  // flags after a save, so the free functions in tile_io.cpp are friends. With
+  // both creators private, this is what makes the Chart read-only guarantee hold
+  // by construction, not just by convention: the only public mutator is `set`
+  // (which gates `Chart`), and external code cannot obtain a mutable tile.
   friend std::size_t save(
     BathymetryStore & store, const std::string & dir, const SourceRegistry * registry);
   friend std::size_t load(
     BathymetryStore & store, const std::string & dir, SourceRegistry * registry);
 
-  /// @brief Find or create the tile for @p grid in @p layer.
+  /// @brief Find or create @p epoch in @p layer with @p provenance (load path).
   ///
-  /// Private: the only mutable tile access. Public mutation goes through `set`
-  /// (which gates `Chart`); persistence reaches this via friendship. This is
-  /// what makes the Chart read-only guarantee hold by construction, not just by
-  /// convention — external code cannot obtain a mutable Chart tile. @p grid may
-  /// be at any valid level (multi-level store, ADR-0002 §D2).
-  /// @throws std::invalid_argument if @p grid is invalid.
-  BathymetryTile & getOrCreateTile(SourceLayer layer, const gggs::GridIndex & grid);
+  /// If the epoch already exists its provenance is left unchanged — creation is
+  /// the only time the argument applies.
+  /// @throws std::invalid_argument if @p epoch is not a valid label.
+  EpochTiles & getOrCreateEpoch(
+    SourceLayer layer, const Epoch & epoch, Provenance provenance);
 
-  std::map<gggs::GridIndex, BathymetryTile> & layerMap(SourceLayer layer)
+  /// @brief Find or create the tile for @p grid in @p layer's @p epoch.
+  ///
+  /// Creates the epoch (as `LiveFused`) if absent — used by load and by
+  /// persistence to clear dirty flags on existing tiles. Private: the only
+  /// mutable tile access. Public mutation goes through `set` (which gates
+  /// `Chart`); persistence reaches this via friendship. @p grid may be at any
+  /// valid level (multi-level store, ADR-0002 §D2).
+  /// @throws std::invalid_argument if @p grid is invalid or @p epoch is not a
+  ///         valid label.
+  BathymetryTile & getOrCreateTile(
+    SourceLayer layer, const Epoch & epoch, const gggs::GridIndex & grid);
+
+  std::map<Epoch, EpochTiles> & layerMap(SourceLayer layer)
   {
     return layers_[static_cast<std::size_t>(layer)];
   }
-  const std::map<gggs::GridIndex, BathymetryTile> & layerMap(SourceLayer layer) const
+  const std::map<Epoch, EpochTiles> & layerMap(SourceLayer layer) const
   {
     return layers_[static_cast<std::size_t>(layer)];
   }
 
   gggs::Level level_;
   bool chart_writable_ = false;
-  std::array<std::map<gggs::GridIndex, BathymetryTile>, source_layer_count> layers_;
+  std::array<std::map<Epoch, EpochTiles>, source_layer_count> layers_;
 };
 
 }  // namespace marine_bathymetry_store

--- a/marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_store.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_store.hpp
@@ -45,21 +45,34 @@ std::size_t save(
 std::size_t load(
   BathymetryStore & store, const std::string & dir, SourceRegistry * registry);
 
-/// @brief In-memory, GGGS-tiled, multi-layer bathymetric store (Phase 1 core).
+/// @brief In-memory, GGGS-tiled, multi-layer, **multi-level** bathymetric store.
 ///
-/// Holds one tile map per `SourceLayer`, keyed by `gggs::GridIndex`. All tiles
-/// live at a single GGGS level fixed at construction. Source priority is a
-/// **non-destructive query-time overlay** (see `query.hpp`): the layers are
-/// independent, so a noisy draft write never clobbers a trusted processed cell
-/// and a later processed import never has to merge with draft (ADR-0002 §D3).
+/// Holds one tile map per `SourceLayer`, keyed by `gggs::GridIndex` (which
+/// itself carries its level). The store is **level-agnostic**: tiles at
+/// heterogeneous GGGS levels coexist in the same layer (ADR-0002 §D2,
+/// amendment #151/#153). The constructor's `gggs_level` is retained only as a
+/// **default for `cellIndex(lat,lon)`** (the write/query convenience that turns
+/// coordinates into a cell) — it is *not* an invariant on stored tiles, so a
+/// coarse chart prior and a fine survey grid can live in the same store and the
+/// query resolves the best-available level per cell.
 ///
-/// This phase has no importers, ROS interface, or distribution — just storage,
-/// in-process queries (`query.hpp`), and per-tile GeoTIFF persistence
-/// (`tile_io.hpp`).
+/// Source priority is a **non-destructive query-time overlay** (see
+/// `query.hpp`): the layers are independent, so a noisy draft write never
+/// clobbers a trusted processed cell and a later processed import never has to
+/// merge with draft (ADR-0002 §D3).
+///
+/// This phase has no ROS interface or distribution — just storage, in-process
+/// queries (`query.hpp`), per-tile GeoTIFF persistence (`tile_io.hpp`), and the
+/// GeoTIFF importer (`geotiff_import.hpp`).
 class BathymetryStore
 {
 public:
-  /// @brief Construct a store whose tiles live at GGGS quadtree @p gggs_level.
+  /// @brief Construct a store with a default level of GGGS quadtree
+  ///        @p gggs_level.
+  ///
+  /// The default level only governs `cellIndex(lat,lon)` (the coordinate→cell
+  /// convenience); stored tiles may be at any level (this store is multi-level,
+  /// ADR-0002 §D2).
   ///
   /// @param chart_writable Opt in to per-cell `set()` writes on the read-only
   ///   `Chart` prior layer. Default `false` — only the chart importer (which
@@ -73,8 +86,8 @@ public:
   explicit BathymetryStore(uint8_t gggs_level, bool chart_writable = false)
   : level_(gggs_level), chart_writable_(chart_writable) {}
 
-  /// @brief Construct a store at the coarsest GGGS level whose cells are no
-  ///        larger than @p cell_size_m (clamped to the finest level, 20).
+  /// @brief Construct a store whose **default** level is the coarsest GGGS level
+  ///        whose cells are no larger than @p cell_size_m (clamped to level 20).
   static BathymetryStore fromCellSize(float cell_size_m, bool chart_writable = false)
   {
     return BathymetryStore(
@@ -84,13 +97,17 @@ public:
   /// @brief Whether per-cell `set()` may write the read-only `Chart` layer.
   bool chartWritable() const noexcept {return chart_writable_;}
 
-  /// @brief The GGGS level all tiles in this store use.
+  /// @brief The store's **default** level (used by `cellIndex(lat,lon)` only).
+  ///
+  /// Stored tiles are not pinned to this level — the store is multi-level
+  /// (ADR-0002 §D2). This is the level the coordinate convenience resolves at.
   const gggs::Level & level() const noexcept {return level_;}
 
-  /// @brief CellIndex at this store's level for a geographic position.
+  /// @brief CellIndex at this store's **default** level for a geographic position.
   ///
-  /// Convenience for callers who think in coordinates — guarantees the returned
-  /// CellIndex is at the store's level (so `set`/`get` won't be rejected).
+  /// Convenience for callers who think in coordinates. The returned CellIndex is
+  /// at the default level; callers wanting a specific level should build the
+  /// CellIndex from a `gggs::Level` of their choosing (the store accepts any).
   gggs::CellIndex cellIndex(double latitude, double longitude) const
   {
     return level_.cellIndex(gggs::geoPoint(latitude, longitude));
@@ -98,9 +115,9 @@ public:
 
   /// @brief Write @p value into @p layer at @p cell.
   ///
-  /// Creates the backing tile on first write to its grid. The cell's grid must
-  /// be at this store's level.
-  /// @throws std::invalid_argument if @p cell is invalid or at the wrong level.
+  /// Creates the backing tile on first write to its grid. The cell may be at
+  /// **any** valid GGGS level — the store is multi-level (ADR-0002 §D2).
+  /// @throws std::invalid_argument if @p cell is invalid.
   /// @throws std::logic_error if @p layer is `Chart` and the store was not
   ///   constructed `chart_writable` — the prior is read-only (ADR-0002 §D3).
   void set(SourceLayer layer, const gggs::CellIndex & cell, const BathyCell & value);
@@ -110,7 +127,8 @@ public:
   ///         A returned cell may still be no-data (`!hasData()`).
   std::optional<BathyCell> get(SourceLayer layer, const gggs::CellIndex & cell) const;
 
-  /// @brief The tiles of a layer (for persistence / iteration).
+  /// @brief The tiles of a layer (for persistence / iteration). Tiles may be at
+  ///        heterogeneous levels (multi-level, ADR-0002 §D2).
   const std::map<gggs::GridIndex, BathymetryTile> & tiles(SourceLayer layer) const
   {
     return layerMap(layer);
@@ -129,8 +147,9 @@ private:
   /// Private: the only mutable tile access. Public mutation goes through `set`
   /// (which gates `Chart`); persistence reaches this via friendship. This is
   /// what makes the Chart read-only guarantee hold by construction, not just by
-  /// convention — external code cannot obtain a mutable Chart tile.
-  /// @throws std::invalid_argument if @p grid is invalid or at the wrong level.
+  /// convention — external code cannot obtain a mutable Chart tile. @p grid may
+  /// be at any valid level (multi-level store, ADR-0002 §D2).
+  /// @throws std::invalid_argument if @p grid is invalid.
   BathymetryTile & getOrCreateTile(SourceLayer layer, const gggs::GridIndex & grid);
 
   std::map<gggs::GridIndex, BathymetryTile> & layerMap(SourceLayer layer)

--- a/marine_bathymetry_store/include/marine_bathymetry_store/epoch.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/epoch.hpp
@@ -1,0 +1,107 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef MARINE_BATHYMETRY_STORE__EPOCH_HPP_
+#define MARINE_BATHYMETRY_STORE__EPOCH_HPP_
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+namespace marine_bathymetry_store
+{
+
+/// @brief A dated instance of a source layer (ADR-0002 Amendment A1).
+///
+/// An epoch is a **labeled key**, by convention the local acquisition date in
+/// ISO-8601 form (`"2026-06-10"`). Labels must sort chronologically as plain
+/// strings — ISO dates do — because epoch resolution walks a `std::map` keyed
+/// by this string newest-first. The label is also used as an on-disk directory
+/// name, so it must be filesystem-safe (see `validateEpochLabel`).
+///
+/// Epochs are never fused across days: a cell surveyed on N days keeps N
+/// records, and differencing two epochs yields a change map (A1.1).
+using Epoch = std::string;
+
+/// @brief How an epoch's surface was produced (ADR-0002 §A1.2).
+///
+/// Ordering rule: `Replayed` (the authoritative end-of-day compaction, one
+/// CUBE run over the full day) supersedes `LiveFused` (incrementally merged
+/// live session snapshots) for the same epoch — **never the reverse**. Once
+/// an epoch is `Replayed` it is immutable.
+///
+/// This is the **compaction-maturity** axis and is orthogonal to the
+/// `SourceRegistry` per-cell source index (the **platform/sensor** axis,
+/// ADR-0005 D2/D8): one is epoch-scoped, the other cell-scoped, and they never
+/// alias. The store carries both (ADR-0002 Amendment A1, OQ1 resolution).
+enum class Provenance : uint8_t
+{
+  LiveFused = 0,  ///< Built incrementally from live session snapshots.
+  Replayed = 1,   ///< Authoritative full-day replay (compaction product).
+};
+
+/// @brief On-disk / manifest token for a provenance (`"live-fused"` / `"replayed"`).
+inline std::string provenanceToken(Provenance provenance)
+{
+  switch (provenance) {
+    case Provenance::LiveFused: return "live-fused";
+    case Provenance::Replayed: return "replayed";
+  }
+  throw std::runtime_error("provenanceToken: unknown Provenance");
+}
+
+/// @brief Parse a provenance token; throws std::invalid_argument on anything else.
+inline Provenance provenanceFromToken(const std::string & token)
+{
+  if (token == "live-fused") {
+    return Provenance::LiveFused;
+  }
+  if (token == "replayed") {
+    return Provenance::Replayed;
+  }
+  throw std::invalid_argument("provenanceFromToken: unknown token '" + token + "'");
+}
+
+/// @brief Throw std::invalid_argument unless @p label is a usable epoch key.
+///
+/// Requires a non-empty label of `[0-9A-Za-z._-]` characters that is neither
+/// `"."` nor `".."` — i.e. safe as a single directory-name component and free
+/// of path separators. (Chronological ordering is a convention the caller
+/// owns: use ISO-8601 dates.)
+inline void validateEpochLabel(const Epoch & label)
+{
+  if (label.empty() || label == "." || label == "..") {
+    throw std::invalid_argument("validateEpochLabel: empty or reserved label");
+  }
+  for (const char c : label) {
+    const bool ok = (c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') ||
+      (c >= 'a' && c <= 'z') || c == '.' || c == '_' || c == '-';
+    if (!ok) {
+      throw std::invalid_argument(
+              "validateEpochLabel: character '" + std::string(1, c) +
+              "' not allowed in epoch label '" + label + "'");
+    }
+  }
+}
+
+}  // namespace marine_bathymetry_store
+
+#endif  // MARINE_BATHYMETRY_STORE__EPOCH_HPP_

--- a/marine_bathymetry_store/include/marine_bathymetry_store/geotiff_import.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/geotiff_import.hpp
@@ -1,0 +1,106 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef MARINE_BATHYMETRY_STORE__GEOTIFF_IMPORT_HPP_
+#define MARINE_BATHYMETRY_STORE__GEOTIFF_IMPORT_HPP_
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <string>
+
+#include "marine_bathymetry_store/bathymetry_store.hpp"
+#include "marine_bathymetry_store/epoch.hpp"
+#include "marine_bathymetry_store/registry.hpp"
+
+/// @file
+/// @brief Import a depth/uncertainty GeoTIFF as one wholesale epoch of a store
+/// (ADR-0002 Phase 2, §A1.2 + §D4). Footprint fill, datum conversion at import,
+/// lowest-uncertainty contention resolution, and per-cell SourceRegistry
+/// provenance stamping (ADR-0005 D2/D8).
+
+namespace marine_bathymetry_store
+{
+
+/// @brief Options governing a GeoTIFF import.
+struct GeoTiffImportOptions
+{
+  /// 1-based raster band holding depth as **ellipsoidal height** (WGS84, m,
+  /// up-positive — the store convention; `bag_to_geotiff` band 1). Non-finite
+  /// pixels are no-data and skipped.
+  int depth_band = 1;
+  /// 1-based raster band holding 1-sigma vertical uncertainty (m), or 0 if
+  /// the file has none (cells then get `default_uncertainty`).
+  int uncertainty_band = 2;
+  /// Uncertainty assigned when `uncertainty_band == 0` or the band reads
+  /// non-finite **or non-positive** (zero uncertainty is treated as missing,
+  /// not perfect — it would pass every reliability gate and carry infinite
+  /// weight in 1/sigma^2 fusion). NaN (the default) makes such cells
+  /// never-reliable in the safety query — the conservative choice.
+  double default_uncertainty = std::numeric_limits<double>::quiet_NaN();
+  /// Acquisition time (Unix seconds) recorded on every imported cell — a
+  /// whole-file product carries no per-cell time. 0 = unset.
+  double timestamp = 0.0;
+  /// Vertical conversion applied at import (ADR-0002 §D4):
+  /// `height = depth_scale * pixel + depth_offset`. The defaults pass
+  /// store-convention inputs (ellipsoidal height, up-positive) through
+  /// unchanged. A positive-down depths-below-lake-surface product imports
+  /// with `depth_scale = -1` and `depth_offset` = the lake surface's
+  /// ellipsoidal height.
+  double depth_scale = 1.0;
+  double depth_offset = 0.0;
+  /// GGGS level to import at. The store is multi-level (ADR-0002 §D2): a coarse
+  /// chart prior imports at a coarse level, a fine survey grid at a fine level,
+  /// and both can share the store. `std::nullopt` (the default) uses the
+  /// store's default level (`store.level()`), preserving the single-level
+  /// caller's behaviour; pass a level to match the source resolution.
+  std::optional<uint8_t> level = std::nullopt;
+  /// Provenance record to register in the store's `SourceRegistry` (ADR-0005
+  /// D2/D8). Every imported cell is stamped with the returned source index. If
+  /// `source.source_id` is empty the importer skips registration and stamps the
+  /// unset index (0) — for callers that don't track provenance.
+  SourceRecord source;
+};
+
+/// @brief Import @p path as the whole content of @p layer's @p epoch.
+///
+/// Reads the GeoTIFF, fills each pixel's **footprint** of GGGS cells at the
+/// target level (every store cell a pixel covers, so a coarser-than-store source
+/// still produces coverage), converts the vertical datum at import (§D4), keeps
+/// the lowest-uncertainty value on contention, and replaces @p epoch wholesale
+/// via `importEpoch`. If `options.source.source_id` is non-empty, registers the
+/// `SourceRecord` in @p registry and stamps its index on every imported cell.
+///
+/// @return The number of distinct cells imported, or `std::nullopt` if
+///         `importEpoch` refused the write (existing epoch is `Replayed` and
+///         @p provenance is `LiveFused`, ADR-0002 §A1.2).
+/// @throws std::invalid_argument on a bad epoch label or band index;
+///         std::runtime_error on GDAL failure, a non-WGS84 / rotated raster, or
+///         a missing geotransform.
+std::optional<std::size_t> importGeoTiff(
+  BathymetryStore & store, SourceRegistry & registry, SourceLayer layer,
+  const Epoch & epoch, const std::string & path, Provenance provenance,
+  const GeoTiffImportOptions & options = GeoTiffImportOptions{});
+
+}  // namespace marine_bathymetry_store
+
+#endif  // MARINE_BATHYMETRY_STORE__GEOTIFF_IMPORT_HPP_

--- a/marine_bathymetry_store/include/marine_bathymetry_store/query.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/query.hpp
@@ -30,6 +30,7 @@
 #include "marine_autonomy/gggs.h"
 #include "marine_bathymetry_store/bathy_cell.hpp"
 #include "marine_bathymetry_store/bathymetry_store.hpp"
+#include "marine_bathymetry_store/epoch.hpp"
 
 namespace marine_bathymetry_store
 {
@@ -55,28 +56,35 @@ struct DepthSample
   /// multi-level (ADR-0002 §D2); the query resolves the best-available level
   /// per cell, so a single region scan can return samples at mixed levels.
   uint8_t level = 0;
+  /// Which epoch within the layer this value came from (ADR-0002 A1). Queries
+  /// resolve a layer newest-epoch-first; this records the winning epoch.
+  /// (Provenance — live-fused vs replayed — is a property of the epoch's
+  /// tiles, not of an individual sample.)
+  Epoch epoch;
 };
 
-/// @brief Best-available depth at @p cell across layers **and levels**.
+/// @brief Best-available depth at @p cell across layers, levels **and epochs**.
 ///
-/// Walks layers in `source_layers_by_priority` order; within a layer it resolves
-/// the **finest GGGS level present** that has data at the query position (the
-/// store is multi-level, ADR-0002 §D2 — a fine survey grid is preferred over the
-/// coarse prior where both cover the cell). Returns the first layer that
-/// resolves. `std::nullopt` means **unknown** — no layer has data here; a
-/// safety-conscious caller must treat that as not-safe (ADR-0002 §D7), not as
-/// deep water.
+/// Walks layers in `source_layers_by_priority` order; within a layer it walks
+/// epochs **newest-first** (ADR-0002 §A1.3 default resolution) and, within each
+/// epoch, resolves the **finest GGGS level present** that has data at the query
+/// position (the store is multi-level, ADR-0002 §D2). Returns the first
+/// (layer, epoch, level) that resolves. `std::nullopt` means **unknown** — no
+/// layer has data here; a safety-conscious caller must treat that as not-safe
+/// (ADR-0002 §D7), not as deep water.
 std::optional<DepthSample> bestSource(
   const BathymetryStore & store, const gggs::CellIndex & cell);
 
 /// @brief Shallowest reliable depth at @p cell (navigation-safety query).
 ///
-/// Among all layers and **all levels present** that (a) have data and (b) have
-/// uncertainty ≤ @p max_uncertainty (a NaN uncertainty is never reliable),
-/// returns the **shallowest** — i.e. the greatest ellipsoidal height, the value
-/// closest to the surface and therefore the most hazardous. `std::nullopt`
-/// means no reliable data covers the cell; the caller must treat that as
-/// not-safe.
+/// Within each layer, walks epochs **newest-first** and takes the first value
+/// passing the reliability gate (uncertainty ≤ @p max_uncertainty; a NaN
+/// uncertainty is never reliable) — the ADR-0002 §A1.3 safety walk: a fresh
+/// noisy pass falls through to a prior epoch's confident value, with no
+/// cross-epoch fusion. Across all levels present and all layers, returns the
+/// **shallowest** — the greatest ellipsoidal height, the value closest to the
+/// surface and therefore the most hazardous. `std::nullopt` means no reliable
+/// data covers the cell; the caller must treat that as not-safe.
 std::optional<DepthSample> shallowestReliable(
   const BathymetryStore & store, const gggs::CellIndex & cell, double max_uncertainty);
 
@@ -95,6 +103,24 @@ void forEachCellBestSource(
   const geographic_msgs::msg::GeoPoint & maximum,
   const std::function<void(const gggs::CellIndex &,
   const std::optional<DepthSample> &)> & visitor);
+
+/// @brief Visit every cell observed in **both** epochs of @p layer (change map).
+///
+/// The reason epochs exist (ADR-0002 §A1.1): differencing two days locates
+/// change instead of averaging it away. Iterates the grids present in both
+/// epochs' tile maps and invokes @p visitor for each cell where both have
+/// usable data, passing the two records (@p epoch_a's, then @p epoch_b's). The
+/// visitor owns the significance test — e.g. comparing `|b.depth - a.depth|`
+/// against the combined uncertainty. Cells observed in only one epoch are
+/// *coverage* change, not depth change, and are not visited. Only grids at the
+/// **same level** in both epochs are compared (a cell has no cross-level
+/// counterpart).
+/// @return The number of cells visited.
+std::size_t forEachChangedCell(
+  const BathymetryStore & store, SourceLayer layer,
+  const Epoch & epoch_a, const Epoch & epoch_b,
+  const std::function<void(const gggs::CellIndex &,
+  const BathyCell &, const BathyCell &)> & visitor);
 
 }  // namespace marine_bathymetry_store
 

--- a/marine_bathymetry_store/include/marine_bathymetry_store/query.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/query.hpp
@@ -41,16 +41,29 @@ namespace marine_bathymetry_store
 /// *greater* (less negative) value. See `shallowestReliable`.
 struct DepthSample
 {
-  double depth;          ///< Ellipsoidal height (WGS84, m, up-positive).
-  double uncertainty;    ///< 1-sigma vertical uncertainty (m).
-  int64_t timestamp;     ///< Acquisition / import time (ns since the Unix epoch).
-  SourceLayer source;    ///< Which layer this value came from.
+  double depth;            ///< Ellipsoidal height (WGS84, m, up-positive).
+  double uncertainty;      ///< 1-sigma vertical uncertainty (m).
+  int64_t timestamp;       ///< Acquisition / import time (ns since the Unix epoch).
+  SourceLayer source;      ///< Which layer this value came from.
+  /// Per-cell registry source index (ADR-0005 D2/D8): which platform/sensor
+  /// contributed this value. 0 = unset (pre-migration / single-platform data).
+  /// The navigation-safety query (`shallowestReliable`) ignores this axis
+  /// (ADR-0005 D5 carve-out); it is exposed so provenance-aware consumers can
+  /// resolve the record off a query result.
+  uint16_t source_index = 0;
+  /// GGGS level of the cell this value was resolved at. The store is
+  /// multi-level (ADR-0002 §D2); the query resolves the best-available level
+  /// per cell, so a single region scan can return samples at mixed levels.
+  uint8_t level = 0;
 };
 
-/// @brief Highest-priority layer that has data at @p cell.
+/// @brief Best-available depth at @p cell across layers **and levels**.
 ///
-/// Walks layers in `source_layers_by_priority` order and returns the first with
-/// usable data. `std::nullopt` means **unknown** — no layer has data here; a
+/// Walks layers in `source_layers_by_priority` order; within a layer it resolves
+/// the **finest GGGS level present** that has data at the query position (the
+/// store is multi-level, ADR-0002 §D2 — a fine survey grid is preferred over the
+/// coarse prior where both cover the cell). Returns the first layer that
+/// resolves. `std::nullopt` means **unknown** — no layer has data here; a
 /// safety-conscious caller must treat that as not-safe (ADR-0002 §D7), not as
 /// deep water.
 std::optional<DepthSample> bestSource(
@@ -58,20 +71,24 @@ std::optional<DepthSample> bestSource(
 
 /// @brief Shallowest reliable depth at @p cell (navigation-safety query).
 ///
-/// Among all layers that (a) have data and (b) have uncertainty ≤
-/// @p max_uncertainty (a NaN uncertainty is never reliable), returns the
-/// **shallowest** — i.e. the greatest ellipsoidal height, the value closest to
-/// the surface and therefore the most hazardous. `std::nullopt` means no
-/// reliable layer covers the cell; the caller must treat that as not-safe.
+/// Among all layers and **all levels present** that (a) have data and (b) have
+/// uncertainty ≤ @p max_uncertainty (a NaN uncertainty is never reliable),
+/// returns the **shallowest** — i.e. the greatest ellipsoidal height, the value
+/// closest to the surface and therefore the most hazardous. `std::nullopt`
+/// means no reliable data covers the cell; the caller must treat that as
+/// not-safe.
 std::optional<DepthSample> shallowestReliable(
   const BathymetryStore & store, const gggs::CellIndex & cell, double max_uncertainty);
 
 /// @brief Visit every GGGS cell overlapping the geographic box, with its best source.
 ///
 /// Iterates the cells covered by the lat/lon box [@p minimum, @p maximum] at the
-/// store's level and invokes @p visitor with each `CellIndex` and its
-/// `bestSource` result (`std::nullopt` = unknown cell). Region form of
-/// `bestSource`; work is bounded by the requested box, so callers control cost.
+/// store's **default** level and invokes @p visitor with each `CellIndex` and
+/// its `bestSource` result (`std::nullopt` = unknown cell). The per-cell
+/// resolution is still multi-level (the returned `DepthSample.level` may differ
+/// from the iteration level); only the iteration granularity is the default
+/// level. Region form of `bestSource`; work is bounded by the requested box, so
+/// callers control cost.
 void forEachCellBestSource(
   const BathymetryStore & store,
   const geographic_msgs::msg::GeoPoint & minimum,

--- a/marine_bathymetry_store/include/marine_bathymetry_store/tile_io.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/tile_io.hpp
@@ -84,20 +84,36 @@ void saveTile(const BathymetryTile & tile, const std::string & path);
 /// companions are read from the derived paths. A **missing** companion fills the
 /// corresponding band with 0 (pre-migration backward compatibility). The grid is
 /// recovered from the value file's geotransform (the cell center maps back
-/// through @p level), so a file written at a different level is rejected. The
-/// returned tile is clean (not dirty).
+/// through @p level), so a file written at a different level is rejected. @p
+/// level must therefore be the level the file was written at — callers loading a
+/// multi-level store recover it from the `<level>_<row>_<col>` filename prefix
+/// (see `levelFromTileFilename`) and pass it per-file.
+/// The returned tile is clean (not dirty).
 /// @throws std::runtime_error on GDAL failure, wrong dimensions, or a
 ///         geotransform that doesn't match any grid at @p level.
 BathymetryTile loadTile(const std::string & path, const gggs::Level & level);
 
+/// @brief Recover the GGGS level encoded in a `<level>_<row>_<col>.tif`
+///        filename (the prefix before the first underscore).
+///
+/// The store is multi-level (ADR-0002 §D2), so tiles at different levels share a
+/// directory; the level is not knowable from the store but is encoded in every
+/// tile filename. Persistence parses it per-file and passes it to `loadTile`.
+/// @throws std::runtime_error if @p filename has no parseable level prefix or a
+///         level out of the GGGS range.
+uint8_t levelFromTileFilename(const std::string & filename);
+
 /// @brief Persist every **dirty** tile of @p store under @p dir, then clear
 ///        their dirty flags. Also writes the store-wide `registry.json`.
 ///
-/// Layout: `<dir>/<layer>/<level>_<row>_<col>{,_time,_source}.tif`, plus
-/// `<dir>/registry.json`. Creates directories as needed. Clean tiles are skipped
-/// (incremental save). The registry (a store-wide sidecar, not per-layer) is
-/// written once at the end via @p registry; pass `nullptr` to skip it (e.g. a
-/// caller with no registry to persist).
+/// Layout: `<dir>/<layer>/<epoch>/<level>_<row>_<col>{,_time,_source}.tif`, plus
+/// a per-epoch `provenance` marker file and a store-wide `<dir>/registry.json`.
+/// Creates directories as needed. Clean tiles are skipped (incremental save). An
+/// epoch flagged `supersedes_disk` (a wholesale import) has its on-disk tile
+/// directory cleared first, so a compacted epoch covering fewer grids never
+/// resurrects a stale tile on the next load. The registry (a store-wide sidecar,
+/// not per-layer) is written once at the end via @p registry; pass `nullptr` to
+/// skip it (e.g. a caller with no registry to persist).
 /// @return The number of tiles written.
 /// @throws std::runtime_error on any GDAL failure; std::filesystem::filesystem_error
 ///         (a std::runtime_error subclass) on a directory-creation failure.
@@ -107,13 +123,16 @@ std::size_t save(
 
 /// @brief Load every tile found under @p dir into @p store, plus the registry.
 ///
-/// Scans `<dir>/<layer>/` for value tiles (`<grid>.tif`), **skipping** the
-/// `_time.tif` / `_source.tif` companions (they are loaded with their value
-/// tile). @p store must already be at the level the tiles were written at
-/// (loadTile enforces per-file). If @p registry is non-null, `registry.json` is
+/// Scans `<dir>/<layer>/<epoch>/` for value tiles (`<level>_<row>_<col>.tif`),
+/// **skipping** the `_time.tif` / `_source.tif` companions (loaded with their
+/// value tile). Each tile's level is recovered from its filename
+/// (`levelFromTileFilename`), so a **mixed-level** store loads correctly — the
+/// store's default level is irrelevant to loading (ADR-0002 §D2). Each epoch's
+/// provenance is read from its `provenance` marker (CRLF-safe; default
+/// `live-fused` if absent). If @p registry is non-null, `registry.json` is
 /// loaded into it. Loaded tiles are clean.
 /// @return The number of tiles loaded.
-/// @throws std::runtime_error on any GDAL failure or level mismatch;
+/// @throws std::runtime_error on any GDAL failure or a per-file level mismatch;
 ///         std::filesystem::filesystem_error (a std::runtime_error subclass) on a
 ///         directory-iteration failure.
 std::size_t load(

--- a/marine_bathymetry_store/package.xml
+++ b/marine_bathymetry_store/package.xml
@@ -17,6 +17,7 @@
   <depend>marine_tiled_raster_store</depend>
   <depend>geographic_msgs</depend>
   <depend>nlohmann_json</depend>
+  <depend>libgdal-dev</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/marine_bathymetry_store/src/bathymetry_store.cpp
+++ b/marine_bathymetry_store/src/bathymetry_store.cpp
@@ -81,6 +81,23 @@ bool BathymetryStore::importEpoch(
   std::map<gggs::GridIndex, BathymetryTile> tiles, Provenance provenance)
 {
   validateEpochLabel(epoch);
+  // Chart is a read-only prior (ADR-0002 §D3). importEpoch is a public mutator
+  // just like set(), so it must honor the same gate -- otherwise the CLI or any
+  // library consumer could overwrite the Chart prior wholesale on a default
+  // store, defeating the read-only guarantee. Only an importer that explicitly
+  // opted in (chart_writable=true) may write Chart.
+  if (layer == SourceLayer::Chart && !chart_writable_) {
+    throw std::logic_error(
+            "BathymetryStore::importEpoch: Chart is a read-only prior layer; construct "
+            "the store with chart_writable=true (importer only) to write it");
+  }
+  // An import with no tiles (e.g. an entirely no-data GeoTIFF) would create an
+  // epoch that holds nothing and silently vanishes on the next load (save writes
+  // only a provenance marker; load reconstructs epochs only from .tif files).
+  // Reject it so epochs(layer) is stable across a save/load round-trip.
+  if (tiles.empty()) {
+    return false;
+  }
   for (const auto & [grid, tile] : tiles) {
     if (!grid.valid()) {
       throw std::invalid_argument("BathymetryStore::importEpoch: invalid GridIndex key");

--- a/marine_bathymetry_store/src/bathymetry_store.cpp
+++ b/marine_bathymetry_store/src/bathymetry_store.cpp
@@ -32,15 +32,10 @@ void BathymetryStore::set(
 {
   // Validate the inputs first, then the layer permission — so a malformed cell
   // always reports invalid_argument (the more actionable error), and the
-  // read-only logic_error fires only for an otherwise-valid Chart write.
+  // read-only logic_error fires only for an otherwise-valid Chart write. The
+  // cell may be at any valid level — the store is multi-level (ADR-0002 §D2).
   if (!cell.valid()) {
     throw std::invalid_argument("BathymetryStore::set: invalid CellIndex");
-  }
-  if (cell.level() != level_.level()) {
-    throw std::invalid_argument(
-            "BathymetryStore::set: CellIndex at level " +
-            std::to_string(cell.level()) + " but store is at level " +
-            std::to_string(level_.level()));
   }
   if (layer == SourceLayer::Chart && !chart_writable_) {
     throw std::logic_error(
@@ -68,14 +63,10 @@ std::optional<BathyCell> BathymetryStore::get(
 BathymetryTile & BathymetryStore::getOrCreateTile(
   SourceLayer layer, const gggs::GridIndex & grid)
 {
+  // Any valid level is accepted — the store is multi-level (ADR-0002 §D2). The
+  // GridIndex carries its own level, so tiles at different levels coexist.
   if (!grid.valid()) {
     throw std::invalid_argument("BathymetryStore::getOrCreateTile: invalid GridIndex");
-  }
-  if (grid.level() != level_.level()) {
-    throw std::invalid_argument(
-            "BathymetryStore::getOrCreateTile: GridIndex at level " +
-            std::to_string(grid.level()) + " but store is at level " +
-            std::to_string(level_.level()));
   }
   auto & m = layerMap(layer);
   auto it = m.find(grid);

--- a/marine_bathymetry_store/src/bathymetry_store.cpp
+++ b/marine_bathymetry_store/src/bathymetry_store.cpp
@@ -23,17 +23,20 @@
 
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 namespace marine_bathymetry_store
 {
 
-void BathymetryStore::set(
-  SourceLayer layer, const gggs::CellIndex & cell, const BathyCell & value)
+bool BathymetryStore::set(
+  SourceLayer layer, const Epoch & epoch, const gggs::CellIndex & cell,
+  const BathyCell & value)
 {
   // Validate the inputs first, then the layer permission — so a malformed cell
   // always reports invalid_argument (the more actionable error), and the
   // read-only logic_error fires only for an otherwise-valid Chart write. The
   // cell may be at any valid level — the store is multi-level (ADR-0002 §D2).
+  validateEpochLabel(epoch);
   if (!cell.valid()) {
     throw std::invalid_argument("BathymetryStore::set: invalid CellIndex");
   }
@@ -42,36 +45,106 @@ void BathymetryStore::set(
             "BathymetryStore::set: Chart is a read-only prior layer; construct "
             "the store with chart_writable=true (importer only) to write it");
   }
-  BathymetryTile & tile = getOrCreateTile(layer, cell.grid());
+  // A compacted (Replayed) epoch is immutable: a live write must not regress it
+  // (ADR-0002 §A1.2). Report the no-op so the caller can log it.
+  auto & m = layerMap(layer);
+  const auto existing = m.find(epoch);
+  if (existing != m.end() && existing->second.provenance == Provenance::Replayed) {
+    return false;
+  }
+  BathymetryTile & tile = getOrCreateTile(layer, epoch, cell.grid());
   tile.set(cell.row(), cell.column(), value);
+  return true;
 }
 
 std::optional<BathyCell> BathymetryStore::get(
-  SourceLayer layer, const gggs::CellIndex & cell) const
+  SourceLayer layer, const Epoch & epoch, const gggs::CellIndex & cell) const
 {
   if (!cell.valid()) {
     return std::nullopt;
   }
   const auto & m = layerMap(layer);
-  const auto it = m.find(cell.grid());
-  if (it == m.end()) {
+  const auto epoch_it = m.find(epoch);
+  if (epoch_it == m.end()) {
     return std::nullopt;
   }
-  return it->second.get(cell.row(), cell.column());
+  const auto & tiles = epoch_it->second.tiles;
+  const auto tile_it = tiles.find(cell.grid());
+  if (tile_it == tiles.end()) {
+    return std::nullopt;
+  }
+  return tile_it->second.get(cell.row(), cell.column());
+}
+
+bool BathymetryStore::importEpoch(
+  SourceLayer layer, const Epoch & epoch,
+  std::map<gggs::GridIndex, BathymetryTile> tiles, Provenance provenance)
+{
+  validateEpochLabel(epoch);
+  for (const auto & [grid, tile] : tiles) {
+    if (!grid.valid()) {
+      throw std::invalid_argument("BathymetryStore::importEpoch: invalid GridIndex key");
+    }
+    // The tile must have been built for the grid it is keyed under: a mismatch
+    // would write a tile under one grid's filename but with another grid's
+    // georeference, corrupting the store on the next load (harvested #148
+    // Copilot med-fix).
+    if (!(tile.index() == grid)) {
+      throw std::invalid_argument(
+              "BathymetryStore::importEpoch: tile GridIndex does not match its map key");
+    }
+  }
+
+  auto & m = layerMap(layer);
+  const auto existing = m.find(epoch);
+  // §A1.2 ordering: live-fused never replaces replayed.
+  if (existing != m.end() &&
+    existing->second.provenance == Provenance::Replayed &&
+    provenance == Provenance::LiveFused)
+  {
+    return false;
+  }
+
+  EpochTiles replacement;
+  replacement.provenance = provenance;
+  replacement.supersedes_disk = true;   // persistence clears stale files first
+  replacement.tiles = std::move(tiles);
+  // A wholesale import is a fresh surface: mark every tile dirty so it persists.
+  for (auto & [grid, tile] : replacement.tiles) {
+    (void)grid;
+    tile.markDirty();
+  }
+  m[epoch] = std::move(replacement);
+  return true;
+}
+
+EpochTiles & BathymetryStore::getOrCreateEpoch(
+  SourceLayer layer, const Epoch & epoch, Provenance provenance)
+{
+  validateEpochLabel(epoch);
+  auto & m = layerMap(layer);
+  auto it = m.find(epoch);
+  if (it == m.end()) {
+    EpochTiles fresh;
+    fresh.provenance = provenance;
+    it = m.emplace(epoch, std::move(fresh)).first;
+  }
+  return it->second;
 }
 
 BathymetryTile & BathymetryStore::getOrCreateTile(
-  SourceLayer layer, const gggs::GridIndex & grid)
+  SourceLayer layer, const Epoch & epoch, const gggs::GridIndex & grid)
 {
   // Any valid level is accepted — the store is multi-level (ADR-0002 §D2). The
   // GridIndex carries its own level, so tiles at different levels coexist.
   if (!grid.valid()) {
     throw std::invalid_argument("BathymetryStore::getOrCreateTile: invalid GridIndex");
   }
-  auto & m = layerMap(layer);
-  auto it = m.find(grid);
-  if (it == m.end()) {
-    it = m.emplace(grid, BathymetryTile(grid)).first;
+  EpochTiles & epoch_tiles = getOrCreateEpoch(layer, epoch, Provenance::LiveFused);
+  auto & tiles = epoch_tiles.tiles;
+  auto it = tiles.find(grid);
+  if (it == tiles.end()) {
+    it = tiles.emplace(grid, BathymetryTile(grid)).first;
   }
   return it->second;
 }

--- a/marine_bathymetry_store/src/geotiff_import.cpp
+++ b/marine_bathymetry_store/src/geotiff_import.cpp
@@ -1,0 +1,209 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "marine_bathymetry_store/geotiff_import.hpp"
+
+#include <gdal_priv.h>
+#include <ogr_spatialref.h>
+
+#include <cmath>
+#include <cstdint>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace marine_bathymetry_store
+{
+
+namespace
+{
+
+/// RAII wrapper so a thrown exception still closes the GDAL dataset.
+struct DatasetCloser
+{
+  GDALDataset * ds = nullptr;
+  ~DatasetCloser() {if (ds) {GDALClose(ds);}}
+};
+
+}  // namespace
+
+std::optional<std::size_t> importGeoTiff(
+  BathymetryStore & store, SourceRegistry & registry, SourceLayer layer,
+  const Epoch & epoch, const std::string & path, Provenance provenance,
+  const GeoTiffImportOptions & options)
+{
+  validateEpochLabel(epoch);
+  if (options.depth_band < 1) {
+    throw std::invalid_argument("importGeoTiff: depth_band must be >= 1");
+  }
+  if (options.uncertainty_band < 0) {
+    throw std::invalid_argument("importGeoTiff: uncertainty_band must be >= 0 (0 = none)");
+  }
+
+  // Register the provenance source (if any) and resolve the per-cell index to
+  // stamp (ADR-0005 D2/D8). An empty source_id means the caller does not track
+  // provenance: stamp the unset index (0).
+  uint16_t source_index = SourceRegistry::kUnset;
+  if (!options.source.source_id.empty()) {
+    source_index = registry.registerSource(options.source);
+  }
+
+  // Target import level: a caller-specified level (multi-level, ADR-0002 §D2) or
+  // the store's default level.
+  const gggs::Level level =
+    options.level.has_value() ? gggs::Level(*options.level) : store.level();
+
+  GDALAllRegister();
+  DatasetCloser in;
+  in.ds = GDALDataset::FromHandle(GDALOpen(path.c_str(), GA_ReadOnly));
+  if (in.ds == nullptr) {
+    throw std::runtime_error("importGeoTiff: could not open " + path);
+  }
+  const int width = in.ds->GetRasterXSize();
+  const int height = in.ds->GetRasterYSize();
+  const int band_count = in.ds->GetRasterCount();
+  if (options.depth_band > band_count || options.uncertainty_band > band_count) {
+    throw std::runtime_error("importGeoTiff: band index beyond raster bands in " + path);
+  }
+
+  // The pixel-center mapping below interprets the geotransform as degrees, so
+  // the file must be a geographic WGS84 raster (same guard as tile_io's load).
+  const OGRSpatialReference * srs = in.ds->GetSpatialRef();
+  OGRErr axis_error = OGRERR_NONE;
+  if (srs == nullptr || !srs->IsGeographic() ||
+    std::abs(srs->GetSemiMajor(&axis_error) - 6378137.0) > 1.0 || axis_error != OGRERR_NONE)
+  {
+    throw std::runtime_error("importGeoTiff: not a geographic WGS84 raster: " + path);
+  }
+
+  double gt[6];
+  if (in.ds->GetGeoTransform(gt) != CE_None) {
+    throw std::runtime_error("importGeoTiff: missing geotransform in " + path);
+  }
+  if (gt[2] != 0.0 || gt[4] != 0.0) {
+    throw std::runtime_error("importGeoTiff: rotated geotransform unsupported in " + path);
+  }
+
+  // Honor a declared no-data value: it may be finite (e.g. -9999), which the
+  // isfinite() skip below would happily import as a 9 km depth.
+  int has_nodata = 0;
+  const double nodata =
+    in.ds->GetRasterBand(options.depth_band)->GetNoDataValue(&has_nodata);
+
+  std::map<gggs::GridIndex, BathymetryTile> tiles;
+  std::size_t imported = 0;
+
+  std::vector<double> depth_row(width);
+  std::vector<double> uncertainty_row(width);
+  for (int y = 0; y < height; ++y) {
+    if (in.ds->GetRasterBand(options.depth_band)->RasterIO(
+        GF_Read, 0, y, width, 1, depth_row.data(), width, 1, GDT_Float64, 0, 0) != CE_None)
+    {
+      throw std::runtime_error("importGeoTiff: depth read failed in " + path);
+    }
+    if (options.uncertainty_band > 0) {
+      if (in.ds->GetRasterBand(options.uncertainty_band)->RasterIO(
+          GF_Read, 0, y, width, 1, uncertainty_row.data(), width, 1, GDT_Float64, 0, 0) !=
+        CE_None)
+      {
+        throw std::runtime_error("importGeoTiff: uncertainty read failed in " + path);
+      }
+    }
+    const double latitude = gt[3] + (y + 0.5) * gt[5];
+    for (int x = 0; x < width; ++x) {
+      if (!std::isfinite(depth_row[x]) || (has_nodata && depth_row[x] == nodata)) {
+        continue;   // no-data pixel
+      }
+      // Vertical conversion at import (§D4): pixel value -> ellipsoidal height.
+      const double depth = options.depth_scale * depth_row[x] + options.depth_offset;
+      // A non-finite OR non-positive uncertainty is *missing*, not perfect:
+      // zero would pass every reliability gate and carry infinite weight in
+      // 1/sigma^2 fusion. Such cells get default_uncertainty (NaN by default
+      // = never reliable — conservative).
+      double uncertainty = options.default_uncertainty;
+      if (options.uncertainty_band > 0 && std::isfinite(uncertainty_row[x]) &&
+        uncertainty_row[x] > 0.0)
+      {
+        uncertainty = uncertainty_row[x];
+      }
+      const double longitude = gt[0] + (x + 0.5) * gt[1];
+      // Fill the pixel's full FOOTPRINT of store cells, not just the cell
+      // under its centre — a coarser-than-store source (e.g. a 5 m contour
+      // prior into a 0.5 m store) must produce coverage, not isolated dots.
+      // The box is shrunk by a hair so adjacent pixels never contend for the
+      // cells on their shared boundary; for aligned or finer inputs it
+      // therefore covers exactly the one containing cell.
+      const double half_lon = 0.495 * std::abs(gt[1]);
+      const double half_lat = 0.495 * std::abs(gt[5]);
+      const auto box_min = gggs::geoPoint(latitude - half_lat, longitude - half_lon);
+      const auto box_max = gggs::geoPoint(latitude + half_lat, longitude + half_lon);
+      gggs::GridAreaIterator grid_it(
+        level.gridIndex(box_min.latitude, box_min.longitude),
+        level.gridIndex(box_max.latitude, box_max.longitude));
+      for (; grid_it.valid(); grid_it.next()) {
+        auto tile_it = tiles.find(*grid_it);
+        for (gggs::CellAreaIterator cell_it(*grid_it, box_min, box_max);
+          cell_it.valid(); cell_it.next())
+        {
+          const gggs::CellIndex & cell = *cell_it;
+          if (!cell.valid()) {
+            continue;   // outside GGGS's usable envelope
+          }
+          if (tile_it == tiles.end()) {
+            tile_it = tiles.emplace(cell.grid(), BathymetryTile(cell.grid())).first;
+          }
+          // Several input pixels can land in one cell when the input is finer
+          // than the store level: keep the lowest-uncertainty value (a finite
+          // uncertainty always beats NaN; ties keep the first read).
+          const BathyCell existing = tile_it->second.get(cell.row(), cell.column());
+          if (existing.hasData()) {
+            const bool existing_unc_finite = std::isfinite(existing.uncertainty);
+            const bool new_unc_finite = std::isfinite(uncertainty);
+            if (!new_unc_finite && existing_unc_finite) {
+              continue;
+            }
+            if (new_unc_finite && existing_unc_finite &&
+              uncertainty >= existing.uncertainty)
+            {
+              continue;
+            }
+            if (!new_unc_finite && !existing_unc_finite) {
+              continue;   // tie among NaNs: keep the first read
+            }
+          } else {
+            ++imported;   // a new cell (replacements don't recount)
+          }
+          tile_it->second.set(cell.row(), cell.column(), BathyCell{depth, uncertainty,
+              static_cast<int64_t>(options.timestamp * 1e9), source_index});
+        }
+      }
+    }
+  }
+
+  if (!store.importEpoch(layer, epoch, std::move(tiles), provenance)) {
+    return std::nullopt;
+  }
+  return imported;
+}
+
+}  // namespace marine_bathymetry_store

--- a/marine_bathymetry_store/src/geotiff_import.cpp
+++ b/marine_bathymetry_store/src/geotiff_import.cpp
@@ -109,6 +109,16 @@ std::optional<std::size_t> importGeoTiff(
   int has_nodata = 0;
   const double nodata =
     in.ds->GetRasterBand(options.depth_band)->GetNoDataValue(&has_nodata);
+  // Honor the uncertainty band's no-data sentinel too: a positive finite
+  // sentinel (e.g. 9999) would otherwise pass the isfinite/>0 gate below and
+  // import as a real, huge-but-finite uncertainty rather than being treated as
+  // missing -- the same trap the depth band is guarded against.
+  int unc_has_nodata = 0;
+  double unc_nodata = 0.0;
+  if (options.uncertainty_band > 0) {
+    unc_nodata =
+      in.ds->GetRasterBand(options.uncertainty_band)->GetNoDataValue(&unc_has_nodata);
+  }
 
   std::map<gggs::GridIndex, BathymetryTile> tiles;
   std::size_t imported = 0;
@@ -142,7 +152,8 @@ std::optional<std::size_t> importGeoTiff(
       // = never reliable — conservative).
       double uncertainty = options.default_uncertainty;
       if (options.uncertainty_band > 0 && std::isfinite(uncertainty_row[x]) &&
-        uncertainty_row[x] > 0.0)
+        uncertainty_row[x] > 0.0 &&
+        !(unc_has_nodata && uncertainty_row[x] == unc_nodata))
       {
         uncertainty = uncertainty_row[x];
       }

--- a/marine_bathymetry_store/src/import_geotiff_main.cpp
+++ b/marine_bathymetry_store/src/import_geotiff_main.cpp
@@ -175,8 +175,13 @@ int main(int argc, char * argv[])
     timestamp = timestampFromEpochLabel(epoch);
   }
 
+  // The importer is the one sanctioned writer of the read-only Chart prior, so
+  // it opts into chart_writable only when the target layer is Chart (ADR-0002
+  // §D3). For Processed/Draft this stays false, so a typo'd layer can't touch
+  // Chart.
+  const bool chart_writable = (layer == marine_bathymetry_store::SourceLayer::Chart);
   auto store = marine_bathymetry_store::BathymetryStore::fromCellSize(
-    static_cast<float>(cell_size));
+    static_cast<float>(cell_size), chart_writable);
   std::cout << "store default level: " << static_cast<int>(store.level().level()) << "\n";
 
   marine_bathymetry_store::SourceRegistry registry;

--- a/marine_bathymetry_store/src/import_geotiff_main.cpp
+++ b/marine_bathymetry_store/src/import_geotiff_main.cpp
@@ -1,0 +1,215 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+/// @file
+/// @brief CLI: import a depth/uncertainty GeoTIFF as one epoch of a store.
+///
+/// usage: import_geotiff <store_dir> <layer> <epoch> <provenance> <geotiff>
+///                       [--cell-size m] [--level N] [--timestamp unix_seconds]
+///                       [--uncertainty m] [--depth-scale s] [--depth-offset m]
+///                       [--source-id ID --platform P --sensor S
+///                        --sensor-class C --campaign K --datum D]
+///
+/// Loads any existing tiles under <store_dir>, imports the GeoTIFF as the
+/// whole content of <layer>/<epoch> (wholesale, ADR-0002 §A1.2), registers the
+/// provenance source (if --source-id given) and stamps every cell with its
+/// registry index (ADR-0005 D2/D8), then saves. If --timestamp is omitted and
+/// <epoch> is an ISO date (YYYY-MM-DD), cells are stamped midnight UTC.
+
+#include <cstring>
+#include <ctime>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+#include "marine_bathymetry_store/bathymetry_store.hpp"
+#include "marine_bathymetry_store/geotiff_import.hpp"
+#include "marine_bathymetry_store/registry.hpp"
+#include "marine_bathymetry_store/tile_io.hpp"
+
+namespace
+{
+
+void usage()
+{
+  std::cout <<
+    "usage: import_geotiff <store_dir> <layer> <epoch> <provenance> <geotiff>\n"
+    "                      [--cell-size m] [--level N] [--timestamp unix_seconds]\n"
+    "                      [--uncertainty m] [--depth-scale s] [--depth-offset m]\n"
+    "                      [--source-id ID --platform P --sensor S\n"
+    "                       --sensor-class C --campaign K --datum D]\n"
+    "  layer:      processed | draft | chart\n"
+    "  epoch:      label, conventionally the acquisition date (YYYY-MM-DD)\n"
+    "  provenance: live-fused | replayed\n"
+    "  --cell-size: store default cell size in metres (default 0.5)\n"
+    "  --level:     GGGS level to import at (default: derived from --cell-size).\n"
+    "               The store is multi-level; pass a level to match the source.\n"
+    "  --timestamp: per-cell acquisition time; defaults to midnight UTC of an\n"
+    "               ISO-date epoch label, else 0\n"
+    "  --uncertainty: ignore the file's uncertainty band and assign this\n"
+    "               constant 1-sigma value (for sources without one)\n"
+    "  --depth-scale / --depth-offset: vertical conversion at import,\n"
+    "               height = scale*pixel + offset (defaults 1, 0). A\n"
+    "               positive-down depths-below-lake-surface product imports\n"
+    "               with scale -1 and offset = lake surface ellipsoidal height\n"
+    "  --source-id ... --datum: register a provenance SourceRecord (ADR-0005);\n"
+    "               every imported cell is stamped with its registry index\n";
+  exit(1);
+}
+
+marine_bathymetry_store::SourceLayer layerFromName(const std::string & name)
+{
+  if (name == "processed") {
+    return marine_bathymetry_store::SourceLayer::Processed;
+  }
+  if (name == "draft") {
+    return marine_bathymetry_store::SourceLayer::Draft;
+  }
+  if (name == "chart") {
+    return marine_bathymetry_store::SourceLayer::Chart;
+  }
+  std::cerr << "unknown layer '" << name << "' (expected processed|draft|chart)\n";
+  exit(1);
+}
+
+/// Midnight UTC of an ISO date label, or 0 if the label isn't one.
+double timestampFromEpochLabel(const std::string & label)
+{
+  std::tm tm = {};
+  std::istringstream in(label);
+  in >> std::get_time(&tm, "%Y-%m-%d");
+  if (in.fail() || !in.eof()) {
+    return 0.0;
+  }
+  return static_cast<double>(timegm(&tm));
+}
+
+}  // namespace
+
+int main(int argc, char * argv[])
+{
+  std::string positional[5];
+  int n_positional = 0;
+  double cell_size = 0.5;
+  int level = -1;                       // sentinel: derive from --cell-size
+  double timestamp = -1.0;              // sentinel: derive from the epoch label
+  double constant_uncertainty = -1.0;   // sentinel: use the file's band
+  double depth_scale = 1.0;
+  double depth_offset = 0.0;
+  marine_bathymetry_store::SourceRecord source;
+
+  const auto need_arg = [&](int & i) -> const char * {
+      if (i + 1 >= argc) {
+        usage();
+      }
+      return argv[++i];
+    };
+
+  for (int i = 1; i < argc; ++i) {
+    if (std::strcmp(argv[i], "--cell-size") == 0) {
+      cell_size = std::stod(need_arg(i));
+    } else if (std::strcmp(argv[i], "--level") == 0) {
+      level = std::stoi(need_arg(i));
+    } else if (std::strcmp(argv[i], "--timestamp") == 0) {
+      timestamp = std::stod(need_arg(i));
+    } else if (std::strcmp(argv[i], "--uncertainty") == 0) {
+      constant_uncertainty = std::stod(need_arg(i));
+    } else if (std::strcmp(argv[i], "--depth-scale") == 0) {
+      depth_scale = std::stod(need_arg(i));
+    } else if (std::strcmp(argv[i], "--depth-offset") == 0) {
+      depth_offset = std::stod(need_arg(i));
+    } else if (std::strcmp(argv[i], "--source-id") == 0) {
+      source.source_id = need_arg(i);
+    } else if (std::strcmp(argv[i], "--platform") == 0) {
+      source.platform = need_arg(i);
+    } else if (std::strcmp(argv[i], "--sensor") == 0) {
+      source.sensor = need_arg(i);
+    } else if (std::strcmp(argv[i], "--sensor-class") == 0) {
+      source.sensor_class = need_arg(i);
+    } else if (std::strcmp(argv[i], "--campaign") == 0) {
+      source.campaign = need_arg(i);
+    } else if (std::strcmp(argv[i], "--datum") == 0) {
+      source.datum = need_arg(i);
+    } else if (n_positional < 5) {
+      positional[n_positional++] = argv[i];
+    } else {
+      usage();
+    }
+  }
+  if (n_positional != 5) {
+    usage();
+  }
+  const std::string & store_dir = positional[0];
+  const auto layer = layerFromName(positional[1]);
+  const std::string & epoch = positional[2];
+  marine_bathymetry_store::Provenance provenance;
+  try {
+    provenance = marine_bathymetry_store::provenanceFromToken(positional[3]);
+  } catch (const std::invalid_argument &) {
+    std::cerr << "unknown provenance '" << positional[3]
+              << "' (expected live-fused|replayed)\n";
+    return 1;
+  }
+  const std::string & geotiff = positional[4];
+  if (timestamp < 0.0) {
+    timestamp = timestampFromEpochLabel(epoch);
+  }
+
+  auto store = marine_bathymetry_store::BathymetryStore::fromCellSize(
+    static_cast<float>(cell_size));
+  std::cout << "store default level: " << static_cast<int>(store.level().level()) << "\n";
+
+  marine_bathymetry_store::SourceRegistry registry;
+  const std::size_t loaded = marine_bathymetry_store::load(store, store_dir, &registry);
+  std::cout << "loaded " << loaded << " existing tile(s) from " << store_dir << "\n";
+
+  marine_bathymetry_store::GeoTiffImportOptions options;
+  options.timestamp = timestamp;
+  options.depth_scale = depth_scale;
+  options.depth_offset = depth_offset;
+  options.source = source;
+  if (level >= 0) {
+    if (level > 20) {
+      std::cerr << "invalid --level " << level << " (GGGS levels are 0..20)\n";
+      return 1;
+    }
+    options.level = static_cast<uint8_t>(level);
+  }
+  if (constant_uncertainty >= 0.0) {
+    options.uncertainty_band = 0;
+    options.default_uncertainty = constant_uncertainty;
+  }
+  const auto imported = marine_bathymetry_store::importGeoTiff(
+    store, registry, layer, epoch, geotiff, provenance, options);
+  if (!imported) {
+    std::cerr << "import refused: epoch '" << epoch << "' is already replayed and the "
+      "requested provenance is live-fused (ADR-0002 A1.2 ordering)\n";
+    return 2;
+  }
+  std::cout << "imported " << *imported << " cell(s) into " << positional[1] << "/" <<
+    epoch << " (" << positional[3] << ")\n";
+
+  const std::size_t saved = marine_bathymetry_store::save(store, store_dir, &registry);
+  std::cout << "saved " << saved << " tile(s) under " << store_dir << "\n";
+  return 0;
+}

--- a/marine_bathymetry_store/src/query.cpp
+++ b/marine_bathymetry_store/src/query.cpp
@@ -41,40 +41,56 @@ geographic_msgs::msg::GeoPoint cellCenter(const gggs::CellIndex & cell)
   return gggs::geoPoint(sw.latitude + 0.5 * lat_per_cell, sw.longitude + 0.5 * lon_per_cell);
 }
 
-/// The distinct GGGS levels present in @p layer, **finest first** (largest level
-/// number = finest resolution). Empty if the layer holds no tiles.
-std::set<uint8_t, std::greater<uint8_t>> levelsPresent(
-  const BathymetryStore & store, SourceLayer layer)
+/// The distinct GGGS levels present in one @p epoch's tile map, **finest first**
+/// (largest level number = finest resolution). Empty if the epoch has no tiles.
+std::set<uint8_t, std::greater<uint8_t>> levelsPresent(const EpochTiles & epoch_tiles)
 {
   std::set<uint8_t, std::greater<uint8_t>> levels;
-  for (const auto & [grid, tile] : store.tiles(layer)) {
+  for (const auto & [grid, tile] : epoch_tiles.tiles) {
     (void)tile;
     levels.insert(grid.level());
   }
   return levels;
 }
 
-/// Resolve a single layer's best-available sample at a cell, scanning the levels
-/// present finest-first and returning the first with usable data (ADR-0002 §D2
-/// best-available-across-levels). @p center is the query position.
-std::optional<DepthSample> sampleFor(
-  const BathymetryStore & store, SourceLayer layer, const gggs::CellIndex & cell)
+/// Look up @p cell in one epoch's tile map, or nullopt if its grid is absent.
+std::optional<BathyCell> cellIn(const EpochTiles & epoch_tiles, const gggs::CellIndex & cell)
 {
-  // Fast path: the cell's own level, queried directly (no re-projection).
-  if (const auto c = store.get(layer, cell); c && c->hasData()) {
-    return DepthSample{c->depth, c->uncertainty, c->timestamp, layer, c->source_index,
-      cell.level()};
+  const auto it = epoch_tiles.tiles.find(cell.grid());
+  if (it == epoch_tiles.tiles.end()) {
+    return std::nullopt;
   }
-  // Multi-level: re-resolve the query position at each level present, finest
-  // first. The cell's own level (tried above) is skipped here.
-  const auto center = cellCenter(cell);
-  for (const uint8_t lvl : levelsPresent(store, layer)) {
-    if (lvl == cell.level()) {
-      continue;
+  return it->second.get(cell.row(), cell.column());
+}
+
+/// Resolve a single epoch's best-available sample at a cell across the levels it
+/// holds, finest-first (ADR-0002 §D2). @p center is the query position.
+std::optional<DepthSample> sampleInEpoch(
+  const EpochTiles & epoch_tiles, SourceLayer layer, const Epoch & epoch,
+  const gggs::CellIndex & cell, const geographic_msgs::msg::GeoPoint & center)
+{
+  for (const uint8_t lvl : levelsPresent(epoch_tiles)) {
+    const gggs::CellIndex lvl_cell =
+      (lvl == cell.level()) ? cell : gggs::Level(lvl).cellIndex(center);
+    const auto c = cellIn(epoch_tiles, lvl_cell);
+    if (c && c->hasData()) {
+      return DepthSample{c->depth, c->uncertainty, c->timestamp, layer, c->source_index,
+        lvl, epoch};
     }
-    const gggs::CellIndex lvl_cell = gggs::Level(lvl).cellIndex(center);
-    if (const auto c = store.get(layer, lvl_cell); c && c->hasData()) {
-      return DepthSample{c->depth, c->uncertainty, c->timestamp, layer, c->source_index, lvl};
+  }
+  return std::nullopt;
+}
+
+/// Resolve a single layer's best-available sample at a cell: newest epoch with
+/// usable data (ADR-0002 §A1.3 default resolution), best level within it.
+std::optional<DepthSample> sampleFor(
+  const BathymetryStore & store, SourceLayer layer, const gggs::CellIndex & cell,
+  const geographic_msgs::msg::GeoPoint & center)
+{
+  const auto & epochs_map = store.epochs(layer);
+  for (auto it = epochs_map.rbegin(); it != epochs_map.rend(); ++it) {
+    if (auto sample = sampleInEpoch(it->second, layer, it->first, cell, center)) {
+      return sample;
     }
   }
   return std::nullopt;
@@ -85,8 +101,9 @@ std::optional<DepthSample> sampleFor(
 std::optional<DepthSample> bestSource(
   const BathymetryStore & store, const gggs::CellIndex & cell)
 {
+  const auto center = cellCenter(cell);
   for (const SourceLayer layer : source_layers_by_priority) {
-    if (auto sample = sampleFor(store, layer, cell)) {
+    if (auto sample = sampleFor(store, layer, cell, center)) {
       return sample;
     }
   }
@@ -102,27 +119,48 @@ std::optional<DepthSample> shallowestReliable(
   // Consider one candidate sample (already known to have data) against the
   // running shallowest, applying the reliability gate. depth is ellipsoidal
   // height (up-positive): shallower == greater height.
-  const auto consider = [&](const BathyCell & c, SourceLayer layer, uint8_t lvl) {
+  const auto consider =
+    [&](const BathyCell & c, SourceLayer layer, uint8_t lvl, const Epoch & epoch) {
       // A NaN uncertainty is never reliable; otherwise require within tolerance.
       if (std::isnan(c.uncertainty) || c.uncertainty > max_uncertainty) {
         return;
       }
       if (!shallowest || c.depth > shallowest->depth) {
         shallowest = DepthSample{c.depth, c.uncertainty, c.timestamp, layer,
-          c.source_index, lvl};
+          c.source_index, lvl, epoch};
       }
     };
 
   for (const SourceLayer layer : source_layers_by_priority) {
-    // Safety query: examine EVERY level present, not just the finest-with-data
-    // — a coarser level could be both shallower and reliable when a finer one is
-    // noisy (ADR-0002 §D2 / §D7). The cell's own level is included via the set.
-    for (const uint8_t lvl : levelsPresent(store, layer)) {
-      const gggs::CellIndex lvl_cell =
-        (lvl == cell.level()) ? cell : gggs::Level(lvl).cellIndex(center);
-      const auto c = store.get(layer, lvl_cell);
-      if (c && c->hasData()) {
-        consider(*c, layer, lvl);
+    const auto & epochs_map = store.epochs(layer);
+    // §A1.3 safety walk: within a layer, take the newest epoch that has a
+    // reliable value at the cell (a noisy fresh epoch falls through to an older
+    // confident one). Resolve each epoch independently (newest-first), and keep
+    // the shallowest across the layers. Within an epoch, examine EVERY level so
+    // a coarse-but-reliable value can win where a finer one is too uncertain.
+    for (auto it = epochs_map.rbegin(); it != epochs_map.rend(); ++it) {
+      std::optional<DepthSample> epoch_pick;
+      for (const uint8_t lvl : levelsPresent(it->second)) {
+        const gggs::CellIndex lvl_cell =
+          (lvl == cell.level()) ? cell : gggs::Level(lvl).cellIndex(center);
+        const auto c = cellIn(it->second, lvl_cell);
+        if (!c || !c->hasData()) {
+          continue;
+        }
+        if (std::isnan(c->uncertainty) || c->uncertainty > max_uncertainty) {
+          continue;
+        }
+        // Within this epoch, prefer the shallowest reliable value.
+        if (!epoch_pick || c->depth > epoch_pick->depth) {
+          epoch_pick = DepthSample{c->depth, c->uncertainty, c->timestamp, layer,
+            c->source_index, lvl, it->first};
+        }
+      }
+      if (epoch_pick) {
+        consider(BathyCell{epoch_pick->depth, epoch_pick->uncertainty,
+            epoch_pick->timestamp, epoch_pick->source_index},
+          layer, epoch_pick->level, epoch_pick->epoch);
+        break;   // newest reliable epoch wins for this layer (§A1.3)
       }
     }
   }
@@ -147,6 +185,47 @@ void forEachCellBestSource(
       visitor(*cell_it, bestSource(store, *cell_it));
     }
   }
+}
+
+std::size_t forEachChangedCell(
+  const BathymetryStore & store, SourceLayer layer,
+  const Epoch & epoch_a, const Epoch & epoch_b,
+  const std::function<void(const gggs::CellIndex &,
+  const BathyCell &, const BathyCell &)> & visitor)
+{
+  const auto & epochs_map = store.epochs(layer);
+  const auto a_it = epochs_map.find(epoch_a);
+  const auto b_it = epochs_map.find(epoch_b);
+  if (a_it == epochs_map.end() || b_it == epochs_map.end()) {
+    return 0;
+  }
+
+  std::size_t visited = 0;
+  // Iterate grids present in both epochs; a grid covered by only one is
+  // coverage change, not depth change. Grids carry their level, so a grid only
+  // matches its same-level counterpart (cross-level cells have no 1:1 pairing).
+  for (const auto & [grid, tile_a] : a_it->second.tiles) {
+    const auto tile_b_it = b_it->second.tiles.find(grid);
+    if (tile_b_it == b_it->second.tiles.end()) {
+      continue;
+    }
+    const BathymetryTile & tile_b = tile_b_it->second;
+    for (uint16_t row = 0; row < BathymetryTile::edge; ++row) {
+      for (uint16_t col = 0; col < BathymetryTile::edge; ++col) {
+        const BathyCell a = tile_a.get(row, col);
+        if (!a.hasData()) {
+          continue;
+        }
+        const BathyCell b = tile_b.get(row, col);
+        if (!b.hasData()) {
+          continue;
+        }
+        visitor(gggs::CellIndex(grid, row, col), a, b);
+        ++visited;
+      }
+    }
+  }
+  return visited;
 }
 
 }  // namespace marine_bathymetry_store

--- a/marine_bathymetry_store/src/query.cpp
+++ b/marine_bathymetry_store/src/query.cpp
@@ -22,6 +22,7 @@
 #include "marine_bathymetry_store/query.hpp"
 
 #include <cmath>
+#include <set>
 
 namespace marine_bathymetry_store
 {
@@ -29,15 +30,54 @@ namespace marine_bathymetry_store
 namespace
 {
 
-/// Resolve a single layer's sample at a cell, or nullopt if it has no usable data.
+/// Geographic center of a cell (its SW corner plus half a cell each way). Used
+/// to re-resolve the query position at other GGGS levels (multi-level store).
+geographic_msgs::msg::GeoPoint cellCenter(const gggs::CellIndex & cell)
+{
+  const gggs::GridIndex & grid = cell.grid();
+  const double lat_per_cell = grid.latitudinalSpan() / gggs::cell_rows_per_grid;
+  const double lon_per_cell = grid.longitudinalSpan() / gggs::cell_columns_per_grid;
+  const auto sw = cell.position();   // SW corner of the cell
+  return gggs::geoPoint(sw.latitude + 0.5 * lat_per_cell, sw.longitude + 0.5 * lon_per_cell);
+}
+
+/// The distinct GGGS levels present in @p layer, **finest first** (largest level
+/// number = finest resolution). Empty if the layer holds no tiles.
+std::set<uint8_t, std::greater<uint8_t>> levelsPresent(
+  const BathymetryStore & store, SourceLayer layer)
+{
+  std::set<uint8_t, std::greater<uint8_t>> levels;
+  for (const auto & [grid, tile] : store.tiles(layer)) {
+    (void)tile;
+    levels.insert(grid.level());
+  }
+  return levels;
+}
+
+/// Resolve a single layer's best-available sample at a cell, scanning the levels
+/// present finest-first and returning the first with usable data (ADR-0002 §D2
+/// best-available-across-levels). @p center is the query position.
 std::optional<DepthSample> sampleFor(
   const BathymetryStore & store, SourceLayer layer, const gggs::CellIndex & cell)
 {
-  const auto c = store.get(layer, cell);
-  if (!c || !c->hasData()) {
-    return std::nullopt;
+  // Fast path: the cell's own level, queried directly (no re-projection).
+  if (const auto c = store.get(layer, cell); c && c->hasData()) {
+    return DepthSample{c->depth, c->uncertainty, c->timestamp, layer, c->source_index,
+      cell.level()};
   }
-  return DepthSample{c->depth, c->uncertainty, c->timestamp, layer};
+  // Multi-level: re-resolve the query position at each level present, finest
+  // first. The cell's own level (tried above) is skipped here.
+  const auto center = cellCenter(cell);
+  for (const uint8_t lvl : levelsPresent(store, layer)) {
+    if (lvl == cell.level()) {
+      continue;
+    }
+    const gggs::CellIndex lvl_cell = gggs::Level(lvl).cellIndex(center);
+    if (const auto c = store.get(layer, lvl_cell); c && c->hasData()) {
+      return DepthSample{c->depth, c->uncertainty, c->timestamp, layer, c->source_index, lvl};
+    }
+  }
+  return std::nullopt;
 }
 
 }  // namespace
@@ -57,18 +97,33 @@ std::optional<DepthSample> shallowestReliable(
   const BathymetryStore & store, const gggs::CellIndex & cell, double max_uncertainty)
 {
   std::optional<DepthSample> shallowest;
+  const auto center = cellCenter(cell);
+
+  // Consider one candidate sample (already known to have data) against the
+  // running shallowest, applying the reliability gate. depth is ellipsoidal
+  // height (up-positive): shallower == greater height.
+  const auto consider = [&](const BathyCell & c, SourceLayer layer, uint8_t lvl) {
+      // A NaN uncertainty is never reliable; otherwise require within tolerance.
+      if (std::isnan(c.uncertainty) || c.uncertainty > max_uncertainty) {
+        return;
+      }
+      if (!shallowest || c.depth > shallowest->depth) {
+        shallowest = DepthSample{c.depth, c.uncertainty, c.timestamp, layer,
+          c.source_index, lvl};
+      }
+    };
+
   for (const SourceLayer layer : source_layers_by_priority) {
-    const auto sample = sampleFor(store, layer, cell);
-    if (!sample) {
-      continue;
-    }
-    // A NaN uncertainty is never reliable; otherwise require it within tolerance.
-    if (std::isnan(sample->uncertainty) || sample->uncertainty > max_uncertainty) {
-      continue;
-    }
-    // depth is ellipsoidal height (up-positive): shallower == greater height.
-    if (!shallowest || sample->depth > shallowest->depth) {
-      shallowest = sample;
+    // Safety query: examine EVERY level present, not just the finest-with-data
+    // — a coarser level could be both shallower and reliable when a finer one is
+    // noisy (ADR-0002 §D2 / §D7). The cell's own level is included via the set.
+    for (const uint8_t lvl : levelsPresent(store, layer)) {
+      const gggs::CellIndex lvl_cell =
+        (lvl == cell.level()) ? cell : gggs::Level(lvl).cellIndex(center);
+      const auto c = store.get(layer, lvl_cell);
+      if (c && c->hasData()) {
+        consider(*c, layer, lvl);
+      }
     }
   }
   return shallowest;

--- a/marine_bathymetry_store/src/tile_io.cpp
+++ b/marine_bathymetry_store/src/tile_io.cpp
@@ -23,11 +23,14 @@
 
 #include <cstdint>
 #include <filesystem>
+#include <fstream>
 #include <limits>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
+#include "marine_bathymetry_store/epoch.hpp"
 #include "marine_tiled_raster_store/tile_io.hpp"
 
 /// @file
@@ -79,7 +82,70 @@ std::string companionPath(const std::string & value_path, const char * suffix)
   const fs::path p(value_path);
   return (p.parent_path() / (p.stem().string() + suffix + p.extension().string())).string();
 }
+
+constexpr const char * kProvenanceMarker = "provenance";
+
+/// Write the epoch's `provenance` marker file (`live-fused` / `replayed`) into
+/// @p epoch_dir, plus a trailing newline.
+void writeProvenanceMarker(const std::filesystem::path & epoch_dir, Provenance provenance)
+{
+  std::ofstream out(epoch_dir / kProvenanceMarker, std::ios::trunc);
+  out << provenanceToken(provenance) << "\n";
+}
+
+/// Read the epoch's `provenance` marker, or `LiveFused` if the file is absent.
+///
+/// CRLF-safe: trailing whitespace (including a `\r` from a Windows / mixed
+/// checkout) is trimmed before parsing, so a sidecar that round-tripped through
+/// a CRLF filesystem is not mis-read as a parse failure that silently downgrades
+/// a Replayed epoch to LiveFused (harvested #148 Copilot round-1 fix). A present
+/// but unparseable marker throws — a corrupt provenance is a hard error, not a
+/// silent downgrade.
+Provenance readProvenanceMarker(const std::filesystem::path & epoch_dir)
+{
+  namespace fs = std::filesystem;
+  const fs::path marker = epoch_dir / kProvenanceMarker;
+  if (!fs::is_regular_file(marker)) {
+    return Provenance::LiveFused;
+  }
+  std::ifstream in(marker);
+  std::string token;
+  std::getline(in, token);
+  // Trim trailing whitespace / CR so a CRLF sidecar parses correctly.
+  while (!token.empty() &&
+    (token.back() == '\r' || token.back() == '\n' || token.back() == ' ' ||
+    token.back() == '\t'))
+  {
+    token.pop_back();
+  }
+  return provenanceFromToken(token);   // throws std::invalid_argument on garbage
+}
 }  // namespace
+
+uint8_t levelFromTileFilename(const std::string & filename)
+{
+  namespace fs = std::filesystem;
+  const std::string stem = fs::path(filename).stem().string();
+  const auto underscore = stem.find('_');
+  if (underscore == std::string::npos || underscore == 0) {
+    throw std::runtime_error(
+            "levelFromTileFilename: no level prefix in tile filename '" + filename + "'");
+  }
+  const std::string level_str = stem.substr(0, underscore);
+  for (const char c : level_str) {
+    if (c < '0' || c > '9') {
+      throw std::runtime_error(
+              "levelFromTileFilename: non-numeric level prefix in '" + filename + "'");
+    }
+  }
+  const int level = std::stoi(level_str);
+  if (level < 0 || level > 20) {
+    throw std::runtime_error(
+            "levelFromTileFilename: level " + std::to_string(level) +
+            " out of GGGS range [0,20] in '" + filename + "'");
+  }
+  return static_cast<uint8_t>(level);
+}
 
 std::string tileFilename(const gggs::GridIndex & grid)
 {
@@ -194,22 +260,67 @@ std::size_t save(
   std::size_t written = 0;
   for (const SourceLayer layer : source_layers_by_priority) {
     const fs::path layer_dir = fs::path(dir) / layerDirName(layer);
-    bool created_dir = false;
-    // Iterate the layer's tiles (a const view) and write each dirty one. The
-    // dirty flag is cleared via getOrCreateTile() on the same (existing) key:
-    // that's a lookup, not an insert, and clearDirty() only flips a bool on the
-    // tile value — neither mutates the map, so the iterator stays valid.
-    for (const auto & [grid, tile] : store.tiles(layer)) {
-      if (!tile.dirty()) {
-        continue;
+    for (const auto & [epoch, epoch_tiles] : store.epochs(layer)) {
+      const fs::path epoch_dir = layer_dir / epoch;
+      bool created_dir = false;
+      const auto ensure_dir = [&]() {
+          if (!created_dir) {
+            fs::create_directories(epoch_dir);
+            created_dir = true;
+          }
+        };
+
+      // A wholesale import (importEpoch) flags supersedes_disk: clear any stale
+      // tile files for this epoch first, so a compacted epoch covering fewer
+      // grids never resurrects a removed tile on the next load. The provenance
+      // marker is rewritten below regardless.
+      if (epoch_tiles.supersedes_disk && fs::is_directory(epoch_dir)) {
+        for (const auto & e : fs::directory_iterator(epoch_dir)) {
+          if (e.is_regular_file() && e.path().extension() == ".tif") {
+            fs::remove(e.path());
+          }
+        }
       }
-      if (!created_dir) {
-        fs::create_directories(layer_dir);
-        created_dir = true;
+
+      // Persist the provenance marker whenever the epoch has anything to write
+      // (a dirty tile or a supersession that just cleared the dir). The marker
+      // is cheap and idempotent, so write it whenever we touch the epoch dir.
+      bool any_dirty = epoch_tiles.supersedes_disk;
+      for (const auto & [grid, tile] : epoch_tiles.tiles) {
+        (void)grid;
+        if (tile.dirty()) {
+          any_dirty = true;
+          break;
+        }
       }
-      saveTile(tile, (layer_dir / tileFilename(grid)).string());
-      store.getOrCreateTile(layer, grid).clearDirty();
-      ++written;
+      if (any_dirty) {
+        ensure_dir();
+        writeProvenanceMarker(epoch_dir, epoch_tiles.provenance);
+      }
+
+      // Iterate the epoch's tiles (a const view) and write each dirty one. The
+      // dirty flag is cleared via getOrCreateTile() on the same (existing)
+      // (epoch, grid): a lookup, not an insert, and clearDirty() only flips a
+      // bool on the tile value — neither mutates the map, so the iterator stays
+      // valid.
+      for (const auto & [grid, tile] : epoch_tiles.tiles) {
+        if (!tile.dirty()) {
+          continue;
+        }
+        ensure_dir();
+        saveTile(tile, (epoch_dir / tileFilename(grid)).string());
+        store.getOrCreateTile(layer, epoch, grid).clearDirty();
+        ++written;
+      }
+
+      // The supersedes_disk flag has done its job once the epoch is written;
+      // reset it so a subsequent incremental save does NOT re-clear the (now
+      // clean) tile dir and silently delete the just-written tiles. The flag is
+      // an in-memory hint only (never persisted). getOrCreateEpoch returns the
+      // existing epoch (provenance unchanged) for the mutable handle.
+      if (epoch_tiles.supersedes_disk) {
+        store.getOrCreateEpoch(layer, epoch, epoch_tiles.provenance).supersedes_disk = false;
+      }
     }
   }
   // The registry is a store-wide sidecar (not per-layer): persist it once at the
@@ -231,25 +342,42 @@ std::size_t load(
     if (!fs::is_directory(layer_dir)) {
       continue;
     }
-    for (const auto & entry : fs::directory_iterator(layer_dir)) {
-      if (!entry.is_regular_file() || entry.path().extension() != ".tif") {
+    // Each subdirectory of the layer dir is an epoch.
+    for (const auto & epoch_entry : fs::directory_iterator(layer_dir)) {
+      if (!epoch_entry.is_directory()) {
         continue;
       }
-      // Skip the companion tiles — they are loaded alongside their value tile,
-      // not as standalone value tiles (must-fix 3: a bare *.tif glob would
-      // otherwise mis-load _time / _source as value tiles).
-      const std::string stem = entry.path().stem().string();
-      const auto ends_with = [&stem](const char * suffix) {
-          const std::string s(suffix);
-          return stem.size() >= s.size() &&
-                 stem.compare(stem.size() - s.size(), s.size(), s) == 0;
-        };
-      if (ends_with(kTimeSuffix) || ends_with(kSourceSuffix)) {
-        continue;
+      const std::string epoch = epoch_entry.path().filename().string();
+      validateEpochLabel(epoch);   // reject a stray non-epoch dir name
+      const fs::path epoch_dir = epoch_entry.path();
+      const Provenance provenance = readProvenanceMarker(epoch_dir);
+
+      for (const auto & entry : fs::directory_iterator(epoch_dir)) {
+        if (!entry.is_regular_file() || entry.path().extension() != ".tif") {
+          continue;
+        }
+        // Skip the companion tiles — they are loaded alongside their value tile,
+        // not as standalone value tiles (a bare *.tif glob would otherwise
+        // mis-load _time / _source as value tiles).
+        const std::string stem = entry.path().stem().string();
+        const auto ends_with = [&stem](const char * suffix) {
+            const std::string s(suffix);
+            return stem.size() >= s.size() &&
+                   stem.compare(stem.size() - s.size(), s.size(), s) == 0;
+          };
+        if (ends_with(kTimeSuffix) || ends_with(kSourceSuffix)) {
+          continue;
+        }
+        // Multi-level: recover each tile's level from its filename and load at
+        // that level (the store is not pinned to one level, ADR-0002 §D2).
+        const uint8_t lvl = levelFromTileFilename(entry.path().filename().string());
+        BathymetryTile tile = loadTile(entry.path().string(), gggs::Level(lvl));
+        // getOrCreateTile creates the epoch as LiveFused; restore the recorded
+        // provenance via getOrCreateEpoch (creation-time only, idempotent).
+        store.getOrCreateEpoch(layer, epoch, provenance);
+        store.getOrCreateTile(layer, epoch, tile.index()) = std::move(tile);
+        ++loaded;
       }
-      BathymetryTile tile = loadTile(entry.path().string(), store.level());
-      store.getOrCreateTile(layer, tile.index()) = std::move(tile);
-      ++loaded;
     }
   }
   if (registry != nullptr) {

--- a/marine_bathymetry_store/test/test_geotiff_import.cpp
+++ b/marine_bathymetry_store/test/test_geotiff_import.cpp
@@ -211,7 +211,8 @@ TEST_F(GeoTiffImportTest, NoSourceIdStampsUnsetIndex)
 TEST_F(GeoTiffImportTest, ImportsAtCallerSpecifiedLevel)
 {
   // Multi-level (ADR-0002 §D2): import at a level other than the store default.
-  BathymetryStore store(11);   // default level 11
+  // Importing to the read-only Chart prior requires the importer opt-in.
+  BathymetryStore store(11, /*chart_writable=*/true);   // default level 11
   const std::vector<float> depth{-30.0f};
   const std::vector<float> unc{0.1f};
   gggs::Level coarse(8);
@@ -298,7 +299,7 @@ TEST_F(GeoTiffImportTest, DepthScaleOffsetAndFiniteNoData)
 {
   // A lake-prior product: depths positive-down below the surface, with a FINITE
   // no-data value (-9999) that must not import as a 9 km depth.
-  BathymetryStore store(11);
+  BathymetryStore store(11, /*chart_writable=*/true);  // imports to Chart
   const std::vector<float> depth{4.0f, -9999.0f};   // 4 m of water; one no-data
   const std::vector<float> unc{0.0f, 0.0f};         // source has no real band
   const auto tif = writeTestTiff(dir_ / "lake.tif", store.level(), 2, 1, depth, unc);
@@ -331,7 +332,7 @@ TEST_F(GeoTiffImportTest, CoarserInputFillsPixelFootprint)
   // A 5x-coarser pixel must fill its whole footprint of store cells — coverage,
   // not isolated dots (the contour-prior case). The helper only does integer
   // pixels-per-cell, so build the 1x1 raster with a 5-cell pixel directly.
-  BathymetryStore store(11);
+  BathymetryStore store(11, /*chart_writable=*/true);  // imports to Chart
   const std::vector<float> depth{-30.0f};
   const std::vector<float> unc{3.0f};
   const gggs::GridIndex grid = store.level().gridIndex(43.0, -70.5);

--- a/marine_bathymetry_store/test/test_geotiff_import.cpp
+++ b/marine_bathymetry_store/test/test_geotiff_import.cpp
@@ -1,0 +1,419 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <gtest/gtest.h>
+
+#include <gdal_priv.h>
+#include <ogr_spatialref.h>
+
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "marine_autonomy/gggs.h"
+#include "marine_bathymetry_store/bathymetry_store.hpp"
+#include "marine_bathymetry_store/geotiff_import.hpp"
+#include "marine_bathymetry_store/registry.hpp"
+
+using marine_bathymetry_store::BathymetryStore;
+using marine_bathymetry_store::GeoTiffImportOptions;
+using marine_bathymetry_store::importGeoTiff;
+using marine_bathymetry_store::Provenance;
+using marine_bathymetry_store::SourceLayer;
+using marine_bathymetry_store::SourceRecord;
+using marine_bathymetry_store::SourceRegistry;
+
+namespace fs = std::filesystem;
+
+namespace
+{
+
+constexpr const char * kDay1 = "2026-06-09";
+
+/// Write a small north-up WGS84 GeoTIFF whose lattice starts at the north-west
+/// corner of the GGGS grid containing (43.0, -70.5) at @p level, with
+/// @p pixels_per_cell input pixels per store cell along each axis. Band 1 =
+/// depth, band 2 = uncertainty (Float32, NaN no-data).
+std::string writeTestTiff(
+  const fs::path & path, const gggs::Level & level, int width, int height,
+  const std::vector<float> & depth, const std::vector<float> & uncertainty,
+  int pixels_per_cell = 1)
+{
+  const gggs::GridIndex grid = level.gridIndex(43.0, -70.5);
+  const double cell_x = grid.longitudinalSpan() / gggs::cell_rows_per_grid;
+  const double cell_y = grid.latitudinalSpan() / gggs::cell_rows_per_grid;
+  const double px = cell_x / pixels_per_cell;
+  const double py = cell_y / pixels_per_cell;
+
+  GDALAllRegister();
+  GDALDriver * driver = GetGDALDriverManager()->GetDriverByName("GTiff");
+  if (driver == nullptr) {
+    throw std::runtime_error("writeTestTiff: GTiff driver unavailable");
+  }
+  GDALDataset * ds =
+    driver->Create(path.string().c_str(), width, height, 2, GDT_Float32, nullptr);
+  if (ds == nullptr) {
+    throw std::runtime_error("writeTestTiff: could not create " + path.string());
+  }
+  double gt[6] = {grid.westLongitude(), px, 0.0, grid.northLatitude(), 0.0, -py};
+  ds->SetGeoTransform(gt);
+  OGRSpatialReference srs;
+  srs.SetWellKnownGeogCS("WGS84");
+  char * wkt = nullptr;
+  srs.exportToWkt(&wkt);
+  ds->SetProjection(wkt);
+  CPLFree(wkt);
+  if (ds->GetRasterBand(1)->RasterIO(
+      GF_Write, 0, 0, width, height, const_cast<float *>(depth.data()), width, height,
+      GDT_Float32, 0, 0) != CE_None ||
+    ds->GetRasterBand(2)->RasterIO(
+      GF_Write, 0, 0, width, height, const_cast<float *>(uncertainty.data()), width, height,
+      GDT_Float32, 0, 0) != CE_None)
+  {
+    GDALClose(ds);
+    throw std::runtime_error("writeTestTiff: band write failed");
+  }
+  GDALClose(ds);
+  return path.string();
+}
+
+/// The NW-corner store cell of the grid containing (43.0, -70.5) at @p level
+/// (the cell whose centre is half a cell in from the grid's NW corner).
+gggs::CellIndex nwCell(const BathymetryStore & store, const gggs::Level & level)
+{
+  const gggs::GridIndex grid = level.gridIndex(43.0, -70.5);
+  const double cell_x = grid.longitudinalSpan() / gggs::cell_rows_per_grid;
+  const double cell_y = grid.latitudinalSpan() / gggs::cell_rows_per_grid;
+  return store.cellIndex(
+    grid.northLatitude() - 0.5 * cell_y, grid.westLongitude() + 0.5 * cell_x);
+}
+
+}  // namespace
+
+class GeoTiffImportTest : public ::testing::Test
+{
+protected:
+  fs::path dir_;
+  SourceRegistry registry_;
+
+  void SetUp() override
+  {
+    const std::string name = ::testing::UnitTest::GetInstance()->current_test_info()->name();
+    dir_ = fs::temp_directory_path() / ("marine_bathy_import_" + name);
+    fs::remove_all(dir_);
+    fs::create_directories(dir_);
+  }
+
+  void TearDown() override
+  {
+    fs::remove_all(dir_);
+  }
+};
+
+TEST_F(GeoTiffImportTest, AlignedImportIsCellExact)
+{
+  BathymetryStore store(11);
+  const float nan = std::numeric_limits<float>::quiet_NaN();
+  // 3x3 pixels at the grid's NW corner; centre pixel is no-data.
+  const std::vector<float> depth{
+    -30.0f, -31.0f, -32.0f,
+    -33.0f, nan, -35.0f,
+    -36.0f, -37.0f, -38.0f};
+  const std::vector<float> unc{
+    0.1f, 0.2f, 0.3f,
+    0.4f, nan, 0.6f,
+    0.7f, 0.8f, 0.9f};
+  const auto tif = writeTestTiff(dir_ / "aligned.tif", store.level(), 3, 3, depth, unc);
+
+  GeoTiffImportOptions options;
+  options.timestamp = 1.78e9;   // Unix seconds; the store stamps int64 ns.
+  const auto imported = importGeoTiff(
+    store, registry_, SourceLayer::Draft, kDay1, tif, Provenance::Replayed, options);
+  ASSERT_TRUE(imported.has_value());
+  EXPECT_EQ(*imported, 8u);   // 9 pixels minus the no-data centre
+
+  const auto nw = store.get(SourceLayer::Draft, kDay1, nwCell(store, store.level()));
+  ASSERT_TRUE(nw.has_value());
+  EXPECT_FLOAT_EQ(static_cast<float>(nw->depth), -30.0f);
+  EXPECT_FLOAT_EQ(static_cast<float>(nw->uncertainty), 0.1f);
+  EXPECT_EQ(nw->timestamp, static_cast<int64_t>(1.78e9 * 1e9));   // seconds -> ns
+
+  // The epoch carries the requested provenance.
+  EXPECT_EQ(store.epochs(SourceLayer::Draft).at(kDay1).provenance, Provenance::Replayed);
+}
+
+TEST_F(GeoTiffImportTest, RegistersSourceAndStampsIndex)
+{
+  // The importer registers the SourceRecord and stamps every cell with its
+  // registry index (ADR-0005 D2/D8) — the #178 provenance axis #148 predated.
+  BathymetryStore store(11);
+  const std::vector<float> depth{-30.0f};
+  const std::vector<float> unc{0.1f};
+  const auto tif = writeTestTiff(dir_ / "prov.tif", store.level(), 1, 1, depth, unc);
+
+  GeoTiffImportOptions options;
+  options.source = SourceRecord{"bizzy:m3:0", "bizzy", "m3", "multibeam",
+    "massabesic-2026", "ellipsoid"};
+  const auto imported = importGeoTiff(
+    store, registry_, SourceLayer::Draft, kDay1, tif, Provenance::Replayed, options);
+  ASSERT_TRUE(imported.has_value());
+
+  // The source was registered (index 1) and stamped on the cell.
+  EXPECT_EQ(registry_.size(), 1u);
+  const auto rec = registry_.lookup(1);
+  ASSERT_TRUE(rec.has_value());
+  EXPECT_EQ(rec->platform, "bizzy");
+  const auto got = store.get(SourceLayer::Draft, kDay1, nwCell(store, store.level()));
+  ASSERT_TRUE(got.has_value());
+  EXPECT_EQ(got->source_index, 1u);
+}
+
+TEST_F(GeoTiffImportTest, NoSourceIdStampsUnsetIndex)
+{
+  // An empty source_id means the caller doesn't track provenance: no record is
+  // registered and the cell carries the unset index (0).
+  BathymetryStore store(11);
+  const std::vector<float> depth{-30.0f};
+  const std::vector<float> unc{0.1f};
+  const auto tif = writeTestTiff(dir_ / "nosrc.tif", store.level(), 1, 1, depth, unc);
+
+  const auto imported = importGeoTiff(
+    store, registry_, SourceLayer::Draft, kDay1, tif, Provenance::Replayed);
+  ASSERT_TRUE(imported.has_value());
+  EXPECT_EQ(registry_.size(), 0u);
+  const auto got = store.get(SourceLayer::Draft, kDay1, nwCell(store, store.level()));
+  ASSERT_TRUE(got.has_value());
+  EXPECT_EQ(got->source_index, SourceRegistry::kUnset);
+}
+
+TEST_F(GeoTiffImportTest, ImportsAtCallerSpecifiedLevel)
+{
+  // Multi-level (ADR-0002 §D2): import at a level other than the store default.
+  BathymetryStore store(11);   // default level 11
+  const std::vector<float> depth{-30.0f};
+  const std::vector<float> unc{0.1f};
+  gggs::Level coarse(8);
+  const auto tif = writeTestTiff(dir_ / "lvl.tif", coarse, 1, 1, depth, unc);
+
+  GeoTiffImportOptions options;
+  options.level = 8;   // import at level 8, not the store's default 11
+  const auto imported = importGeoTiff(
+    store, registry_, SourceLayer::Chart, kDay1, tif, Provenance::Replayed, options);
+  ASSERT_TRUE(imported.has_value());
+
+  // The imported tile is at level 8, queryable at that level. The fixture's
+  // single pixel sits at the level-8 grid's NW corner, so query that cell.
+  const gggs::GridIndex grid8 = coarse.gridIndex(43.0, -70.5);
+  const double cell_x = grid8.longitudinalSpan() / gggs::cell_rows_per_grid;
+  const double cell_y = grid8.latitudinalSpan() / gggs::cell_rows_per_grid;
+  const auto cell = coarse.cellIndex(gggs::geoPoint(
+      grid8.northLatitude() - 0.5 * cell_y, grid8.westLongitude() + 0.5 * cell_x));
+  const auto got = store.get(SourceLayer::Chart, kDay1, cell);
+  ASSERT_TRUE(got.has_value());
+  EXPECT_FLOAT_EQ(static_cast<float>(got->depth), -30.0f);
+  // And the stored grid carries the level-8 prefix.
+  const auto & tiles = store.epochs(SourceLayer::Chart).at(kDay1).tiles;
+  ASSERT_FALSE(tiles.empty());
+  EXPECT_EQ(tiles.begin()->first.level(), 8u);
+}
+
+TEST_F(GeoTiffImportTest, FinerInputKeepsLowestUncertainty)
+{
+  BathymetryStore store(11);
+  // 2x2 input pixels per store cell, covering exactly one cell: four candidate
+  // values; the lowest-uncertainty one must win.
+  const std::vector<float> depth{-30.0f, -31.0f, -32.0f, -33.0f};
+  const std::vector<float> unc{0.5f, 0.2f, 0.9f, 0.7f};
+  const auto tif = writeTestTiff(dir_ / "fine.tif", store.level(), 2, 2, depth, unc, 2);
+
+  const auto imported = importGeoTiff(
+    store, registry_, SourceLayer::Draft, kDay1, tif, Provenance::Replayed);
+  ASSERT_TRUE(imported.has_value());
+  EXPECT_EQ(*imported, 1u);   // four pixels, one cell
+
+  const auto got = store.get(SourceLayer::Draft, kDay1, nwCell(store, store.level()));
+  ASSERT_TRUE(got.has_value());
+  EXPECT_FLOAT_EQ(static_cast<float>(got->depth), -31.0f);       // unc 0.2 wins
+  EXPECT_FLOAT_EQ(static_cast<float>(got->uncertainty), 0.2f);
+}
+
+TEST_F(GeoTiffImportTest, ProvenanceOrderingRefusesLiveOverReplayed)
+{
+  BathymetryStore store(11);
+  const std::vector<float> depth{-30.0f};
+  const std::vector<float> unc{0.1f};
+  const auto tif = writeTestTiff(dir_ / "one.tif", store.level(), 1, 1, depth, unc);
+
+  ASSERT_TRUE(
+    importGeoTiff(
+      store, registry_, SourceLayer::Draft, kDay1, tif, Provenance::Replayed).has_value());
+  // A live-fused re-import of the compacted epoch must be refused.
+  EXPECT_FALSE(
+    importGeoTiff(
+      store, registry_, SourceLayer::Draft, kDay1, tif, Provenance::LiveFused).has_value());
+}
+
+TEST_F(GeoTiffImportTest, MissingUncertaintyBandUsesDefault)
+{
+  BathymetryStore store(11);
+  const std::vector<float> depth{-30.0f};
+  const std::vector<float> unc{0.1f};   // present in the file but ignored
+  const auto tif = writeTestTiff(dir_ / "nounc.tif", store.level(), 1, 1, depth, unc);
+
+  GeoTiffImportOptions options;
+  options.uncertainty_band = 0;
+  options.default_uncertainty = 3.5;
+  const auto imported = importGeoTiff(
+    store, registry_, SourceLayer::Processed, kDay1, tif, Provenance::Replayed, options);
+  ASSERT_TRUE(imported.has_value());
+
+  const auto got = store.get(SourceLayer::Processed, kDay1, nwCell(store, store.level()));
+  ASSERT_TRUE(got.has_value());
+  EXPECT_DOUBLE_EQ(got->uncertainty, 3.5);
+}
+
+TEST_F(GeoTiffImportTest, DepthScaleOffsetAndFiniteNoData)
+{
+  // A lake-prior product: depths positive-down below the surface, with a FINITE
+  // no-data value (-9999) that must not import as a 9 km depth.
+  BathymetryStore store(11);
+  const std::vector<float> depth{4.0f, -9999.0f};   // 4 m of water; one no-data
+  const std::vector<float> unc{0.0f, 0.0f};         // source has no real band
+  const auto tif = writeTestTiff(dir_ / "lake.tif", store.level(), 2, 1, depth, unc);
+  {
+    GDALAllRegister();
+    GDALDataset * ds = GDALDataset::FromHandle(GDALOpen(tif.c_str(), GA_Update));
+    ASSERT_NE(ds, nullptr);
+    ds->GetRasterBand(1)->SetNoDataValue(-9999.0);
+    GDALClose(ds);
+  }
+
+  GeoTiffImportOptions options;
+  options.uncertainty_band = 0;
+  options.default_uncertainty = 3.0;
+  options.depth_scale = -1.0;       // positive-down -> up-positive
+  options.depth_offset = -20.0;     // lake surface ellipsoidal height
+  const auto imported = importGeoTiff(
+    store, registry_, SourceLayer::Chart, kDay1, tif, Provenance::Replayed, options);
+  ASSERT_TRUE(imported.has_value());
+  EXPECT_EQ(*imported, 1u);         // the -9999 pixel was skipped
+
+  const auto got = store.get(SourceLayer::Chart, kDay1, nwCell(store, store.level()));
+  ASSERT_TRUE(got.has_value());
+  EXPECT_DOUBLE_EQ(got->depth, -24.0);          // -1 * 4 + (-20)
+  EXPECT_DOUBLE_EQ(got->uncertainty, 3.0);
+}
+
+TEST_F(GeoTiffImportTest, CoarserInputFillsPixelFootprint)
+{
+  // A 5x-coarser pixel must fill its whole footprint of store cells — coverage,
+  // not isolated dots (the contour-prior case). The helper only does integer
+  // pixels-per-cell, so build the 1x1 raster with a 5-cell pixel directly.
+  BathymetryStore store(11);
+  const std::vector<float> depth{-30.0f};
+  const std::vector<float> unc{3.0f};
+  const gggs::GridIndex grid = store.level().gridIndex(43.0, -70.5);
+  const double cell_x = grid.longitudinalSpan() / gggs::cell_rows_per_grid;
+  const double cell_y = grid.latitudinalSpan() / gggs::cell_rows_per_grid;
+  const auto path = (dir_ / "coarse.tif").string();
+  {
+    GDALAllRegister();
+    GDALDriver * driver = GetGDALDriverManager()->GetDriverByName("GTiff");
+    ASSERT_NE(driver, nullptr);
+    GDALDataset * ds = driver->Create(path.c_str(), 1, 1, 2, GDT_Float32, nullptr);
+    ASSERT_NE(ds, nullptr);
+    double gt[6] = {grid.westLongitude(), 5.0 * cell_x, 0.0,
+      grid.northLatitude(), 0.0, -5.0 * cell_y};
+    ds->SetGeoTransform(gt);
+    OGRSpatialReference srs;
+    srs.SetWellKnownGeogCS("WGS84");
+    char * wkt = nullptr;
+    srs.exportToWkt(&wkt);
+    ds->SetProjection(wkt);
+    CPLFree(wkt);
+    ASSERT_EQ(
+      ds->GetRasterBand(1)->RasterIO(
+        GF_Write, 0, 0, 1, 1, const_cast<float *>(depth.data()), 1, 1, GDT_Float32, 0, 0),
+      CE_None);
+    ASSERT_EQ(
+      ds->GetRasterBand(2)->RasterIO(
+        GF_Write, 0, 0, 1, 1, const_cast<float *>(unc.data()), 1, 1, GDT_Float32, 0, 0),
+      CE_None);
+    GDALClose(ds);
+  }
+
+  const auto imported = importGeoTiff(
+    store, registry_, SourceLayer::Chart, kDay1, path, Provenance::Replayed);
+  ASSERT_TRUE(imported.has_value());
+  EXPECT_EQ(*imported, 25u);   // 5x5 store cells under the one pixel
+
+  // Every cell of the footprint carries the value — spot-check a middle one.
+  const auto mid = store.cellIndex(
+    grid.northLatitude() - 2.5 * cell_y, grid.westLongitude() + 2.5 * cell_x);
+  const auto got = store.get(SourceLayer::Chart, kDay1, mid);
+  ASSERT_TRUE(got.has_value());
+  EXPECT_FLOAT_EQ(static_cast<float>(got->depth), -30.0f);
+}
+
+TEST_F(GeoTiffImportTest, ZeroUncertaintyIsMissingNotPerfect)
+{
+  // A source cell with uncertainty 0 must not import as "perfectly certain" —
+  // it gets default_uncertainty (NaN here), so it never passes a gate.
+  BathymetryStore store(11);
+  const std::vector<float> depth{-30.0f, -31.0f};
+  const std::vector<float> unc{0.0f, 0.4f};
+  const auto tif = writeTestTiff(dir_ / "zerounc.tif", store.level(), 2, 1, depth, unc);
+
+  const auto imported = importGeoTiff(
+    store, registry_, SourceLayer::Draft, kDay1, tif, Provenance::Replayed);
+  ASSERT_TRUE(imported.has_value());
+  EXPECT_EQ(*imported, 2u);   // both cells import (depth is real)
+
+  const gggs::GridIndex grid = store.level().gridIndex(43.0, -70.5);
+  const double cell_x = grid.longitudinalSpan() / gggs::cell_rows_per_grid;
+  const double cell_y = grid.latitudinalSpan() / gggs::cell_rows_per_grid;
+  const auto zero_cell = store.cellIndex(
+    grid.northLatitude() - 0.5 * cell_y, grid.westLongitude() + 0.5 * cell_x);
+  const auto good_cell = store.cellIndex(
+    grid.northLatitude() - 0.5 * cell_y, grid.westLongitude() + 1.5 * cell_x);
+
+  const auto zero = store.get(SourceLayer::Draft, kDay1, zero_cell);
+  ASSERT_TRUE(zero.has_value());
+  EXPECT_TRUE(std::isnan(zero->uncertainty));   // missing, not 0
+
+  const auto good = store.get(SourceLayer::Draft, kDay1, good_cell);
+  ASSERT_TRUE(good.has_value());
+  EXPECT_FLOAT_EQ(static_cast<float>(good->uncertainty), 0.4f);
+}
+
+TEST_F(GeoTiffImportTest, MissingFileThrows)
+{
+  BathymetryStore store(11);
+  EXPECT_THROW(
+    importGeoTiff(
+      store, registry_, SourceLayer::Draft, kDay1, (dir_ / "absent.tif").string(),
+      Provenance::Replayed),
+    std::runtime_error);
+}

--- a/marine_bathymetry_store/test/test_query.cpp
+++ b/marine_bathymetry_store/test/test_query.cpp
@@ -183,6 +183,69 @@ TEST(Query, ShallowestReliableUnaffectedBySourceIndex)
   EXPECT_EQ(result2->source, SourceLayer::Draft);
 }
 
+TEST(Query, BestSourcePrefersFinerLevelAcrossLevels)
+{
+  // Multi-level store (ADR-0002 §D2): a coarse chart prior and a fine survey
+  // grid in the SAME layer at DIFFERENT levels. best-available resolves the
+  // finest level present that has data at the query position.
+  BathymetryStore store(5, /*chart_writable=*/true);
+  gggs::Level coarse(4);
+  gggs::Level fine(7);
+  const auto pt = gggs::geoPoint(43.0, -70.5);
+
+  store.set(SourceLayer::Chart, coarse.cellIndex(pt), BathyCell{38.0, 3.0, 1LL});
+  store.set(SourceLayer::Chart, fine.cellIndex(pt), BathyCell{40.0, 0.5, 2LL});
+
+  // Query at the finest present level (its center is closest to the survey
+  // point, so the coarse cell also covers it): best-available resolves the
+  // finer (level 7) value, not the coarse prior, where both cover the cell.
+  const auto best = bestSource(store, fine.cellIndex(pt));
+  ASSERT_TRUE(best.has_value());
+  EXPECT_EQ(best->source, SourceLayer::Chart);
+  EXPECT_DOUBLE_EQ(best->depth, 40.0);   // finer level wins
+  EXPECT_EQ(best->level, 7u);
+}
+
+TEST(Query, BestSourceFallsToCoarseLevelWhereFineAbsent)
+{
+  // Where only the coarse level covers a cell, the query falls through to it.
+  BathymetryStore store(5, /*chart_writable=*/true);
+  gggs::Level coarse(4);
+  gggs::Level fine(7);
+  const auto surveyed = gggs::geoPoint(43.0, -70.5);
+  const auto unsurveyed = gggs::geoPoint(43.0, -70.4);
+
+  store.set(SourceLayer::Chart, coarse.cellIndex(surveyed), BathyCell{38.0, 3.0, 1LL});
+  store.set(SourceLayer::Chart, coarse.cellIndex(unsurveyed), BathyCell{37.0, 3.0, 1LL});
+  store.set(SourceLayer::Chart, fine.cellIndex(surveyed), BathyCell{40.0, 0.5, 2LL});
+
+  // Cell with no fine-level data: only the coarse level covers it -> resolves
+  // to the coarse value.
+  const auto best = bestSource(store, store.cellIndex(43.0, -70.4));
+  ASSERT_TRUE(best.has_value());
+  EXPECT_DOUBLE_EQ(best->depth, 37.0);
+  EXPECT_EQ(best->level, 4u);
+}
+
+TEST(Query, ShallowestReliableConsidersAllLevels)
+{
+  // The safety query must examine every level present: a coarse level can be
+  // both shallower and reliable where a finer one is too uncertain.
+  BathymetryStore store(5);
+  gggs::Level coarse(4);
+  gggs::Level fine(7);
+  const auto pt = gggs::geoPoint(43.0, -70.5);
+
+  // Fine level: shallower but too uncertain. Coarse: deeper but reliable.
+  store.set(SourceLayer::Draft, fine.cellIndex(pt), BathyCell{-20.0, 5.0, 2LL});
+  store.set(SourceLayer::Draft, coarse.cellIndex(pt), BathyCell{-30.0, 0.2, 1LL});
+
+  const auto result = shallowestReliable(store, store.cellIndex(43.0, -70.5), 1.0);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_DOUBLE_EQ(result->depth, -30.0);   // fine excluded by uncertainty
+  EXPECT_EQ(result->level, 4u);
+}
+
 TEST(Query, ShallowestReliableGatesChartByUncertainty)
 {
   // The coarse Chart prior carries a fixed import uncertainty (3.0 m). It feeds

--- a/marine_bathymetry_store/test/test_query.cpp
+++ b/marine_bathymetry_store/test/test_query.cpp
@@ -37,12 +37,15 @@ using marine_bathymetry_store::forEachCellBestSource;
 using marine_bathymetry_store::shallowestReliable;
 using marine_bathymetry_store::SourceLayer;
 
+// A single ISO-date epoch label for the single-epoch query tests (ADR-0002 A1).
+static const char * const kEpoch = "2026-06-10";
+
 TEST(Query, BestSourcePrefersHigherPriorityLayer)
 {
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Draft, cell, BathyCell{-12.0, 2.0, 2LL});
-  store.set(SourceLayer::Processed, cell, BathyCell{-10.0, 0.1, 1LL});
+  store.set(SourceLayer::Draft, kEpoch, cell, BathyCell{-12.0, 2.0, 2LL});
+  store.set(SourceLayer::Processed, kEpoch, cell, BathyCell{-10.0, 0.1, 1LL});
 
   const auto best = bestSource(store, cell);
   ASSERT_TRUE(best.has_value());
@@ -54,7 +57,7 @@ TEST(Query, BestSourceFallsBackToLowerPriority)
 {
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Draft, cell, BathyCell{-12.0, 2.0, 2LL});
+  store.set(SourceLayer::Draft, kEpoch, cell, BathyCell{-12.0, 2.0, 2LL});
 
   const auto best = bestSource(store, cell);
   ASSERT_TRUE(best.has_value());
@@ -68,7 +71,7 @@ TEST(Query, UnknownCellIsNullopt)
   EXPECT_FALSE(bestSource(store, cell).has_value());
 
   // A written-but-no-data cell is still unknown (not "deep water").
-  store.set(SourceLayer::Draft, cell, BathyCell{});
+  store.set(SourceLayer::Draft, kEpoch, cell, BathyCell{});
   EXPECT_FALSE(bestSource(store, cell).has_value());
 }
 
@@ -77,8 +80,8 @@ TEST(Query, ShallowestReliablePicksGreatestHeight)
   // depth is ellipsoidal height (up-positive): shallower == greater value.
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Processed, cell, BathyCell{-30.0, 0.1, 1LL});  // deeper
-  store.set(SourceLayer::Draft, cell, BathyCell{-25.0, 0.2, 2LL});      // shallower
+  store.set(SourceLayer::Processed, kEpoch, cell, BathyCell{-30.0, 0.1, 1LL});  // deeper
+  store.set(SourceLayer::Draft, kEpoch, cell, BathyCell{-25.0, 0.2, 2LL});      // shallower
 
   const auto result = shallowestReliable(store, cell, 1.0);
   ASSERT_TRUE(result.has_value());
@@ -90,8 +93,9 @@ TEST(Query, ShallowestReliableExcludesOverUncertain)
 {
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Processed, cell, BathyCell{-30.0, 0.1, 1LL});  // reliable, deeper
-  store.set(SourceLayer::Draft, cell, BathyCell{-25.0, 5.0, 2LL});      // shallower, too uncertain
+  store.set(SourceLayer::Processed, kEpoch, cell, BathyCell{-30.0, 0.1, 1LL});  // reliable, deeper
+  // shallower, but too uncertain to be reliable:
+  store.set(SourceLayer::Draft, kEpoch, cell, BathyCell{-25.0, 5.0, 2LL});
 
   const auto result = shallowestReliable(store, cell, 1.0);
   ASSERT_TRUE(result.has_value());
@@ -103,7 +107,7 @@ TEST(Query, ShallowestReliableTreatsNaNUncertaintyAsUnreliable)
 {
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Draft, cell, BathyCell{-25.0, std::nan(""), 2LL});
+  store.set(SourceLayer::Draft, kEpoch, cell, BathyCell{-25.0, std::nan(""), 2LL});
   EXPECT_FALSE(shallowestReliable(store, cell, 1.0).has_value());
 }
 
@@ -111,7 +115,7 @@ TEST(Query, ForEachRegionVisitsCoveredCells)
 {
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Draft, cell, BathyCell{-20.0, 0.5, 1LL});
+  store.set(SourceLayer::Draft, kEpoch, cell, BathyCell{-20.0, 0.5, 1LL});
 
   std::size_t visited = 0;
   std::size_t with_data = 0;
@@ -136,9 +140,9 @@ TEST(Query, BestSourceFallsThroughToChartPrior)
   const auto unsurveyed = store.cellIndex(43.0, -70.5);
   const auto surveyed = store.cellIndex(43.0, -70.4);
 
-  store.set(SourceLayer::Chart, unsurveyed, BathyCell{38.0, 3.0, 1LL});
-  store.set(SourceLayer::Chart, surveyed, BathyCell{38.0, 3.0, 1LL});
-  store.set(SourceLayer::Draft, surveyed, BathyCell{40.0, 0.5, 2LL});
+  store.set(SourceLayer::Chart, kEpoch, unsurveyed, BathyCell{38.0, 3.0, 1LL});
+  store.set(SourceLayer::Chart, kEpoch, surveyed, BathyCell{38.0, 3.0, 1LL});
+  store.set(SourceLayer::Draft, kEpoch, surveyed, BathyCell{40.0, 0.5, 2LL});
 
   // Unsurveyed cell falls through to the chart prior.
   const auto a = bestSource(store, unsurveyed);
@@ -165,8 +169,8 @@ TEST(Query, ShallowestReliableUnaffectedBySourceIndex)
 
   // Deeper cell from a "high" source index; shallower from a "low" one. If the
   // query ever consulted source_index, the answer could flip — it must not.
-  store.set(SourceLayer::Processed, cell, BathyCell{-30.0, 0.1, 1LL, 9000u});  // deeper
-  store.set(SourceLayer::Draft, cell, BathyCell{-25.0, 0.2, 2LL, 1u});         // shallower
+  store.set(SourceLayer::Processed, kEpoch, cell, BathyCell{-30.0, 0.1, 1LL, 9000u});  // deeper
+  store.set(SourceLayer::Draft, kEpoch, cell, BathyCell{-25.0, 0.2, 2LL, 1u});         // shallower
 
   const auto result = shallowestReliable(store, cell, 1.0);
   ASSERT_TRUE(result.has_value());
@@ -175,8 +179,8 @@ TEST(Query, ShallowestReliableUnaffectedBySourceIndex)
 
   // Same geometry with source indices swapped -> identical result.
   BathymetryStore swapped(5);
-  swapped.set(SourceLayer::Processed, cell, BathyCell{-30.0, 0.1, 1LL, 1u});
-  swapped.set(SourceLayer::Draft, cell, BathyCell{-25.0, 0.2, 2LL, 9000u});
+  swapped.set(SourceLayer::Processed, kEpoch, cell, BathyCell{-30.0, 0.1, 1LL, 1u});
+  swapped.set(SourceLayer::Draft, kEpoch, cell, BathyCell{-25.0, 0.2, 2LL, 9000u});
   const auto result2 = shallowestReliable(swapped, cell, 1.0);
   ASSERT_TRUE(result2.has_value());
   EXPECT_DOUBLE_EQ(result2->depth, -25.0);
@@ -193,8 +197,8 @@ TEST(Query, BestSourcePrefersFinerLevelAcrossLevels)
   gggs::Level fine(7);
   const auto pt = gggs::geoPoint(43.0, -70.5);
 
-  store.set(SourceLayer::Chart, coarse.cellIndex(pt), BathyCell{38.0, 3.0, 1LL});
-  store.set(SourceLayer::Chart, fine.cellIndex(pt), BathyCell{40.0, 0.5, 2LL});
+  store.set(SourceLayer::Chart, kEpoch, coarse.cellIndex(pt), BathyCell{38.0, 3.0, 1LL});
+  store.set(SourceLayer::Chart, kEpoch, fine.cellIndex(pt), BathyCell{40.0, 0.5, 2LL});
 
   // Query at the finest present level (its center is closest to the survey
   // point, so the coarse cell also covers it): best-available resolves the
@@ -215,9 +219,9 @@ TEST(Query, BestSourceFallsToCoarseLevelWhereFineAbsent)
   const auto surveyed = gggs::geoPoint(43.0, -70.5);
   const auto unsurveyed = gggs::geoPoint(43.0, -70.4);
 
-  store.set(SourceLayer::Chart, coarse.cellIndex(surveyed), BathyCell{38.0, 3.0, 1LL});
-  store.set(SourceLayer::Chart, coarse.cellIndex(unsurveyed), BathyCell{37.0, 3.0, 1LL});
-  store.set(SourceLayer::Chart, fine.cellIndex(surveyed), BathyCell{40.0, 0.5, 2LL});
+  store.set(SourceLayer::Chart, kEpoch, coarse.cellIndex(surveyed), BathyCell{38.0, 3.0, 1LL});
+  store.set(SourceLayer::Chart, kEpoch, coarse.cellIndex(unsurveyed), BathyCell{37.0, 3.0, 1LL});
+  store.set(SourceLayer::Chart, kEpoch, fine.cellIndex(surveyed), BathyCell{40.0, 0.5, 2LL});
 
   // Cell with no fine-level data: only the coarse level covers it -> resolves
   // to the coarse value.
@@ -237,8 +241,8 @@ TEST(Query, ShallowestReliableConsidersAllLevels)
   const auto pt = gggs::geoPoint(43.0, -70.5);
 
   // Fine level: shallower but too uncertain. Coarse: deeper but reliable.
-  store.set(SourceLayer::Draft, fine.cellIndex(pt), BathyCell{-20.0, 5.0, 2LL});
-  store.set(SourceLayer::Draft, coarse.cellIndex(pt), BathyCell{-30.0, 0.2, 1LL});
+  store.set(SourceLayer::Draft, kEpoch, fine.cellIndex(pt), BathyCell{-20.0, 5.0, 2LL});
+  store.set(SourceLayer::Draft, kEpoch, coarse.cellIndex(pt), BathyCell{-30.0, 0.2, 1LL});
 
   const auto result = shallowestReliable(store, store.cellIndex(43.0, -70.5), 1.0);
   ASSERT_TRUE(result.has_value());
@@ -253,7 +257,7 @@ TEST(Query, ShallowestReliableGatesChartByUncertainty)
   // only when the caller's tolerance allows — both sides of the threshold.
   BathymetryStore store(5, /*chart_writable=*/true);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Chart, cell, BathyCell{38.0, 3.0, 1LL});
+  store.set(SourceLayer::Chart, kEpoch, cell, BathyCell{38.0, 3.0, 1LL});
 
   // Tolerance below the chart uncertainty excludes it -> cell reads as unknown.
   EXPECT_FALSE(shallowestReliable(store, cell, 2.9).has_value());
@@ -263,4 +267,80 @@ TEST(Query, ShallowestReliableGatesChartByUncertainty)
   ASSERT_TRUE(at.has_value());
   EXPECT_EQ(at->source, SourceLayer::Chart);
   EXPECT_DOUBLE_EQ(at->depth, 38.0);
+}
+
+TEST(Query, BestSourceResolvesNewestEpochFirst)
+{
+  // Within a layer, the default query walks epochs newest-first (ADR-0002
+  // §A1.3) — a later day's value supersedes an earlier day's without fusion.
+  BathymetryStore store(5);
+  const auto cell = store.cellIndex(43.0, -70.5);
+  store.set(SourceLayer::Draft, "2026-06-09", cell, BathyCell{-30.0, 0.5, 1LL});
+  store.set(SourceLayer::Draft, "2026-06-11", cell, BathyCell{-28.0, 0.5, 2LL});
+
+  const auto best = bestSource(store, cell);
+  ASSERT_TRUE(best.has_value());
+  EXPECT_DOUBLE_EQ(best->depth, -28.0);          // newest epoch wins
+  EXPECT_EQ(best->epoch, "2026-06-11");
+}
+
+TEST(Query, EpochsAreNeverFused)
+{
+  // The point of epochs: N days surveyed keep N records, never averaged. Each
+  // epoch reads back its own value exactly; the default query is the newest,
+  // not a blend.
+  BathymetryStore store(5);
+  const auto cell = store.cellIndex(43.0, -70.5);
+  store.set(SourceLayer::Draft, "2026-06-09", cell, BathyCell{-30.0, 0.5, 1LL});
+  store.set(SourceLayer::Draft, "2026-06-10", cell, BathyCell{-20.0, 0.5, 2LL});
+  store.set(SourceLayer::Draft, "2026-06-11", cell, BathyCell{-25.0, 0.5, 3LL});
+
+  // Three distinct epochs, each holding its own depth (no fusion to a mean).
+  EXPECT_EQ(store.epochs(SourceLayer::Draft).size(), 3u);
+  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Draft, "2026-06-09", cell)->depth, -30.0);
+  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Draft, "2026-06-10", cell)->depth, -20.0);
+  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Draft, "2026-06-11", cell)->depth, -25.0);
+  // The newest is the default query result, not the mean (-25 vs a fused -25
+  // would be ambiguous, so the older two are deliberately not -25's average).
+  EXPECT_DOUBLE_EQ(bestSource(store, cell)->depth, -25.0);
+}
+
+TEST(Query, ShallowestReliableFallsThroughNoisyNewestEpoch)
+{
+  // §A1.3 safety walk: a fresh-but-noisy epoch fails the gate and falls through
+  // to the prior epoch's confident value — no cross-epoch fusion.
+  BathymetryStore store(5);
+  const auto cell = store.cellIndex(43.0, -70.5);
+  store.set(SourceLayer::Draft, "2026-06-09", cell, BathyCell{-30.0, 0.2, 1LL});  // confident
+  store.set(SourceLayer::Draft, "2026-06-11", cell, BathyCell{-20.0, 5.0, 2LL});  // noisy, newer
+
+  const auto result = shallowestReliable(store, cell, 1.0);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_DOUBLE_EQ(result->depth, -30.0);        // noisy newest skipped
+  EXPECT_EQ(result->epoch, "2026-06-09");
+}
+
+TEST(Query, ForEachChangedCellDiffsTwoEpochs)
+{
+  // The change map: cells observed in BOTH epochs are visited with both
+  // records; cells in only one are coverage change, not visited (ADR-0002 A1.1).
+  BathymetryStore store(5);
+  const auto both = store.cellIndex(43.0, -70.5);
+  const auto only_a = store.cellIndex(43.0, -70.4);
+  store.set(SourceLayer::Draft, "2026-06-09", both, BathyCell{-30.0, 0.5, 1LL});
+  store.set(SourceLayer::Draft, "2026-06-09", only_a, BathyCell{-31.0, 0.5, 1LL});
+  store.set(SourceLayer::Draft, "2026-06-11", both, BathyCell{-28.5, 0.5, 2LL});
+
+  std::size_t visited = 0;
+  double delta = 0.0;
+  const auto n = marine_bathymetry_store::forEachChangedCell(
+    store, SourceLayer::Draft, "2026-06-09", "2026-06-11",
+    [&](const gggs::CellIndex &, const BathyCell & a, const BathyCell & b) {
+      ++visited;
+      delta = b.depth - a.depth;
+    });
+
+  EXPECT_EQ(n, 1u);          // only the doubly-observed cell
+  EXPECT_EQ(visited, 1u);
+  EXPECT_DOUBLE_EQ(delta, 1.5);   // -28.5 - (-30.0)
 }

--- a/marine_bathymetry_store/test/test_store.cpp
+++ b/marine_bathymetry_store/test/test_store.cpp
@@ -263,3 +263,33 @@ TEST(Store, ImportEpochRejectsTileKeyMismatch)
     marine_bathymetry_store::Provenance::Replayed),
     std::invalid_argument);
 }
+
+TEST(Store, ImportEpochHonorsChartReadOnlyGate)
+{
+  // importEpoch is a public mutator like set(), so it must honor the Chart
+  // read-only gate (ADR-0002 §D3) — otherwise a wholesale import would overwrite
+  // the prior on a default store. Only a chart_writable (importer) store may.
+  const auto cell = BathymetryStore(5).cellIndex(43.0, -70.5);
+
+  BathymetryStore read_only(5);
+  EXPECT_THROW(
+    read_only.importEpoch(SourceLayer::Chart, kEpoch,
+    oneTile(cell, BathyCell{-10.0, 3.0, 1LL}),
+    marine_bathymetry_store::Provenance::Replayed),
+    std::logic_error);
+
+  BathymetryStore importer(5, /*chart_writable=*/true);
+  EXPECT_TRUE(importer.importEpoch(
+      SourceLayer::Chart, kEpoch, oneTile(cell, BathyCell{-10.0, 3.0, 1LL}),
+      marine_bathymetry_store::Provenance::Replayed));
+}
+
+TEST(Store, ImportEpochRejectsEmptyTiles)
+{
+  // An empty import (e.g. an entirely no-data GeoTIFF) must not create a phantom
+  // epoch that vanishes on the next load — it returns false and adds no epoch.
+  BathymetryStore store(5);
+  EXPECT_FALSE(store.importEpoch(
+      SourceLayer::Draft, kEpoch, {}, marine_bathymetry_store::Provenance::Replayed));
+  EXPECT_TRUE(store.epochs(SourceLayer::Draft).empty());
+}

--- a/marine_bathymetry_store/test/test_store.cpp
+++ b/marine_bathymetry_store/test/test_store.cpp
@@ -96,12 +96,27 @@ TEST(Store, NoDataCellReadsBackAsNoData)
   EXPECT_FALSE(got->hasData());      // but the cell carries no usable depth
 }
 
-TEST(Store, WrongLevelCellThrows)
+TEST(Store, MultiLevelTilesCoexist)
 {
+  // The store is multi-level (ADR-0002 §D2): a cell at a level other than the
+  // store's default level is accepted, stored, and read back independently.
   BathymetryStore store(5);
-  gggs::Level other(6);
-  const auto level6_cell = other.cellIndex(gggs::geoPoint(43.0, -70.5));
-  EXPECT_THROW(store.set(SourceLayer::Draft, level6_cell, BathyCell{}), std::invalid_argument);
+  gggs::Level fine(6);
+  const auto fine_cell = fine.cellIndex(gggs::geoPoint(43.0, -70.5));
+  const auto default_cell = store.cellIndex(43.0, -70.5);
+  ASSERT_NE(fine_cell.level(), default_cell.level());
+
+  EXPECT_NO_THROW(store.set(SourceLayer::Draft, fine_cell, BathyCell{-22.0, 0.3, 1LL}));
+  store.set(SourceLayer::Draft, default_cell, BathyCell{-20.0, 0.5, 2LL});
+
+  // Both tiles exist in the same layer at different levels.
+  EXPECT_EQ(store.tiles(SourceLayer::Draft).size(), 2u);
+  const auto fine_got = store.get(SourceLayer::Draft, fine_cell);
+  ASSERT_TRUE(fine_got.has_value());
+  EXPECT_DOUBLE_EQ(fine_got->depth, -22.0);
+  const auto default_got = store.get(SourceLayer::Draft, default_cell);
+  ASSERT_TRUE(default_got.has_value());
+  EXPECT_DOUBLE_EQ(default_got->depth, -20.0);
 }
 
 TEST(Store, InvalidCellThrows)

--- a/marine_bathymetry_store/test/test_store.cpp
+++ b/marine_bathymetry_store/test/test_store.cpp
@@ -21,23 +21,40 @@
 
 #include <gtest/gtest.h>
 
+#include <cstddef>
+#include <map>
 #include <stdexcept>
+#include <string>
+#include <utility>
 
 #include "marine_autonomy/gggs.h"
 #include "marine_bathymetry_store/bathymetry_store.hpp"
+#include "marine_bathymetry_store/bathymetry_tile.hpp"
 
 using marine_bathymetry_store::BathyCell;
 using marine_bathymetry_store::BathymetryStore;
 using marine_bathymetry_store::SourceLayer;
+
+// A single ISO-date epoch label for the single-epoch store tests (ADR-0002 A1).
+static const char * const kEpoch = "2026-06-10";
+
+// Tile count of one (layer, epoch) — 0 if the epoch is absent.
+static std::size_t tilesIn(
+  const BathymetryStore & store, SourceLayer layer, const std::string & epoch)
+{
+  const auto & epochs = store.epochs(layer);
+  const auto it = epochs.find(epoch);
+  return it == epochs.end() ? 0u : it->second.tiles.size();
+}
 
 TEST(Store, SetGetRoundTrip)
 {
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
   // timestamp is int64 nanoseconds since the epoch (1 s = 1e9 ns).
-  store.set(SourceLayer::Draft, cell, BathyCell{-30.0, 0.5, 1'000'000'000'000LL});
+  store.set(SourceLayer::Draft, kEpoch, cell, BathyCell{-30.0, 0.5, 1'000'000'000'000LL});
 
-  const auto got = store.get(SourceLayer::Draft, cell);
+  const auto got = store.get(SourceLayer::Draft, kEpoch, cell);
   ASSERT_TRUE(got.has_value());
   EXPECT_DOUBLE_EQ(got->depth, -30.0);
   EXPECT_DOUBLE_EQ(got->uncertainty, 0.5);
@@ -49,9 +66,9 @@ TEST(Store, SetGetRoundTripWithSourceIndex)
 {
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Draft, cell, BathyCell{-30.0, 0.5, 2'000'000'000LL, 3u});
+  store.set(SourceLayer::Draft, kEpoch, cell, BathyCell{-30.0, 0.5, 2'000'000'000LL, 3u});
 
-  const auto got = store.get(SourceLayer::Draft, cell);
+  const auto got = store.get(SourceLayer::Draft, kEpoch, cell);
   ASSERT_TRUE(got.has_value());
   EXPECT_DOUBLE_EQ(got->depth, -30.0);
   EXPECT_EQ(got->timestamp, 2'000'000'000LL);
@@ -61,7 +78,7 @@ TEST(Store, SetGetRoundTripWithSourceIndex)
 TEST(Store, GetEmptyLayerIsNullopt)
 {
   BathymetryStore store(5);
-  EXPECT_FALSE(store.get(SourceLayer::Processed, store.cellIndex(43.0, -70.5)).has_value());
+  EXPECT_FALSE(store.get(SourceLayer::Processed, kEpoch, store.cellIndex(43.0, -70.5)).has_value());
 }
 
 TEST(Store, LayersAreIndependent)
@@ -69,29 +86,29 @@ TEST(Store, LayersAreIndependent)
   // A draft write must not touch the processed layer at the same cell.
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Processed, cell, BathyCell{-10.0, 0.1, 1LL});
-  store.set(SourceLayer::Draft, cell, BathyCell{-12.0, 2.0, 2LL});
-  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Processed, cell)->depth, -10.0);
-  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Draft, cell)->depth, -12.0);
+  store.set(SourceLayer::Processed, kEpoch, cell, BathyCell{-10.0, 0.1, 1LL});
+  store.set(SourceLayer::Draft, kEpoch, cell, BathyCell{-12.0, 2.0, 2LL});
+  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Processed, kEpoch, cell)->depth, -10.0);
+  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Draft, kEpoch, cell)->depth, -12.0);
 }
 
 TEST(Store, TilesAllocatedLazilyPerLayer)
 {
   BathymetryStore store(5);
-  EXPECT_TRUE(store.tiles(SourceLayer::Draft).empty());
-  EXPECT_TRUE(store.tiles(SourceLayer::Processed).empty());
+  EXPECT_TRUE(store.epochs(SourceLayer::Draft).empty());
+  EXPECT_TRUE(store.epochs(SourceLayer::Processed).empty());
 
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1LL});
-  EXPECT_EQ(store.tiles(SourceLayer::Draft).size(), 1u);
-  EXPECT_TRUE(store.tiles(SourceLayer::Processed).empty());
+  store.set(SourceLayer::Draft, kEpoch, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1LL});
+  EXPECT_EQ(tilesIn(store, SourceLayer::Draft, kEpoch), 1u);
+  EXPECT_TRUE(store.epochs(SourceLayer::Processed).empty());
 }
 
 TEST(Store, NoDataCellReadsBackAsNoData)
 {
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Draft, cell, BathyCell{});  // depth NaN
-  const auto got = store.get(SourceLayer::Draft, cell);
+  store.set(SourceLayer::Draft, kEpoch, cell, BathyCell{});  // depth NaN
+  const auto got = store.get(SourceLayer::Draft, kEpoch, cell);
   ASSERT_TRUE(got.has_value());      // tile exists
   EXPECT_FALSE(got->hasData());      // but the cell carries no usable depth
 }
@@ -106,15 +123,15 @@ TEST(Store, MultiLevelTilesCoexist)
   const auto default_cell = store.cellIndex(43.0, -70.5);
   ASSERT_NE(fine_cell.level(), default_cell.level());
 
-  EXPECT_NO_THROW(store.set(SourceLayer::Draft, fine_cell, BathyCell{-22.0, 0.3, 1LL}));
-  store.set(SourceLayer::Draft, default_cell, BathyCell{-20.0, 0.5, 2LL});
+  EXPECT_NO_THROW(store.set(SourceLayer::Draft, kEpoch, fine_cell, BathyCell{-22.0, 0.3, 1LL}));
+  store.set(SourceLayer::Draft, kEpoch, default_cell, BathyCell{-20.0, 0.5, 2LL});
 
-  // Both tiles exist in the same layer at different levels.
-  EXPECT_EQ(store.tiles(SourceLayer::Draft).size(), 2u);
-  const auto fine_got = store.get(SourceLayer::Draft, fine_cell);
+  // Both tiles exist in the same layer/epoch at different levels.
+  EXPECT_EQ(tilesIn(store, SourceLayer::Draft, kEpoch), 2u);
+  const auto fine_got = store.get(SourceLayer::Draft, kEpoch, fine_cell);
   ASSERT_TRUE(fine_got.has_value());
   EXPECT_DOUBLE_EQ(fine_got->depth, -22.0);
-  const auto default_got = store.get(SourceLayer::Draft, default_cell);
+  const auto default_got = store.get(SourceLayer::Draft, kEpoch, default_cell);
   ASSERT_TRUE(default_got.has_value());
   EXPECT_DOUBLE_EQ(default_got->depth, -20.0);
 }
@@ -122,7 +139,7 @@ TEST(Store, MultiLevelTilesCoexist)
 TEST(Store, InvalidCellThrows)
 {
   BathymetryStore store(5);
-  EXPECT_THROW(store.set(SourceLayer::Draft, gggs::CellIndex{}, BathyCell{}),
+  EXPECT_THROW(store.set(SourceLayer::Draft, kEpoch, gggs::CellIndex{}, BathyCell{}),
     std::invalid_argument);
 }
 
@@ -140,11 +157,11 @@ TEST(Store, ChartIsReadOnlyByDefault)
   BathymetryStore store(5);
   EXPECT_FALSE(store.chartWritable());
   EXPECT_THROW(
-    store.set(SourceLayer::Chart, store.cellIndex(43.0, -70.5), BathyCell{-10.0, 3.0, 1LL}),
+    store.set(SourceLayer::Chart, kEpoch, store.cellIndex(43.0, -70.5), BathyCell{-10.0, 3.0, 1LL}),
     std::logic_error);
   // Other layers are unaffected by the guard.
-  EXPECT_NO_THROW(
-    store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-12.0, 2.0, 2LL}));
+  const auto cell = store.cellIndex(43.0, -70.5);
+  EXPECT_NO_THROW(store.set(SourceLayer::Draft, kEpoch, cell, BathyCell{-12.0, 2.0, 2LL}));
 }
 
 TEST(Store, ChartWritableStoreAllowsChartSet)
@@ -153,8 +170,8 @@ TEST(Store, ChartWritableStoreAllowsChartSet)
   BathymetryStore store(5, /*chart_writable=*/true);
   EXPECT_TRUE(store.chartWritable());
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Chart, cell, BathyCell{38.58, 3.0, 1000LL});
-  const auto got = store.get(SourceLayer::Chart, cell);
+  store.set(SourceLayer::Chart, kEpoch, cell, BathyCell{38.58, 3.0, 1000LL});
+  const auto got = store.get(SourceLayer::Chart, kEpoch, cell);
   ASSERT_TRUE(got.has_value());
   EXPECT_DOUBLE_EQ(got->depth, 38.58);
 }
@@ -164,5 +181,85 @@ TEST(Store, FromCellSizePropagatesChartWritable)
   auto store = BathymetryStore::fromCellSize(30.0f, /*chart_writable=*/true);
   EXPECT_TRUE(store.chartWritable());
   EXPECT_NO_THROW(
-    store.set(SourceLayer::Chart, store.cellIndex(43.0, -70.5), BathyCell{40.0, 3.0, 1LL}));
+    store.set(SourceLayer::Chart, kEpoch, store.cellIndex(43.0, -70.5), BathyCell{40.0, 3.0, 1LL}));
+}
+
+TEST(Store, InvalidEpochLabelThrows)
+{
+  // Epoch labels must be filesystem-safe single components (validateEpochLabel).
+  BathymetryStore store(5);
+  const auto cell = store.cellIndex(43.0, -70.5);
+  EXPECT_THROW(store.set(SourceLayer::Draft, "../escape", cell, BathyCell{}),
+    std::invalid_argument);
+  EXPECT_THROW(store.set(SourceLayer::Draft, "", cell, BathyCell{}), std::invalid_argument);
+}
+
+namespace
+{
+// Build a one-cell tile map for importEpoch from a (cell, value) pair.
+std::map<gggs::GridIndex, marine_bathymetry_store::BathymetryTile> oneTile(
+  const gggs::CellIndex & cell, const BathyCell & value)
+{
+  std::map<gggs::GridIndex, marine_bathymetry_store::BathymetryTile> tiles;
+  marine_bathymetry_store::BathymetryTile tile(cell.grid());
+  tile.set(cell.row(), cell.column(), value);
+  tiles.emplace(cell.grid(), std::move(tile));
+  return tiles;
+}
+}  // namespace
+
+TEST(Store, ImportEpochReplacesWholesale)
+{
+  BathymetryStore store(5);
+  const auto cell = store.cellIndex(43.0, -70.5);
+  EXPECT_TRUE(store.importEpoch(
+      SourceLayer::Draft, kEpoch, oneTile(cell, BathyCell{-30.0, 0.5, 1LL}),
+      marine_bathymetry_store::Provenance::Replayed));
+  const auto got = store.get(SourceLayer::Draft, kEpoch, cell);
+  ASSERT_TRUE(got.has_value());
+  EXPECT_DOUBLE_EQ(got->depth, -30.0);
+}
+
+TEST(Store, ReplayedEpochIsImmutableToLiveWrites)
+{
+  // ADR-0002 §A1.2: a compacted (Replayed) epoch must not be regressed by a
+  // later live (LiveFused) write or import — both are no-ops returning false.
+  BathymetryStore store(5);
+  const auto cell = store.cellIndex(43.0, -70.5);
+  store.importEpoch(
+    SourceLayer::Draft, kEpoch, oneTile(cell, BathyCell{-30.0, 0.5, 1LL}),
+    marine_bathymetry_store::Provenance::Replayed);
+
+  // A live per-cell write is refused (no-op).
+  EXPECT_FALSE(store.set(SourceLayer::Draft, kEpoch, cell, BathyCell{-99.0, 9.0, 2LL}));
+  // A live-fused wholesale import is refused too.
+  EXPECT_FALSE(store.importEpoch(
+      SourceLayer::Draft, kEpoch, oneTile(cell, BathyCell{-99.0, 9.0, 2LL}),
+      marine_bathymetry_store::Provenance::LiveFused));
+  // The replayed value is intact.
+  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Draft, kEpoch, cell)->depth, -30.0);
+
+  // A re-compaction (Replayed over Replayed) IS allowed.
+  EXPECT_TRUE(store.importEpoch(
+      SourceLayer::Draft, kEpoch, oneTile(cell, BathyCell{-28.0, 0.4, 3LL}),
+      marine_bathymetry_store::Provenance::Replayed));
+  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Draft, kEpoch, cell)->depth, -28.0);
+}
+
+TEST(Store, ImportEpochRejectsTileKeyMismatch)
+{
+  // A tile must be built for the grid it is keyed under (harvested #148 fix).
+  BathymetryStore store(5);
+  const auto cell_a = store.cellIndex(43.0, -70.5);
+  const auto cell_b = store.cellIndex(44.0, -71.0);
+  ASSERT_FALSE(cell_a.grid() == cell_b.grid());
+
+  std::map<gggs::GridIndex, marine_bathymetry_store::BathymetryTile> tiles;
+  // Tile built for grid_b but inserted under grid_a's key.
+  marine_bathymetry_store::BathymetryTile mismatched(cell_b.grid());
+  tiles.emplace(cell_a.grid(), std::move(mismatched));
+  EXPECT_THROW(
+    store.importEpoch(SourceLayer::Draft, kEpoch, std::move(tiles),
+    marine_bathymetry_store::Provenance::Replayed),
+    std::invalid_argument);
 }

--- a/marine_bathymetry_store/test/test_tile_io.cpp
+++ b/marine_bathymetry_store/test/test_tile_io.cpp
@@ -25,23 +25,32 @@
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
+#include <map>
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 #include <nlohmann/json.hpp>
 
 #include "marine_bathymetry_store/bathymetry_store.hpp"
+#include "marine_bathymetry_store/bathymetry_tile.hpp"
+#include "marine_bathymetry_store/epoch.hpp"
 #include "marine_bathymetry_store/registry.hpp"
 #include "marine_bathymetry_store/tile_io.hpp"
 #include "marine_tiled_raster_store/tile_io.hpp"
 
 using marine_bathymetry_store::BathyCell;
 using marine_bathymetry_store::BathymetryStore;
+using marine_bathymetry_store::Provenance;
 using marine_bathymetry_store::SourceLayer;
 using marine_bathymetry_store::SourceRecord;
 using marine_bathymetry_store::SourceRegistry;
 
 namespace fs = std::filesystem;
+
+// A single ISO-date epoch label used by the persistence round-trip tests. The
+// on-disk layout is `<dir>/<layer>/<epoch>/<level>_<row>_<col>.tif`.
+static const char * const kEpoch = "2026-06-10";
 
 class TileIoTest : public ::testing::Test
 {
@@ -69,10 +78,10 @@ TEST_F(TileIoTest, RoundTripPreservesCells)
   const int64_t ts_draft = 1'780'000'000'123'456'789LL;
   const int64_t ts_proc = 1'790'000'000'987'654'321LL;
   store.set(
-    SourceLayer::Draft, store.cellIndex(43.0, -70.5),
+    SourceLayer::Draft, kEpoch, store.cellIndex(43.0, -70.5),
     BathyCell{-30.123, 0.456, ts_draft, 7u});
   store.set(
-    SourceLayer::Processed, store.cellIndex(44.0, -71.0),
+    SourceLayer::Processed, kEpoch, store.cellIndex(44.0, -71.0),
     BathyCell{-12.5, 0.2, ts_proc, 0u});
 
   EXPECT_EQ(marine_bathymetry_store::save(store, dir_.string()), 2u);
@@ -80,7 +89,7 @@ TEST_F(TileIoTest, RoundTripPreservesCells)
   BathymetryStore reloaded(5);
   EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 2u);
 
-  const auto draft = reloaded.get(SourceLayer::Draft, reloaded.cellIndex(43.0, -70.5));
+  const auto draft = reloaded.get(SourceLayer::Draft, kEpoch, reloaded.cellIndex(43.0, -70.5));
   ASSERT_TRUE(draft.has_value());
   EXPECT_DOUBLE_EQ(draft->depth, -30.123);
   EXPECT_DOUBLE_EQ(draft->uncertainty, 0.456);
@@ -88,7 +97,8 @@ TEST_F(TileIoTest, RoundTripPreservesCells)
   EXPECT_EQ(draft->timestamp, ts_draft);
   EXPECT_EQ(draft->source_index, 7u);
 
-  const auto processed = reloaded.get(SourceLayer::Processed, reloaded.cellIndex(44.0, -71.0));
+  const auto pcell = reloaded.cellIndex(44.0, -71.0);
+  const auto processed = reloaded.get(SourceLayer::Processed, kEpoch, pcell);
   ASSERT_TRUE(processed.has_value());
   EXPECT_DOUBLE_EQ(processed->depth, -12.5);
   EXPECT_EQ(processed->timestamp, ts_proc);
@@ -100,17 +110,17 @@ TEST_F(TileIoTest, RoundTripPreservesSourceIndex)
   // through the separate UInt16 _source.tif independently of depth/time.
   BathymetryStore store(5);
   store.set(
-    SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 10LL, 1u});
+    SourceLayer::Draft, kEpoch, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 10LL, 1u});
   store.set(
-    SourceLayer::Draft, store.cellIndex(43.0, -70.4), BathyCell{-31.0, 0.5, 11LL, 4242u});
+    SourceLayer::Draft, kEpoch, store.cellIndex(43.0, -70.4), BathyCell{-31.0, 0.5, 11LL, 4242u});
   EXPECT_EQ(marine_bathymetry_store::save(store, dir_.string()), 1u);
 
   BathymetryStore reloaded(5);
   EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 1u);
   EXPECT_EQ(
-    reloaded.get(SourceLayer::Draft, reloaded.cellIndex(43.0, -70.5))->source_index, 1u);
+    reloaded.get(SourceLayer::Draft, kEpoch, reloaded.cellIndex(43.0, -70.5))->source_index, 1u);
   EXPECT_EQ(
-    reloaded.get(SourceLayer::Draft, reloaded.cellIndex(43.0, -70.4))->source_index, 4242u);
+    reloaded.get(SourceLayer::Draft, kEpoch, reloaded.cellIndex(43.0, -70.4))->source_index, 4242u);
 }
 
 TEST_F(TileIoTest, MissingTimeTileLoadsAsZero)
@@ -119,7 +129,7 @@ TEST_F(TileIoTest, MissingTimeTileLoadsAsZero)
   // must not fail — the timestamp band fills with 0 (backward compatibility).
   BathymetryStore store(5);
   store.set(
-    SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 99LL, 2u});
+    SourceLayer::Draft, kEpoch, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 99LL, 2u});
   marine_bathymetry_store::save(store, dir_.string());
 
   // Remove every _time.tif under the draft layer.
@@ -132,7 +142,7 @@ TEST_F(TileIoTest, MissingTimeTileLoadsAsZero)
 
   BathymetryStore reloaded(5);
   EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 1u);
-  const auto got = reloaded.get(SourceLayer::Draft, reloaded.cellIndex(43.0, -70.5));
+  const auto got = reloaded.get(SourceLayer::Draft, kEpoch, reloaded.cellIndex(43.0, -70.5));
   ASSERT_TRUE(got.has_value());
   EXPECT_DOUBLE_EQ(got->depth, -30.0);   // value tile still loaded
   EXPECT_EQ(got->timestamp, 0);          // missing time tile -> 0
@@ -143,7 +153,7 @@ TEST_F(TileIoTest, MissingSourceTileLoadsAsZero)
 {
   BathymetryStore store(5);
   store.set(
-    SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 99LL, 5u});
+    SourceLayer::Draft, kEpoch, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 99LL, 5u});
   marine_bathymetry_store::save(store, dir_.string());
 
   for (const auto & e : fs::recursive_directory_iterator(dir_ / "draft")) {
@@ -156,7 +166,7 @@ TEST_F(TileIoTest, MissingSourceTileLoadsAsZero)
 
   BathymetryStore reloaded(5);
   EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 1u);
-  const auto got = reloaded.get(SourceLayer::Draft, reloaded.cellIndex(43.0, -70.5));
+  const auto got = reloaded.get(SourceLayer::Draft, kEpoch, reloaded.cellIndex(43.0, -70.5));
   ASSERT_TRUE(got.has_value());
   EXPECT_EQ(got->timestamp, 99);         // time tile still loaded
   EXPECT_EQ(got->source_index, 0u);      // missing source tile -> 0
@@ -165,7 +175,7 @@ TEST_F(TileIoTest, MissingSourceTileLoadsAsZero)
 TEST_F(TileIoTest, LoadedTilesAreCleanAndDontResave)
 {
   BathymetryStore store(5);
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1LL});
+  store.set(SourceLayer::Draft, kEpoch, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1LL});
 
   EXPECT_EQ(marine_bathymetry_store::save(store, dir_.string()), 1u);
   // No changes since the last save -> nothing re-written (incremental save).
@@ -180,32 +190,48 @@ TEST_F(TileIoTest, LoadedTilesAreCleanAndDontResave)
 TEST_F(TileIoTest, WritingAfterSaveRedirties)
 {
   BathymetryStore store(5);
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1LL});
+  store.set(SourceLayer::Draft, kEpoch, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1LL});
   EXPECT_EQ(marine_bathymetry_store::save(store, dir_.string()), 1u);
 
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-31.0, 0.4, 2LL});
+  store.set(SourceLayer::Draft, kEpoch, store.cellIndex(43.0, -70.5), BathyCell{-31.0, 0.4, 2LL});
   EXPECT_EQ(marine_bathymetry_store::save(store, dir_.string()), 1u);
 }
 
 TEST_F(TileIoTest, LayersWriteToSeparateSubdirectories)
 {
   BathymetryStore store(5);
-  store.set(SourceLayer::Processed, store.cellIndex(43.0, -70.5), BathyCell{-10.0, 0.1, 1LL});
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-12.0, 0.5, 2LL});
+  const auto pcell = store.cellIndex(43.0, -70.5);
+  store.set(SourceLayer::Processed, kEpoch, pcell, BathyCell{-10.0, 0.1, 1LL});
+  store.set(SourceLayer::Draft, kEpoch, pcell, BathyCell{-12.0, 0.5, 2LL});
   marine_bathymetry_store::save(store, dir_.string());
 
   EXPECT_TRUE(fs::is_directory(dir_ / "processed"));
   EXPECT_TRUE(fs::is_directory(dir_ / "draft"));
 }
 
-TEST_F(TileIoTest, LoadRejectsTilesFromAnotherLevel)
+TEST_F(TileIoTest, LoadAcceptsMixedLevelTiles)
 {
-  BathymetryStore store(5);
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1LL});
-  marine_bathymetry_store::save(store, dir_.string());
+  // The store is multi-level (ADR-0002 §D2): tiles at different levels share an
+  // epoch directory, and load recovers each tile's level from its filename. A
+  // store loaded with a DIFFERENT default level still reads them all back.
+  BathymetryStore writer(5);
+  gggs::Level coarse(4);
+  gggs::Level fine(7);
+  const auto coarse_cell = coarse.cellIndex(gggs::geoPoint(43.0, -70.5));
+  const auto fine_cell = fine.cellIndex(gggs::geoPoint(43.0, -70.5));
+  writer.set(SourceLayer::Draft, kEpoch, coarse_cell, BathyCell{-30.0, 0.5, 1LL});
+  writer.set(SourceLayer::Draft, kEpoch, fine_cell, BathyCell{-22.0, 0.3, 2LL});
+  EXPECT_EQ(marine_bathymetry_store::save(writer, dir_.string()), 2u);
 
-  BathymetryStore wrong_level(6);
-  EXPECT_THROW(marine_bathymetry_store::load(wrong_level, dir_.string()), std::runtime_error);
+  // Reload into a store whose default level (6) matches NEITHER stored level.
+  BathymetryStore reloaded(6);
+  EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 2u);
+  const auto coarse_got = reloaded.get(SourceLayer::Draft, kEpoch, coarse_cell);
+  ASSERT_TRUE(coarse_got.has_value());
+  EXPECT_DOUBLE_EQ(coarse_got->depth, -30.0);
+  const auto fine_got = reloaded.get(SourceLayer::Draft, kEpoch, fine_cell);
+  ASSERT_TRUE(fine_got.has_value());
+  EXPECT_DOUBLE_EQ(fine_got->depth, -22.0);
 }
 
 TEST_F(TileIoTest, ChartRoundTripsAndLoadsIntoReadOnlyStore)
@@ -215,7 +241,7 @@ TEST_F(TileIoTest, ChartRoundTripsAndLoadsIntoReadOnlyStore)
   // set(), so the prior loads even though live set(Chart) stays forbidden.
   const int64_t ts = 1'780'000'000'000'000'000LL;
   BathymetryStore writer(5, /*chart_writable=*/true);
-  writer.set(SourceLayer::Chart, writer.cellIndex(43.0, -70.5), BathyCell{38.58, 3.0, ts});
+  writer.set(SourceLayer::Chart, kEpoch, writer.cellIndex(43.0, -70.5), BathyCell{38.58, 3.0, ts});
   EXPECT_EQ(marine_bathymetry_store::save(writer, dir_.string()), 1u);
   EXPECT_TRUE(fs::is_directory(dir_ / "chart"));
 
@@ -223,14 +249,15 @@ TEST_F(TileIoTest, ChartRoundTripsAndLoadsIntoReadOnlyStore)
   EXPECT_FALSE(runtime.chartWritable());
   EXPECT_EQ(marine_bathymetry_store::load(runtime, dir_.string()), 1u);
 
-  const auto got = runtime.get(SourceLayer::Chart, runtime.cellIndex(43.0, -70.5));
+  const auto rcell = runtime.cellIndex(43.0, -70.5);
+  const auto got = runtime.get(SourceLayer::Chart, kEpoch, rcell);
   ASSERT_TRUE(got.has_value());
   EXPECT_DOUBLE_EQ(got->depth, 38.58);
   EXPECT_EQ(got->timestamp, ts);
 
   // The read-only guard still holds after the prior is loaded.
   EXPECT_THROW(
-    runtime.set(SourceLayer::Chart, runtime.cellIndex(43.0, -70.5), BathyCell{1.0, 1.0, 1LL}),
+    runtime.set(SourceLayer::Chart, kEpoch, rcell, BathyCell{1.0, 1.0, 1LL}),
     std::logic_error);
 }
 
@@ -239,13 +266,13 @@ TEST_F(TileIoTest, ProcessedDraftOnlyStoreLoadsWithoutChartDir)
   // Back-compat: a Phase-1 store with no chart/ subdir still saves and loads;
   // the absent chart layer is simply skipped, not an error.
   BathymetryStore store(5);
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1LL});
+  store.set(SourceLayer::Draft, kEpoch, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1LL});
   marine_bathymetry_store::save(store, dir_.string());
   EXPECT_FALSE(fs::exists(dir_ / "chart"));   // no spurious empty chart/ dir
 
   BathymetryStore reloaded(5);
   EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 1u);
-  EXPECT_TRUE(reloaded.tiles(SourceLayer::Chart).empty());
+  EXPECT_TRUE(reloaded.epochs(SourceLayer::Chart).empty());
 }
 
 TEST_F(TileIoTest, RegistryAtomicWrite)
@@ -287,7 +314,8 @@ TEST_F(TileIoTest, SaveWritesRegistryWhenProvided)
 {
   // The store save() persists the registry sidecar once, at the store root.
   BathymetryStore store(5);
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1LL, 1u});
+  store.set(SourceLayer::Draft, kEpoch, store.cellIndex(43.0, -70.5),
+    BathyCell{-30.0, 0.5, 1LL, 1u});
   SourceRegistry registry;
   registry.registerSource(SourceRecord{"bizzy:m3:0", "bizzy", "m3", "multibeam", "", "ellipsoid"});
 
@@ -355,13 +383,13 @@ TEST_F(TileIoTest, LoadTileRejectsLegacyThreeBandValueTile)
   // seconds layout) must be rejected with a clear error on load rather than
   // silently loading 2 bands and discarding the third.
   namespace mtrs = marine_tiled_raster_store;
-  fs::create_directories(dir_ / "draft");
+  fs::create_directories(dir_ / "draft" / kEpoch);
 
   // Create a fake 3-band Float64 tile that mimics the old layout.
   const gggs::Level level(5);
   const gggs::GridIndex grid = level.gridIndex(43.0, -70.5);
   const std::string filename = marine_bathymetry_store::tileFilename(grid);
-  const std::string path = (dir_ / "draft" / filename).string();
+  const std::string path = (dir_ / "draft" / kEpoch / filename).string();
 
   mtrs::TiledRasterTile<double> legacy_tile(grid, 3, 0.0);
   legacy_tile.set(10, 20, 0, -12.5);    // depth
@@ -383,7 +411,7 @@ TEST_F(TileIoTest, LoadTileRejectsCompanionWithWrongGrid)
   // error rather than silently combining cell-for-cell data from two different
   // geographic locations.
   namespace mtrs = marine_tiled_raster_store;
-  fs::create_directories(dir_ / "draft");
+  fs::create_directories(dir_ / "draft" / kEpoch);
 
   const gggs::Level level(5);
   // Two grids in different locations.
@@ -393,7 +421,8 @@ TEST_F(TileIoTest, LoadTileRejectsCompanionWithWrongGrid)
 
   // Save a normal tile for grid_a.
   BathymetryStore store(5);
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 42LL, 1u});
+  store.set(SourceLayer::Draft, kEpoch, store.cellIndex(43.0, -70.5),
+    BathyCell{-30.0, 0.5, 42LL, 1u});
   marine_bathymetry_store::save(store, dir_.string());
 
   // Replace grid_a's _time companion with a time tile written for grid_b.
@@ -401,7 +430,7 @@ TEST_F(TileIoTest, LoadTileRejectsCompanionWithWrongGrid)
   // + "_time.tif"), but we write a file whose geotransform encodes grid_b.
   const std::string value_filename = marine_bathymetry_store::tileFilename(grid_a);
   const fs::path time_path =
-    dir_ / "draft" / (fs::path(value_filename).stem().string() + "_time.tif");
+    dir_ / "draft" / kEpoch / (fs::path(value_filename).stem().string() + "_time.tif");
   // Write a time tile for grid_b at that path (overwrites any existing companion).
   mtrs::TiledRasterTile<int64_t> wrong_time(grid_b, 1, int64_t{0});
   wrong_time.set(0, 0, 0, 99LL);
@@ -409,4 +438,120 @@ TEST_F(TileIoTest, LoadTileRejectsCompanionWithWrongGrid)
 
   BathymetryStore reloaded(5);
   EXPECT_THROW(marine_bathymetry_store::load(reloaded, dir_.string()), std::runtime_error);
+}
+
+// --- Epoch persistence (ADR-0002 Amendment A1) ---
+
+TEST_F(TileIoTest, EpochProvenanceRoundTrips)
+{
+  // A Replayed epoch's provenance must survive save/load via the marker file,
+  // so a reloaded compacted epoch stays immutable to live writes.
+  BathymetryStore writer(5);
+  const auto cell = writer.cellIndex(43.0, -70.5);
+  std::map<gggs::GridIndex, marine_bathymetry_store::BathymetryTile> tiles;
+  marine_bathymetry_store::BathymetryTile tile(cell.grid());
+  tile.set(cell.row(), cell.column(), BathyCell{-30.0, 0.5, 1LL});
+  tiles.emplace(cell.grid(), std::move(tile));
+  ASSERT_TRUE(
+    writer.importEpoch(SourceLayer::Draft, kEpoch, std::move(tiles), Provenance::Replayed));
+  marine_bathymetry_store::save(writer, dir_.string());
+
+  // The provenance marker exists in the epoch dir.
+  EXPECT_TRUE(fs::is_regular_file(dir_ / "draft" / kEpoch / "provenance"));
+
+  BathymetryStore reloaded(5);
+  EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 1u);
+  // The reloaded epoch is Replayed -> a live write is refused (no-op).
+  EXPECT_FALSE(reloaded.set(SourceLayer::Draft, kEpoch, cell, BathyCell{-99.0, 9.0, 2LL}));
+  EXPECT_DOUBLE_EQ(reloaded.get(SourceLayer::Draft, kEpoch, cell)->depth, -30.0);
+}
+
+TEST_F(TileIoTest, ReadProvenanceMarkerIsCrlfSafe)
+{
+  // A CRLF-terminated provenance marker (Windows / mixed checkout) must not be
+  // mis-parsed as garbage and silently downgraded to LiveFused — that would let
+  // live writes regress a Replayed epoch after a reload (harvested #148 fix).
+  BathymetryStore writer(5);
+  const auto cell = writer.cellIndex(43.0, -70.5);
+  std::map<gggs::GridIndex, marine_bathymetry_store::BathymetryTile> tiles;
+  marine_bathymetry_store::BathymetryTile tile(cell.grid());
+  tile.set(cell.row(), cell.column(), BathyCell{-30.0, 0.5, 1LL});
+  tiles.emplace(cell.grid(), std::move(tile));
+  writer.importEpoch(SourceLayer::Draft, kEpoch, std::move(tiles), Provenance::Replayed);
+  marine_bathymetry_store::save(writer, dir_.string());
+
+  // Rewrite the provenance marker with a CRLF line ending.
+  {
+    std::ofstream out(dir_ / "draft" / kEpoch / "provenance", std::ios::trunc | std::ios::binary);
+    out << "replayed\r\n";
+  }
+
+  BathymetryStore reloaded(5);
+  EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 1u);
+  // Still recognized as Replayed despite the CRLF -> live write refused.
+  EXPECT_FALSE(reloaded.set(SourceLayer::Draft, kEpoch, cell, BathyCell{-99.0, 9.0, 2LL}));
+}
+
+TEST_F(TileIoTest, SupersedesDiskClearsStaleTiles)
+{
+  // A wholesale re-import (importEpoch) that covers fewer grids must remove the
+  // stale tile files of the grids it no longer covers, so they aren't
+  // resurrected on the next load (supersedes_disk).
+  BathymetryStore writer(5);
+  const auto cell_a = writer.cellIndex(43.0, -70.5);
+  const auto cell_b = writer.cellIndex(44.0, -71.0);
+  ASSERT_FALSE(cell_a.grid() == cell_b.grid());
+
+  // First import covers two grids.
+  std::map<gggs::GridIndex, marine_bathymetry_store::BathymetryTile> first;
+  for (const auto & c : {cell_a, cell_b}) {
+    marine_bathymetry_store::BathymetryTile t(c.grid());
+    t.set(c.row(), c.column(), BathyCell{-30.0, 0.5, 1LL});
+    first.emplace(c.grid(), std::move(t));
+  }
+  writer.importEpoch(SourceLayer::Draft, kEpoch, std::move(first), Provenance::Replayed);
+  EXPECT_EQ(marine_bathymetry_store::save(writer, dir_.string()), 2u);
+
+  // Re-import the SAME epoch covering only grid_a.
+  std::map<gggs::GridIndex, marine_bathymetry_store::BathymetryTile> second;
+  {
+    marine_bathymetry_store::BathymetryTile t(cell_a.grid());
+    t.set(cell_a.row(), cell_a.column(), BathyCell{-28.0, 0.4, 2LL});
+    second.emplace(cell_a.grid(), std::move(t));
+  }
+  writer.importEpoch(SourceLayer::Draft, kEpoch, std::move(second), Provenance::Replayed);
+  marine_bathymetry_store::save(writer, dir_.string());
+
+  // grid_b's tile files must be gone; a fresh load sees only grid_a.
+  BathymetryStore reloaded(5);
+  EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 1u);
+  EXPECT_TRUE(reloaded.get(SourceLayer::Draft, kEpoch, cell_a).has_value());
+  EXPECT_FALSE(reloaded.get(SourceLayer::Draft, kEpoch, cell_b).has_value());
+}
+
+TEST_F(TileIoTest, EpochsPersistToSeparateDirectories)
+{
+  // Two epochs of one layer save to distinct subdirectories and both reload.
+  BathymetryStore writer(5);
+  const auto cell = writer.cellIndex(43.0, -70.5);
+  writer.set(SourceLayer::Draft, "2026-06-09", cell, BathyCell{-30.0, 0.5, 1LL});
+  writer.set(SourceLayer::Draft, "2026-06-11", cell, BathyCell{-28.0, 0.5, 2LL});
+  EXPECT_EQ(marine_bathymetry_store::save(writer, dir_.string()), 2u);
+
+  EXPECT_TRUE(fs::is_directory(dir_ / "draft" / "2026-06-09"));
+  EXPECT_TRUE(fs::is_directory(dir_ / "draft" / "2026-06-11"));
+
+  BathymetryStore reloaded(5);
+  EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 2u);
+  EXPECT_EQ(reloaded.epochs(SourceLayer::Draft).size(), 2u);
+  EXPECT_DOUBLE_EQ(reloaded.get(SourceLayer::Draft, "2026-06-09", cell)->depth, -30.0);
+  EXPECT_DOUBLE_EQ(reloaded.get(SourceLayer::Draft, "2026-06-11", cell)->depth, -28.0);
+}
+
+TEST_F(TileIoTest, LevelFromTileFilenameParsesPrefix)
+{
+  EXPECT_EQ(marine_bathymetry_store::levelFromTileFilename("7_12_34.tif"), 7u);
+  EXPECT_EQ(marine_bathymetry_store::levelFromTileFilename("12_0_0.tif"), 12u);
+  EXPECT_THROW(marine_bathymetry_store::levelFromTileFilename("foo.tif"), std::runtime_error);
+  EXPECT_THROW(marine_bathymetry_store::levelFromTileFilename("99_0_0.tif"), std::runtime_error);
 }


### PR DESCRIPTION
## Summary

PR-A of bathymetric-store Phase-2 import, **re-platformed onto the current store**.
This supersedes #148, which was built on the pre-#172/#178 store API (generic
tiled-raster core refactor + Int64-time/UInt16-source tile format + SourceRegistry)
and had diverged ~74 commits. #148's *designs* (per-day epoch model, GeoTIFF importer,
change maps — field-validated end-to-end on real pier + Massabesic data) are harvested
here and rebuilt on the new foundation. **Part of #147** (PR-B = cube-side bag-replay
importer via the merged `DetectionsProjector` #43, follows).

## What's in PR-A
- **Multi-level / level-aware best-available query** (resolves the old M1 blocker — the
  store holds heterogeneous GGGS levels; `bestSource`/`shallowestReliable` resolve
  best-available across levels). `DepthSample` gains `source_index`, `level`, `epoch`.
- **Per-day epoch model**: each layer is `map<Epoch, EpochTiles>`; a cell surveyed N days
  keeps N epochs, never fused (repeat surveys *locate change*). `importEpoch` wholesale-
  replace, `Replayed`-immutable ordering, newest-first epoch-walk query, `forEachChangedCell`.
- **Epoch-aware persistence**: `<layer>/<epoch>/<level>_<row>_<col>.tif`, mixed-level load
  (level parsed from filename), CRLF-safe provenance marker, stale-tile cleanup.
- **GeoTIFF footprint importer + CLI + SourceRegistry provenance** (datum-at-import,
  lowest-uncertainty contention, no-data guards on both bands, per-cell source index).
- **ADR-0002 Amendment A1** (per-day epoch model) authored fresh, reconciled with the
  merged D2 (heterogeneous levels) / D5 (#178).
- **Read-only Chart prior preserved by construction**: both `set()` and `importEpoch`
  gate Chart behind `chart_writable` (the importer is the only sanctioned writer).

## Tests
68 gtests, 0 failures (test_store 18, test_query 17, test_tile_io 22, test_geotiff_import 11)
— epoch never-fused, multi-level resolution, mixed-level persistence, Chart read-only gate
(incl. via importEpoch), importer round-trips. Deep pre-push review (two adversarial passes)
approved; 1 must-fix (Chart gate) + 2 suggestions resolved.

Part of #147


---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
