### PR TITLE
build(store): export nlohmann_json + GDAL deps for consumers (#203)

### DIFF
--- a/.agent/work-plans/issue-203/progress.md
+++ b/.agent/work-plans/issue-203/progress.md
@@ -1,0 +1,29 @@
+---
+issue: 203
+---
+
+# Issue #203 — marine_bathymetry_store: export nlohmann_json (and GDAL) deps
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-21 11:27 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved
+**Round**: 1
+**Ship**: recommended
+
+**Branch**: feature/issue-203 at `f3a384f`
+**Mode**: pre-push
+**Depth**: Light (reason: one-line ament_export_dependencies change; CMake export only)
+**Must-fix**: 0 | **Suggestions**: 0
+
+Host self-review (full adversarial dispatch disproportionate for a 1-line export change).
+Verified: the generated ament_cmake_export_dependencies-extras.cmake now lists
+`nlohmann_json;GDAL` (was missing them); store builds clean; gtests pass (the 3 test.sh
+failures are the known local uncrustify-0.78.1 drift on unmodified base files). The change
+only ADDS exports consumers already needed via the static lib's $<LINK_ONLY> propagation —
+no interface widening risk. Follow-up: remove cube_bathymetry's find_package(nlohmann_json)
+workaround once this merges + syncs (noted in #57's review entry / unh_marine_autonomy#203).
+
+### Findings
+- [ ] No issues found. LGTM.

--- a/marine_bathymetry_store/CMakeLists.txt
+++ b/marine_bathymetry_store/CMakeLists.txt
@@ -73,7 +73,13 @@ add_executable(import_geotiff src/import_geotiff_main.cpp)
 target_link_libraries(import_geotiff ${PROJECT_NAME})
 
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
-ament_export_dependencies(marine_autonomy marine_tiled_raster_store geographic_msgs)
+# nlohmann_json and GDAL are PRIVATE link deps, but a static library propagates them
+# into the export's INTERFACE_LINK_LIBRARIES as $<LINK_ONLY:...>, so a consumer that
+# just find_package(marine_bathymetry_store) + links it must still resolve those
+# targets at generate time. Export them so consumers don't each have to re-find them
+# (#203; cube_bathymetry#57 hit this).
+ament_export_dependencies(
+  marine_autonomy marine_tiled_raster_store geographic_msgs nlohmann_json GDAL)
 
 install(TARGETS import_geotiff RUNTIME DESTINATION lib/${PROJECT_NAME})
 


### PR DESCRIPTION
## Summary

Export `marine_bathymetry_store`'s `nlohmann_json` and GDAL dependencies so
downstream consumers don't each have to re-`find_package` them.

## Why
Both are PRIVATE link deps, but a static library propagates them into the export's
`INTERFACE_LINK_LIBRARIES` as `$<LINK_ONLY:...>`. So a consumer that just
`find_package(marine_bathymetry_store)` + links it must still resolve
`nlohmann_json::nlohmann_json` at CMake-generate time — which fails unless the
consumer also `find_package(nlohmann_json)` itself. cube_bathymetry#57 (the
bag-replay store importer) hit exactly this and carried a workaround.

## Change
`ament_export_dependencies(... nlohmann_json GDAL)`. Verified the generated
`ament_cmake_export_dependencies-extras.cmake` now lists `nlohmann_json;GDAL`
(previously only `marine_autonomy;marine_tiled_raster_store;geographic_msgs`).
Store builds clean; gtests pass. Only ADDS exports consumers already needed via the
static-lib LINK_ONLY propagation — no interface widening.

Once this syncs, the cube_bathymetry workaround (`find_package(nlohmann_json)` +
`nlohmann-json-dev` depend) is removed in a follow-up.

Closes #203


---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
