### PR TITLE
fix(bathymetry_layer): read tide from map_frame, not the costmap global frame (#220)

### DIFF
--- a/.agent/work-plans/issue-220/progress.md
+++ b/.agent/work-plans/issue-220/progress.md
@@ -1,0 +1,23 @@
+---
+issue: 220
+---
+
+# Issue #220 — bathymetry_layer tide-frame fix
+
+## Local Review (Post-PR)
+**Status**: complete
+**When**: 2026-06-25
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: changes-requested (1 must-fix-class, pre-existing; PR otherwise correct + sim-verified)
+
+**PR**: #222 at `a9285bc`
+**Mode**: post-PR
+**Depth**: Deep (reason: safety-relevant navigation costmap, cross-layer)
+**Must-fix**: 1 | **Suggestions**: 3
+
+### Findings
+- [ ] (must-fix) Stale-tide latch / fail-OPEN: map_tide_valid_ is monotonic-true; a later TF failure or a never-throwing TimePointZero lookup keeps a frozen map_tide_z_ in use, current_ stays true → a dropped/stale tide can turn a real shoal FREE. No tide-age bound (cf. max_age for samples). Pre-existing, but in scope for a tide-gate safety fix — `bathymetry_layer.cpp` updateBounds tide lookup. Cross-confirmed by both adversarial lenses.
+- [ ] (suggestion) DegenerateTideFrameConfigRejected proves the gate only via tf2's same-frame identity fast-path; strengthen by publishing a transform tree so the gate is unambiguously isolated — `test/test_bathymetry_layer.cpp`
+- [ ] (suggestion) onInitialize degenerate-config ERROR is skipped when BOTH frames are empty (and for empty map_frame); only a throttled runtime WARN fires — make empty/degenerate equally loud at init — `bathymetry_layer.cpp` onInitialize
+- [ ] (suggestion) ExpandUserPathHandlesTilde leaks HOME=/home/tester globally; ROS_LOG_DIR workaround in SetUpTestSuite is fragile — restore HOME in that test instead — `test/test_bathymetry_layer.cpp`
+- [ ] (dismissed) Lens-B "map_frame == global frame unguarded": the only identity-producing case is map_frame == map_tide_frame, already guarded; if global != map_tide_frame the lookup is a real transform (non-zero). Doc comment slightly overstates; not a safety gap.

--- a/bathymetry_layer/src/bathymetry_layer.cpp
+++ b/bathymetry_layer/src/bathymetry_layer.cpp
@@ -94,6 +94,19 @@ void BathymetryLayer::onInitialize()
   declareParameter("map_tide_frame", rclcpp::ParameterValue(map_tide_frame_));
   node->get_parameter(name_ + ".map_tide_frame", map_tide_frame_);
 
+  // The water-surface ellipsoidal height is read as the z of map_tide_frame
+  // expressed in map_frame. map_frame MUST be the ellipsoid-referenced world
+  // frame (REP-105 'map'): its z=0 is the WGS84 ellipsoid, matching the store's
+  // ellipsoidal-height datum, so lookupTransform(map_frame, map_tide_frame).z is
+  // the surface ellipsoidal height (~+48.9 m at Lake Massabesic full pool).
+  // This must NOT be the costmap's own global frame: bizzy's costmaps render in
+  // map_tide, so referencing global_frame_id_ (the previous behaviour) was a
+  // degenerate self-lookup → identity → z=0 → every cell LETHAL (#220). Compare
+  // s57_layer, which likewise references a dedicated datum frame
+  // (chart_datum_frame), never the costmap global frame.
+  declareParameter("map_frame", rclcpp::ParameterValue(map_frame_));
+  node->get_parameter(name_ + ".map_frame", map_frame_);
+
   const double default_buffer_fraction = buffer_fraction_;
   declareParameter("buffer_fraction", rclcpp::ParameterValue(buffer_fraction_));
   node->get_parameter(name_ + ".buffer_fraction", buffer_fraction_);
@@ -114,6 +127,23 @@ void BathymetryLayer::onInitialize()
         "no costs until one is configured.");
   }
 
