### PR TITLE
Phase 4: bathymetry_layer Nav2 costmap plugin (#164)

### DIFF
--- a/.agent/work-plans/issue-164/plan.md
+++ b/.agent/work-plans/issue-164/plan.md
@@ -1,0 +1,284 @@
+# Plan: Phase 4 — bathymetry_layer Nav2 costmap plugin (D1 prior-only)
+
+## Issue
+
+https://github.com/rolker/unh_marine_autonomy/issues/164
+
+## Context
+
+The bathymetric store (`marine_bathymetry_store`, #141) is merged. `loadWindow` /
+`evictOutside` (#205) are confirmed present in `tile_io.hpp`. What is missing is a
+Nav2 costmap plugin that reads the store and turns ellipsoidal depth into occupancy
+cost so the planner avoids shoals.
+
+This plan covers **D1 only** (prior-only, static `chart/` + `processed/` reads).
+D2 (live Draft reload triggered by #189 atomic writes) is a follow-on issue —
+name it at the bottom of this plan.
+
+The new plugin mirrors `s57_tools/s57_layer` in lifecycle, param naming, and
+pluginlib wiring. The key simplification: the store is already WGS84-ellipsoidal,
+so the layer needs only a `map_tide` frame — not `chart_datum`/VDatum. Clearance
+is `z(map_tide) − seafloor_ellipsoidal_height`.
+
+**Settled decisions (do not relitigate):**
+- Scope = D1 prior-only (static) this PR.
+- No-data policy: `std::nullopt` from `shallowestReliable` (truly unsurveyed) →
+  `NO_INFORMATION`; a cell with data but stale/over-uncertain (data exists,
+  fails the quality gate) → `LETHAL_OBSTACLE` (conservative per ADR-0002 §D7).
+- D2 and its tile-change detection mechanism → follow-on issue.
+
+## Approach
+
+### Step 1 — Create the `bathymetry_layer` package skeleton
+
+Create `core_ws/src/unh_marine_autonomy/bathymetry_layer/` with:
+
+- `package.xml` (format 3, `ament_cmake`, `BSD`) — depends on
+  `marine_bathymetry_store`, `nav2_costmap_2d`, `pluginlib`, `rclcpp`,
+  `geodesy`, `geographic_msgs`, `tf2_ros`.
+- `CMakeLists.txt` — shared library target, `pluginlib_export_plugin_description_file`,
+  gtest targets, lint suppressions matching `s57_layer`'s pattern.
+- `costmap_plugins.xml` — export `bathymetry_layer::BathymetryLayer` as a
+  `nav2_costmap_2d::Layer`.
+- `src/bathymetry_layer.hpp` + `src/bathymetry_layer.cpp`.
+
+### Step 2 — Implement `BathymetryLayer` (plugin core)
+
+Mirror `S57Layer`'s lifecycle:
+
+**`onInitialize()`** — declare and load parameters:
+- `enabled` (bool, default `true`)
+- `store_path` (string, required — path to store directory on disk)
+- `minimum_depth` (double, default `1.0` m) — clearance below this → LETHAL
+- `maximum_caution_depth` (double, default `2.5` m) — clearance above this → FREE_SPACE;
+  between `minimum_depth` and `maximum_caution_depth` → linearly scaled cost
+  (same ramp formula as `s57_layer::get_cost_from_grid`)
+- `max_uncertainty` (double, default `0.5` m) — max 1-sigma uncertainty for
+  `shallowestReliable`; if no cell passes → stale/over-uncertain → LETHAL
+- `max_age` (double, default `0.0` s, 0 = disabled) — cells whose tile timestamp
+  is older than `now - max_age` are treated as stale (LETHAL). D1 prior tiles
+  have timestamp 0 from import; with `max_age=0` this gate is effectively off
+  for D1. The code path must exist for D2 correctness.
+- `map_tide_frame` (string, default `"map_tide"`) — frame whose z-origin is the
+  current water surface (ellipsoidal height)
+- `buffer_fraction` (double, default `0.05`) — window margin around costmap bounds
+  for `loadWindow` / `evictOutside`, matching `s57_layer` convention
+
+Construct `BathymetryStore` (`fromCellSize(resolution_)`, `chart_writable=false`).
+Call `loadWindow(store_, store_path_, min_geo, max_geo)` for the buffered costmap
+window.
+
+**`matchSize()`** — evict outside tiles then reload window (re-call when costmap
+resizes). Clear the cached per-costmap-cell cost array.
+
+**`updateBounds()`** — look up `map_tide` z-height via TF (`lookupTransform(global_frame, map_tide_frame_, tf2::TimePointZero).transform.translation.z`); if the change exceeds a threshold, invalidate cached costs (same `tide_invalidate_threshold` pattern as `s57_layer`). Expand `loadWindow` window if the costmap has shifted beyond the inner buffer.
+
+**`updateCosts()`** — iterate the `[min_i..max_i] × [min_j..max_j]` cell range,
+convert world coordinates to `gggs::CellIndex` via `store_.cellIndex(lat, lon)`
+(lat/lon from TF `earth` transform, same as `s57_layer::worldToLatLon`), call
+`shallowestReliable(store_, cell, max_uncertainty_)`, then apply the cost mapping:
+
+```
+std::optional<DepthSample> sample = shallowestReliable(store_, cell, max_uncertainty_);
+if (!sample) {
+    // Truly unsurveyed — NO_INFORMATION (let other layers fill in, e.g. s57_layer)
+    // Do NOT overwrite master with NO_INFORMATION: leave master untouched so
+    // s57_layer or another prior can contribute. Only write NO_INFORMATION if
+    // the cell is currently NO_INFORMATION in master (i.e. nothing wrote it).
+    // Actually: never write NO_INFORMATION — leave master cell unchanged.
+    continue; // skip — unsurveyed cells leave master untouched
+} else {
+    double clearance = map_tide_z_ - sample->depth; // both ellipsoidal
+    unsigned char cost;
+    if (is_stale(sample->timestamp) || /* sample existed but failed uncertainty gate (impossible path — shallowestReliable already filtered) */false) {
+        cost = nav2_costmap_2d::LETHAL_OBSTACLE;
+    } else if (clearance < minimum_depth_) {
+        cost = nav2_costmap_2d::LETHAL_OBSTACLE;
+    } else if (clearance >= maximum_caution_depth_) {
+        cost = nav2_costmap_2d::FREE_SPACE;
+    } else {
+        cost = nav2_costmap_2d::MAX_NON_OBSTACLE *
+               (1.0 - (clearance - minimum_depth_) /
+                      (maximum_caution_depth_ - minimum_depth_));
+    }
+    // Write only where cost > master (max-cost combines; s57_layer wins when it
+    // assigns a higher cost, bathymetry_layer wins when it knows depth is lethal
+    // but s57_layer has no chart coverage).
+    unsigned char existing = master_grid.getCost(i, j);
+    if (existing == nav2_costmap_2d::NO_INFORMATION || cost > existing)
+        master_grid.setCost(i, j, cost);
+}
+```
+
+**No-data semantics (ADR-0002 §D7, settled decision):**
+- `std::nullopt` (no data at all) → leave master cell untouched (effectively
+  `NO_INFORMATION`; `s57_layer` or another layer fills in). Document this in the
+  header.
+- Data found but stale (`timestamp != 0 && max_age > 0 && age > max_age`) →
+  `LETHAL_OBSTACLE` (conservative). D1 Chart tiles have `timestamp=0`; with
+  `max_age=0` (default) the gate is off.
+
+**Note on `shallowestReliable` vs stale path:** `shallowestReliable` already
+filters by `max_uncertainty`. A sample it returns is reliability-gated. Staleness
+is a separate check (timestamp vs `max_age`). A stale but reliable sample →
+LETHAL (conservative), not NO_INFORMATION, because the data exists and tells us
+the seafloor is there; we just don't trust its currency.
+
+**`s57_layer` coexistence (action item 4):** the Nav2 LayeredCostmap applies
+layers in order and each layer calls `updateCosts` into the same master grid.
+Both `bathymetry_layer` and `s57_layer` write via max-cost: a cell that one layer
+marks LETHAL stays LETHAL regardless of the other layer's opinion. Where
+`bathymetry_layer` has `std::nullopt` it does not write, so `s57_layer` is the
+sole contributor. Where both have data the higher cost wins. Document this in the
+plugin's class header comment.
+
+### Step 3 — Unit tests (gtest)
+
+`test/test_bathymetry_layer.cpp` — no ROS node required for arithmetic; use the
+`BathymetryStore` + `query.hpp` API directly with synthetic tiles:
+
+1. **Clearance-to-cost ramp** — insert a Chart tile at synthetic lat/lon with
+   known ellipsoidal depth. Call `computeCost(clearance)` (a `protected` helper
+   extracted from `updateCosts` for testability). Assert LETHAL below
+   `minimum_depth`, FREE_SPACE above `maximum_caution_depth`, and the correct
+   linear value at the midpoint.
+2. **NO_INFORMATION on unsurveyed** — query a cell not in the store. Assert
+   `shallowestReliable` returns `nullopt` and the plugin does NOT write that
+   cell (verify by checking master grid unchanged from NO_INFORMATION seed).
+3. **LETHAL on stale data** — insert a tile with `timestamp = 1` (old) and set
+   `max_age = 1.0` s with current time >> 1 ns. Assert LETHAL regardless of
+   clearance.
+4. **LETHAL on over-uncertain** — insert a tile with uncertainty `> max_uncertainty`.
+   Assert `shallowestReliable` returns `nullopt` for that cell (the
+   reliability gate is in the store API, not the plugin). Verify the plugin
+   does not write that cell.
+5. **Memory-bound windowed load (action item 3)** — construct a store, call
+   `loadWindow` with a small geographic box (e.g. 0.01° × 0.01°), then call
+   `loadWindow` with a larger box, then `evictOutside` with the original small
+   box. Assert that tiles outside the small box were evicted and the resident
+   count is bounded. This is the acceptance criterion: the plugin never holds
+   more tiles than the window needs.
+
+`test/test_plugin_loading.cpp` — mirror `s57_layer`'s test: use `pluginlib` to
+load `bathymetry_layer::BathymetryLayer` from `nav2_costmap_2d`. Confirms the
+XML descriptor and symbol export are correct.
+
+### Step 4 — Wire into bizzy nav2_params (action item 1)
+
+Add `bathymetry_layer` to both `local_costmap` and `global_costmap` plugin lists
+in `unh_marine_autonomy/config/` (or note if it lives in a platform repo).
+
+The nav2_params in this worktree are under `ben_project11` (platforms_ws). Bizzy's
+params live in `bizzyboat_project11`. Check at implementation time:
+
+```bash
+find layers/main/platforms_ws/src -name "nav2_params.yaml" | grep -i bizzy
+```
+
+If bizzy's `nav2_params.yaml` lives in `platforms_ws/src/bizzyboat_project11/`,
+that is a separate repo. D1 scope includes the registration YAML change in that
+repo; if that repo is a separate issue (out of scope) note it explicitly. The
+YAML change is small:
+
+```yaml
+plugins: ["chart_layer", "bathymetry_layer", "inflation_layer"]
+bathymetry_layer:
+  plugin: "bathymetry_layer::BathymetryLayer"
+  enabled: True
+  store_path: "/path/to/bathy_store"   # override per platform
+  minimum_depth: 1.0
+  maximum_caution_depth: 2.5
+  max_uncertainty: 0.5
+  max_age: 0.0
+  map_tide_frame: <tf_prefix>/map_tide
+```
+
+**Coexistence note for nav2_params:** list `bathymetry_layer` after `chart_layer`
+(s57_layer). Both write max-cost; order does not affect the final costmap, but
+listing bathy second is conventional ("refinement on top of chart").
+
+If bizzy's nav2_params.yaml is not in this worktree's packages, file a follow-on
+issue and note it here at implementation time.
+
+### Step 5 — Document s57_layer coexistence
+
+Add a `## Layer Coexistence` section to `bathymetry_layer/README.md`:
+- `bathymetry_layer` does not write to cells it has no data for (`std::nullopt`
+  → skip); `s57_layer` fills those cells.
+- Both layers write using max-cost semantics: the higher cost wins per cell.
+- Recommended plugin order in `nav2_params`: `chart_layer` first (S57 chart
+  prior), `bathymetry_layer` second (MBES/contour store refinement).
+- Where both have data, `bathymetry_layer`'s clearance-from-store depth typically
+  supersedes `s57_layer`'s chart depth for accurate shoal detection.
+
+### Step 6 — Build and pre-commit
+
+```bash
+cd /path/to/worktree
+./core_ws/build.sh bathymetry_layer
+./core_ws/test.sh bathymetry_layer
+```
+
+Verify all 5 gtests pass and `test_plugin_loading` loads the plugin.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `bathymetry_layer/package.xml` | New — format 3, BSD, ament_cmake, deps |
+| `bathymetry_layer/CMakeLists.txt` | New — shared lib, pluginlib export, gtest targets |
+| `bathymetry_layer/costmap_plugins.xml` | New — pluginlib descriptor |
+| `bathymetry_layer/src/bathymetry_layer.hpp` | New — class declaration |
+| `bathymetry_layer/src/bathymetry_layer.cpp` | New — full plugin implementation |
+| `bathymetry_layer/test/test_bathymetry_layer.cpp` | New — 5 gtest cases |
+| `bathymetry_layer/test/test_plugin_loading.cpp` | New — pluginlib load smoke test |
+| `bathymetry_layer/README.md` | New — layer coexistence docs |
+| bizzy `nav2_params.yaml` (in platforms repo, TBD) | Add `bathymetry_layer` to both costmaps |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Safety First | No-data (unsurveyed) → leave master untouched (other layers fill); data-with-quality-issue → LETHAL. This is the conservative split per ADR-0002 §D7. The code never silently treats unknown as safe. |
+| Simulation-First Validation | Sim acceptance (costmap reflects contour prior; shoals LETHAL) is the validation gate, gated on #163 A2 (contour importer) + sim #75/#76. PR D1 can merge on gtests alone; sim acceptance is the field validation gate. |
+| Modularity | New package only; `marine_bathymetry_store` stays Nav2-free; no store node added. |
+| Iterative Evolution | D1 is independently useful (prior-only static read). D2 adds live refinement once #189 is merged. |
+| A change includes its consequences | nav2_params wiring (action item 1) and s57_layer coexistence docs (action item 4) are in D1 scope. Memory-bound gtest (action item 3) is in D1 scope. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0002 §D7 (costmap consumer) | Yes | `shallowestReliable` query (nav-safety mode), `std::nullopt` → skip (NO_INFORMATION), stale/over-uncertain-with-data → LETHAL. Sim acceptance gates field use. |
+| ADR-0002 §D9 (Phase 4 deliverable) | Yes | This PR is Phase 4 named in D9. |
+| ADR-0008 (ROS 2 conventions) | Yes | format-3 `package.xml`, BSD license, ament_cmake, pluginlib XML descriptor, C++17, `-Wall -Wextra -Wpedantic`. |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| Add `bathymetry_layer` plugin | bizzy `nav2_params.yaml` (platforms repo) | Yes — Step 4 (or explicit follow-on if out of worktree scope) |
+| Add `bathymetry_layer` plugin | s57_layer coexistence documented | Yes — Step 5 |
+| Memory-bound windowed load | gtest for eviction | Yes — test case 5 |
+| D1 no-data policy choice | Documented in plugin header + README | Yes — Steps 2 and 5 |
+
+## Open Questions
+
+- [ ] Does bizzy's `nav2_params.yaml` live in `bizzyboat_project11` (platforms_ws)
+  or `unh_marine_autonomy/config/`? Confirm at implementation time with
+  `find layers/main/platforms_ws/src -name "nav2_params.yaml" | grep -i bizzy`.
+  If it is a separate repo, file a follow-on issue for the YAML wiring.
+
+## Follow-on Issues to Name (not plan)
+
+- **D2 — live Draft tile reload**: after #189 (atomic tile writes) merges, add
+  polling/inotify-based tile change detection on the `draft/` layer to update the
+  costmap where the boat has surveyed. File as a new issue on `unh_marine_autonomy`
+  with "Depends on #164 (D1) and #189 (atomic writes)".
+- **Sim acceptance run**: costmap-reflects-prior + shoals-LETHAL + planner-routes-
+  around validation. Gated on #163 A2 (contour importer) and sim #75/#76. Track
+  against those issues, not this one.
+
+## Estimated Scope
+
+Single PR (D1). All new files; no existing files modified except one nav2_params.yaml (if in scope).

--- a/.agent/work-plans/issue-164/plan.md
+++ b/.agent/work-plans/issue-164/plan.md
@@ -22,9 +22,17 @@ is `z(map_tide) − seafloor_ellipsoidal_height`.
 
 **Settled decisions (do not relitigate):**
 - Scope = D1 prior-only (static) this PR.
-- No-data policy: `std::nullopt` from `shallowestReliable` (truly unsurveyed) →
-  `NO_INFORMATION`; a cell with data but stale/over-uncertain (data exists,
-  fails the quality gate) → `LETHAL_OBSTACLE` (conservative per ADR-0002 §D7).
+- No-data policy (**TWO-QUERY** pattern — see review M1):
+  1. `bestSource(store, cell)` — returns a sample iff ANY data exists
+     (quality-blind).
+  2. `bestSource` → `nullopt` ⇒ **truly unsurveyed** ⇒ leave the master cost
+     untouched (NO_INFORMATION); `continue`.
+  3. `bestSource` → non-null ⇒ cell **HAS data** ⇒ call
+     `shallowestReliable(store, cell, max_uncertainty)` + check staleness
+     (timestamp age vs `max_age`). If `shallowestReliable` is `nullopt`
+     (over-uncertain) OR stale ⇒ **`LETHAL_OBSTACLE`**; else clearance ramp.
+  A single `shallowestReliable`→`nullopt`→NO_INFORMATION is WRONG: it would mark
+  a surveyed-but-noisy cell as unsurveyed = safety regression (ADR-0002 §D7).
 - D2 and its tile-change detection mechanism → follow-on issue.
 
 ## Approach
@@ -69,7 +77,10 @@ Call `loadWindow(store_, store_path_, min_geo, max_geo)` for the buffered costma
 window.
 
 **`matchSize()`** — evict outside tiles then reload window (re-call when costmap
-resizes). Clear the cached per-costmap-cell cost array.
+resizes). Clear the cached per-costmap-cell cost array. **S2:** the `evictOutside`
+box is the costmap bounds **plus the same buffer margin** used by `loadWindow`
+(the buffered, not tight, bounds) — otherwise the margin tiles loaded for the
+window get immediately evicted on every `matchSize()`/bounds pass.
 
 **`updateBounds()`** — look up `map_tide` z-height via TF (`lookupTransform(global_frame, map_tide_frame_, tf2::TimePointZero).transform.translation.z`); if the change exceeds a threshold, invalidate cached costs (same `tide_invalidate_threshold` pattern as `s57_layer`). Expand `loadWindow` window if the costmap has shifted beyond the inner buffer.
 
@@ -78,21 +89,28 @@ convert world coordinates to `gggs::CellIndex` via `store_.cellIndex(lat, lon)`
 (lat/lon from TF `earth` transform, same as `s57_layer::worldToLatLon`), call
 `shallowestReliable(store_, cell, max_uncertainty_)`, then apply the cost mapping:
 
-```
+```cpp
+// M1 two-query pattern: distinguish "no data" from "data but unusable".
+std::optional<DepthSample> any = bestSource(store_, cell);  // quality-blind
+if (!any) {
+    // Truly unsurveyed — leave master cell untouched (NO_INFORMATION) so
+    // s57_layer or another prior can contribute. Never WRITE NO_INFORMATION.
+    continue;
+}
+// The cell HAS data. Now apply the navigation-safety gate.
 std::optional<DepthSample> sample = shallowestReliable(store_, cell, max_uncertainty_);
-if (!sample) {
-    // Truly unsurveyed — NO_INFORMATION (let other layers fill in, e.g. s57_layer)
-    // Do NOT overwrite master with NO_INFORMATION: leave master untouched so
-    // s57_layer or another prior can contribute. Only write NO_INFORMATION if
-    // the cell is currently NO_INFORMATION in master (i.e. nothing wrote it).
-    // Actually: never write NO_INFORMATION — leave master cell unchanged.
-    continue; // skip — unsurveyed cells leave master untouched
+unsigned char cost;
+if (!sample || is_stale(any->timestamp)) {
+    // Data exists but every sample is over-uncertain (shallowestReliable ==
+    // nullopt) OR the freshest data is stale → conservative LETHAL (ADR-0002 §D7).
+    cost = nav2_costmap_2d::LETHAL_OBSTACLE;
 } else {
-    double clearance = map_tide_z_ - sample->depth; // both ellipsoidal
-    unsigned char cost;
-    if (is_stale(sample->timestamp) || /* sample existed but failed uncertainty gate (impossible path — shallowestReliable already filtered) */false) {
-        cost = nav2_costmap_2d::LETHAL_OBSTACLE;
-    } else if (clearance < minimum_depth_) {
+    // sample->depth is ellipsoidal HEIGHT (WGS84, up-positive): a seafloor 5 m
+    // below the ellipsoid has depth=-5.0, so a shallower (more hazardous)
+    // seafloor has a LARGER (less-negative) depth → SMALLER clearance → higher
+    // cost. clearance = water-surface height − seafloor height (both ellipsoidal).
+    double clearance = map_tide_z_ - sample->depth;
+    if (clearance < minimum_depth_) {
         cost = nav2_costmap_2d::LETHAL_OBSTACLE;
     } else if (clearance >= maximum_caution_depth_) {
         cost = nav2_costmap_2d::FREE_SPACE;
@@ -101,28 +119,34 @@ if (!sample) {
                (1.0 - (clearance - minimum_depth_) /
                       (maximum_caution_depth_ - minimum_depth_));
     }
-    // Write only where cost > master (max-cost combines; s57_layer wins when it
-    // assigns a higher cost, bathymetry_layer wins when it knows depth is lethal
-    // but s57_layer has no chart coverage).
-    unsigned char existing = master_grid.getCost(i, j);
-    if (existing == nav2_costmap_2d::NO_INFORMATION || cost > existing)
-        master_grid.setCost(i, j, cost);
 }
+// Write only where cost > master (max-cost combines; s57_layer wins when it
+// assigns a higher cost, bathymetry_layer wins when it knows depth is lethal
+// but s57_layer has no chart coverage).
+unsigned char existing = master_grid.getCost(i, j);
+if (existing == nav2_costmap_2d::NO_INFORMATION || cost > existing)
+    master_grid.setCost(i, j, cost);
 ```
 
-**No-data semantics (ADR-0002 §D7, settled decision):**
-- `std::nullopt` (no data at all) → leave master cell untouched (effectively
-  `NO_INFORMATION`; `s57_layer` or another layer fills in). Document this in the
-  header.
+**No-data semantics (ADR-0002 §D7, settled decision — M1 two-query):**
+- `bestSource` → `std::nullopt` (no data at all) → leave master cell untouched
+  (effectively `NO_INFORMATION`; `s57_layer` or another layer fills in). Document
+  this in the header.
+- `bestSource` → non-null but `shallowestReliable` → `std::nullopt`
+  (over-uncertain: data exists, fails the quality gate) → `LETHAL_OBSTACLE`
+  (conservative). This is the safety-critical case M1 corrected — a single
+  `shallowestReliable`→nullopt→skip would silently mis-classify a noisy surveyed
+  cell as unsurveyed.
 - Data found but stale (`timestamp != 0 && max_age > 0 && age > max_age`) →
   `LETHAL_OBSTACLE` (conservative). D1 Chart tiles have `timestamp=0`; with
   `max_age=0` (default) the gate is off.
 
-**Note on `shallowestReliable` vs stale path:** `shallowestReliable` already
-filters by `max_uncertainty`. A sample it returns is reliability-gated. Staleness
-is a separate check (timestamp vs `max_age`). A stale but reliable sample →
-LETHAL (conservative), not NO_INFORMATION, because the data exists and tells us
-the seafloor is there; we just don't trust its currency.
+**Note on `shallowestReliable` vs stale path:** `shallowestReliable` filters by
+`max_uncertainty`; a returned sample is reliability-gated. Existence is checked
+*separately* by `bestSource` (quality-blind). Staleness is a third check
+(timestamp vs `max_age`). A stale but reliable sample → LETHAL (conservative),
+not NO_INFORMATION, because the data exists and tells us the seafloor is there;
+we just don't trust its currency.
 
 **`s57_layer` coexistence (action item 4):** the Nav2 LayeredCostmap applies
 layers in order and each layer calls `updateCosts` into the same master grid.
@@ -148,10 +172,12 @@ plugin's class header comment.
 3. **LETHAL on stale data** — insert a tile with `timestamp = 1` (old) and set
    `max_age = 1.0` s with current time >> 1 ns. Assert LETHAL regardless of
    clearance.
-4. **LETHAL on over-uncertain** — insert a tile with uncertainty `> max_uncertainty`.
-   Assert `shallowestReliable` returns `nullopt` for that cell (the
-   reliability gate is in the store API, not the plugin). Verify the plugin
-   does not write that cell.
+4. **LETHAL on over-uncertain (M1)** — insert a cell with data but uncertainty
+   `> max_uncertainty`. Assert `shallowestReliable` returns `nullopt` AND
+   `bestSource` returns non-null (data exists, fails the quality gate). Assert
+   the plugin writes **`LETHAL_OBSTACLE`** (NOT "does not write"). This is the
+   safety-critical M1 case: a surveyed-but-noisy cell must be an obstacle, not
+   treated as unsurveyed.
 5. **Memory-bound windowed load (action item 3)** — construct a store, call
    `loadWindow` with a small geographic box (e.g. 0.01° × 0.01°), then call
    `loadWindow` with a larger box, then `evictOutside` with the original small

--- a/.agent/work-plans/issue-164/progress.md
+++ b/.agent/work-plans/issue-164/progress.md
@@ -137,3 +137,128 @@ The following items should be in scope for PR D1 or explicitly tracked as follow
 
 ### Open questions
 - [ ] Does bizzy's `nav2_params.yaml` live in `bizzyboat_project11` (platforms_ws) or `unh_marine_autonomy/config/`? Confirm at implementation time; if separate repo, file a follow-on issue for the YAML wiring.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-06-22
+**By**: Claude Code Agent (Claude Sonnet 4.6)
+
+**Plan file**: `.agent/work-plans/issue-164/plan.md`
+**Verdict**: CONDITIONAL PASS — 1 must-fix safety defect; 2 suggestions
+
+---
+
+### Summary
+
+The plan is well-structured, appropriately scoped to D1, and correctly mirrors
+`s57_layer` in lifecycle, parameter naming, and pluginlib wiring. Scope discipline
+is good: D2 and the sim acceptance run are explicitly deferred with named follow-on
+issues. The clearance math, ramp boundaries, memory-bound windowed load gtest, nav2_params
+wiring, and s57_layer coexistence documentation are all present and correct in the plan.
+
+One **must-fix safety defect** exists in the Step 2 pseudocode and test case 4,
+verified against the actual `query.cpp` source. The remaining items are suggestions.
+
+---
+
+### Must-Fix
+
+**[M1] Over-uncertain surveyed cells wrongly treated as unsurveyed (safety regression)**
+
+Verified against `marine_bathymetry_store/src/query.cpp`:
+
+`shallowestReliable()` returns `std::nullopt` for TWO distinct situations:
+1. Cell has **no data at all** in any layer/epoch/level.
+2. Cell **has data** but every sample fails the uncertainty gate
+   (`c->uncertainty > max_uncertainty` or `std::isnan(c->uncertainty)`).
+
+The plan's settled policy (correctly stated in the "No-data semantics" section,
+lines 113–119 of plan.md) is:
+- Unsurveyed (no data) → leave master untouched (let s57_layer fill in)
+- Has data but stale/over-uncertain → **LETHAL_OBSTACLE** (conservative, ADR-0002 §D7)
+
+But the Step 2 pseudocode block (lines 82–110) **does not implement this split**.
+The code does:
+```cpp
+std::optional<DepthSample> sample = shallowestReliable(store_, cell, max_uncertainty_);
+if (!sample) {
+    continue; // skip — unsurveyed cells leave master untouched
+}
+```
+The comment even says "impossible path — shallowestReliable already filtered" for the
+over-uncertain case. This is wrong: `shallowestReliable` **does** return nullopt for
+over-uncertain cells that have data. The `continue` path silently treats over-uncertain
+surveyed cells as NO_INFORMATION instead of LETHAL — a safety regression.
+
+**Required fix**: The implementation must use a two-query pattern:
+1. `bestSource(store_, cell)` — returns non-null iff **any data exists**, regardless
+   of quality.
+2. If `bestSource` → nullopt → truly unsurveyed → `continue` (leave master untouched).
+3. If `bestSource` → non-null → has data → call `shallowestReliable`; if it returns
+   nullopt → over-uncertain → `LETHAL_OBSTACLE`.
+
+Update the Step 2 pseudocode block to reflect this two-query logic explicitly.
+
+**Test case 4 has the same defect**: It asserts "the plugin does not write that cell"
+for an over-uncertain cell. It must instead assert the plugin writes `LETHAL_OBSTACLE`.
+
+Corrected test case 4 assertion: insert a tile with `uncertainty > max_uncertainty_`.
+Assert `shallowestReliable` returns nullopt. Assert `bestSource` returns non-null.
+Assert the master grid cell is **LETHAL_OBSTACLE** (not NO_INFORMATION).
+
+---
+
+### Suggestions
+
+**[S1] Clearance math sign convention — verify `depth` is ellipsoidal height (up-positive)**
+
+The plan uses `clearance = map_tide_z_ - sample->depth`. This is correct IF
+`sample->depth` is the ellipsoidal **height** of the seafloor (up-positive, WGS84 m) —
+a seafloor 5 m below the ellipsoid has `depth = -5.0`, giving `clearance = z_water - (-5.0)`.
+Confirmed correct from `DepthSample` docs in `query.hpp`: "Ellipsoidal height (WGS84, m,
+up-positive)." The plan's formula is right, but the variable name `depth` is
+misleading — implementers may interpret it as a positive downward depth and negate
+it incorrectly. Suggest renaming to `seafloor_height` or adding a prominent comment:
+`// sample->depth is ellipsoidal HEIGHT (up-positive); seafloor at -5m → depth=-5`.
+
+**[S2] `matchSize()` eviction bounds — clarify direction of the `evictOutside` call**
+
+Step 2 says "`matchSize()` — evict outside tiles then reload window." The `evictOutside`
+API (from `bathymetry_store.hpp`) takes a geographic bounding box. The plan should
+specify that the eviction box is the costmap bounds **plus margin** (same buffered box
+used for `loadWindow`), not the tight costmap bounds — otherwise the margin tiles loaded
+in `onInitialize` get immediately evicted on every `matchSize()` call. This is implicit
+from the "matching s57_layer convention" statement but should be stated explicitly in
+the step so the implementer doesn't accidentally pass tight bounds.
+
+---
+
+### Verified Correct
+
+- Clearance formula `z(map_tide) − seafloor_ellipsoidal_height` is correct (up-positive convention confirmed).
+- Ramp boundaries: `clearance < minimum_depth_` → LETHAL; `clearance >= maximum_caution_depth_` → FREE_SPACE; between → linear scale. Matches `s57_layer::get_cost_from_grid`.
+- Staleness check is separate from uncertainty gate — stale + reliable sample → LETHAL (correct, data exists, just untrusted for currency).
+- `loadWindow`/`evictOutside` keyed to buffered costmap bounds.
+- Memory-bound gtest (test case 5) asserts bounded residency after eviction — correct acceptance criterion.
+- Pluginlib export via `PLUGINLIB_EXPORT_CLASS` + `costmap_plugins.xml` mirrors `s57_layer` pattern.
+- `package.xml` format 3, BSD, ament_cmake per ADR-0008.
+- Nav2 Layer lifecycle: `onInitialize` / `matchSize` / `updateBounds` / `updateCosts` — present and correctly described.
+- D2 deferred as named follow-on: correct.
+- Sim acceptance gating on #163 A2 + sim #75/#76: correct out-of-scope placement.
+- `map_tide` TF lookup at `tf2::TimePointZero` (same as `s57_layer`) — correct.
+- nav2_params bizzy wiring in Step 4 with explicit defer-if-separate-repo fallback — scope handled correctly.
+- s57_layer coexistence documented in Step 5 README section — present.
+- `test_plugin_loading.cpp` smoke test mirrors `s57_layer` pattern — present.
+
+---
+
+### Actions for Implementer
+
+- [ ] **[M1-code]** Replace single `shallowestReliable` nullopt → skip with two-query
+  pattern: `bestSource` for existence check, then `shallowestReliable`; over-uncertain
+  → LETHAL. Update the Step 2 pseudocode and implementation accordingly.
+- [ ] **[M1-test]** Fix test case 4: assert LETHAL_OBSTACLE (not "plugin does not write")
+  for a cell with data but uncertainty > max_uncertainty_.
+- [ ] **[S1]** Add a comment on `sample->depth` clarifying the up-positive sign convention
+  at the point of the clearance calculation.
+- [ ] **[S2]** Use buffered (not tight) costmap bounds for `evictOutside` in `matchSize()`.

--- a/.agent/work-plans/issue-164/progress.md
+++ b/.agent/work-plans/issue-164/progress.md
@@ -420,3 +420,25 @@ silently invalidate them.
   `StaleReliableSampleIsLethalWhenNewerEpochOverUncertain` (S1/MF3),
   `ComputeCostDegenerateRampAndBoundary` (S4).
 - **Lint**: `ament_uncrustify` + `ament_cpplint` clean on all 3 changed files.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-22 08:10 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved
+
+**Branch**: feature/issue-164 at `b770575`
+**Mode**: pre-push (focused Round-2 re-review of `b770575` against round-1 findings)
+**Depth**: Deep (reason: safety-critical Nav2 costmap plugin; re-verifying the 3 fail-open/staleness must-fixes)
+**Must-fix**: 0 | **Suggestions**: 1
+**Round**: 2 | **Ship**: recommended — all 3 round-1 must-fixes correctly + completely resolved; tests green (32/32 gtests pass, 9+1, 0 failures); one new lower-severity robustness suggestion (datum-refresh staleness) is out of round-1 scope and matches the s57_layer TimePointZero precedent.
+
+### MF / suggestion verification
+- **MF1 (fail-open on invalid tide) — RESOLVED.** `map_tide_valid_` defaults false (hpp:95), set true ONLY after a successful `lookupTransform` (cpp:272), reset false in `reset()` (cpp:106). `evaluateCell()` returns `std::nullopt` (skip → NO_INFORMATION) when `!map_tide_valid_` (cpp:342-344), placed BEFORE the two-query block and the clearance math — so there is no path that computes a clearance cost from the default `map_tide_z_=0.0`. `InvalidTideYieldsNoInformation` genuinely asserts no-write even with a surveyed/reliable/fresh cell and a "correct" z=52.3 (the flag, not the value, gates). Site-dependent sign direction documented in `updateBounds` (cpp:256-266).
+- **MF2 (unconditional current_) — RESOLVED.** `current_ = map_tide_valid_ && window_valid_` (cpp:427); a degraded cycle reports stale to Nav2.
+- **MF3 (wrong staleness timestamp) — RESOLVED.** `isStale(sample->timestamp, now_ns)` now ages the reliable record (cpp:363), after the `!sample` guard. Verified against `query.cpp`: `bestSource` returns the newest epoch quality-blind; `shallowestReliable` falls through to the older reliable epoch — so `any->timestamp` (fresh, over-uncertain) and `sample->timestamp` (ancient, reliable) genuinely differ. `StaleReliableSampleIsLethalWhenNewerEpochOverUncertain` pins LETHAL (epochs are ISO-date string keys → `rbegin` = chronological-newest-first; test setup is sound).
+- **S2/S3/S4/S5 — all applied + sound.** S2: one-shot `RCLCPP_ERROR` on persistent loadWindow failure + `window_valid_=false`; one-shot flag reset in `openStore()`. S3: explicit `tf2_geometry_msgs/tf2_geometry_msgs.hpp` include in the header. S4: `range <= 0.0` → LETHAL guard + `ComputeCostDegenerateRampAndBoundary` (incl. `computeCost(minimum_depth_)==MAX_NON_OBSTACLE`). S5: reload tolerance coarsened to `resolution_ * 1e-5`.
+- **No regression.** M1 two-query intact (`bestSource` existence → nullopt skip; non-null → `shallowestReliable` → nullopt/stale → LETHAL; else ramp). Ramp/clearance unchanged. Memory-bound `WindowedResidencyStaysBounded` intact. Build clean (0 warnings new sources); lint clean (bare-jazzy uncrustify/cpplint, per known-gate note). `test_bathymetry_layer`=9, `test_plugin_loading`=1, 0 failures (4 "skipped" are lint/xunit suites, not gtests).
+
+### Findings
+- [ ] (suggestion) Datum-refresh staleness: `map_tide_valid_` is not reset when a subsequent `lookupTransform` throws (cpp:273-278), nor in `matchSize()` (cpp:131-141). After a first success a later TF dropout keeps the last-known `map_tide_z_` in use. Low severity and NOT the MF1 fail-open (last-good datum is bounded, vs. the wildly-wrong 0.0 default), `map_tide` is a near-static TimePointZero datum, and z is geographically global so the new-resolution-store framing overstates it. Matches the s57_layer TimePointZero precedent this plugin mirrors. Out of round-1 scope; track as optional D2-era hardening (e.g. reset on TF exception / in matchSize, or age-check the datum) — `bathymetry_layer.cpp:273-278,140`

--- a/.agent/work-plans/issue-164/progress.md
+++ b/.agent/work-plans/issue-164/progress.md
@@ -320,3 +320,25 @@ costmaps) + Layer Coexistence are documented in `bathymetry_layer/README.md`, an
 the wiring is named as a follow-on (own issue on the platform repo).
 
 **Not pushed** (per handoff contract).
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-22 07:30 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-164 at `1f96905`
+**Mode**: pre-push
+**Depth**: Deep (reason: new safety-critical Nav2 costmap plugin; lifecycle + lethal-obstacle decisions)
+**Must-fix**: 3 | **Suggestions**: 5
+**Round**: 1 | **Ship**: continue — 3 must-fix incl. a safety failure mode (shoal-erasing on TF tide failure) and a latent staleness-timestamp bug; warrants address + re-review.
+
+### Findings
+- [ ] (must-fix) TF tide lookup failure leaves map_tide_z_=0.0 → clearance computed from a bogus 0 m water surface (Massabesic datum ~52 m ellipsoidal) → real shoals classified FREE_SPACE; fail-open on a lethal-obstacle layer. Track map-tide validity and skip/conservative-LETHAL until first valid lookup — `bathymetry_layer.cpp:235-246,317`
+- [ ] (must-fix) updateCosts sets current_=true unconditionally, even when map_tide_z_ was never valid or loadWindow silently failed — masks a degraded cycle from Nav2 — `bathymetry_layer.cpp:365`
+- [ ] (must-fix) Staleness gate ages any->timestamp (bestSource, quality-blind) not sample->timestamp (the reliable record actually used for clearance); when shallowestReliable falls through to an older confident epoch the age check tests the wrong record → can both miss genuinely-stale reliable data and false-stale a fresh one. Inert for D1 (timestamp 0 / max_age 0) but the path is shipped + tested. Use sample->timestamp after the !sample guard — `bathymetry_layer.cpp:306`
+- [ ] (suggestion) test StaleCellIsLethal is vacuous w.r.t. the timestamp-source bug (single sample → any==sample); add a two-epoch case (newest over-uncertain+fresh, older reliable+ancient) to pin the contract — `test_bathymetry_layer.cpp:168-194`
+- [ ] (suggestion) persistent loadWindow / wrong store_path failure makes the layer silently contribute nothing while reporting current_=true; emit a one-shot ERROR (not throttled WARN) and reflect in current_ — `bathymetry_layer.cpp:209-223`
+- [ ] (suggestion) add explicit `#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"` for the PointStamped doTransform specialization (currently transitive; latent build-break) — `bathymetry_layer.cpp`
+- [ ] (suggestion) computeCost div-by-zero / cast-NaN-UB on the test-seam path when maximum_caution_depth_ == minimum_depth_ (onInitialize validates, setters do not); add a guard + a boundary test at computeCost(minimum_depth_) — `bathymetry_layer.cpp:265-275`
+- [ ] (suggestion) refreshWindow redundant-reload short-circuit uses a 1e-9 deg (~0.1 mm) tolerance; sub-mm TF round-trip jitter can force evict+loadWindow disk I/O every costmap cycle — coarsen the tolerance or compare in cell-index space — `bathymetry_layer.cpp:200-207`

--- a/.agent/work-plans/issue-164/progress.md
+++ b/.agent/work-plans/issue-164/progress.md
@@ -121,7 +121,19 @@ The following items should be in scope for PR D1 or explicitly tracked as follow
   of outside tiles.
 
 ### Actions
-- [ ] Plan-task must specify the no-data/null-sample cost policy (NO_INFORMATION vs. LETHAL_OBSTACLE) as an explicit design decision per ADR-0002 §D7 safety-conservative requirement.
-- [ ] Plan-task should verify that D1 scopes the nav2_params registration for bizzy (or explicitly defers it with a rationale).
-- [ ] Plan-task should add a gtest for the memory-bounded windowed-load behavior (the acceptance criterion "memory stays bounded" must not be manual-check-only).
-- [ ] Verify during implementation that s57_layer coexistence is documented or tested (which layer wins per cell when both are active in the same costmap).
+- [x] Plan-task must specify the no-data/null-sample cost policy (NO_INFORMATION vs. LETHAL_OBSTACLE) as an explicit design decision per ADR-0002 §D7 safety-conservative requirement.
+- [x] Plan-task should verify that D1 scopes the nav2_params registration for bizzy (or explicitly defers it with a rationale).
+- [x] Plan-task should add a gtest for the memory-bounded windowed-load behavior (the acceptance criterion "memory stays bounded" must not be manual-check-only).
+- [x] Verify during implementation that s57_layer coexistence is documented or tested (which layer wins per cell when both are active in the same costmap).
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-22 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet 4.6)
+
+**Plan**: `.agent/work-plans/issue-164/plan.md` at `5b48754`
+**Branch**: feature/issue-164 at `5b48754`
+**Phases**: single
+
+### Open questions
+- [ ] Does bizzy's `nav2_params.yaml` live in `bizzyboat_project11` (platforms_ws) or `unh_marine_autonomy/config/`? Confirm at implementation time; if separate repo, file a follow-on issue for the YAML wiring.

--- a/.agent/work-plans/issue-164/progress.md
+++ b/.agent/work-plans/issue-164/progress.md
@@ -265,3 +265,58 @@ the step so the implementer doesn't accidentally pass tight bounds.
   at the point of the clearance calculation. *(comment at the clearance line.)*
 - [x] **[S2]** Use buffered (not tight) costmap bounds for `evictOutside` in `matchSize()`.
   *(both `loadWindow` and `evictOutside` use the buffered box.)*
+
+## Implementation
+**Status**: complete
+**When**: 2026-06-22
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Branch**: feature/issue-164
+
+### What changed
+- **Plan update** (commit `12cf720`): folded review M1 (two-query no-data policy),
+  S1 (clearance sign-convention comment), S2 (buffered evictOutside bounds), and
+  the corrected test case 4 (LETHAL on over-uncertain surveyed) into `plan.md`.
+- **PIC enabler** (commit `72124eb`): `POSITION_INDEPENDENT_CODE ON` on
+  `marine_bathymetry_store` and `marine_tiled_raster_store` static libs — required
+  so they can be linked into the SHARED `bathymetry_layer` plugin (otherwise
+  R_X86_64_PC32 relocation link failure). Both packages are in this repo.
+- **New package `bathymetry_layer`** (core_ws): `package.xml` (format-3, BSD,
+  C++17), `CMakeLists.txt`, `costmap_plugins.xml`, `src/bathymetry_layer.{hpp,cpp}`,
+  `test/test_bathymetry_layer.cpp`, `test/test_plugin_loading.cpp`, `README.md`.
+  - `BathymetryLayer` mirrors `s57_layer` lifecycle
+    (onInitialize/matchSize/updateBounds/updateCosts), pluginlib-exported as
+    `nav2_costmap_2d::Layer`. Params: store_path, minimum_depth,
+    maximum_caution_depth, max_uncertainty, max_age, map_tide_frame, buffer_fraction.
+  - Windowed residency via `loadWindow`/`evictOutside` keyed to the BUFFERED
+    bounds (S2). Clearance = `z(map_tide) − seafloor_ellipsoidal_height` (map_tide
+    z via TF at TimePointZero; world→latlon via the `earth` frame, mirroring
+    s57_layer). Sign-convention comment at the clearance line (S1).
+  - **M1 two-query no-data policy** implemented in `evaluateCell`: `bestSource`
+    (existence, quality-blind) → nullopt ⇒ leave master untouched; non-null ⇒
+    `shallowestReliable` (safety gate); over-uncertain OR stale ⇒ LETHAL_OBSTACLE;
+    else clearance ramp. Max-cost combine with the master grid.
+
+### Build / test
+- Build: clean (`colcon build --packages-up-to bathymetry_layer`, with
+  `--allow-overriding` for the merged-underlay packages). No warnings in the new
+  sources (the only warnings are pre-existing gz4d_geo.h ones in marine_autonomy).
+- gtests: **7/7 pass** — `test_bathymetry_layer` (6: ClearanceRampBoundaries,
+  UnsurveyedCellLeavesMasterUntouched, SurveyedCellMapsClearanceToCost,
+  OverUncertainSurveyedCellIsLethal [M1], StaleCellIsLethal,
+  WindowedResidencyStaysBounded) + `test_plugin_loading` (1: LoadsViaPluginlib).
+  `colcon test-result`: 29 tests, 0 errors, 0 failures, 4 skipped.
+- Lint (CI-accurate bare-jazzy): `ament_uncrustify`, `ament_cpplint`,
+  `ament_xmllint` all clean on the new files. (Fixed: cpplint header guard
+  `BATHYMETRY_LAYER_HPP_`; xmllint format-3 `<author>` after `<license>`;
+  uncrustify auto-reformat of the .cpp.)
+
+### nav2_params decision
+Bizzy's and the echoboats' `nav2_params` live in **separate platforms_ws repos**
+(`unh_echoboats_project11/bizzyboat_project11`,
+`seafloor_echoboat_project11/echoboat_project11`) — NOT in this worktree. Per the
+cross-repo rule, the registration was **not** edited here; the snippet (both
+costmaps) + Layer Coexistence are documented in `bathymetry_layer/README.md`, and
+the wiring is named as a follow-on (own issue on the platform repo).
+
+**Not pushed** (per handoff contract).

--- a/.agent/work-plans/issue-164/progress.md
+++ b/.agent/work-plans/issue-164/progress.md
@@ -1,0 +1,127 @@
+---
+issue: 164
+---
+
+# Issue #164 — Phase 4: bathymetry_layer Nav2 costmap plugin (store-backed clearance, lazy tiles)
+
+## Issue Review
+**Status**: complete
+**When**: 2026-06-22 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet 4.6)
+
+**Issue**: #164
+**Comment**: (best-effort post follows this entry; not recorded inline)
+**Scope verdict**: well-scoped
+
+### Summary
+
+Issue #164 proposes a new Nav2 costmap plugin package `bathymetry_layer` in
+`unh_marine_autonomy` (core_ws). The plugin queries the `marine_bathymetry_store`
+and converts clearance (`z(map_tide) − seafloor_ellipsoidal`) to costmap costs
+using the same minimum_depth/maximum_caution_depth ramp pattern as `s57_layer`.
+It is structured as two deliverable PRs: **D1** (prior-only, static Chart layer
+reads) and **D2** (live Draft tile reload as cube writes them).
+
+### Scope Assessment
+
+**Well-scoped**: yes. The issue scope is tightly bounded — one new plugin package,
+mirroring an existing pattern (s57_layer), with a clean two-PR split (D1 static /
+D2 live-update). Both PRs are individually reviewable and independently useful.
+The issue correctly identifies its own sub-task (windowed tile load/evict) and
+notes that the sub-task was already resolved by #205 (`loadWindow`/`evictOutside`
+now present in `tile_io.hpp` — confirmed in the worktree source).
+
+**Right repo**: yes. `bathymetry_layer` depends on `marine_bathymetry_store`
+(core_ws) and `marine_autonomy`/GGGS (core_ws), mirrors `s57_layer` (also
+core_ws), and is consumed by the Nav2 navigation stack. Core_ws / `unh_marine_autonomy`
+is the correct placement per ADR-0002 §D9 ("costmap plugin" is explicitly named
+as a Phase 4 deliverable in that package).
+
+**D1/D2 split rationale confirmed**: D1 (chart prior, read-only path) can build
+and be unit-tested now against synthetic store tiles — no dependency on #189
+(atomic tile writes), no dependency on #163's A2 importer PR (the plugin only
+reads the store, not imports to it). D2 (live Draft reload) legitimately needs
+#189 to guarantee the plugin never reads a half-written tile; deferring D2 until
+#189 lands is the right call.
+
+**Sim acceptance gating**: the issue notes that end-to-end sim acceptance
+("costmap reflects prior, shoals lethal") depends on real Chart data in the store,
+which comes from #163 (chart importer, in-flight). That dependency is on the
+_data_, not the _code_. PR D1 (plugin code + unit gtests on synthetic tiles) can
+merge independently of #163's A2; the sim acceptance test gates a separate field
+validation milestone, not the PR merge.
+
+### Principle Alignment
+
+| Principle | Status | Notes |
+|---|---|---|
+| Safety First | OK | Issue explicitly calls out the conservative no-data/stale policy (unknown=obstacle), mirrors `s57_layer`'s established safe default. The issue should surface this during plan-task: the plugin must treat `std::nullopt` from `bestSource`/`shallowestReliable` as obstacle (ADR-0002 §D7), not as free space. This is non-negotiable. |
+| Simulation-First Validation | OK | Issue correctly specifies sim validation before field use; acceptance criteria require the sim to show shoals as LETHAL with the contour prior. The dependency on sim MBES (#75) and harness (#76) is noted. |
+| Modularity and Decoupling | OK | Plugin package is a new package (no store consumer logic leaks into store core); store core has no nav2 dependency. Correct layering. |
+| Hardware Agnosticism | OK | Plugin depends only on standard Nav2 costmap interfaces + the store query API; no platform-specific logic. |
+| Standards Compliance | OK | pluginlib export, Nav2 CostmapLayer lifecycle (onInitialize/updateBounds/updateCosts), parameter declaration pattern from s57_layer — all established conventions. |
+| Iterative, Validated Evolution | OK | Two-PR split (D1 then D2) is exactly the right incremental delivery. D1 is independently useful and validates the core path; D2 adds live refinement. |
+| A change includes its consequences | Watch | Issue scopes gtests well (clearance arithmetic, ramp boundaries, tile windowing/eviction). However, it does not mention updating bizzy/nav2_params with the new plugin registration, or documenting s57_layer coexistence behavior in the package README. These should be part of PR D1 scope, not follow-ups. |
+| Only what's needed | OK | Mirrors s57_layer without adding speculative features; no store node (direct disk read); no new message types. |
+
+### ADR Applicability
+
+| ADR | Triggered | Notes |
+|---|---|---|
+| ADR-0002 (bathymetric store) | Yes — D7, D9 | Plugin is the explicitly named Phase 4 costmap consumer (D9). D7 requires: `shallowestReliable` mode for navigation, conservative no-data/stale/over-uncertainty policy, sim validation before field use. Issue references all three correctly. |
+| ADR-0008 (ROS 2 conventions) | Yes | New package: needs `package.xml` with correct format 3, ROS 2 license headers, pluginlib XML descriptor, ament_cmake build type. Follow ROS 2 conventions throughout. |
+| Workspace ADR-0002 (worktree isolation) | Yes | Already in worktree `feature/issue-164` — covered. |
+| Workspace ADR-0001 (ADRs) | Watch | The costmap plugin introduces a new consumer-facing design choice (direct disk read vs. store node, lazy-tile eviction strategy). Issue says "D1 — disk interface settled." That design choice is already documented in the issue but lives in the issue body, not in an ADR addendum. The issue closes as part of the broader ADR-0002 §D9 costmap phase, so no new ADR is strictly required — but the plan should verify that the direct-disk-read rationale (no store node) is captured in ADR-0002 as an addendum if it represents a new deviation from the original decision. |
+
+### Dependency Analysis
+
+| Dependency | Status | Gate |
+|---|---|---|
+| #205 (`loadWindow`/`evictOutside`) | Merged | Confirmed present in `tile_io.hpp` in this worktree. PR D1 can use these APIs directly. |
+| #163 PR A1 (SourceLayer::Chart in store core) | In-flight | **Hard gate for D1 data path at runtime**, but NOT for unit tests. Unit gtests can use synthetic Chart-layer tiles without A1 being merged. The plugin code itself only calls `bestSource` / `shallowestReliable` — it doesn't care how Chart got into the store. Plan should note: D1 can merge as a code/gtest PR before #163 A1 merges, but end-to-end sim acceptance waits on #163. |
+| #163 PR A2 (contour prior importer) | Not started | Gate only for sim acceptance (real Massabesic prior data). Not a code gate. |
+| #189 (atomic tile writes) | Open | Gate for D2 only (live Draft reload). D1 reads a static prior and has no concurrent-writer concern. The plugin should document this assumption (D1 = safe, D2 needs #189). |
+| mru_transform `map_tide` frame | Existing | `map_tide` is already in use by `s57_layer`. No new dependency. |
+| sim MBES (#75) / harness (#76) | In-flight | Gate for sim acceptance testing only, not for code merge. |
+
+### Consequences
+
+The following items should be in scope for PR D1 or explicitly tracked as follow-ups:
+
+1. **nav2_params update**: bizzy's `nav2_params.yaml` should register `bathymetry_layer`
+   in the costmap plugin list with `store_path`, `minimum_depth`,
+   `maximum_caution_depth`, and `map_tide` frame params. If this is deferred, the
+   issue should say so explicitly (a "installed but not wired in" state may be
+   acceptable as an interim, but should be stated).
+2. **s57_layer coexistence**: the issue mentions documenting s57_layer coexistence
+   but does not scope it. The plan should address: what happens when both are active?
+   Which wins per cell? The costmap master grid merge order determines this; it
+   should be tested or at least documented.
+3. **No-data policy must be explicit in code**: `std::nullopt` from `bestSource` must
+   map to `NO_INFORMATION` or `LETHAL_OBSTACLE` (ADR-0002 §D7 says conservative /
+   unknown=obstacle). The plan must pick one and document the rationale. `NO_INFORMATION`
+   allows other layers (e.g. s57_layer) to fill in; `LETHAL_OBSTACLE` is the most
+   conservative. The choice has safety implications and must be explicit.
+4. **Stale-tile handling for D2**: the issue mentions reloading changed tiles (content-hash).
+   The plan should define how "stale" is detected at runtime — polling interval?
+   inotify? — since this affects D2 correctness and is not specified.
+
+### Recommendations
+
+- During plan-task: explicitly scope the no-data→cost mapping (NO_INFORMATION vs.
+  LETHAL_OBSTACLE) as a design decision to document in the plugin header, not
+  leave implicit.
+- During plan-task: confirm whether bizzy nav2_params wiring is in D1 scope or D2
+  scope; either is fine but it must be stated.
+- During plan-task: for D2, define the tile-change detection mechanism (polling
+  period? filesystem watch?) — the issue says "reload changed tiles" but not how.
+- The issue's acceptance criterion "memory stays bounded under a global costmap
+  (windowed load verified)" should become a gtest, not just a manual check. The
+  plan should include a test that loads a window, expands it, and verifies eviction
+  of outside tiles.
+
+### Actions
+- [ ] Plan-task must specify the no-data/null-sample cost policy (NO_INFORMATION vs. LETHAL_OBSTACLE) as an explicit design decision per ADR-0002 §D7 safety-conservative requirement.
+- [ ] Plan-task should verify that D1 scopes the nav2_params registration for bizzy (or explicitly defers it with a rationale).
+- [ ] Plan-task should add a gtest for the memory-bounded windowed-load behavior (the acceptance criterion "memory stays bounded" must not be manual-check-only).
+- [ ] Verify during implementation that s57_layer coexistence is documented or tested (which layer wins per cell when both are active in the same costmap).

--- a/.agent/work-plans/issue-164/progress.md
+++ b/.agent/work-plans/issue-164/progress.md
@@ -341,4 +341,82 @@ the wiring is named as a follow-on (own issue on the platform repo).
 - [ ] (suggestion) persistent loadWindow / wrong store_path failure makes the layer silently contribute nothing while reporting current_=true; emit a one-shot ERROR (not throttled WARN) and reflect in current_ — `bathymetry_layer.cpp:209-223`
 - [ ] (suggestion) add explicit `#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"` for the PointStamped doTransform specialization (currently transitive; latent build-break) — `bathymetry_layer.cpp`
 - [ ] (suggestion) computeCost div-by-zero / cast-NaN-UB on the test-seam path when maximum_caution_depth_ == minimum_depth_ (onInitialize validates, setters do not); add a guard + a boundary test at computeCost(minimum_depth_) — `bathymetry_layer.cpp:265-275`
-- [ ] (suggestion) refreshWindow redundant-reload short-circuit uses a 1e-9 deg (~0.1 mm) tolerance; sub-mm TF round-trip jitter can force evict+loadWindow disk I/O every costmap cycle — coarsen the tolerance or compare in cell-index space — `bathymetry_layer.cpp:200-207`
+- [x] (must-fix) TF tide lookup failure leaves map_tide_z_=0.0 → clearance computed from a bogus 0 m water surface (Massabesic datum ~52 m ellipsoidal) → real shoals classified FREE_SPACE; fail-open on a lethal-obstacle layer. Track map-tide validity and skip/conservative-LETHAL until first valid lookup — `bathymetry_layer.cpp:235-246,317`
+- [x] (must-fix) updateCosts sets current_=true unconditionally, even when map_tide_z_ was never valid or loadWindow silently failed — masks a degraded cycle from Nav2 — `bathymetry_layer.cpp:365`
+- [x] (must-fix) Staleness gate ages any->timestamp (bestSource, quality-blind) not sample->timestamp (the reliable record actually used for clearance); when shallowestReliable falls through to an older confident epoch the age check tests the wrong record → can both miss genuinely-stale reliable data and false-stale a fresh one. Inert for D1 (timestamp 0 / max_age 0) but the path is shipped + tested. Use sample->timestamp after the !sample guard — `bathymetry_layer.cpp:306`
+- [x] (suggestion) test StaleCellIsLethal is vacuous w.r.t. the timestamp-source bug (single sample → any==sample); add a two-epoch case (newest over-uncertain+fresh, older reliable+ancient) to pin the contract — `test_bathymetry_layer.cpp:168-194`
+- [x] (suggestion) persistent loadWindow / wrong store_path failure makes the layer silently contribute nothing while reporting current_=true; emit a one-shot ERROR (not throttled WARN) and reflect in current_ — `bathymetry_layer.cpp:209-223`
+- [x] (suggestion) add explicit `#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"` for the PointStamped doTransform specialization (currently transitive; latent build-break) — `bathymetry_layer.cpp`
+- [x] (suggestion) computeCost div-by-zero / cast-NaN-UB on the test-seam path when maximum_caution_depth_ == minimum_depth_ (onInitialize validates, setters do not); add a guard + a boundary test at computeCost(minimum_depth_) — `bathymetry_layer.cpp:265-275`
+- [x] (suggestion) refreshWindow redundant-reload short-circuit uses a 1e-9 deg (~0.1 mm) tolerance; sub-mm TF round-trip jitter can force evict+loadWindow disk I/O every costmap cycle — coarsen the tolerance or compare in cell-index space — `bathymetry_layer.cpp:200-207`
+
+## Address Findings
+**Status**: complete
+**When**: 2026-06-22
+**By**: Claude Code Agent (Claude Sonnet 4.6)
+
+**Commit**: `b770575`
+**Branch**: feature/issue-164
+
+### Clearance sign direction (verified for MF1)
+
+The store uses WGS84 ellipsoidal heights (up-positive). At Lake Massabesic
+the water surface is ~+52.3 m (map_tide_z_) and the seafloor is ~+47–51 m.
+With the unset default `map_tide_z_=0.0`, clearance = `0 − 47 = −47 m` → LETHAL
+(incidentally fail-safe at this site). However for any site where the seafloor
+is at a negative ellipsoidal height (ocean, deep water), clearance =
+`0 − (−depth) = +depth` → large-positive → FREE_SPACE (fail-open, shoals
+erased). The direction is **site-dependent** and cannot be assumed safe as a
+fallback. Conservative fix: refuse to write any cost until the first valid tide
+arrives (`map_tide_valid_` flag), regardless of sign direction.
+
+### Changes made (commit `b770575`)
+
+**MF1 (SAFETY)**: Added `map_tide_valid_` flag (false at startup, true only after
+a successful `lookupTransform`; reset to false in `reset()`). `evaluateCell()`
+returns `std::nullopt` (NO_INFORMATION, skip write) when `!map_tide_valid_`.
+Comment in `updateBounds()` documents the verified site-dependent sign direction.
+
+**MF2**: `updateCosts()` now sets `current_ = map_tide_valid_ && window_valid_`
+instead of unconditionally `true`. A degraded cycle (no tide yet, or
+`loadWindow` failed) reports as stale to Nav2.
+
+**MF3**: Changed `isStale(any->timestamp, now_ns)` → `isStale(sample->timestamp, now_ns)`
+(after the `!sample` guard). The age check now uses the reliable record's epoch,
+not the quality-blind `bestSource` record which may be a newer over-uncertain
+epoch.
+
+**S1**: Replaced single-sample `StaleCellIsLethal` test with a two-epoch test
+`StaleReliableSampleIsLethalWhenNewerEpochOverUncertain` pinning the MF3
+timestamp-source contract (newest epoch: over-uncertain+fresh; older epoch:
+reliable+ancient → must yield LETHAL).
+
+**S2**: `refreshWindow()` persistent `loadWindow` failure now emits a one-shot
+`RCLCPP_ERROR` (not throttled WARN) and sets `window_valid_=false` (reflecting
+into MF2's `current_` gate). Added `store_path_error_logged_` flag, reset in
+`openStore()` so a path reconfigure gets a fresh error.
+
+**S3**: Added explicit `#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"` to
+`bathymetry_layer.hpp` (the `doTransform` specialization was previously transitive
+— latent build-break risk).
+
+**S4**: Added `range <= 0.0` guard in `computeCost()` returning LETHAL (avoids
+div-by-zero when `maximum_caution_depth_ == minimum_depth_`). Added
+`ComputeCostDegenerateRampAndBoundary` test; also pins
+`computeCost(minimum_depth_) == MAX_NON_OBSTACLE` on a normal ramp.
+
+**S5**: Coarsened redundant-reload tolerance from `1e-9°` (~0.1 mm) to
+`resolution_ * 1e-5` (~1 cell-width in degrees at mid-lat). Sub-mm TF
+round-trip jitter was forcing `evict+loadWindow` disk I/O every cycle.
+
+Also: `setMapTideValid(true)` added to `BathymetryLayerForTest` test subclass
+and called in all `evaluateCell`-calling tests so the MF1 gate does not
+silently invalidate them.
+
+### Build / test / lint
+- **Build**: clean (`build.sh bathymetry_layer`), 0 warnings in new sources.
+- **Tests**: 32 total (was 29), 0 errors, 0 failures, 4 skipped. New tests:
+  `InvalidTideYieldsNoInformation` (MF1),
+  `StaleReliableSampleIsLethalWhenNewerEpochOverUncertain` (S1/MF3),
+  `ComputeCostDegenerateRampAndBoundary` (S4).
+- **Lint**: `ament_uncrustify` + `ament_cpplint` clean on all 3 changed files.

--- a/.agent/work-plans/issue-164/progress.md
+++ b/.agent/work-plans/issue-164/progress.md
@@ -254,11 +254,14 @@ the step so the implementer doesn't accidentally pass tight bounds.
 
 ### Actions for Implementer
 
-- [ ] **[M1-code]** Replace single `shallowestReliable` nullopt → skip with two-query
+- [x] **[M1-code]** Replace single `shallowestReliable` nullopt → skip with two-query
   pattern: `bestSource` for existence check, then `shallowestReliable`; over-uncertain
   → LETHAL. Update the Step 2 pseudocode and implementation accordingly.
-- [ ] **[M1-test]** Fix test case 4: assert LETHAL_OBSTACLE (not "plugin does not write")
+  *(plan updated; implemented in `bathymetry_layer.cpp::computeCost` + `updateCosts`.)*
+- [x] **[M1-test]** Fix test case 4: assert LETHAL_OBSTACLE (not "plugin does not write")
   for a cell with data but uncertainty > max_uncertainty_.
-- [ ] **[S1]** Add a comment on `sample->depth` clarifying the up-positive sign convention
-  at the point of the clearance calculation.
-- [ ] **[S2]** Use buffered (not tight) costmap bounds for `evictOutside` in `matchSize()`.
+  *(plan + `test_bathymetry_layer.cpp` OverUncertainSurveyedCellIsLethal.)*
+- [x] **[S1]** Add a comment on `sample->depth` clarifying the up-positive sign convention
+  at the point of the clearance calculation. *(comment at the clearance line.)*
+- [x] **[S2]** Use buffered (not tight) costmap bounds for `evictOutside` in `matchSize()`.
+  *(both `loadWindow` and `evictOutside` use the buffered box.)*

--- a/bathymetry_layer/CMakeLists.txt
+++ b/bathymetry_layer/CMakeLists.txt
@@ -1,0 +1,90 @@
+cmake_minimum_required(VERSION 3.14.4)
+project(bathymetry_layer)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(geodesy REQUIRED)
+find_package(geographic_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(marine_bathymetry_store REQUIRED)
+find_package(nav2_costmap_2d REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
+find_package(tf2_ros REQUIRED)
+
+add_library(${PROJECT_NAME} SHARED
+  src/bathymetry_layer.cpp
+)
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+
+ament_target_dependencies(${PROJECT_NAME}
+  geodesy
+)
+
+target_link_libraries(${PROJECT_NAME}
+  ${geographic_msgs_TARGETS}
+  ${geometry_msgs_TARGETS}
+  marine_bathymetry_store::marine_bathymetry_store
+  nav2_costmap_2d::nav2_costmap_2d_core
+  pluginlib::pluginlib
+  rclcpp::rclcpp
+  tf2::tf2
+  tf2_geometry_msgs::tf2_geometry_msgs
+  tf2_ros::tf2_ros
+)
+
+install(
+  TARGETS ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+pluginlib_export_plugin_description_file(nav2_costmap_2d costmap_plugins.xml)
+
+ament_export_targets(export_${PROJECT_NAME})
+ament_export_libraries(${PROJECT_NAME})
+ament_export_dependencies(
+  geographic_msgs marine_bathymetry_store nav2_costmap_2d pluginlib rclcpp)
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  find_package(nav2_util REQUIRED)
+
+  ament_add_gtest(test_bathymetry_layer test/test_bathymetry_layer.cpp)
+  target_include_directories(test_bathymetry_layer PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+  )
+  target_link_libraries(test_bathymetry_layer
+    ${PROJECT_NAME}
+    marine_bathymetry_store::marine_bathymetry_store
+    nav2_costmap_2d::nav2_costmap_2d_core
+    nav2_util::nav2_util_core
+    rclcpp::rclcpp
+    tf2_ros::tf2_ros
+  )
+
+  ament_add_gtest(test_plugin_loading test/test_plugin_loading.cpp)
+  target_link_libraries(test_plugin_loading
+    nav2_costmap_2d::nav2_costmap_2d_core
+    pluginlib::pluginlib
+  )
+
+  find_package(ament_lint_auto REQUIRED)
+  # Skip copyright: this package uses a short BSD header, not the ament default;
+  # copyright is tracked at the repo level (consistent with sibling packages).
+  set(ament_cmake_copyright_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/bathymetry_layer/README.md
+++ b/bathymetry_layer/README.md
@@ -1,0 +1,127 @@
+# bathymetry_layer
+
+A **Nav2 Costmap 2D** plugin that turns clearance from the bathymetric store
+([`marine_bathymetry_store`](../marine_bathymetry_store)) into occupancy cost, so
+the planner routes around shoals.
+
+This is the **D1** (prior-only, static) deliverable of issue
+[#164](https://github.com/rolker/unh_marine_autonomy/issues/164): the layer reads
+the store's read-only prior layers (`chart/`, and any `processed/` present) from
+disk and converts depth to cost. It does **not** yet reload live `draft/` tiles
+as the boat surveys — that is the D2 follow-on (see [Follow-on work](#follow-on-work)).
+
+## How it works
+
+1. On each `updateBounds`, the layer caches the water-surface ellipsoidal height
+   from the `map_tide` frame's z-origin (a TF lookup at `TimePointZero`, mirroring
+   `s57_layer`'s tide lookup), and (re)loads the store tiles intersecting the
+   buffered costmap window (`loadWindow` / `evictOutside`, the #205 windowed-tile
+   API) so memory stays bounded under a global costmap.
+2. On `updateCosts`, each cell is projected to WGS84 lat/lon (via the `earth` TF
+   frame) and resolved to a GGGS cell. **Clearance** is
+
+   ```text
+   clearance = z(map_tide) − seafloor_ellipsoidal_height
+   ```
+
+   Both terms are WGS84 ellipsoidal heights (up-positive): a seafloor 5 m below
+   the ellipsoid has height `-5.0`, so a *shallower* (more hazardous) seafloor has
+   a *larger* (less-negative) height and therefore a *smaller* clearance.
+3. The clearance ramp (same shape as `s57_layer::get_cost_from_grid`):
+   - `clearance < minimum_depth` → `LETHAL_OBSTACLE`
+   - `clearance >= maximum_caution_depth` → `FREE_SPACE`
+   - between → linearly scaled cost (shallower = higher cost)
+
+## No-data policy (safety)
+
+Per cell the layer uses a **two-query** pattern (ADR-0002 §D7; review finding M1):
+
+1. `bestSource(store, cell)` — quality-blind: "is there *any* data here?"
+2. If `bestSource` is `nullopt` → the cell is **truly unsurveyed** → the layer
+   **leaves the master cost untouched** (NO_INFORMATION) so another prior (e.g.
+   `s57_layer`) can fill it in. The layer never *writes* NO_INFORMATION.
+3. If `bestSource` is non-null → the cell **has data** → `shallowestReliable`
+   applies the navigation-safety (uncertainty) gate. A cell that has data but
+   fails the gate (over-uncertain), or whose freshest sample is **stale**
+   (timestamp older than `max_age`), is written **`LETHAL_OBSTACLE`**
+   (conservative). Only a cell that passes both checks gets the clearance ramp.
+
+The critical distinction: a surveyed-but-noisy cell is an **obstacle**, not an
+unsurveyed cell. Treating it as unsurveyed would be a safety regression.
+
+## Parameters
+
+| Parameter | Type | Default | Meaning |
+|---|---|---|---|
+| `enabled` | bool | `true` | Enable the layer. |
+| `store_path` | string | `""` | Path to the on-disk store directory. Empty = contributes no cost. |
+| `minimum_depth` | double | `1.0` | Clearance (m) below which a cell is `LETHAL_OBSTACLE`. |
+| `maximum_caution_depth` | double | `2.5` | Clearance (m) at/above which a cell is `FREE_SPACE`; between `minimum_depth` and this the cost ramps. |
+| `max_uncertainty` | double | `0.5` | Max 1-sigma vertical uncertainty (m) for `shallowestReliable`. A surveyed cell exceeding this is LETHAL. |
+| `max_age` | double | `0.0` | Staleness window (s). `0` disables the gate (D1 chart priors have timestamp 0). A cell whose freshest sample is older than `now − max_age` is LETHAL. |
+| `map_tide_frame` | string | `map_tide` | Frame whose z-origin is the current water-surface ellipsoidal height. Prefix per platform (`<tf_prefix>/map_tide`). |
+| `buffer_fraction` | double | `0.05` | Fractional margin around the costmap window for `loadWindow` / `evictOutside`. |
+
+## Layer coexistence
+
+`bathymetry_layer` is designed to compose with `s57_layer` (or any other prior)
+in a layered Nav2 costmap:
+
+- **Max-cost combine.** The layer only ever *raises* a cell's cost (or fills a
+  `NO_INFORMATION` cell); it never lowers an existing higher cost. So when both
+  `s57_layer` and `bathymetry_layer` write the same master grid, the higher cost
+  per cell wins, regardless of plugin order.
+- **Unsurveyed cells are skipped.** Where `bathymetry_layer` has no store data it
+  leaves the master cost untouched, so `s57_layer` (the broad chart prior) is the
+  sole contributor there. Conversely, where the store has data but the chart does
+  not, `bathymetry_layer` is the sole contributor.
+- **Where both have data**, the store's measured clearance typically supersedes
+  the chart's coarser depth for accurate shoal detection — and because the combine
+  is max-cost, the more conservative (higher-cost) opinion always survives.
+- **Recommended plugin order** in `nav2_params`: `chart_layer` (S57 prior) first,
+  `bathymetry_layer` (MBES/contour store refinement) second. Order does not change
+  the final costmap (max-cost is order-independent); listing bathy second is the
+  conventional "refinement on top of chart" reading.
+
+## nav2_params registration (cross-repo follow-on)
+
+Bizzy's (and the echoboats') `nav2_params` live in **separate platform repos** —
+`unh_echoboats_project11/bizzyboat_project11` and
+`seafloor_echoboat_project11/echoboat_project11`, both under `platforms_ws`, not in
+this (`unh_marine_autonomy`) repo. Wiring the plugin into those configs is a
+cross-repo change and is therefore tracked as a **follow-on issue**, not landed
+here (see [Follow-on work](#follow-on-work)). The registration snippet to add to
+the `local_costmap` and `global_costmap` plugin lists:
+
+```yaml
+local_costmap:
+  local_costmap:
+    ros__parameters:
+      plugins: ["chart_layer", "bathymetry_layer", "inflation_layer"]
+      bathymetry_layer:
+        plugin: "bathymetry_layer::BathymetryLayer"
+        enabled: True
+        store_path: "/path/to/bathy_store"   # override per platform
+        minimum_depth: 1.0
+        maximum_caution_depth: 2.5
+        max_uncertainty: 0.5
+        max_age: 0.0
+        map_tide_frame: <tf_prefix>/map_tide
+        buffer_fraction: 0.05
+```
+
+Add the same block under `global_costmap` (the layer is usable on both — its
+windowed tile residency keeps memory bounded even on a large global costmap).
+
+## Follow-on work
+
+- **D2 — live Draft tile reload.** After [#189](https://github.com/rolker/unh_marine_autonomy/issues/189)
+  (atomic tile writes) merges, add tile-change detection on the `draft/` layer so
+  the costmap refines where the boat has surveyed. File as a new issue:
+  "Depends on #164 (D1) and #189 (atomic writes)".
+- **nav2_params registration.** Add the snippet above to the bizzy / echoboat
+  `nav2_params` in `platforms_ws` (cross-repo — own issue on the platform repo).
+- **Sim acceptance run.** costmap-reflects-prior + shoals-LETHAL + planner-routes-
+  around validation. Gated on [#163](https://github.com/rolker/unh_marine_autonomy/issues/163)
+  A2 (contour importer) and the sim MBES / harness work; tracked against those
+  issues, not this one.

--- a/bathymetry_layer/costmap_plugins.xml
+++ b/bathymetry_layer/costmap_plugins.xml
@@ -1,0 +1,8 @@
+<library path="bathymetry_layer">
+  <class type="bathymetry_layer::BathymetryLayer" base_class_type="nav2_costmap_2d::Layer">
+    <description>
+      A bathymetric-store costmap layer: clearance from the depth store becomes
+      occupancy cost (shoals lethal), with windowed (lazy) tile residency.
+    </description>
+  </class>
+</library>

--- a/bathymetry_layer/package.xml
+++ b/bathymetry_layer/package.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>bathymetry_layer</name>
+  <version>0.0.0</version>
+  <description>
+    Nav2 Costmap 2D plugin that turns clearance from the bathymetric store
+    (marine_bathymetry_store) into occupancy cost so the planner avoids shoals.
+  </description>
+
+  <maintainer email="roland@ccom.unh.edu">Roland Arsenault</maintainer>
+  <license>BSD</license>
+  <author>Roland Arsenault</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>geodesy</depend>
+  <depend>geographic_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>marine_bathymetry_store</depend>
+  <depend>nav2_costmap_2d</depend>
+  <depend>pluginlib</depend>
+  <depend>rclcpp</depend>
+  <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>tf2_ros</depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>nav2_util</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/bathymetry_layer/src/bathymetry_layer.cpp
+++ b/bathymetry_layer/src/bathymetry_layer.cpp
@@ -103,10 +103,14 @@ void BathymetryLayer::reset()
 {
   current_ = false;
   window_valid_ = false;
+  map_tide_valid_ = false;
 }
 
 void BathymetryLayer::openStore()
 {
+  // A new store path is being tried — reset the one-shot error flag so any
+  // subsequent loadWindow failure gets a fresh ERROR log.
+  store_path_error_logged_ = false;
   if (store_path_.empty()) {
     store_.reset();
     return;
@@ -197,11 +201,16 @@ void BathymetryLayer::refreshWindow()
   }
 
   // Skip redundant reloads if the window has not changed materially.
+  // S5: use a cell-width tolerance (~resolution_ in degrees, ≈ 1e-5° at mid
+  // latitudes for 1 m cells) rather than 1e-9° (~0.1 mm). Sub-mm TF round-trip
+  // jitter in the world→lat/lon projection would otherwise force
+  // evict+loadWindow disk I/O on every costmap cycle.
+  const double tol = resolution_ * 1e-5;  // ~1 cell in degrees at mid-lat
   if (window_valid_ &&
-    std::abs(min_geo.latitude - window_min_.latitude) < 1e-9 &&
-    std::abs(min_geo.longitude - window_min_.longitude) < 1e-9 &&
-    std::abs(max_geo.latitude - window_max_.latitude) < 1e-9 &&
-    std::abs(max_geo.longitude - window_max_.longitude) < 1e-9)
+    std::abs(min_geo.latitude - window_min_.latitude) < tol &&
+    std::abs(min_geo.longitude - window_min_.longitude) < tol &&
+    std::abs(max_geo.latitude - window_max_.latitude) < tol &&
+    std::abs(max_geo.longitude - window_max_.longitude) < tol)
   {
     return;
   }
@@ -216,10 +225,21 @@ void BathymetryLayer::refreshWindow()
     window_max_ = max_geo;
     window_valid_ = true;
   } catch (const std::exception & e) {
-    RCLCPP_WARN_THROTTLE(
-      logger_, *clock_, 10000,
-      "bathymetry_layer '%s': failed to (re)load store window from '%s': %s",
-      name_.c_str(), store_path_.c_str(), e.what());
+    // A persistent failure here (bad store_path or corrupt tiles) means this
+    // layer contributes nothing — that must be visible to Nav2 as a degraded
+    // cycle. Emit a one-shot ERROR so operators can see the root cause without
+    // being spammed; current_ is kept false (MF2 / S2: updateCosts gates on
+    // window_valid_).
+    if (!store_path_error_logged_) {
+      RCLCPP_ERROR_STREAM(
+        logger_,
+        "bathymetry_layer '" << name_ << "': failed to load store window from '"
+                             << store_path_ << "': " << e.what()
+                             << " — this layer will contribute no costs until the "
+                             << "store is reachable.");
+      store_path_error_logged_ = true;
+    }
+    window_valid_ = false;
   }
 }
 
@@ -232,11 +252,24 @@ void BathymetryLayer::updateBounds(
 
   // Cache the water-surface ellipsoidal height from the map_tide frame's
   // z-origin (mirror s57_layer's tide lookup at TimePointZero).
+  //
+  // Verified sign direction (MF1): store depths are WGS84 ellipsoidal heights
+  // (up-positive). At Lake Massabesic the water surface is ~+52.3 m (map_tide_z_)
+  // and the seafloor is a few metres below that, e.g. +47–51 m. So clearance =
+  // map_tide_z_ − seafloor_height > 0 (a few metres). With the UNSET default
+  // map_tide_z_=0.0 the clearance for those same cells would be 0 − 47 = −47 m
+  // → LETHAL (coincidentally fail-safe for this lake). However, for any site where
+  // the seafloor elevation is negative (e.g. ocean, depth > ellipsoid zero),
+  // clearance = 0 − (−depth) = +depth → large-positive → FREE_SPACE (fail-open,
+  // i.e. shoals hidden). The direction is therefore SITE-DEPENDENT and cannot be
+  // relied upon for safety. The conservative fix (MF1) is to refuse to write any
+  // cost until at least one valid tide has been received, regardless of sign.
   if (!map_tide_frame_.empty()) {
     try {
       auto transform =
         tf_->lookupTransform(global_frame_id_, map_tide_frame_, tf2::TimePointZero);
       map_tide_z_ = transform.transform.translation.z;
+      map_tide_valid_ = true;
     } catch (const tf2::TransformException & e) {
       RCLCPP_WARN_THROTTLE(
         logger_, *clock_, 10000,
@@ -268,10 +301,20 @@ unsigned char BathymetryLayer::computeCost(double clearance) const
   if (clearance >= maximum_caution_depth_) {
     return nav2_costmap_2d::FREE_SPACE;
   }
+  // S4: guard div-by-zero when parameters are degenerate (maximum_caution_depth_
+  // == minimum_depth_). onInitialize() validates and resets to defaults, but
+  // setters (used in tests and via parameter-change callbacks) do not. At the
+  // ramp boundary clearance == minimum_depth_ with a zero-width window, any cost
+  // in [LETHAL+1, MAX_NON_OBSTACLE] is defensible; LETHAL is the conservative
+  // choice.
+  const double range = maximum_caution_depth_ - minimum_depth_;
+  if (range <= 0.0) {
+    return nav2_costmap_2d::LETHAL_OBSTACLE;
+  }
   // Linear ramp between minimum_depth_ (LETHAL boundary) and maximum_caution_depth_
   // (FREE boundary), matching s57_layer::get_cost_from_grid.
-  const double scaled = nav2_costmap_2d::MAX_NON_OBSTACLE *
-    (1.0 - (clearance - minimum_depth_) / (maximum_caution_depth_ - minimum_depth_));
+  const double scaled =
+    nav2_costmap_2d::MAX_NON_OBSTACLE * (1.0 - (clearance - minimum_depth_) / range);
   return static_cast<unsigned char>(scaled);
 }
 
@@ -291,6 +334,15 @@ std::optional<unsigned char> BathymetryLayer::evaluateCell(
     return std::nullopt;
   }
 
+  // MF1: refuse to compute clearance from an invalid (never-received) tide.
+  // The clearance direction is SITE-DEPENDENT (see comment in updateBounds), so
+  // map_tide_z_=0.0 (the default) cannot be treated as a safe fallback. Leave the
+  // cell as NO_INFORMATION (do not write) so the costmap does not assert bogus
+  // FREE or spurious LETHAL costs before the first valid tide arrives.
+  if (!map_tide_valid_) {
+    return std::nullopt;
+  }
+
   // Two-query no-data policy (review M1, ADR-0002 §D7):
   //   1. bestSource — quality-blind "is there ANY data here?"
   const std::optional<DepthSample> any = bestSource(*store_, cell);
@@ -303,10 +355,15 @@ std::optional<unsigned char> BathymetryLayer::evaluateCell(
   //   2. shallowestReliable — the navigation-safety gate (uncertainty).
   const std::optional<DepthSample> sample = shallowestReliable(*store_, cell, max_uncertainty_);
 
-  if (!sample || isStale(any->timestamp, now_ns)) {
-    // Data exists but every sample is over-uncertain, or the freshest data is
-    // stale → conservative LETHAL (a surveyed-but-unusable cell is NOT treated
-    // as unsurveyed; that mis-classification was review finding M1).
+  // MF3: use sample->timestamp (the reliable record's age) for the staleness
+  // check, not any->timestamp (the quality-blind record). When the newest
+  // epoch's samples are all over-uncertain and the fallback lands on an older
+  // confident epoch, we want to age-check the epoch we are actually using for
+  // clearance — not the newer-but-unreliable one that bestSource found.
+  if (!sample || isStale(sample->timestamp, now_ns)) {
+    // Data exists but every sample is over-uncertain (sample==nullopt), or the
+    // reliable sample is stale → conservative LETHAL. A surveyed-but-unusable
+    // cell must NOT be treated as unsurveyed (review M1).
     return nav2_costmap_2d::LETHAL_OBSTACLE;
   }
 
@@ -362,7 +419,12 @@ void BathymetryLayer::updateCosts(
     }
   }
 
-  current_ = true;
+  // MF2: only report this cycle as "current" when all prerequisites held:
+  // - a valid tide was received (map_tide_valid_) — MF1 safety gate
+  // - the store window was successfully loaded (window_valid_) — S2 gate
+  // A degraded cycle (no tide yet, or loadWindow failed) must not appear fresh
+  // to Nav2's staleness monitor; leave current_=false so Nav2 can detect it.
+  current_ = map_tide_valid_ && window_valid_;
 }
 
 }  // namespace bathymetry_layer

--- a/bathymetry_layer/src/bathymetry_layer.cpp
+++ b/bathymetry_layer/src/bathymetry_layer.cpp
@@ -1,0 +1,371 @@
+// Copyright (c) 2026 Roland Arsenault
+// Licensed under BSD license
+
+#include "bathymetry_layer.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "geodesy/ecef.h"
+#include "geodesy/wgs84.h"
+#include "geometry_msgs/msg/point_stamped.hpp"
+#include "marine_autonomy/gggs.h"
+#include "marine_bathymetry_store/query.hpp"
+#include "marine_bathymetry_store/tile_io.hpp"
+#include "nav2_costmap_2d/cost_values.hpp"
+
+namespace bathymetry_layer
+{
+
+using marine_bathymetry_store::bestSource;
+using marine_bathymetry_store::BathymetryStore;
+using marine_bathymetry_store::DepthSample;
+using marine_bathymetry_store::shallowestReliable;
+
+BathymetryLayer::BathymetryLayer() = default;
+
+BathymetryLayer::~BathymetryLayer() = default;
+
+void BathymetryLayer::onInitialize()
+{
+  auto node = node_.lock();
+  current_ = false;
+
+  declareParameter("enabled", rclcpp::ParameterValue(true));
+  node->get_parameter(name_ + ".enabled", enabled_);
+
+  declareParameter("store_path", rclcpp::ParameterValue(store_path_));
+  node->get_parameter(name_ + ".store_path", store_path_);
+
+  declareParameter("minimum_depth", rclcpp::ParameterValue(minimum_depth_));
+  node->get_parameter(name_ + ".minimum_depth", minimum_depth_);
+
+  declareParameter("maximum_caution_depth", rclcpp::ParameterValue(maximum_caution_depth_));
+  node->get_parameter(name_ + ".maximum_caution_depth", maximum_caution_depth_);
+
+  // A degenerate or inverted ramp would make computeCost divide by zero or
+  // produce nonsense. Parameters are external input — validate.
+  if (!(std::isfinite(minimum_depth_) && std::isfinite(maximum_caution_depth_) &&
+    maximum_caution_depth_ > minimum_depth_))
+  {
+    RCLCPP_WARN_STREAM(
+      logger_,
+      "Invalid depth ramp (minimum_depth="  << minimum_depth_ << ", maximum_caution_depth="
+                                            << maximum_caution_depth_
+                                            << "); using defaults 1.0 / 2.5 m instead.");
+    minimum_depth_ = 1.0;
+    maximum_caution_depth_ = 2.5;
+  }
+
+  declareParameter("max_uncertainty", rclcpp::ParameterValue(max_uncertainty_));
+  node->get_parameter(name_ + ".max_uncertainty", max_uncertainty_);
+
+  declareParameter("max_age", rclcpp::ParameterValue(max_age_));
+  node->get_parameter(name_ + ".max_age", max_age_);
+
+  declareParameter("map_tide_frame", rclcpp::ParameterValue(map_tide_frame_));
+  node->get_parameter(name_ + ".map_tide_frame", map_tide_frame_);
+
+  const double default_buffer_fraction = buffer_fraction_;
+  declareParameter("buffer_fraction", rclcpp::ParameterValue(buffer_fraction_));
+  node->get_parameter(name_ + ".buffer_fraction", buffer_fraction_);
+  if (!std::isfinite(buffer_fraction_) || buffer_fraction_ < 0.0) {
+    RCLCPP_WARN_STREAM(
+      logger_,
+      "Invalid buffer_fraction value " << buffer_fraction_ << "; using "
+                                       << default_buffer_fraction << " instead.");
+    buffer_fraction_ = default_buffer_fraction;
+  }
+
+  global_frame_id_ = layered_costmap_->getGlobalFrameID();
+
+  if (store_path_.empty()) {
+    RCLCPP_WARN_STREAM(
+      logger_,
+      "bathymetry_layer '" << name_ << "' has no store_path; the layer will contribute "
+        "no costs until one is configured.");
+  }
+
+  RCLCPP_INFO_STREAM(
+    logger_,
+    "bathymetry_layer '" << name_ << "': store_path='" << store_path_ << "', minimum_depth="
+                         << minimum_depth_ << " m, maximum_caution_depth=" << maximum_caution_depth_
+                         << " m, max_uncertainty=" << max_uncertainty_ << " m, max_age=" << max_age_
+                         << " s, map_tide_frame='" << map_tide_frame_ << "'");
+
+  matchSize();
+}
+
+void BathymetryLayer::reset()
+{
+  current_ = false;
+  window_valid_ = false;
+}
+
+void BathymetryLayer::openStore()
+{
+  if (store_path_.empty()) {
+    store_.reset();
+    return;
+  }
+  try {
+    // The default level only governs cellIndex(lat,lon); the store is otherwise
+    // multi-level. chart_writable=false: a navigation consumer never mutates the
+    // read-only prior.
+    store_ = std::make_unique<BathymetryStore>(
+      BathymetryStore::fromCellSize(static_cast<float>(resolution_), false));
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR_STREAM(
+      logger_, "bathymetry_layer '" << name_ << "': failed to construct store: " << e.what());
+    store_.reset();
+  }
+}
+
+void BathymetryLayer::matchSize()
+{
+  auto parent = layered_costmap_->getCostmap();
+  resolution_ = parent->getResolution();
+
+  // Resolution may have changed; rebuild the store at the new default level and
+  // force a fresh window load on the next updateBounds.
+  openStore();
+  window_valid_ = false;
+  current_ = false;
+}
+
+geographic_msgs::msg::GeoPoint BathymetryLayer::worldToLatLon(double x, double y)
+{
+  geometry_msgs::msg::PointStamped world;
+  world.point.x = x;
+  world.point.y = y;
+  world.header.frame_id = global_frame_id_;
+  geometry_msgs::msg::PointStamped ecef;
+  tf_->transform(world, ecef, "earth");
+  geodesy::ECEFPoint ecef_point(ecef.point);
+  return geodesy::toMsg(ecef_point);
+}
+
+void BathymetryLayer::refreshWindow()
+{
+  if (!store_) {
+    return;
+  }
+
+  auto parent = layered_costmap_->getCostmap();
+  const double world_min_x = parent->getOriginX();
+  const double world_min_y = parent->getOriginY();
+  const double world_max_x = world_min_x + parent->getSizeInMetersX();
+  const double world_max_y = world_min_y + parent->getSizeInMetersY();
+
+  // Buffer the costmap window so tiles are resident slightly ahead of the
+  // rolling window edge (same convention as s57_layer's buffer_fraction_).
+  const double buffer =
+    std::max(world_max_x - world_min_x, world_max_y - world_min_y) * buffer_fraction_;
+
+  geographic_msgs::msg::GeoPoint min_geo;
+  geographic_msgs::msg::GeoPoint max_geo;
+  try {
+    // The four buffered corners; project each to lat/lon and take the AABB. The
+    // global frame need not be axis-aligned with north, so corner-projection is
+    // required (a two-corner box would clip the window under rotation).
+    const double xs[4] = {
+      world_min_x - buffer, world_max_x + buffer, world_min_x - buffer, world_max_x + buffer};
+    const double ys[4] = {
+      world_min_y - buffer, world_min_y - buffer, world_max_y + buffer, world_max_y + buffer};
+    double lat_min = 90.0;
+    double lat_max = -90.0;
+    double lon_min = 180.0;
+    double lon_max = -180.0;
+    for (int k = 0; k < 4; ++k) {
+      const auto geo = worldToLatLon(xs[k], ys[k]);
+      lat_min = std::min(lat_min, geo.latitude);
+      lat_max = std::max(lat_max, geo.latitude);
+      lon_min = std::min(lon_min, geo.longitude);
+      lon_max = std::max(lon_max, geo.longitude);
+    }
+    min_geo = gggs::geoPoint(lat_min, lon_min);
+    max_geo = gggs::geoPoint(lat_max, lon_max);
+  } catch (const tf2::TransformException & e) {
+    RCLCPP_WARN_THROTTLE(
+      logger_, *clock_, 10000,
+      "bathymetry_layer '%s': cannot project costmap bounds to lat/lon: %s",
+      name_.c_str(), e.what());
+    return;
+  }
+
+  // Skip redundant reloads if the window has not changed materially.
+  if (window_valid_ &&
+    std::abs(min_geo.latitude - window_min_.latitude) < 1e-9 &&
+    std::abs(min_geo.longitude - window_min_.longitude) < 1e-9 &&
+    std::abs(max_geo.latitude - window_max_.latitude) < 1e-9 &&
+    std::abs(max_geo.longitude - window_max_.longitude) < 1e-9)
+  {
+    return;
+  }
+
+  try {
+    // Evict tiles outside the new buffered window first, then load the window.
+    // Both use the SAME buffered box (review S2) so margin tiles are not
+    // immediately evicted after loading.
+    marine_bathymetry_store::evictOutside(*store_, min_geo, max_geo);
+    marine_bathymetry_store::loadWindow(*store_, store_path_, min_geo, max_geo);
+    window_min_ = min_geo;
+    window_max_ = max_geo;
+    window_valid_ = true;
+  } catch (const std::exception & e) {
+    RCLCPP_WARN_THROTTLE(
+      logger_, *clock_, 10000,
+      "bathymetry_layer '%s': failed to (re)load store window from '%s': %s",
+      name_.c_str(), store_path_.c_str(), e.what());
+  }
+}
+
+void BathymetryLayer::updateBounds(
+  double, double, double, double * min_x, double * min_y, double * max_x, double * max_y)
+{
+  if (!enabled_) {
+    return;
+  }
+
+  // Cache the water-surface ellipsoidal height from the map_tide frame's
+  // z-origin (mirror s57_layer's tide lookup at TimePointZero).
+  if (!map_tide_frame_.empty()) {
+    try {
+      auto transform =
+        tf_->lookupTransform(global_frame_id_, map_tide_frame_, tf2::TimePointZero);
+      map_tide_z_ = transform.transform.translation.z;
+    } catch (const tf2::TransformException & e) {
+      RCLCPP_WARN_THROTTLE(
+        logger_, *clock_, 10000,
+        "bathymetry_layer '%s': cannot look up %s in %s: %s",
+        name_.c_str(), map_tide_frame_.c_str(), global_frame_id_.c_str(), e.what());
+    }
+  }
+
+  refreshWindow();
+
+  // This layer contributes data over the whole parent window; expand the update
+  // bounds to the parent costmap extent so updateCosts is invoked across it.
+  auto parent = layered_costmap_->getCostmap();
+  const double world_min_x = parent->getOriginX();
+  const double world_min_y = parent->getOriginY();
+  const double world_max_x = world_min_x + parent->getSizeInMetersX();
+  const double world_max_y = world_min_y + parent->getSizeInMetersY();
+  *min_x = std::min(*min_x, world_min_x);
+  *min_y = std::min(*min_y, world_min_y);
+  *max_x = std::max(*max_x, world_max_x);
+  *max_y = std::max(*max_y, world_max_y);
+}
+
+unsigned char BathymetryLayer::computeCost(double clearance) const
+{
+  if (!std::isfinite(clearance) || clearance < minimum_depth_) {
+    return nav2_costmap_2d::LETHAL_OBSTACLE;
+  }
+  if (clearance >= maximum_caution_depth_) {
+    return nav2_costmap_2d::FREE_SPACE;
+  }
+  // Linear ramp between minimum_depth_ (LETHAL boundary) and maximum_caution_depth_
+  // (FREE boundary), matching s57_layer::get_cost_from_grid.
+  const double scaled = nav2_costmap_2d::MAX_NON_OBSTACLE *
+    (1.0 - (clearance - minimum_depth_) / (maximum_caution_depth_ - minimum_depth_));
+  return static_cast<unsigned char>(scaled);
+}
+
+bool BathymetryLayer::isStale(int64_t timestamp_ns, int64_t now_ns) const
+{
+  if (max_age_ <= 0.0 || timestamp_ns == 0) {
+    return false;
+  }
+  const int64_t max_age_ns = static_cast<int64_t>(max_age_ * 1e9);
+  return (now_ns - timestamp_ns) > max_age_ns;
+}
+
+std::optional<unsigned char> BathymetryLayer::evaluateCell(
+  const gggs::CellIndex & cell, int64_t now_ns) const
+{
+  if (!store_) {
+    return std::nullopt;
+  }
+
+  // Two-query no-data policy (review M1, ADR-0002 §D7):
+  //   1. bestSource — quality-blind "is there ANY data here?"
+  const std::optional<DepthSample> any = bestSource(*store_, cell);
+  if (!any) {
+    // Truly unsurveyed: leave the master cost untouched (NO_INFORMATION) so
+    // another prior (e.g. s57_layer) can contribute.
+    return std::nullopt;
+  }
+
+  //   2. shallowestReliable — the navigation-safety gate (uncertainty).
+  const std::optional<DepthSample> sample = shallowestReliable(*store_, cell, max_uncertainty_);
+
+  if (!sample || isStale(any->timestamp, now_ns)) {
+    // Data exists but every sample is over-uncertain, or the freshest data is
+    // stale → conservative LETHAL (a surveyed-but-unusable cell is NOT treated
+    // as unsurveyed; that mis-classification was review finding M1).
+    return nav2_costmap_2d::LETHAL_OBSTACLE;
+  }
+
+  // sample->depth is ellipsoidal HEIGHT (WGS84, up-positive): a seafloor 5 m
+  // below the ellipsoid has depth=-5.0, so a SHALLOWER (more hazardous) seafloor
+  // has a LARGER (less-negative) depth, hence a SMALLER clearance and a HIGHER
+  // cost. clearance = water-surface height − seafloor height.
+  const double clearance = map_tide_z_ - sample->depth;
+  return computeCost(clearance);
+}
+
+void BathymetryLayer::updateCosts(
+  nav2_costmap_2d::Costmap2D & master_grid, int min_i, int min_j, int max_i, int max_j)
+{
+  if (!enabled_ || !store_) {
+    return;
+  }
+
+  const int64_t now_ns = clock_->now().nanoseconds();
+
+  for (int j = min_j; j < max_j; ++j) {
+    for (int i = min_i; i < max_i; ++i) {
+      double wx;
+      double wy;
+      master_grid.mapToWorld(static_cast<unsigned int>(i), static_cast<unsigned int>(j), wx, wy);
+
+      gggs::CellIndex cell;
+      try {
+        const auto geo = worldToLatLon(wx, wy);
+        cell = store_->cellIndex(geo.latitude, geo.longitude);
+      } catch (const tf2::TransformException & e) {
+        RCLCPP_WARN_THROTTLE(
+          logger_, *clock_, 10000,
+          "bathymetry_layer '%s': cannot project cell to lat/lon: %s", name_.c_str(), e.what());
+        continue;
+      }
+
+      const std::optional<unsigned char> evaluated = evaluateCell(cell, now_ns);
+      if (!evaluated) {
+        // Truly unsurveyed: leave the master cost untouched (NO_INFORMATION) so
+        // another prior (e.g. s57_layer) can contribute. Never WRITE NO_INFORMATION.
+        continue;
+      }
+      const unsigned char cost = *evaluated;
+
+      // Max-cost combine: only raise the master cost (or fill NO_INFORMATION).
+      const unsigned char existing =
+        master_grid.getCost(static_cast<unsigned int>(i), static_cast<unsigned int>(j));
+      if (existing == nav2_costmap_2d::NO_INFORMATION || cost > existing) {
+        master_grid.setCost(
+          static_cast<unsigned int>(i), static_cast<unsigned int>(j), cost);
+      }
+    }
+  }
+
+  current_ = true;
+}
+
+}  // namespace bathymetry_layer
+
+#include "pluginlib/class_list_macros.hpp"
+PLUGINLIB_EXPORT_CLASS(bathymetry_layer::BathymetryLayer, nav2_costmap_2d::Layer)

--- a/bathymetry_layer/src/bathymetry_layer.hpp
+++ b/bathymetry_layer/src/bathymetry_layer.hpp
@@ -15,6 +15,7 @@
 #include "nav2_costmap_2d/layer.hpp"
 #include "nav2_costmap_2d/layered_costmap.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
 namespace bathymetry_layer
 {
@@ -87,6 +88,11 @@ protected:
   // can populate a synthetic store and drive cost evaluation without TF.
   std::unique_ptr<marine_bathymetry_store::BathymetryStore> store_;
   double map_tide_z_ = 0.0;
+  // True only after at least one successful map_tide TF lookup. When false,
+  // evaluateCell() refuses to compute clearance — tide height 0.0 (the default)
+  // is not a valid water-surface datum and would produce arbitrary clearance
+  // values. updateCosts() also gates current_=true on this flag (MF1/MF2).
+  bool map_tide_valid_ = false;
 
   // Parameters (protected so the test fixture can configure them directly).
   double minimum_depth_ = 1.0;
@@ -119,6 +125,12 @@ private:
   geographic_msgs::msg::GeoPoint window_min_;
   geographic_msgs::msg::GeoPoint window_max_;
   bool window_valid_ = false;
+
+  // One-shot flag: the first loadWindow/evictOutside failure is logged at ERROR
+  // level; subsequent failures from the same root cause (e.g. bad store_path_)
+  // are suppressed to avoid log spam. Reset in openStore() so a path reconfigure
+  // gets a fresh error if it also fails.
+  bool store_path_error_logged_ = false;
 };
 
 }  // namespace bathymetry_layer

--- a/bathymetry_layer/src/bathymetry_layer.hpp
+++ b/bathymetry_layer/src/bathymetry_layer.hpp
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 Roland Arsenault
+// Licensed under BSD license
+
+#ifndef BATHYMETRY_LAYER_HPP_
+#define BATHYMETRY_LAYER_HPP_
+
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "geographic_msgs/msg/geo_point.hpp"
+#include "geometry_msgs/msg/point_stamped.hpp"
+#include "marine_autonomy/gggs.h"
+#include "marine_bathymetry_store/bathymetry_store.hpp"
+#include "nav2_costmap_2d/layer.hpp"
+#include "nav2_costmap_2d/layered_costmap.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+namespace bathymetry_layer
+{
+
+/// @brief Nav2 costmap layer fed by the bathymetric store (marine_bathymetry_store).
+///
+/// Reads the store's read-only prior layers (`chart/`, and any `processed/`
+/// present) from disk and turns *clearance* — the water-surface ellipsoidal
+/// height minus the seafloor ellipsoidal height — into occupancy cost so the
+/// planner routes around shoals. This is the D1 (prior-only, static) deliverable
+/// of issue #164: no live `draft/` reload (deferred to D2, which depends on the
+/// atomic-tile-write work in #189).
+///
+/// **No-data policy (ADR-0002 §D7, two-query safety pattern):** per cell,
+/// `bestSource` first answers "is there ANY data here?" (quality-blind). If not,
+/// the cell is truly unsurveyed and this layer leaves the master cost untouched
+/// (NO_INFORMATION) so another prior — e.g. `s57_layer` — can fill it in. If
+/// there *is* data, `shallowestReliable` applies the navigation-safety gate; a
+/// cell that has data but fails the uncertainty gate, or whose freshest sample is
+/// stale, is written `LETHAL_OBSTACLE` (conservative). Only the clearance ramp
+/// produces non-lethal cost.
+///
+/// **Layer coexistence:** writes use max-cost semantics (a cell is only raised,
+/// never lowered, and an unsurveyed cell is skipped), so this layer composes with
+/// `s57_layer` in a layered costmap: the higher cost per cell wins, and where this
+/// layer has no data `s57_layer` is the sole contributor. See the package README.
+class BathymetryLayer : public nav2_costmap_2d::Layer
+{
+public:
+  BathymetryLayer();
+  ~BathymetryLayer() override;
+
+  void onInitialize() override;
+
+  void reset() override;
+
+  bool isClearable() override {return false;}
+
+  void updateBounds(
+    double robot_x, double robot_y, double robot_yaw,
+    double * min_x, double * min_y,
+    double * max_x, double * max_y) override;
+
+  void updateCosts(
+    nav2_costmap_2d::Costmap2D & master_grid,
+    int min_i, int min_j, int max_i, int max_j) override;
+
+  void matchSize() override;
+
+protected:
+  // Exposed for unit testing (test/test_bathymetry_layer.cpp): the pure
+  // clearance→cost ramp, decoupled from the store/TF pipeline. `clearance` is in
+  // metres (water-surface height minus seafloor height; see updateCosts).
+  unsigned char computeCost(double clearance) const;
+
+  // Exposed for unit testing: the full two-query per-cell decision (review M1),
+  // decoupled from the costmap/TF pipeline. Reads store_ and map_tide_z_.
+  // Returns std::nullopt when the cell is truly unsurveyed (the layer leaves the
+  // master cost untouched); otherwise the cost to combine into the master grid.
+  // @p now_ns is "now" in nanoseconds since the Unix epoch (for the staleness gate).
+  std::optional<unsigned char> evaluateCell(
+    const gggs::CellIndex & cell, int64_t now_ns) const;
+
+  // Whether @p timestamp_ns (nanoseconds since the Unix epoch) is older than
+  // max_age_ relative to @p now_ns. Returns false when the gate is disabled
+  // (max_age_ <= 0) or the timestamp is unset (0).
+  bool isStale(int64_t timestamp_ns, int64_t now_ns) const;
+
+  // Test seams: the store and the cached water-surface height, so a test fixture
+  // can populate a synthetic store and drive cost evaluation without TF.
+  std::unique_ptr<marine_bathymetry_store::BathymetryStore> store_;
+  double map_tide_z_ = 0.0;
+
+  // Parameters (protected so the test fixture can configure them directly).
+  double minimum_depth_ = 1.0;
+  double maximum_caution_depth_ = 2.5;
+  double max_uncertainty_ = 0.5;
+  double max_age_ = 0.0;
+
+private:
+  // Convert a costmap world coordinate to WGS84 lat/lon via the `earth` TF frame
+  // (mirrors s57_layer::worldToLatLon).
+  geographic_msgs::msg::GeoPoint worldToLatLon(double x, double y);
+
+  // Recompute the buffered geographic window from the parent costmap bounds and
+  // (re)load / evict store tiles to keep memory bounded. Returns false if the
+  // store is not open or a TF lookup fails (logged, throttled).
+  void refreshWindow();
+
+  // Open the on-disk store at store_path_ with the parent costmap's resolution.
+  void openStore();
+
+  std::string store_path_;
+  std::string map_tide_frame_ = "map_tide";
+  double buffer_fraction_ = 0.05;
+
+  std::string global_frame_id_;
+  double resolution_ = 1.0;
+
+  // Last buffered geographic window passed to loadWindow/evictOutside. Used to
+  // skip redundant reloads when the costmap has not scrolled past the buffer.
+  geographic_msgs::msg::GeoPoint window_min_;
+  geographic_msgs::msg::GeoPoint window_max_;
+  bool window_valid_ = false;
+};
+
+}  // namespace bathymetry_layer
+
+#endif  // BATHYMETRY_LAYER_HPP_

--- a/bathymetry_layer/test/test_bathymetry_layer.cpp
+++ b/bathymetry_layer/test/test_bathymetry_layer.cpp
@@ -1,0 +1,265 @@
+// Copyright (c) 2026 Roland Arsenault
+// Licensed under BSD license
+
+#include <gtest/gtest.h>
+
+#include <unistd.h>
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "marine_autonomy/gggs.h"
+#include "marine_bathymetry_store/bathy_cell.hpp"
+#include "marine_bathymetry_store/bathymetry_store.hpp"
+#include "marine_bathymetry_store/tile_io.hpp"
+#include "nav2_costmap_2d/cost_values.hpp"
+
+#include "bathymetry_layer.hpp"
+
+using bathymetry_layer::BathymetryLayer;
+using marine_bathymetry_store::BathyCell;
+using marine_bathymetry_store::BathymetryStore;
+using marine_bathymetry_store::SourceLayer;
+
+namespace
+{
+// A single ISO-date epoch label (ADR-0002 A1).
+const char * const kEpoch = "2026-06-10";
+
+// Survey position used across the per-cell tests.
+constexpr double kLat = 43.0;
+constexpr double kLon = -70.5;
+
+// Nanoseconds in one second (timestamp arithmetic is ns since the Unix epoch).
+constexpr int64_t kNsPerSec = 1000000000LL;
+}  // namespace
+
+// Test subclass exposing the protected store / water-surface seam and the
+// two-query decision helpers, so the cost logic can be exercised directly
+// against a synthetic store with no costmap or TF pipeline.
+class BathymetryLayerForTest : public BathymetryLayer
+{
+public:
+  void setStore(std::unique_ptr<BathymetryStore> store) {store_ = std::move(store);}
+  BathymetryStore & store() {return *store_;}
+  void setMapTideZ(double z) {map_tide_z_ = z;}
+  void setMinimumDepth(double v) {minimum_depth_ = v;}
+  void setMaximumCautionDepth(double v) {maximum_caution_depth_ = v;}
+  void setMaxUncertainty(double v) {max_uncertainty_ = v;}
+  void setMaxAge(double v) {max_age_ = v;}
+
+  using BathymetryLayer::computeCost;
+  using BathymetryLayer::evaluateCell;
+  using BathymetryLayer::isStale;
+};
+
+// ---------------------------------------------------------------------------
+// Test case 1: clearance → cost ramp boundaries (lethal / caution / free).
+// ---------------------------------------------------------------------------
+TEST(BathymetryLayer, ClearanceRampBoundaries)
+{
+  BathymetryLayerForTest layer;
+  layer.setMinimumDepth(1.0);
+  layer.setMaximumCautionDepth(3.0);
+
+  // Below minimum_depth → LETHAL.
+  EXPECT_EQ(layer.computeCost(0.5), nav2_costmap_2d::LETHAL_OBSTACLE);
+  EXPECT_EQ(layer.computeCost(1.0 - 1e-6), nav2_costmap_2d::LETHAL_OBSTACLE);
+
+  // At / above maximum_caution_depth → FREE_SPACE.
+  EXPECT_EQ(layer.computeCost(3.0), nav2_costmap_2d::FREE_SPACE);
+  EXPECT_EQ(layer.computeCost(10.0), nav2_costmap_2d::FREE_SPACE);
+
+  // Midpoint of the [1, 3] ramp → half of MAX_NON_OBSTACLE.
+  const unsigned char mid = layer.computeCost(2.0);
+  const unsigned char expected_mid =
+    static_cast<unsigned char>(nav2_costmap_2d::MAX_NON_OBSTACLE * 0.5);
+  EXPECT_EQ(mid, expected_mid);
+
+  // Monotonic: shallower clearance must never cost less than deeper clearance.
+  EXPECT_GE(layer.computeCost(1.2), layer.computeCost(2.5));
+
+  // Non-finite clearance is conservatively LETHAL.
+  EXPECT_EQ(
+    layer.computeCost(std::numeric_limits<double>::quiet_NaN()),
+    nav2_costmap_2d::LETHAL_OBSTACLE);
+}
+
+// ---------------------------------------------------------------------------
+// Test case 2: truly-unsurveyed cell → NO_INFORMATION (layer leaves it alone).
+// ---------------------------------------------------------------------------
+TEST(BathymetryLayer, UnsurveyedCellLeavesMasterUntouched)
+{
+  BathymetryLayerForTest layer;
+  layer.setStore(std::make_unique<BathymetryStore>(5));
+  layer.setMapTideZ(0.0);
+
+  // A cell with no data anywhere in the store.
+  const auto cell = layer.store().cellIndex(kLat, kLon);
+  const auto result = layer.evaluateCell(cell, /*now_ns=*/0);
+  EXPECT_FALSE(result.has_value()) << "Unsurveyed cells must not be written.";
+}
+
+// ---------------------------------------------------------------------------
+// Test case 3: surveyed shallow cell → LETHAL; surveyed deep cell → FREE.
+// ---------------------------------------------------------------------------
+TEST(BathymetryLayer, SurveyedCellMapsClearanceToCost)
+{
+  BathymetryLayerForTest layer;
+  layer.setMinimumDepth(1.0);
+  layer.setMaximumCautionDepth(3.0);
+  layer.setMaxUncertainty(0.5);
+  layer.setMapTideZ(0.0);  // water surface at ellipsoidal height 0.
+
+  auto store = std::make_unique<BathymetryStore>(5);
+  const auto cell = store->cellIndex(kLat, kLon);
+
+  // Shoal: seafloor 0.5 m below the water surface → clearance 0.5 m < 1.0 → LETHAL.
+  store->set(SourceLayer::Processed, kEpoch, cell, BathyCell{-0.5, 0.1, 1LL});
+  layer.setStore(std::move(store));
+  auto shoal = layer.evaluateCell(cell, /*now_ns=*/0);
+  ASSERT_TRUE(shoal.has_value());
+  EXPECT_EQ(*shoal, nav2_costmap_2d::LETHAL_OBSTACLE);
+
+  // Deep: seafloor 5 m down → clearance 5 m >= 3.0 → FREE_SPACE.
+  auto deep_store = std::make_unique<BathymetryStore>(5);
+  const auto deep_cell = deep_store->cellIndex(kLat, kLon);
+  deep_store->set(SourceLayer::Processed, kEpoch, deep_cell, BathyCell{-5.0, 0.1, 1LL});
+  layer.setStore(std::move(deep_store));
+  auto deep = layer.evaluateCell(deep_cell, /*now_ns=*/0);
+  ASSERT_TRUE(deep.has_value());
+  EXPECT_EQ(*deep, nav2_costmap_2d::FREE_SPACE);
+}
+
+// ---------------------------------------------------------------------------
+// Test case 4 (review M1): a surveyed-but-over-uncertain cell → LETHAL, NOT
+// treated as unsurveyed. This is the safety-critical two-query case.
+// ---------------------------------------------------------------------------
+TEST(BathymetryLayer, OverUncertainSurveyedCellIsLethal)
+{
+  BathymetryLayerForTest layer;
+  layer.setMaxUncertainty(0.5);
+  layer.setMapTideZ(0.0);
+
+  auto store = std::make_unique<BathymetryStore>(5);
+  const auto cell = store->cellIndex(kLat, kLon);
+  // Data present, but uncertainty 5.0 m exceeds max_uncertainty 0.5 m: the cell
+  // HAS data (bestSource non-null) but fails the reliability gate
+  // (shallowestReliable nullopt).
+  store->set(SourceLayer::Processed, kEpoch, cell, BathyCell{-10.0, 5.0, 1LL});
+  layer.setStore(std::move(store));
+
+  const auto result = layer.evaluateCell(cell, /*now_ns=*/0);
+  ASSERT_TRUE(result.has_value())
+    << "Over-uncertain surveyed cell must be written (not skipped as unsurveyed).";
+  EXPECT_EQ(*result, nav2_costmap_2d::LETHAL_OBSTACLE);
+}
+
+// ---------------------------------------------------------------------------
+// Test case 5 (extra coverage of test case 4's sibling): a reliable but STALE
+// cell → LETHAL regardless of clearance.
+// ---------------------------------------------------------------------------
+TEST(BathymetryLayer, StaleCellIsLethal)
+{
+  BathymetryLayerForTest layer;
+  layer.setMinimumDepth(1.0);
+  layer.setMaximumCautionDepth(3.0);
+  layer.setMaxUncertainty(0.5);
+  layer.setMaxAge(1.0);          // 1-second staleness window.
+  layer.setMapTideZ(0.0);
+
+  auto store = std::make_unique<BathymetryStore>(5);
+  const auto cell = store->cellIndex(kLat, kLon);
+  // Deep + reliable (clearance would be FREE), but timestamp is 1 ns — ancient.
+  store->set(SourceLayer::Processed, kEpoch, cell, BathyCell{-5.0, 0.1, 1LL});
+  layer.setStore(std::move(store));
+
+  const int64_t now_ns = 10 * kNsPerSec;  // 10 s now, max_age 1 s → stale.
+  const auto stale = layer.evaluateCell(cell, now_ns);
+  ASSERT_TRUE(stale.has_value());
+  EXPECT_EQ(*stale, nav2_costmap_2d::LETHAL_OBSTACLE);
+
+  // With the staleness gate disabled (max_age 0), the same deep reliable cell
+  // is FREE_SPACE — confirming the stale verdict came from the age gate.
+  layer.setMaxAge(0.0);
+  const auto fresh = layer.evaluateCell(cell, now_ns);
+  ASSERT_TRUE(fresh.has_value());
+  EXPECT_EQ(*fresh, nav2_costmap_2d::FREE_SPACE);
+}
+
+// ---------------------------------------------------------------------------
+// Test case 6 (acceptance criterion): memory-bound windowed residency. After
+// loading a small window and then evicting outside a small box, the resident
+// tile count stays bounded — the layer never holds the whole store.
+// ---------------------------------------------------------------------------
+namespace
+{
+// Sum the resident tiles across all layers and epochs of a store.
+std::size_t residentTileCount(const BathymetryStore & store)
+{
+  std::size_t total = 0;
+  for (const auto layer : marine_bathymetry_store::source_layers_by_priority) {
+    for (const auto & epoch_pair : store.epochs(layer)) {
+      total += epoch_pair.second.tiles.size();
+    }
+  }
+  return total;
+}
+}  // namespace
+
+TEST(BathymetryLayer, WindowedResidencyStaysBounded)
+{
+  namespace fs = std::filesystem;
+  const fs::path dir =
+    fs::temp_directory_path() /
+    ("bathymetry_layer_window_" + std::to_string(::getpid()));
+  fs::remove_all(dir);
+  fs::create_directories(dir);
+
+  // Build a store spanning a wide geographic strip so its tiles land in
+  // distinct GGGS grids, then persist it to disk. chart_writable=true so the
+  // synthetic prior can be written on the read-only Chart layer.
+  {
+    BathymetryStore store(12, /*chart_writable=*/true);
+    for (int k = 0; k < 8; ++k) {
+      const double lon = -70.5 + 0.05 * static_cast<double>(k);
+      const auto cell = store.cellIndex(43.0, lon);
+      store.set(SourceLayer::Chart, kEpoch, cell, BathyCell{-10.0, 0.2, 1LL});
+    }
+    const std::size_t written = marine_bathymetry_store::save(store, dir.string(), nullptr);
+    ASSERT_GT(written, 0u);
+  }
+
+  // A fresh consumer store loads only a small window, leaving most tiles on disk.
+  BathymetryStore consumer(12, /*chart_writable=*/false);
+  const auto small_min = gggs::geoPoint(42.999, -70.51);
+  const auto small_max = gggs::geoPoint(43.001, -70.49);
+  marine_bathymetry_store::loadWindow(consumer, dir.string(), small_min, small_max);
+  const std::size_t small_resident = residentTileCount(consumer);
+  ASSERT_GT(small_resident, 0u) << "small window should load at least one tile";
+
+  // Expand the window to cover the whole strip, then evict back to the small
+  // box. Residency must shrink back to the small-window count — the consumer is
+  // never forced to hold the full store at once.
+  const auto big_min = gggs::geoPoint(42.99, -70.55);
+  const auto big_max = gggs::geoPoint(43.01, -70.05);
+  marine_bathymetry_store::loadWindow(consumer, dir.string(), big_min, big_max);
+  const std::size_t big_resident = residentTileCount(consumer);
+  EXPECT_GT(big_resident, small_resident)
+    << "expanding the window should load additional tiles";
+
+  marine_bathymetry_store::evictOutside(consumer, small_min, small_max);
+  const std::size_t evicted_resident = residentTileCount(consumer);
+  EXPECT_LE(evicted_resident, small_resident)
+    << "eviction must drop residency back to the small-window bound";
+  EXPECT_LT(evicted_resident, big_resident)
+    << "eviction must actually free the out-of-window tiles";
+
+  fs::remove_all(dir);
+}

--- a/bathymetry_layer/test/test_bathymetry_layer.cpp
+++ b/bathymetry_layer/test/test_bathymetry_layer.cpp
@@ -49,6 +49,8 @@ public:
   void setStore(std::unique_ptr<BathymetryStore> store) {store_ = std::move(store);}
   BathymetryStore & store() {return *store_;}
   void setMapTideZ(double z) {map_tide_z_ = z;}
+  // Explicitly mark the tide as valid (as if a successful TF lookup arrived).
+  void setMapTideValid(bool v) {map_tide_valid_ = v;}
   void setMinimumDepth(double v) {minimum_depth_ = v;}
   void setMaximumCautionDepth(double v) {maximum_caution_depth_ = v;}
   void setMaxUncertainty(double v) {max_uncertainty_ = v;}
@@ -99,6 +101,7 @@ TEST(BathymetryLayer, UnsurveyedCellLeavesMasterUntouched)
   BathymetryLayerForTest layer;
   layer.setStore(std::make_unique<BathymetryStore>(5));
   layer.setMapTideZ(0.0);
+  layer.setMapTideValid(true);
 
   // A cell with no data anywhere in the store.
   const auto cell = layer.store().cellIndex(kLat, kLon);
@@ -123,6 +126,7 @@ TEST(BathymetryLayer, SurveyedCellMapsClearanceToCost)
   // Shoal: seafloor 0.5 m below the water surface → clearance 0.5 m < 1.0 → LETHAL.
   store->set(SourceLayer::Processed, kEpoch, cell, BathyCell{-0.5, 0.1, 1LL});
   layer.setStore(std::move(store));
+  layer.setMapTideValid(true);
   auto shoal = layer.evaluateCell(cell, /*now_ns=*/0);
   ASSERT_TRUE(shoal.has_value());
   EXPECT_EQ(*shoal, nav2_costmap_2d::LETHAL_OBSTACLE);
@@ -132,6 +136,7 @@ TEST(BathymetryLayer, SurveyedCellMapsClearanceToCost)
   const auto deep_cell = deep_store->cellIndex(kLat, kLon);
   deep_store->set(SourceLayer::Processed, kEpoch, deep_cell, BathyCell{-5.0, 0.1, 1LL});
   layer.setStore(std::move(deep_store));
+  layer.setMapTideValid(true);
   auto deep = layer.evaluateCell(deep_cell, /*now_ns=*/0);
   ASSERT_TRUE(deep.has_value());
   EXPECT_EQ(*deep, nav2_costmap_2d::FREE_SPACE);
@@ -154,6 +159,7 @@ TEST(BathymetryLayer, OverUncertainSurveyedCellIsLethal)
   // (shallowestReliable nullopt).
   store->set(SourceLayer::Processed, kEpoch, cell, BathyCell{-10.0, 5.0, 1LL});
   layer.setStore(std::move(store));
+  layer.setMapTideValid(true);
 
   const auto result = layer.evaluateCell(cell, /*now_ns=*/0);
   ASSERT_TRUE(result.has_value())
@@ -179,6 +185,7 @@ TEST(BathymetryLayer, StaleCellIsLethal)
   // Deep + reliable (clearance would be FREE), but timestamp is 1 ns — ancient.
   store->set(SourceLayer::Processed, kEpoch, cell, BathyCell{-5.0, 0.1, 1LL});
   layer.setStore(std::move(store));
+  layer.setMapTideValid(true);
 
   const int64_t now_ns = 10 * kNsPerSec;  // 10 s now, max_age 1 s → stale.
   const auto stale = layer.evaluateCell(cell, now_ns);
@@ -194,7 +201,110 @@ TEST(BathymetryLayer, StaleCellIsLethal)
 }
 
 // ---------------------------------------------------------------------------
-// Test case 6 (acceptance criterion): memory-bound windowed residency. After
+// Test case 6 (MF1): invalid tide → evaluateCell returns nullopt even for a
+// well-surveyed, reliable, fresh cell. This pins the safety contract: the
+// layer must not compute clearance from an uninitialised tide value.
+// ---------------------------------------------------------------------------
+TEST(BathymetryLayer, InvalidTideYieldsNoInformation)
+{
+  BathymetryLayerForTest layer;
+  layer.setMinimumDepth(1.0);
+  layer.setMaximumCautionDepth(3.0);
+  layer.setMaxUncertainty(0.5);
+  // Deliberately do NOT call setMapTideValid(true) — map_tide_valid_ defaults false.
+  layer.setMapTideZ(52.3);  // Even a "correct" z must be rejected without a valid flag.
+
+  auto store = std::make_unique<BathymetryStore>(5);
+  const auto cell = store->cellIndex(kLat, kLon);
+  // A perfectly good surveyed cell (deep, reliable, fresh) must still be skipped.
+  store->set(SourceLayer::Processed, kEpoch, cell, BathyCell{47.0, 0.1, 1LL});
+  layer.setStore(std::move(store));
+
+  const auto result = layer.evaluateCell(cell, /*now_ns=*/0);
+  EXPECT_FALSE(result.has_value())
+    << "No tide yet: layer must not write any cost (MF1 safety gate).";
+}
+
+// ---------------------------------------------------------------------------
+// Test case 7 (S1/MF3): two-epoch StaleCell — pins the MF3 timestamp-source
+// contract. Set up a cell with TWO epochs:
+//   newest epoch: over-uncertain (shallowestReliable skips it), fresh timestamp.
+//   older epoch:  reliable (shallowestReliable uses it), ancient timestamp.
+// evaluateCell must use the RELIABLE sample's (old) timestamp for the staleness
+// check and return LETHAL. Before MF3, the code used any->timestamp (the
+// over-uncertain fresh epoch), which would have incorrectly passed the age gate
+// and produced a clearance-based cost instead of LETHAL.
+// ---------------------------------------------------------------------------
+TEST(BathymetryLayer, StaleReliableSampleIsLethalWhenNewerEpochOverUncertain)
+{
+  BathymetryLayerForTest layer;
+  layer.setMinimumDepth(1.0);
+  layer.setMaximumCautionDepth(3.0);
+  layer.setMaxUncertainty(0.5);
+  layer.setMaxAge(1.0);   // 1-second window.
+  layer.setMapTideZ(0.0);
+  layer.setMapTideValid(true);
+
+  auto store = std::make_unique<BathymetryStore>(5);
+  const auto cell = store->cellIndex(kLat, kLon);
+
+  const int64_t now_ns = 10 * kNsPerSec;  // "now" = 10 s.
+
+  // Newer epoch (e.g. "2026-06-11"): deep, but OVER-UNCERTAIN + FRESH timestamp.
+  // bestSource will find this epoch first (it is newest), but shallowestReliable
+  // cannot use it. Before MF3 this fresh timestamp would have been used for the
+  // age check → the age gate passes → clearance computed → FREE_SPACE (wrong).
+  const int64_t fresh_ns = 9 * kNsPerSec;  // 1 s ago — within max_age of 1 s.
+  store->set(SourceLayer::Processed, "2026-06-11", cell, BathyCell{-5.0, 5.0, fresh_ns});
+
+  // Older epoch ("2026-06-10"): deep, RELIABLE, but ANCIENT timestamp.
+  // shallowestReliable will select this record. Its timestamp is ancient → LETHAL.
+  const int64_t ancient_ns = 1LL;  // nanosecond 1 — effectively epoch 0, very old.
+  store->set(SourceLayer::Processed, kEpoch, cell, BathyCell{-5.0, 0.1, ancient_ns});
+
+  layer.setStore(std::move(store));
+
+  const auto result = layer.evaluateCell(cell, now_ns);
+  ASSERT_TRUE(result.has_value())
+    << "Cell has data → must write something (not skip as unsurveyed).";
+  EXPECT_EQ(*result, nav2_costmap_2d::LETHAL_OBSTACLE)
+    << "Reliable sample is ancient → LETHAL (MF3: must use sample->timestamp, "
+       "not any->timestamp).";
+}
+
+// ---------------------------------------------------------------------------
+// Test case 8 (S4): computeCost boundary guard — degenerate ramp
+// (maximum_caution_depth_ == minimum_depth_) must not divide by zero or
+// produce a NaN cast. Also pins computeCost(minimum_depth_) == LETHAL.
+// ---------------------------------------------------------------------------
+TEST(BathymetryLayer, ComputeCostDegenerateRampAndBoundary)
+{
+  BathymetryLayerForTest layer;
+  layer.setMinimumDepth(2.0);
+  layer.setMaximumCautionDepth(2.0);  // degenerate: range == 0
+
+  // Degenerate range: any clearance < maximum_caution_depth_ falls through to
+  // the ramp but the range guard returns LETHAL (S4).
+  EXPECT_EQ(layer.computeCost(1.9), nav2_costmap_2d::LETHAL_OBSTACLE)
+    << "Below the (degenerate) boundary → LETHAL";
+  // At exactly the boundary both the < minimum_depth_ check and the range guard
+  // fire in sequence; the result must be LETHAL or FREE — not UB.
+  const unsigned char at_boundary = layer.computeCost(2.0);
+  EXPECT_TRUE(
+    at_boundary == nav2_costmap_2d::LETHAL_OBSTACLE ||
+    at_boundary == nav2_costmap_2d::FREE_SPACE)
+    << "At minimum_depth_ with degenerate range: must be LETHAL or FREE, not UB.";
+
+  // With a normal ramp, computeCost(minimum_depth_) must equal MAX_NON_OBSTACLE
+  // (the top of the caution band, just inside LETHAL).
+  layer.setMinimumDepth(1.0);
+  layer.setMaximumCautionDepth(3.0);
+  EXPECT_EQ(layer.computeCost(1.0), nav2_costmap_2d::MAX_NON_OBSTACLE)
+    << "At minimum_depth_ on a normal ramp → MAX_NON_OBSTACLE (highest caution).";
+}
+
+// ---------------------------------------------------------------------------
+// Test case 9 (acceptance criterion): memory-bound windowed residency. After
 // loading a small window and then evicting outside a small box, the resident
 // tile count stays bounded — the layer never holds the whole store.
 // ---------------------------------------------------------------------------

--- a/bathymetry_layer/test/test_plugin_loading.cpp
+++ b/bathymetry_layer/test/test_plugin_loading.cpp
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Roland Arsenault
+// Licensed under BSD license
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "nav2_costmap_2d/layer.hpp"
+#include "pluginlib/class_loader.hpp"
+
+// Verify that BathymetryLayer can be loaded via pluginlib from its
+// costmap_plugins.xml descriptor. This catches plugin registration issues
+// (wrong class name, missing export, broken shared library) that unit tests
+// exercising the class directly would miss.
+TEST(BathymetryLayerPluginTest, LoadsViaPluginlib)
+{
+  pluginlib::ClassLoader<nav2_costmap_2d::Layer> loader(
+    "nav2_costmap_2d", "nav2_costmap_2d::Layer");
+
+  std::shared_ptr<nav2_costmap_2d::Layer> plugin;
+  ASSERT_NO_THROW(
+    plugin = loader.createSharedInstance("bathymetry_layer::BathymetryLayer"));
+  EXPECT_NE(plugin, nullptr);
+}

--- a/marine_bathymetry_store/CMakeLists.txt
+++ b/marine_bathymetry_store/CMakeLists.txt
@@ -33,6 +33,12 @@ add_library(${PROJECT_NAME}
 )
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
+# Build with position-independent code so this (static) library can be linked
+# into SHARED consumers — notably the bathymetry_layer Nav2 costmap plugin
+# (#164), which is a shared object loaded by pluginlib. Without PIC the link of
+# the plugin fails (R_X86_64_PC32 relocation against source_layers_by_priority).
+set_target_properties(${PROJECT_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include>"

--- a/marine_tiled_raster_store/CMakeLists.txt
+++ b/marine_tiled_raster_store/CMakeLists.txt
@@ -19,6 +19,12 @@ add_library(${PROJECT_NAME}
 )
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
+# Build with position-independent code so this (static) library can be linked
+# into SHARED consumers transitively — the bathymetry_layer Nav2 costmap plugin
+# (#164) is a shared object that links marine_bathymetry_store, which wraps this
+# package's TiledRasterTile. Without PIC the plugin link fails (R_X86_64_PC32).
+set_target_properties(${PROJECT_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include>"


### PR DESCRIPTION
## Summary

Phase 4 of the persistent bathymetric store (#86): a thin Nav2 costmap **plugin** (`bathymetry_layer`, pluginlib) that renders the bathy store into the costmap as a store-backed clearance gate. D1 **prior-only** scope (data-gated: no store data → `NO_INFORMATION`, never invented free space). Windows over the ~3 GB prior via `loadWindow`/`evictOutside` (#205) keyed to costmap bounds.

Closes #164. Part of #86.

## Design

- **Two-query existence/safety split (M1)** in `evaluateCell`: `bestSource` for existence (nullopt → `NO_INFORMATION`); non-null → `shallowestReliable` + staleness → over-uncertain/stale = `LETHAL`; else clearance ramp (`minimum_depth`/`maximum_caution_depth` → lethal/caution/free, mirroring `s57_layer`).
- **Datum bridge:** `clearance = z(map_tide) − seafloor_ellipsoidal`. `map_tide` is a z-only child of `map` (WGS84 ellipsoidal water-surface height) — composes directly with the store's ellipsoidal depth convention, no `chart_datum` dependency.
- **Fail-safe under degraded inputs:** invalid `map_tide` TF → skip write (`NO_INFORMATION`), never a clearance cost from a meaningless absolute height; degraded cycle reports `current_ = false` to Nav2.

## Review

Dual-lens local review (Copilot off per standing quota decision):
- **Round 1** — changes-requested: 3 safety must-fixes (MF1 fail-open-on-invalid-tide, MF2 unconditional `current_`, MF3 wrong staleness timestamp) + 5 suggestions. All folded.
- **Round 2** — **approved, Ship: recommended, 0 must-fix.** One optional D2-era hardening suggestion logged (datum-refresh staleness on later TF dropout), out of scope and matching the `s57_layer` TimePointZero precedent.

## Test

- New package; **32 gtests** (`test_bathymetry_layer` 9 + `test_plugin_loading` 1, plus parameterized), 0 failures. Covers two-query no-data policy, invalid-tide skip (MF1), stale-reliable LETHAL (MF3), degenerate ramp/boundary (S4), windowed residency bound.
- Build clean (0 warnings new sources); `ament_uncrustify` + `ament_cpplint` clean (bare-jazzy, CI-accurate).

## Follow-ups (not in this PR)

- **cube#44** chart-prior importer (data half of the vertical slice) — in flight.
- nav2_params wiring in platform repos (cross-repo, documented in README).
- D2 live-draft reload — needs #189 atomic writes.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
