### PR TITLE
feat(bathymetry_layer): unsurveyed_is_lethal parameter (no-data cells → LETHAL) (#216)

### DIFF
--- a/bathymetry_layer/README.md
+++ b/bathymetry_layer/README.md
@@ -37,9 +37,16 @@ as the boat surveys — that is the D2 follow-on (see [Follow-on work](#follow-o
 Per cell the layer uses a **two-query** pattern (ADR-0002 §D7; review finding M1):
 
 1. `bestSource(store, cell)` — quality-blind: "is there *any* data here?"
-2. If `bestSource` is `nullopt` → the cell is **truly unsurveyed** → the layer
-   **leaves the master cost untouched** (NO_INFORMATION) so another prior (e.g.
-   `s57_layer`) can fill it in. The layer never *writes* NO_INFORMATION.
+2. If `bestSource` is `nullopt` → the cell is **truly unsurveyed** → by default the
+   layer **leaves the master cost untouched** (NO_INFORMATION) so another prior
+   (e.g. `s57_layer`) can fill it in. The layer never *writes* NO_INFORMATION.
+   Setting **`unsurveyed_is_lethal: true`** flips this: a no-data cell is written
+   **`LETHAL_OBSTACLE`** instead. This is for a closed-basin water body whose prior
+   covers the whole navigable interior, so the only no-data cells are land — the
+   layer then marks the shoreline lethal without a separate land-mask. It is a
+   blanket rule (every no-data cell, not just "land") and, via max-cost combine,
+   overrides other priors on those cells, so enable it per deployment. It stays
+   behind the tide gate (below): no lethal-land is written before a valid tide.
 3. If `bestSource` is non-null → the cell **has data** → `shallowestReliable`
    applies the navigation-safety (uncertainty) gate. A cell that has data but
    fails the gate (over-uncertain), or whose freshest sample is **stale**
@@ -59,6 +66,7 @@ unsurveyed cell. Treating it as unsurveyed would be a safety regression.
 | `maximum_caution_depth` | double | `2.5` | Clearance (m) at/above which a cell is `FREE_SPACE`; between `minimum_depth` and this the cost ramps. |
 | `max_uncertainty` | double | `0.5` | Max 1-sigma vertical uncertainty (m) for `shallowestReliable`. A surveyed cell exceeding this is LETHAL. |
 | `max_age` | double | `0.0` | Staleness window (s). `0` disables the gate (D1 chart priors have timestamp 0). A cell whose freshest sample is older than `now − max_age` is LETHAL. |
+| `unsurveyed_is_lethal` | bool | `false` | When `true`, a truly-unsurveyed (no-data) cell is `LETHAL_OBSTACLE` instead of left untouched. Blanket rule — suits a closed basin whose prior fills the whole interior (no-data = land). Still gated by the tide (no cost before a valid `map_tide`). |
 | `map_tide_frame` | string | `map_tide` | Frame whose z-origin is the current water-surface ellipsoidal height. Prefix per platform (`<tf_prefix>/map_tide`). |
 | `buffer_fraction` | double | `0.05` | Fractional margin around the costmap window for `loadWindow` / `evictOutside`. |
 
@@ -74,7 +82,10 @@ in a layered Nav2 costmap:
 - **Unsurveyed cells are skipped.** Where `bathymetry_layer` has no store data it
   leaves the master cost untouched, so `s57_layer` (the broad chart prior) is the
   sole contributor there. Conversely, where the store has data but the chart does
-  not, `bathymetry_layer` is the sole contributor.
+  not, `bathymetry_layer` is the sole contributor. **Exception:** with
+  `unsurveyed_is_lethal: true` this layer writes `LETHAL_OBSTACLE` on no-data
+  cells, which (max-cost) overrides `s57_layer` there — so use that mode only when
+  this layer should own the "no data = land" verdict for the whole window.
 - **Where both have data**, the store's measured clearance typically supersedes
   the chart's coarser depth for accurate shoal detection — and because the combine
   is max-cost, the more conservative (higher-cost) opinion always survives.
@@ -106,6 +117,7 @@ local_costmap:
         maximum_caution_depth: 2.5
         max_uncertainty: 0.5
         max_age: 0.0
+        unsurveyed_is_lethal: False   # True for a closed basin (no-data = land)
         map_tide_frame: <tf_prefix>/map_tide
         buffer_fraction: 0.05
 ```

--- a/bathymetry_layer/src/bathymetry_layer.cpp
+++ b/bathymetry_layer/src/bathymetry_layer.cpp
@@ -66,6 +66,9 @@ void BathymetryLayer::onInitialize()
   declareParameter("max_age", rclcpp::ParameterValue(max_age_));
   node->get_parameter(name_ + ".max_age", max_age_);
 
+  declareParameter("unsurveyed_is_lethal", rclcpp::ParameterValue(unsurveyed_is_lethal_));
+  node->get_parameter(name_ + ".unsurveyed_is_lethal", unsurveyed_is_lethal_);
+
   declareParameter("map_tide_frame", rclcpp::ParameterValue(map_tide_frame_));
   node->get_parameter(name_ + ".map_tide_frame", map_tide_frame_);
 
@@ -89,12 +92,14 @@ void BathymetryLayer::onInitialize()
         "no costs until one is configured.");
   }
 
+  const char * const unsurveyed_lethal_str = unsurveyed_is_lethal_ ? "true" : "false";
   RCLCPP_INFO_STREAM(
     logger_,
     "bathymetry_layer '" << name_ << "': store_path='" << store_path_ << "', minimum_depth="
                          << minimum_depth_ << " m, maximum_caution_depth=" << maximum_caution_depth_
                          << " m, max_uncertainty=" << max_uncertainty_ << " m, max_age=" << max_age_
-                         << " s, map_tide_frame='" << map_tide_frame_ << "'");
+                         << " s, unsurveyed_is_lethal=" << unsurveyed_lethal_str
+                         << ", map_tide_frame='" << map_tide_frame_ << "'");
 
   matchSize();
 }
@@ -254,10 +259,10 @@ void BathymetryLayer::updateBounds(
   // z-origin (mirror s57_layer's tide lookup at TimePointZero).
   //
   // Verified sign direction (MF1): store depths are WGS84 ellipsoidal heights
-  // (up-positive). At Lake Massabesic the water surface is ~+52.3 m (map_tide_z_)
-  // and the seafloor is a few metres below that, e.g. +47–51 m. So clearance =
-  // map_tide_z_ − seafloor_height > 0 (a few metres). With the UNSET default
-  // map_tide_z_=0.0 the clearance for those same cells would be 0 − 47 = −47 m
+  // (up-positive). At Lake Massabesic the water surface is ~+48.88 m (map_tide_z_,
+  // the full-pool datum) and the seafloor is a few metres below that, e.g. +44–48 m.
+  // So clearance = map_tide_z_ − seafloor_height > 0 (a few metres). With the UNSET
+  // default map_tide_z_=0.0 the clearance for those same cells would be 0 − 47 = −47 m
   // → LETHAL (coincidentally fail-safe for this lake). However, for any site where
   // the seafloor elevation is negative (e.g. ocean, depth > ellipsoid zero),
   // clearance = 0 − (−depth) = +depth → large-positive → FREE_SPACE (fail-open,
@@ -347,8 +352,15 @@ std::optional<unsigned char> BathymetryLayer::evaluateCell(
   //   1. bestSource — quality-blind "is there ANY data here?"
   const std::optional<DepthSample> any = bestSource(*store_, cell);
   if (!any) {
-    // Truly unsurveyed: leave the master cost untouched (NO_INFORMATION) so
-    // another prior (e.g. s57_layer) can contribute.
+    // Truly unsurveyed. By default leave the master cost untouched
+    // (NO_INFORMATION) so another prior (e.g. s57_layer) can contribute. When
+    // unsurveyed_is_lethal_ is set, treat no-data as an obstacle instead — for a
+    // closed basin whose prior fills the whole interior, the only no-data cells
+    // are land (see the class doc). This still sits behind the MF1 tide gate
+    // above, so no lethal-land is written before a valid tide arrives.
+    if (unsurveyed_is_lethal_) {
+      return nav2_costmap_2d::LETHAL_OBSTACLE;
+    }
     return std::nullopt;
   }
 

--- a/bathymetry_layer/src/bathymetry_layer.hpp
+++ b/bathymetry_layer/src/bathymetry_layer.hpp
@@ -32,8 +32,16 @@ namespace bathymetry_layer
 /// **No-data policy (ADR-0002 §D7, two-query safety pattern):** per cell,
 /// `bestSource` first answers "is there ANY data here?" (quality-blind). If not,
 /// the cell is truly unsurveyed and this layer leaves the master cost untouched
-/// (NO_INFORMATION) so another prior — e.g. `s57_layer` — can fill it in. If
-/// there *is* data, `shallowestReliable` applies the navigation-safety gate; a
+/// (NO_INFORMATION) so another prior — e.g. `s57_layer` — can fill it in. The
+/// opt-in `unsurveyed_is_lethal` parameter (default false) overrides this: when
+/// set, a truly-unsurveyed cell is written `LETHAL_OBSTACLE` instead. This suits a
+/// closed-basin water body whose prior covers the whole navigable interior (so the
+/// only no-data cells are land), letting the layer mark the shoreline lethal
+/// without a separate land-mask. It is a blanket rule (every no-data cell, not just
+/// "land") and, via max-cost combine, overrides other priors on those cells — so
+/// choose it per deployment. It is still held behind the tide gate: no cost,
+/// lethal-land included, is emitted before a valid `map_tide` arrives.
+/// If there *is* data, `shallowestReliable` applies the navigation-safety gate; a
 /// cell that has data but fails the uncertainty gate, or whose freshest sample is
 /// stale, is written `LETHAL_OBSTACLE` (conservative). Only the clearance ramp
 /// produces non-lethal cost.
@@ -99,6 +107,11 @@ protected:
   double maximum_caution_depth_ = 2.5;
   double max_uncertainty_ = 0.5;
   double max_age_ = 0.0;
+  // When true, a truly-unsurveyed (no-data) cell is written LETHAL_OBSTACLE
+  // instead of being left untouched (NO_INFORMATION). Opt-in (default false):
+  // a blanket rule suited to a closed basin whose prior covers the whole
+  // interior, so the only no-data cells are land. Still subject to the tide gate.
+  bool unsurveyed_is_lethal_ = false;
 
 private:
   // Convert a costmap world coordinate to WGS84 lat/lon via the `earth` TF frame

--- a/bathymetry_layer/test/test_bathymetry_layer.cpp
+++ b/bathymetry_layer/test/test_bathymetry_layer.cpp
@@ -55,6 +55,7 @@ public:
   void setMaximumCautionDepth(double v) {maximum_caution_depth_ = v;}
   void setMaxUncertainty(double v) {max_uncertainty_ = v;}
   void setMaxAge(double v) {max_age_ = v;}
+  void setUnsurveyedIsLethal(bool v) {unsurveyed_is_lethal_ = v;}
 
   using BathymetryLayer::computeCost;
   using BathymetryLayer::evaluateCell;
@@ -107,6 +108,44 @@ TEST(BathymetryLayer, UnsurveyedCellLeavesMasterUntouched)
   const auto cell = layer.store().cellIndex(kLat, kLon);
   const auto result = layer.evaluateCell(cell, /*now_ns=*/0);
   EXPECT_FALSE(result.has_value()) << "Unsurveyed cells must not be written.";
+}
+
+// ---------------------------------------------------------------------------
+// Test case 2b (#216): with unsurveyed_is_lethal enabled, a no-data cell is
+// LETHAL instead of skipped — the closed-basin "no data = land" mode.
+// ---------------------------------------------------------------------------
+TEST(BathymetryLayer, UnsurveyedCellLethalWhenParamEnabled)
+{
+  BathymetryLayerForTest layer;
+  layer.setStore(std::make_unique<BathymetryStore>(5));
+  layer.setMapTideZ(48.88);
+  layer.setMapTideValid(true);
+  layer.setUnsurveyedIsLethal(true);
+
+  const auto cell = layer.store().cellIndex(kLat, kLon);
+  const auto result = layer.evaluateCell(cell, /*now_ns=*/0);
+  ASSERT_TRUE(result.has_value())
+    << "With unsurveyed_is_lethal, a no-data cell must be written.";
+  EXPECT_EQ(*result, nav2_costmap_2d::LETHAL_OBSTACLE);
+}
+
+// ---------------------------------------------------------------------------
+// Test case 2c (#216): unsurveyed_is_lethal stays behind the tide gate (option
+// A). Even with the param set, no-data cells are NOT written before a valid
+// tide — the layer never emits a half-initialised "lethal land + unknown water"
+// costmap at startup.
+// ---------------------------------------------------------------------------
+TEST(BathymetryLayer, UnsurveyedLethalStillGatedByTide)
+{
+  BathymetryLayerForTest layer;
+  layer.setStore(std::make_unique<BathymetryStore>(5));
+  layer.setUnsurveyedIsLethal(true);
+  // Deliberately do NOT mark the tide valid (map_tide_valid_ defaults false).
+
+  const auto cell = layer.store().cellIndex(kLat, kLon);
+  const auto result = layer.evaluateCell(cell, /*now_ns=*/0);
+  EXPECT_FALSE(result.has_value())
+    << "No tide yet: unsurveyed-lethal must still be gated (MF1).";
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Adds an opt-in `unsurveyed_is_lethal` parameter (bool, **default `false`**) to
`bathymetry_layer`. When set, a truly-unsurveyed (no-data) cell is written
`LETHAL_OBSTACLE` instead of being left `NO_INFORMATION`.

Closes #216.

## Why

The bathy store represents land/out-of-bounds as no-data (NaN) — e.g. the NH GRANIT
chart prior is masked to the lake outline. Today those cells are skipped
(`NO_INFORMATION`), so a planner doesn't see land as an obstacle from this layer.
For a closed basin whose prior covers the whole navigable interior (Lake
Massabesic), the only no-data cells are land, so this mode marks the shoreline
lethal without a separate land-mask layer.

## Behavior & design

- Default `false` preserves the existing ADR-0002 §D7 two-query policy and
  coexistence with `s57_layer`.
- **Kept behind the tide gate (option A, per design discussion):** the new branch
  sits *after* the MF1 `map_tide_valid_` check, so no lethal-land is written before
  a valid `map_tide` arrives — the layer stays all-or-nothing at startup rather than
  emitting "lethal land + unknown water".
- Blanket rule (every no-data cell) + max-cost combine overrides other priors on
  those cells → documented as per-deployment in the README.

## Changes

- `unsurveyed_is_lethal_` member + `declareParameter`/`get_parameter`; branch in
  `evaluateCell`; param echoed in the init log.
- README: no-data policy, parameter table, coexistence note, example config.
- Drive-by: corrected the stale "water surface ~+52.3 m" comment to 48.88 m
  (full-pool datum), matching the recent sim/datum-store correction.

## Tests

- `UnsurveyedCellLethalWhenParamEnabled` — param on + valid tide + no data → LETHAL.
- `UnsurveyedLethalStillGatedByTide` — param on + no tide → still `nullopt`.
- Existing `UnsurveyedCellLeavesMasterUntouched` covers the default-off path.
- Full package: 34 tests, 0 failures (lint clean).

## Build note

The main-tree installs of `marine_bathymetry_store` and `marine_tiled_raster_store`
were stale (built ~11 min before the PIC commit `72124eb`), which broke the plugin
link with `-fPIC` errors. Rebuilt both in place; no source change needed (the
`POSITION_INDEPENDENT_CODE ON` setting was already present).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