+  // Fail loud on a degenerate tide reference. If map_frame == map_tide_frame the
+  // tide lookup is an identity transform (z=0): clearance collapses to
+  // -seafloor_height and the whole survey reads LETHAL (#220). This is a config
+  // error, not a runtime condition — surface it once, clearly, rather than
+  // letting the MF1 gate silently accept the bogus z=0 (the gate in updateBounds
+  // also rejects this case so no cost is written until it is fixed).
+  if (!map_frame_.empty() && map_frame_ == map_tide_frame_) {
+    RCLCPP_ERROR_STREAM(
+      logger_,
+      "bathymetry_layer '" << name_ << "': map_frame and map_tide_frame are both '"
+                           << map_frame_ << "' — the tide lookup would be a degenerate "
+                           << "identity (z=0) and every cell would read LETHAL. map_frame "
+                           << "must be the ellipsoid-referenced world frame (REP-105 'map'), "
+                           << "distinct from the tide frame. This layer will contribute no "
+                           << "costs until the frames differ.");
+  }
+
   const char * const unsurveyed_lethal_str = unsurveyed_is_lethal_ ? "true" : "false";
   RCLCPP_INFO_STREAM(
     logger_,
@@ -121,7 +151,8 @@ void BathymetryLayer::onInitialize()
                          << minimum_depth_ << " m, maximum_caution_depth=" << maximum_caution_depth_
                          << " m, max_uncertainty=" << max_uncertainty_ << " m, max_age=" << max_age_
                          << " s, unsurveyed_is_lethal=" << unsurveyed_lethal_str
-                         << ", map_tide_frame='" << map_tide_frame_ << "'");
+                         << ", map_frame='" << map_frame_ << "', map_tide_frame='"
+                         << map_tide_frame_ << "'");
 
   matchSize();
 }
@@ -277,32 +308,44 @@ void BathymetryLayer::updateBounds(
     return;
   }
 
-  // Cache the water-surface ellipsoidal height from the map_tide frame's
-  // z-origin (mirror s57_layer's tide lookup at TimePointZero).
+  // Cache the water-surface ellipsoidal height as the z of map_tide_frame
+  // expressed in map_frame (the REP-105 'map' frame, whose z=0 is the WGS84
+  // ellipsoid). lookupTransform(map_frame, map_tide_frame).z is then the surface
+  // ellipsoidal height (~+48.9 m at Lake Massabesic full pool).
   //
