### PR TITLE
test(integration): gate discovery on heartbeat publisher match — fix flaky heartbeat race (#146)

### DIFF
--- a/.agent/work-plans/issue-146/plan.md
+++ b/.agent/work-plans/issue-146/plan.md
@@ -29,6 +29,12 @@ count.
    before returning `True`. The existing `get_subscription_count()` pattern on the publisher
    side is symmetric; `get_publisher_count()` on the subscriber side is the idiomatic
    rclpy API (confirmed available via `Subscription.get_publisher_count()`).
+   **Also update the discovery-timeout assert message (`:142-143`)** — it currently
+   says only "no subscribers were discovered", but with the new gate the loop can
+   also time out on the heartbeat-*publisher* side; reword to name both conditions
+   (command-bridge subscriber **and** heartbeat publisher) so a future timeout is
+   diagnosable (review-plan suggestion; only `command_flow.py` has the specific
+   message — the four nav files use a generic "DDS discovery timed out.").
 
 2. **Apply the same fix to the other four affected test files** — `_wait_for_discovery()`
    in each of these files gates only on `cmd_pub.get_subscription_count() > 0`, leaving
@@ -46,7 +52,7 @@ count.
 
 | File | Change |
 |------|--------|
-| `marine_autonomy_integration_tests/test/test_mission_command_flow.py` | Add `and self.heartbeat_sub.get_publisher_count() > 0` to the `_wait_for_discovery` condition (line 155) |
+| `marine_autonomy_integration_tests/test/test_mission_command_flow.py` | Add `and self.heartbeat_sub.get_publisher_count() > 0` to the `_wait_for_discovery` condition (line 155); update the discovery-timeout assert message (`:142-143`) to name both the command-bridge subscriber and the heartbeat publisher |
 | `marine_autonomy_integration_tests/test/test_mission_navigation_flow.py` | Same gate addition in `_wait_for_discovery` (line 134) |
 | `marine_autonomy_integration_tests/test/test_mission_navigation_override.py` | Same gate addition in `_wait_for_discovery` (line 129) |
 | `marine_autonomy_integration_tests/test/test_mission_navigation_rejection.py` | Same gate addition in `_wait_for_discovery` (line 127) |

--- a/.agent/work-plans/issue-146/plan.md
+++ b/.agent/work-plans/issue-146/plan.md
@@ -1,0 +1,84 @@
+# Plan: Flaky CI: test_mission_reaches_navigator_and_heartbeat fails with empty heartbeats
+
+## Issue
+
+https://github.com/rolker/unh_marine_autonomy/issues/146
+
+## Context
+
+`TestMissionCommandFlow.test_mission_reaches_navigator_and_heartbeat` fails intermittently
+with `heartbeats: []` even when code is unchanged. Root cause: `setUp._wait_for_discovery()`
+gates only on `send_command_pub.get_subscription_count() > 0` (command bridge routing is
+connected), but does not wait for the test's `heartbeat_sub` to match with
+`mission_manager`'s lifecycle publisher on `marine/status/mission_manager`.
+
+The lifecycle publisher is created in `on_configure()` and becomes active only after the
+configure+activate transitions complete. Heartbeats are published during mock navigator
+feedback (2 messages at 0.3 s intervals = ~0.6 s window). If DDS subscriber matching
+hasn't completed before that window, the messages are lost (no transient-local QoS) and
+`_spin_until(has_active_heartbeat, timeout=20.0)` returns with an empty list.
+
+The same subscriber-discovery gap exists in four other test files that also subscribe to
+`marine/status/mission_manager` but gate only on their command publisher's subscription
+count.
+
+## Approach
+
+1. **Add heartbeat-subscriber discovery gate in `test_mission_command_flow.py`** — extend
+   `_wait_for_discovery()` to also require `self.heartbeat_sub.get_publisher_count() > 0`
+   before returning `True`. The existing `get_subscription_count()` pattern on the publisher
+   side is symmetric; `get_publisher_count()` on the subscriber side is the idiomatic
+   rclpy API (confirmed available via `Subscription.get_publisher_count()`).
+
+2. **Apply the same fix to the other four affected test files** — `_wait_for_discovery()`
+   in each of these files gates only on `cmd_pub.get_subscription_count() > 0`, leaving
+   the heartbeat subscriber without a matching gate:
+   - `test_mission_navigation_flow.py`
+   - `test_mission_navigation_override.py`
+   - `test_mission_navigation_rejection.py`
+   - `test_mission_navigation_failure.py`
+
+3. **No QoS changes** — the issue review recommended against transient-local QoS on the
+   heartbeat topic because that alters production topic behavior. The subscription-count
+   gate is sufficient and keeps the fix test-local.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `marine_autonomy_integration_tests/test/test_mission_command_flow.py` | Add `and self.heartbeat_sub.get_publisher_count() > 0` to the `_wait_for_discovery` condition (line 155) |
+| `marine_autonomy_integration_tests/test/test_mission_navigation_flow.py` | Same gate addition in `_wait_for_discovery` (line 134) |
+| `marine_autonomy_integration_tests/test/test_mission_navigation_override.py` | Same gate addition in `_wait_for_discovery` (line 129) |
+| `marine_autonomy_integration_tests/test/test_mission_navigation_rejection.py` | Same gate addition in `_wait_for_discovery` (line 127) |
+| `marine_autonomy_integration_tests/test/test_mission_navigation_failure.py` | Same gate addition in `_wait_for_discovery` (line 135) |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Test what breaks | Fix targets the observed CI race directly; no timeout inflation or unrelated changes |
+| A change includes its consequences | All five affected test files are fixed in the same PR |
+| Only what's needed | One-line change per file; no QoS changes, no new infrastructure |
+| Safety First (project) | Heartbeat is safety-relevant telemetry; reliable test coverage matters |
+| Standards Compliance (project) | `Subscription.get_publisher_count()` is the idiomatic rclpy pattern |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0008 — ROS 2 conventions | Yes | Uses standard rclpy subscription API (`get_publisher_count()`); matches existing `get_subscription_count()` pattern already in these files |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `_wait_for_discovery` in `test_mission_command_flow.py` | The other 4 test files with the same gap | Yes — all 5 files in scope |
+| Discovery timeout (currently 10 s in four files, 10 s hardcoded in one) | No change needed; adding a second condition to the same loop is sufficient | N/A |
+
+## Open Questions
+
+- None — the fix approach is unambiguous and confirmed by the issue review.
+
+## Estimated Scope
+
+Single PR — five one-line changes in five test files, all in the same package.

--- a/.agent/work-plans/issue-146/progress.md
+++ b/.agent/work-plans/issue-146/progress.md
@@ -122,3 +122,18 @@ No QoS, timeout, or production-code changes (per plan §3 and review-plan).
 
 ### Open questions
 - [ ] None.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-22 03:09 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-146 at `021313b`
+**Mode**: pre-push
+**Depth**: Light (reason: small, test-only Python change — 14 changed code lines, no production code)
+**Must-fix**: 0 | **Suggestions**: 0
+**Round**: 1 | **Ship**: recommended — no Must-fix findings; both static analysis and the Lens A adversarial pass came back clean
+
+### Findings
+- [ ] No issues found. LGTM.

--- a/.agent/work-plans/issue-146/progress.md
+++ b/.agent/work-plans/issue-146/progress.md
@@ -67,3 +67,21 @@ timeout=20.0)` times out with an empty list.
 
 ### Open questions
 - [ ] No open questions — plan is review-plan-ready.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-06-22 01:59 +00:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Plan**: `.agent/work-plans/issue-146/plan.md` at `c9375d4`
+**PR**: PR-less (--issue mode)
+**Verdict**: approve-with-suggestions
+
+### Findings
+- [ ] (suggestion) `test_mission_command_flow.py:142-143` assert message still says "no subscribers were discovered"; after adding the heartbeat-publisher gate the loop can also fail on the subscriber side. Update the message to name both conditions so a future discovery timeout is diagnosable. (The four nav files use a generic "DDS discovery timed out." message, so this only affects command_flow.) — `plan.md:49`
+- [ ] (verified, no action) All four nav-test files share the exact gap: same `heartbeat_sub` on `marine/status/mission_manager`, gated only on `cmd_pub.get_subscription_count()`. Each genuinely consumes heartbeats (incl. `test_mission_navigation_rejection`, which asserts heartbeat *absence* — the gate prevents a false pass from an undiscovered subscriber). Consequence coverage is complete. — `plan.md:33-39`
+
+### Notes
+- Line numbers in the Files-to-Change table (155/134/129/127/135) all match the current code. `Subscription.get_publisher_count()` is a valid rclpy/Jazzy API and mirrors the existing `get_subscription_count()` pattern — idiomatic per ADR-0008.
+- review-issue findings are all addressed: the subscription-count gate (option 1) is chosen over transient-local QoS (option 3), and all four sibling files flagged in the consequences are in scope.
+- Discovery timeout stays at 10s; since the heartbeat publisher only matches after configure+activate, confirm CI brings the lifecycle node to active well within 10s (the downstream `_spin_until(has_active_heartbeat, timeout=20.0)` already assumes this, so no added risk). No change requested.

--- a/.agent/work-plans/issue-146/progress.md
+++ b/.agent/work-plans/issue-146/progress.md
@@ -85,3 +85,40 @@ timeout=20.0)` times out with an empty list.
 - Line numbers in the Files-to-Change table (155/134/129/127/135) all match the current code. `Subscription.get_publisher_count()` is a valid rclpy/Jazzy API and mirrors the existing `get_subscription_count()` pattern — idiomatic per ADR-0008.
 - review-issue findings are all addressed: the subscription-count gate (option 1) is chosen over transient-local QoS (option 3), and all four sibling files flagged in the consequences are in scope.
 - Discovery timeout stays at 10s; since the heartbeat publisher only matches after configure+activate, confirm CI brings the lifecycle node to active well within 10s (the downstream `_spin_until(has_active_heartbeat, timeout=20.0)` already assumes this, so no added risk). No change requested.
