### PR TITLE
Correct 'Norbit M3' → 'Kongsberg M3' sensor misnomer (#211)

### DIFF
--- a/docs/decisions/0005-multi-platform-provenance-registry.md
+++ b/docs/decisions/0005-multi-platform-provenance-registry.md
@@ -17,7 +17,7 @@ Depth and backscatter data will increasingly come from **more than one platform
 and sensor**, and be fused on a shared/central server. A representative near-term
 case: a joint operation where a **DriX** carrying a **Kongsberg EM2040** MBES
 contributes bathymetry *and* backscatter, while **BizzyBoat** contributes
-bathymetry from its **Norbit M3** and side-scan imagery from its **Garmin GCV**.
+bathymetry from its **Kongsberg M3** and side-scan imagery from its **Garmin GCV**.
 We want one "best bottom" answer per location — and the ability to ask "show me
 only the DriX EM2040 backscatter," or "what did BizzyBoat see here last week."
 
@@ -111,7 +111,7 @@ not need.
 | Field | Purpose / example |
 |-------|-------------------|
 | `platform` | `bizzyboat`, `drix-12` |
-| `sensor` | model — `garmin-gcv20`, `kongsberg-em2040`, `norbit-m3` |
+| `sensor` | model — `garmin-gcv20`, `kongsberg-em2040`, `kongsberg-m3` |
 | `sensor_class` | the **arbitration class** D5 priority keys on — `sidescan`, `mbes-backscatter`, `mbes-bathy`. Not the store identity (that is implicit). |
 | `campaign` | survey / deployment id + UTC time range |
 

--- a/docs/decisions/0006-multi-platform-backscatter-store.md
+++ b/docs/decisions/0006-multi-platform-backscatter-store.md
@@ -11,7 +11,7 @@ Part of the sidescan-mosaic umbrella
 this ADR is the *sidescan* backscatter store only.** It originally framed itself as
 the single backscatter store for *all* sensors (Garmin side-scan first, EM2040 / M3
 backscatter as later adopters into the same store). That is superseded: **MBES
-backscatter (Norbit M3, Kongsberg EM2040) has its own store** — single-tier and
+backscatter (Kongsberg M3, Kongsberg EM2040) has its own store** — single-tier and
 CUBE-coupled — in **ADR-0007**, because it is co-estimated with bathymetry by the
 CUBE pass and so has a fundamentally different ingest path and tiering than
 slant-archived sidescan (ADR-0007 draws the contrast). The two remain **sibling

--- a/docs/decisions/0007-mbes-backscatter-store.md
+++ b/docs/decisions/0007-mbes-backscatter-store.md
@@ -13,7 +13,7 @@ Sibling to **ADR-0006** (sidescan backscatter store). Builds on **ADR-0002**
 `cube_bathymetry`, the bathy store, `marine_tiled_raster_store`, and
 `marine_autonomy` GGGS).
 