-  // Verified sign direction (MF1): store depths are WGS84 ellipsoidal heights
-  // (up-positive). At Lake Massabesic the water surface is ~+48.88 m (map_tide_z_,
-  // the full-pool datum) and the seafloor is a few metres below that, e.g. +44–48 m.
-  // So clearance = map_tide_z_ − seafloor_height > 0 (a few metres). With the UNSET
-  // default map_tide_z_=0.0 the clearance for those same cells would be 0 − 47 = −47 m
-  // → LETHAL (coincidentally fail-safe for this lake). However, for any site where
-  // the seafloor elevation is negative (e.g. ocean, depth > ellipsoid zero),
-  // clearance = 0 − (−depth) = +depth → large-positive → FREE_SPACE (fail-open,
-  // i.e. shoals hidden). The direction is therefore SITE-DEPENDENT and cannot be
-  // relied upon for safety. The conservative fix (MF1) is to refuse to write any
-  // cost until at least one valid tide has been received, regardless of sign.
-  if (!map_tide_frame_.empty()) {
+  // #220: this previously referenced global_frame_id_ (the costmap's global
+  // frame). bizzy's costmaps render in map_tide, so that was a degenerate
+  // self-lookup (lookupTransform(map_tide, map_tide) → identity → z=0), making
+  // clearance = 0 − seafloor_height ≈ −47 m and reading the whole survey LETHAL.
+  // map_frame must be the tide-free ellipsoid frame, distinct from map_tide_frame
+  // — exactly as s57_layer references a dedicated chart_datum_frame rather than
+  // the costmap global frame.
+  //
+  // Sign (MF1): store depths are WGS84 ellipsoidal heights (up-positive); the
+  // seafloor sits below the surface, so clearance = map_tide_z_ − seafloor_height
+  // > 0. The MF1 gate refuses to write any cost until a valid tide is received;
+  // a degenerate frame config (map_frame == map_tide_frame) is treated as no
+  // valid tide so a misconfigured z=0 can never be accepted as a real surface.
+  const bool tide_frames_ok =
+    !map_frame_.empty() && !map_tide_frame_.empty() && map_frame_ != map_tide_frame_;
+  if (tide_frames_ok) {
     try {
       auto transform =
-        tf_->lookupTransform(global_frame_id_, map_tide_frame_, tf2::TimePointZero);
+        tf_->lookupTransform(map_frame_, map_tide_frame_, tf2::TimePointZero);
       map_tide_z_ = transform.transform.translation.z;
       map_tide_valid_ = true;
     } catch (const tf2::TransformException & e) {
       RCLCPP_WARN_THROTTLE(
         logger_, *clock_, 10000,
         "bathymetry_layer '%s': cannot look up %s in %s: %s",
-        name_.c_str(), map_tide_frame_.c_str(), global_frame_id_.c_str(), e.what());
+        name_.c_str(), map_tide_frame_.c_str(), map_frame_.c_str(), e.what());
     }
+  } else {
+    RCLCPP_WARN_THROTTLE(
+      logger_, *clock_, 10000,
+      "bathymetry_layer '%s': no usable tide reference (map_frame='%s', "
+      "map_tide_frame='%s'); contributing no costs.",
+      name_.c_str(), map_frame_.c_str(), map_tide_frame_.c_str());
   }
 
   refreshWindow();

--- a/bathymetry_layer/src/bathymetry_layer.hpp
+++ b/bathymetry_layer/src/bathymetry_layer.hpp
@@ -133,6 +133,10 @@ private:
 
   std::string store_path_;
   std::string map_tide_frame_ = "map_tide";
+  // Ellipsoid-referenced world frame (REP-105 'map'): z=0 is the WGS84 ellipsoid.
+  // The water-surface height is read as map_tide_frame's z in this frame. MUST be
+  // distinct from both map_tide_frame_ and the costmap global frame (#220).
+  std::string map_frame_ = "map";
   double buffer_fraction_ = 0.05;
 
   std::string global_frame_id_;

--- a/bathymetry_layer/test/test_bathymetry_layer.cpp
+++ b/bathymetry_layer/test/test_bathymetry_layer.cpp
@@ -20,6 +20,11 @@
 #include "marine_bathymetry_store/bathymetry_store.hpp"
 #include "marine_bathymetry_store/tile_io.hpp"
 #include "nav2_costmap_2d/cost_values.hpp"
+#include "nav2_costmap_2d/layered_costmap.hpp"
+#include "nav2_util/lifecycle_node.hpp"
+#include "tf2_ros/buffer.h"
+#include "geometry_msgs/msg/transform_stamped.hpp"
+#include "rclcpp/rclcpp.hpp"
 
 #include "bathymetry_layer.hpp"
 
@@ -50,8 +55,10 @@ public:
   void setStore(std::unique_ptr<BathymetryStore> store) {store_ = std::move(store);}
   BathymetryStore & store() {return *store_;}
   void setMapTideZ(double z) {map_tide_z_ = z;}
+  double getMapTideZ() const {return map_tide_z_;}
   // Explicitly mark the tide as valid (as if a successful TF lookup arrived).
   void setMapTideValid(bool v) {map_tide_valid_ = v;}
+  bool isMapTideValid() const {return map_tide_valid_;}
   void setMinimumDepth(double v) {minimum_depth_ = v;}
   void setMaximumCautionDepth(double v) {maximum_caution_depth_ = v;}
   void setMaxUncertainty(double v) {max_uncertainty_ = v;}