+
+## Implementation
+**Status**: complete
+**When**: 2026-06-22 02:53 +00:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Plan**: `.agent/work-plans/issue-146/plan.md` at `eb920a3`
+**Branch**: feature/issue-146 at `4d76935`
+**Phases**: single
+
+### What changed
+Extended the `_wait_for_discovery()` return condition in all five affected
+integration test files to also require the heartbeat subscriber to have matched
+a publisher (`and self.heartbeat_sub.get_publisher_count() > 0`) before
+returning `True`. Confirmed the subscriber attribute is `self.heartbeat_sub` in
+each file. This closes the DDS subscriber-discovery race that allowed the
+~0.6 s heartbeat burst to be lost before subscriber matching completed.
+
+- `marine_autonomy_integration_tests/test/test_mission_command_flow.py` — gate added; **also** reworded the discovery-timeout assert message (was "no subscribers were discovered") to name *both* conditions: the `marine/send_command` command-bridge subscriber **and** the `marine/status/mission_manager` heartbeat publisher, so a future timeout is diagnosable.
+- `marine_autonomy_integration_tests/test/test_mission_navigation_flow.py` — gate added.
+- `marine_autonomy_integration_tests/test/test_mission_navigation_override.py` — gate added.
+- `marine_autonomy_integration_tests/test/test_mission_navigation_rejection.py` — gate added (the heartbeat-*absence* assertion benefits most: the gate prevents a false pass from an undiscovered subscriber).
+- `marine_autonomy_integration_tests/test/test_mission_navigation_failure.py` — gate added.
+
+No QoS, timeout, or production-code changes (per plan §3 and review-plan).
+
+### Verification
+- `python3 -m py_compile` on all five edited files — clean.
+- Integration test (`test_mission_reaches_navigator_and_heartbeat`) was **not**
+  run locally: this layer worktree has no built workspace (no `core_ws/install`),
+  and these `launch_testing` tests require the full mission stack (mission_manager
+  lifecycle node, command bridge, mock navigator). CI is the real gate. As noted
+  in the task, a single green run would be necessary-not-sufficient for a timing
+  race anyway.
+
+### Open questions
+- [ ] None.

