### PR TITLE
Add marine_sonar_widgets to ui_ws manifest

### DIFF
--- a/config/repos/ui.repos
+++ b/config/repos/ui.repos
@@ -27,3 +27,7 @@ repositories:
     type: git
     url: https://github.com/rolker/marine_colormap.git
     version: jazzy
+  marine_sonar_widgets:
+    type: git
+    url: https://github.com/rolker/marine_sonar_widgets.git
+    version: jazzy


### PR DESCRIPTION
Adds the new shared sonar-display library `marine_sonar_widgets` to the `ui_ws`
layer manifest so it is checked out and built alongside its consumers
(`rqt_operator_tools`, `marine_perception_tools`).

One entry in `config/repos/ui.repos`, pinned to `jazzy` like its siblings.

This unblocks the package scaffold + the widget extraction tracked in
rolker/marine_sonar_widgets#1.

Closes #213

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8`