@@ -435,4 +442,104 @@ TEST(BathymetryLayer, WindowedResidencyStaysBounded)
     << "eviction must actually free the out-of-window tiles";
 
   fs::remove_all(dir);
+}
+
+// ---------------------------------------------------------------------------
+// Test case (#220): the water-surface height is read from map_frame, NOT the
+// costmap's global frame. bizzy's costmaps render in map_tide, so referencing
+// the global frame was a degenerate self-lookup (identity → z=0) that read the
+// whole survey LETHAL. These tests pin the frame the tide is measured against.
+// ---------------------------------------------------------------------------
+
+// Publish a map_frame -> map_tide transform with the sea surface at the given
+// ellipsoidal height (z of map_tide in map). map_frame's z=0 is the ellipsoid.
+static void publishMapTide(
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer,
+  const std::string & map_frame,
+  double surface_z)
+{
+  static int64_t stamp_ns = 1;
+  geometry_msgs::msg::TransformStamped mt;
+  mt.header.stamp = rclcpp::Time(stamp_ns++);
+  mt.header.frame_id = map_frame;
+  mt.child_frame_id = "map_tide";
+  mt.transform.translation.z = surface_z;
+  mt.transform.rotation.w = 1.0;
+  tf_buffer->setTransform(mt, "test_authority", false);
+}
+
+class TideFrameTest : public ::testing::Test
+{
+protected:
+  static void SetUpTestSuite()
+  {
+    // ExpandUserPathHandlesTilde overwrites HOME to a non-existent path; without
+    // a writable log directory rclcpp::init() throws while configuring logging.
+    // Pin ROS_LOG_DIR to a writable temp dir so init succeeds regardless of the
+    // HOME another test may have left behind (test-ordering isolation).
+    ::setenv("ROS_LOG_DIR", "/tmp/bathymetry_layer_test_log", 1);
+    if (!rclcpp::ok()) {
+      rclcpp::init(0, nullptr);
+    }
+  }
+  static void TearDownTestSuite()
+  {
+    if (rclcpp::ok()) {
+      rclcpp::shutdown();
+    }
+  }
+};
+
+// The costmap global frame is map_tide (as on bizzy), map_frame is the distinct
+// ellipsoid frame. updateBounds must read the surface height from map_frame ->
+// map_tide (≈ +48.88 m), not from a global-frame self-lookup (which would be 0).
+TEST_F(TideFrameTest, MapTideZReadFromMapFrameNotGlobalFrame)
+{
+  auto node = std::make_shared<nav2_util::LifecycleNode>("test_tide_frame");
+  node->declare_parameter("bathymetry_layer.map_frame", std::string("map"));
+  node->declare_parameter("bathymetry_layer.map_tide_frame", std::string("map_tide"));
+
+  auto tf_buffer = std::make_shared<tf2_ros::Buffer>(node->get_clock());
+  publishMapTide(tf_buffer, "map", 48.88);
+
+  // Global frame is map_tide — the exact deployment that triggered #220.
+  nav2_costmap_2d::LayeredCostmap layered_costmap("map_tide", false, false);
+  layered_costmap.resizeMap(10, 10, 1.0, 0.0, 0.0);
+
+  BathymetryLayerForTest layer;
+  layer.initialize(&layered_costmap, "bathymetry_layer", tf_buffer.get(), node, nullptr);
+
+  double minx = 1e30, miny = 1e30, maxx = -1e30, maxy = -1e30;
+  layer.updateBounds(0.0, 0.0, 0.0, &minx, &miny, &maxx, &maxy);
+
+  EXPECT_TRUE(layer.isMapTideValid())
+    << "a valid map_frame -> map_tide transform must open the tide gate";
+  EXPECT_NEAR(layer.getMapTideZ(), 48.88, 1e-6)
+    << "map_tide_z_ must be the surface height in map_frame, not 0 from a "
+       "global-frame self-lookup";
+}
+
+// A degenerate config (map_frame == map_tide_frame) must NOT be accepted: the
+// lookup would be an identity (z=0). The tide gate stays closed so no bogus
+// LETHAL flood is written — fail loud, do not paper over it.
+TEST_F(TideFrameTest, DegenerateTideFrameConfigRejected)
+{
+  auto node = std::make_shared<nav2_util::LifecycleNode>("test_tide_frame_degenerate");
+  node->declare_parameter("bathymetry_layer.map_frame", std::string("map_tide"));
+  node->declare_parameter("bathymetry_layer.map_tide_frame", std::string("map_tide"));
+
+  auto tf_buffer = std::make_shared<tf2_ros::Buffer>(node->get_clock());
+
+  nav2_costmap_2d::LayeredCostmap layered_costmap("map_tide", false, false);
+  layered_costmap.resizeMap(10, 10, 1.0, 0.0, 0.0);
+
+  BathymetryLayerForTest layer;
+  layer.initialize(&layered_costmap, "bathymetry_layer", tf_buffer.get(), node, nullptr);
+
+  double minx = 1e30, miny = 1e30, maxx = -1e30, maxy = -1e30;
+  layer.updateBounds(0.0, 0.0, 0.0, &minx, &miny, &maxx, &maxy);
+
+  EXPECT_FALSE(layer.isMapTideValid())
+    << "map_frame == map_tide_frame is a degenerate identity lookup and must be "
+       "rejected as an invalid tide";
 }