--- a/.agent/work-plans/issue-146/progress.md
+++ b/.agent/work-plans/issue-146/progress.md
@@ -55,3 +55,15 @@ timeout=20.0)` times out with an empty list.
 - [ ] In `_wait_for_discovery()` (or `setUp()`), add heartbeat subscriber match gate: wait until `self.heartbeat_sub.get_publisher_count() > 0` before returning True.
 - [ ] Audit other integration test files for the same subscriber-discovery gap; fix in the same PR or open follow-up issues.
 - [ ] Prefer the subscription-count gate (option 1) over transient-local QoS changes (option 3) — the former fixes the test without altering production topic behavior.
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-22 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Plan**: `.agent/work-plans/issue-146/plan.md` at `c9375d4`
+**Branch**: feature/issue-146 at `c9375d4`
+**Phases**: single
+
+### Open questions
+- [ ] No open questions — plan is review-plan-ready.

--- a/.agent/work-plans/issue-146/progress.md
+++ b/.agent/work-plans/issue-146/progress.md
@@ -1,0 +1,57 @@
+---
+issue: 146
+---
+
+# Issue #146 — Flaky CI: test_mission_reaches_navigator_and_heartbeat fails with empty heartbeats
+
+## Issue Review
+**Status**: complete
+**When**: 2026-06-21 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Issue**: #146
+**Comment**: (best-effort post follows this entry; not recorded inline)
+**Scope verdict**: well-scoped
+
+### Summary
+
+`TestMissionCommandFlow.test_mission_reaches_navigator_and_heartbeat` fails on CI
+with `heartbeats: []` on a docs-only PR — pass-on-rerun confirms a DDS timing race,
+not a code regression.
+
+Root cause: `setUp()` calls `_wait_for_discovery()` which gates only on
+`send_command_pub.get_subscription_count() > 0`. The heartbeat subscriber
+(`self.heartbeat_sub`) has no corresponding discovery gate. If mission_manager
+publishes heartbeats before DDS matches the subscriber, those messages are lost
+(no transient-local QoS on the heartbeat topic) and `_spin_until(has_active_heartbeat,
+timeout=20.0)` times out with an empty list.
+
+### Principle Alignment
+
+| Principle | Status | Notes |
+|---|---|---|
+| Test what breaks | OK | Targets a real, observed CI failure with concrete evidence (PR #142 failing run vs. rerun). Fix addresses the root race, not a timeout band-aid. |
+| A change includes its consequences | Watch | Other integration tests (`test_mission_navigation_flow.py`, etc.) share the same discovery pattern and likely have the same gap. |
+| Only what's needed | Watch | Three options proposed; prefer minimal subscription-count gate (option 1) over QoS changes (option 3) which alter production behavior. |
+| Improve incrementally | OK | Targeted single-file fix; single PR viable. |
+| Safety First (project) | OK | Heartbeat is safety-relevant telemetry; reliable test coverage for it is important. |
+| Standards Compliance (project) | OK | `get_publisher_count()` is the standard ROS 2 subscriber-side discovery pattern. |
+
+### ADR Applicability
+
+| ADR | Triggered | Notes |
+|---|---|---|
+| ADR-0008 — ROS 2 conventions | Yes | Implementation should follow jazzy discovery patterns; `get_publisher_count()` on the subscriber is idiomatic. |
+| ADR-0002 — Worktree isolation | Already satisfied | Worktree for issue-146 exists. |
+
+### Consequences
+
+- Other test files in `marine_autonomy_integration_tests/test/` should be audited
+  for the same heartbeat-subscriber discovery gap
+  (`test_mission_navigation_flow.py`, `test_mission_navigation_override.py`,
+  `test_mission_navigation_rejection.py`, `test_mission_navigation_failure.py`).
+
+### Actions
+- [ ] In `_wait_for_discovery()` (or `setUp()`), add heartbeat subscriber match gate: wait until `self.heartbeat_sub.get_publisher_count() > 0` before returning True.
+- [ ] Audit other integration test files for the same subscriber-discovery gap; fix in the same PR or open follow-up issues.
+- [ ] Prefer the subscription-count gate (option 1) over transient-local QoS changes (option 3) — the former fixes the test without altering production topic behavior.

--- a/marine_autonomy_integration_tests/test/test_mission_command_flow.py
+++ b/marine_autonomy_integration_tests/test/test_mission_command_flow.py
@@ -139,8 +139,10 @@ class TestMissionCommandFlow(unittest.TestCase):
         discovered = self._wait_for_discovery()
         self.assertTrue(
             discovered,
-            'DDS discovery did not complete for "marine/send_command" '
-            'within 10 seconds; no subscribers were discovered.',
+            'DDS discovery did not complete within 10 seconds: '
+            'either the "marine/send_command" subscriber (command bridge) '
+            'or the "marine/status/mission_manager" heartbeat publisher '
+            'was not discovered.',
         )
 
     def tearDown(self):
@@ -152,7 +154,8 @@ class TestMissionCommandFlow(unittest.TestCase):
         end_time = time.time() + 10.0
         while time.time() < end_time:
             rclpy.spin_once(self.node, timeout_sec=0.1)
-            if self.send_command_pub.get_subscription_count() > 0:
+            if (self.send_command_pub.get_subscription_count() > 0
+                    and self.heartbeat_sub.get_publisher_count() > 0):
                 return True
         return False
 

--- a/marine_autonomy_integration_tests/test/test_mission_navigation_failure.py
+++ b/marine_autonomy_integration_tests/test/test_mission_navigation_failure.py
@@ -132,7 +132,8 @@ class TestMissionNavigationFailure(unittest.TestCase):
         end_time = time.time() + timeout
         while time.time() < end_time:
             rclpy.spin_once(self.node, timeout_sec=0.1)
-            if self.cmd_pub.get_subscription_count() > 0:
+            if (self.cmd_pub.get_subscription_count() > 0
+                    and self.heartbeat_sub.get_publisher_count() > 0):
                 return True
         return False
 

--- a/marine_autonomy_integration_tests/test/test_mission_navigation_flow.py
+++ b/marine_autonomy_integration_tests/test/test_mission_navigation_flow.py
@@ -131,7 +131,8 @@ class TestMissionNavigationFlow(unittest.TestCase):
         end_time = time.time() + timeout
         while time.time() < end_time:
             rclpy.spin_once(self.node, timeout_sec=0.1)
-            if self.cmd_pub.get_subscription_count() > 0:
+            if (self.cmd_pub.get_subscription_count() > 0
+                    and self.heartbeat_sub.get_publisher_count() > 0):
                 return True
         return False
 

--- a/marine_autonomy_integration_tests/test/test_mission_navigation_override.py
+++ b/marine_autonomy_integration_tests/test/test_mission_navigation_override.py
@@ -126,7 +126,8 @@ class TestMissionNavigationOverride(unittest.TestCase):
         end_time = time.time() + timeout
         while time.time() < end_time:
             rclpy.spin_once(self.node, timeout_sec=0.1)
-            if self.cmd_pub.get_subscription_count() > 0:
+            if (self.cmd_pub.get_subscription_count() > 0
+                    and self.heartbeat_sub.get_publisher_count() > 0):
                 return True
         return False
 

--- a/marine_autonomy_integration_tests/test/test_mission_navigation_rejection.py
+++ b/marine_autonomy_integration_tests/test/test_mission_navigation_rejection.py
@@ -124,7 +124,8 @@ class TestMissionNavigationRejection(unittest.TestCase):
         end_time = time.time() + timeout
         while time.time() < end_time:
             rclpy.spin_once(self.node, timeout_sec=0.1)
-            if self.cmd_pub.get_subscription_count() > 0:
+            if (self.cmd_pub.get_subscription_count() > 0
+                    and self.heartbeat_sub.get_publisher_count() > 0):
                 return True
         return False
 


### PR DESCRIPTION
Closes #146.

## Problem

`TestMissionCommandFlow.test_mission_reaches_navigator_and_heartbeat` (and four sibling nav tests) flake in CI with `heartbeats: []` on unchanged code — a startup race, confirmed by pass-on-rerun on a docs-only PR (#142).

**Root cause:** `_wait_for_discovery()` gates only on the *command* publisher's `get_subscription_count() > 0` — it does **not** wait for the test's `heartbeat_sub` to match `mission_manager`'s lifecycle publisher on `marine/status/mission_manager`. That publisher only goes live after configure+activate; heartbeats publish in a ~0.6 s window (2 msgs @ 0.3 s) with no transient-local QoS. On a slow CI runner, DDS subscriber matching can miss the window → empty list.

## Fix (test-only, 5 files)

Add a heartbeat-subscriber discovery gate to `_wait_for_discovery()` in all five integration tests that subscribe to `marine/status/mission_manager`:

```python
... and self.heartbeat_sub.get_publisher_count() > 0
```

`Subscription.get_publisher_count()` is the idiomatic rclpy/Jazzy mirror of the `get_subscription_count()` already used on the publisher side (ADR-0008). No QoS change, no timeout inflation, no production code touched.

Files: `test_mission_command_flow.py`, `test_mission_navigation_flow.py`, `test_mission_navigation_override.py`, `test_mission_navigation_rejection.py`, `test_mission_navigation_failure.py`.

Also: `test_mission_command_flow.py`'s discovery-timeout assert message now names **both** the command-bridge subscriber and the heartbeat publisher, so a future timeout is diagnosable from either side.

Note: `test_mission_navigation_rejection` asserts heartbeat *absence* — the gate specifically prevents a **false pass** from an undiscovered subscriber there.

## Verification

`python3 -m py_compile` clean on all five. The integration test couldn't be exercised in the sandboxed dispatch environment (no built ROS workspace) — **CI is the gate**. Being a timing race, a single green run is necessary-not-sufficient; the gate is the structural fix.

## Provenance

`/run-issue`, all phases container-dispatched via the #552 `--context-file` flow: review-issue → plan → review-plan (1 suggestion: diagnosable timeout message — folded in) → implement (Opus) → review-code R1 **approved, 0 must-fix** (static + adversarial clean). plan-task hit a transient API 529-overload once and was retried clean.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8`
