### PR TITLE
feat(bathymetry_layer): expand leading ~ in store_path (#218)

### DIFF
--- a/bathymetry_layer/README.md
+++ b/bathymetry_layer/README.md
@@ -61,7 +61,7 @@ unsurveyed cell. Treating it as unsurveyed would be a safety regression.
 | Parameter | Type | Default | Meaning |
 |---|---|---|---|
 | `enabled` | bool | `true` | Enable the layer. |
-| `store_path` | string | `""` | Path to the on-disk store directory. Empty = contributes no cost. |
+| `store_path` | string | `""` | Path to the on-disk store directory. Empty = contributes no cost. A leading `~`/`~/` is expanded to `$HOME`, so one portable value (`~/data/stores/bathymetry`) resolves on both the boat (`field` user) and a dev/sim host. |
 | `minimum_depth` | double | `1.0` | Clearance (m) below which a cell is `LETHAL_OBSTACLE`. |
 | `maximum_caution_depth` | double | `2.5` | Clearance (m) at/above which a cell is `FREE_SPACE`; between `minimum_depth` and this the cost ramps. |
 | `max_uncertainty` | double | `0.5` | Max 1-sigma vertical uncertainty (m) for `shallowestReliable`. A surveyed cell exceeding this is LETHAL. |

--- a/bathymetry_layer/src/bathymetry_layer.cpp
+++ b/bathymetry_layer/src/bathymetry_layer.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
 #include <memory>
 #include <optional>
 #include <string>
@@ -25,6 +26,25 @@ using marine_bathymetry_store::BathymetryStore;
 using marine_bathymetry_store::DepthSample;
 using marine_bathymetry_store::shallowestReliable;
 
+// Expand a leading "~" or "~/" in a path to $HOME so one portable store_path
+// value (e.g. "~/data/stores/bathymetry") resolves on both the boat (field user)
+// and a dev/sim host with a different home. std::filesystem does no such
+// expansion. A bare absolute/relative path, an empty string, or the unsupported
+// "~user" form is returned unchanged (the latter would need getpwnam).
+std::string BathymetryLayer::expandUserPath(const std::string & path)
+{
+  if (path.empty() || path[0] != '~') {
+    return path;
+  }
+  if (path.size() == 1 || path[1] == '/') {
+    const char * home = std::getenv("HOME");
+    if (home != nullptr && home[0] != '\0') {
+      return std::string(home) + path.substr(1);
+    }
+  }
+  return path;
+}
+
 BathymetryLayer::BathymetryLayer() = default;
 
 BathymetryLayer::~BathymetryLayer() = default;
@@ -39,6 +59,8 @@ void BathymetryLayer::onInitialize()
 
   declareParameter("store_path", rclcpp::ParameterValue(store_path_));
   node->get_parameter(name_ + ".store_path", store_path_);
+  // Expand a leading "~" so one portable value works on the boat and dev/sim.
+  store_path_ = expandUserPath(store_path_);
 
   declareParameter("minimum_depth", rclcpp::ParameterValue(minimum_depth_));
   node->get_parameter(name_ + ".minimum_depth", minimum_depth_);

--- a/bathymetry_layer/src/bathymetry_layer.hpp
+++ b/bathymetry_layer/src/bathymetry_layer.hpp
@@ -92,6 +92,11 @@ protected:
   // (max_age_ <= 0) or the timestamp is unset (0).
   bool isStale(int64_t timestamp_ns, int64_t now_ns) const;
 
+  // Expand a leading "~"/"~/" in @p path to $HOME (so one portable store_path
+  // resolves on both the boat and dev/sim). Absolute, empty, and "~user" paths
+  // are returned unchanged. Exposed for unit testing.
+  static std::string expandUserPath(const std::string & path);
+
   // Test seams: the store and the cached water-surface height, so a test fixture
   // can populate a synthetic store and drive cost evaluation without TF.
   std::unique_ptr<marine_bathymetry_store::BathymetryStore> store_;

--- a/bathymetry_layer/test/test_bathymetry_layer.cpp
+++ b/bathymetry_layer/test/test_bathymetry_layer.cpp
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <filesystem>
 #include <limits>
 #include <memory>
@@ -60,7 +61,30 @@ public:
   using BathymetryLayer::computeCost;
   using BathymetryLayer::evaluateCell;
   using BathymetryLayer::isStale;
+  using BathymetryLayer::expandUserPath;
 };
+
+// ---------------------------------------------------------------------------
+// Test case 0 (#218): store_path "~"/"~/" expansion to $HOME — one portable
+// value resolves on both the boat and dev/sim; other paths are untouched.
+// ---------------------------------------------------------------------------
+TEST(BathymetryLayer, ExpandUserPathHandlesTilde)
+{
+  ::setenv("HOME", "/home/tester", 1);
+
+  EXPECT_EQ(
+    BathymetryLayerForTest::expandUserPath("~/data/stores/bathymetry"),
+    "/home/tester/data/stores/bathymetry");
+  EXPECT_EQ(BathymetryLayerForTest::expandUserPath("~"), "/home/tester");
+  // Absolute, relative, and empty paths are returned unchanged.
+  EXPECT_EQ(
+    BathymetryLayerForTest::expandUserPath("/home/field/data/stores/bathymetry"),
+    "/home/field/data/stores/bathymetry");
+  EXPECT_EQ(BathymetryLayerForTest::expandUserPath("relative/path"), "relative/path");
+  EXPECT_EQ(BathymetryLayerForTest::expandUserPath(""), "");
+  // The unsupported "~user" form is left untouched (not expanded).
+  EXPECT_EQ(BathymetryLayerForTest::expandUserPath("~field/x"), "~field/x");
+}
 
 // ---------------------------------------------------------------------------
 // Test case 1: clearance → cost ramp boundaries (lethal / caution / free).


### PR DESCRIPTION
## What

`bathymetry_layer` now expands a leading `~`/`~/` in `store_path` to `$HOME`
(`onInitialize`). One portable value — `~/data/stores/bathymetry` — then resolves
on both the boat (`/home/field/...`) and a dev/sim host (`/home/roland/...`).
Absolute, relative, empty, and the unsupported `~user` form are unchanged.

Closes #218.

## Why

`store_path` is consumed via `std::filesystem`, which doesn't expand `~`, so
configs had to hardcode an absolute user-specific path. The bizzy wiring
(unh_echoboats_project11#319) baked in the boat path, leaving the layer unable to
find the store in sim on a dev box (it silently no-ops). This unblocks a sim test
and removes a portability wart.

## Changes

- `expandUserPath` (static, leading-`~` → `$HOME`); applied once to `store_path_`
  after the param is read. Exposed for unit testing (matches the existing
  `computeCost`/`isStale` test-seam pattern).
- README: documents the `~` support on `store_path`.
- Unit test `ExpandUserPathHandlesTilde` (`~/x`, bare `~`, absolute, relative,
  empty, `~user`).

## Tests

35 tests, 0 failures (lint clean).

## Follow-on

The bizzy config (`unh_echoboats_project11`) will be updated to use
`~/data/stores/bathymetry` in a companion PR so it resolves in both environments.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