### PR DESCRIPTION
## Problem

In a live Nav2 costmap the `bathymetry_layer` marked **the whole lake LETHAL** — including
the robot's own position — even though the chart store is navigable (71 % free-clearance where
it has data). Root cause: `map_tide_z_` (the water-surface ellipsoidal height) was read as
`lookupTransform(global_frame_id_, map_tide_frame_).z`. On bizzy the costmap global frame **is**
`<tf_prefix>/map_tide` and `map_tide_frame` is **also** `<tf_prefix>/map_tide`, so the lookup was
a degenerate self-reference → identity → **z = 0**. `clearance = 0 − seafloor_height ≈ −47 m`
→ every surveyed cell LETHAL, and no-data → `unsurveyed_is_lethal` → LETHAL. The MF1 tide gate
opened on the bogus 0 because the lookup *succeeded*.

Found by an instrumented headless bizzy sim (the window/load and per-cell store query were both
correct; the only fault was `map_tide_z_ == 0`). `tf2_echo <prefix>/map <prefix>/map_tide` = +48.886 m.

## Fix

- Add a **`map_frame`** parameter (default `map`, the REP-105 ellipsoid-referenced world frame
  whose z = 0 is the WGS84 ellipsoid). Read the surface height as
  `lookupTransform(map_frame, map_tide_frame).z` (≈ +48.9 m at full pool), matching the store's
  ellipsoidal-height datum. This mirrors `s57_layer`, which references a dedicated
  `chart_datum_frame` rather than the costmap global frame.
- **Harden the MF1 gate**: a degenerate config (`map_frame == map_tide_frame`, or either empty)
  is treated as *no valid tide* — the layer refuses to write any cost and logs an ERROR, so a
  vertical-datum misconfig can never again be silently accepted as a real surface.
- Two regression tests (mirroring s57's `test_tide_offset.cpp`): with the costmap in `map_tide`
  and a `map → map_tide` transform, `map_tide_z_` resolves to the surface height (not 0); an
  identical-frame config leaves the tide invalid. **14/14 tests pass.**

## Verification (headless bizzy sim)

| | before | after |
|---|---|---|
| FREE (0) | 0 % | **19.6 %** |
| ramp (1–252) | ~0 % | 6.3 % |
| LETHAL (254) | 100 % | 74.1 % (land + shoals — correct for a closed basin) |
| robot cell | 254 (lethal) | **222** (navigable ramp; near-shore shallow, clr ≈ 1.18 m) |

The lake interior is now a proper free/ramp/lethal depth gradient.

## Companion change (separate repo)

The bizzy config must set `map_frame: <tf_prefix>/map` (the code default `map` is unprefixed
and won't match a namespaced TF tree): rolker/unh_echoboats_project11#327 / its PR.

Closes #220

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