-First sensor: **BizzyBoat Norbit M3** (via `kongsberg_em_bridge`), whose per-beam
+First sensor: **BizzyBoat Kongsberg M3** (via `kongsberg_em_bridge`), whose per-beam
 reflectivity (dB) is now carried into the soundings point cloud by
 [cube_bathymetry#52](https://github.com/rolker/cube_bathymetry/issues/52) (merged).
 Kongsberg EM2040 is a later adopter of the *same* store.
@@ -181,7 +181,7 @@ a separate **`Int64`-ns time tile**. (This is the one place the MBES schema depa
 from ADR-0006, where value/quality/source-index share a dtype and co-locate.)
 Provenance is ADR-0005: the per-cell **local source index** resolves through the
 registry to a global, origin-namespaced `source-id`; the M3 registry entry is
-`platform: bizzyboat, sensor: norbit-m3, sensor_class: mbes-backscatter`, with
+`platform: bizzyboat, sensor: kongsberg-m3, sensor_class: mbes-backscatter`, with
 `calibration_ref` empty until a beam-pattern calibration exists (relative
 backscatter).
 

--- a/marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/registry.hpp
+++ b/marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/registry.hpp
@@ -55,7 +55,7 @@ struct SourceRecord
 {
   std::string source_id;        ///< Origin-namespaced wide id (ADR-0005 D4).
   std::string platform;         ///< Contributing platform (e.g. "bizzyboat").
-  std::string sensor;           ///< Contributing sensor (e.g. "norbit-m3").
+  std::string sensor;           ///< Contributing sensor (e.g. "kongsberg-m3").
   std::string sensor_class;     ///< Sensor class (e.g. "mbes-backscatter").
   std::string campaign;         ///< Acquisition campaign / deployment.
   std::string calibration_ref;  ///< MBES extension: beam-pattern calibration ref.

--- a/marine_mbes_backscatter_store/test/test_tile_io.cpp
+++ b/marine_mbes_backscatter_store/test/test_tile_io.cpp
@@ -227,12 +227,12 @@ TEST_F(TileIoTest, RegistryWriteInternRoundTrip)
 
   SourceRegistry registry;
   const uint16_t a = registry.registerSource(
-    SourceRecord{"bizzy:norbit-m3:0", "bizzyboat", "norbit-m3", "mbes-backscatter",
+    SourceRecord{"bizzy:kongsberg-m3:0", "bizzyboat", "kongsberg-m3", "mbes-backscatter",
       "massabesic-2026", ""});
   const uint16_t b = registry.registerSource(
-    SourceRecord{"izzy:norbit-m3:0", "izzyboat", "norbit-m3", "mbes-backscatter", "", ""});
+    SourceRecord{"izzy:kongsberg-m3:0", "izzyboat", "kongsberg-m3", "mbes-backscatter", "", ""});
   const uint16_t a2 = registry.registerSource(
-    SourceRecord{"bizzy:norbit-m3:0", "x", "y", "", "", ""});   // idempotent
+    SourceRecord{"bizzy:kongsberg-m3:0", "x", "y", "", "", ""});   // idempotent
   EXPECT_EQ(a, 1u);                  // first real index (0 reserved)
   EXPECT_EQ(b, 2u);
   EXPECT_EQ(a2, a);                  // same source_id -> same index, no new entry


### PR DESCRIPTION
## Summary

Corrects a sensor-model misnomer: the BizzyBoat multibeam is a **Kongsberg M3**
(driven by `kongsberg_em_bridge`, which decodes Kongsberg `.all`/EM datagrams).
The "M3" model is Kongsberg's; **NorBit** makes the WBMS/iWBMS, not an "M3" — so
"Norbit M3" / `norbit-m3` was wrong. The cube bathymetry importer already writes
the canonical id `kongsberg-m3`.

## Changes (`Norbit M3` → `Kongsberg M3`, `norbit-m3` → `kongsberg-m3`)
- `docs/decisions/0005-…`: prose + `sensor` example
- `docs/decisions/0006-…`: prose
- `docs/decisions/0007-…`: prose + example `sensor:` line
- `marine_mbes_backscatter_store/include/.../registry.hpp`: doc-comment
- `marine_mbes_backscatter_store/test/test_tile_io.cpp`: `SourceRecord` fixtures

Doc/example only; no behavior change — the registry stores arbitrary id strings,
and the idempotency test still holds with the renamed `source_id`.

## Not touched
The legitimate `norbit_driver` / `norbit_interfaces` underlay packages (a real
NorBit ROS driver) are unrelated to this misnomer and left as-is.

## Testing
`colcon test marine_mbes_backscatter_store`: gtests pass (9, 0 failures). The
local uncrustify failures are the known 0.78.1 version-drift on **unmodified**
base lines (266/288/308 — not touched by this diff); the edited lines are
uncrustify-clean.

Closes #211

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8`
