### PR TITLE
perf(bathymetry_layer): cache static prior in world-anchored cost tiles

### DIFF
--- a/.agent/work-plans/issue-226/plan.md
+++ b/.agent/work-plans/issue-226/plan.md
@@ -32,6 +32,16 @@ per cell = 1 tf transform (`worldToLatLon`→`tf_->transform(...,"earth")`) + 2 
      8-tiles/cycle throttle that caused `planner_server` "Costmap timed out waiting for update").
      `tileHasCoverage()` pads the AABB by ~1e-4 deg (~11 m) so an edge-straddling tile is treated as
      covered (full render) — never the reverse, so a covered cell is never dropped.
+   - **Empty-coverage safety guard** (review #2): if the window has NO store coverage AND
+     `unsurveyed_is_lethal_`, every tile would short-circuit to LETHAL (whole costmap incl. the boat's
+     cell). `coverage_empty_lethal_` flags this; `updateCosts` holds `current_` false and the layer warns,
+     rather than asserting a fabricated all-lethal grid as usable. Scoped to `unsurveyed_is_lethal_` so the
+     explore case (unknown lake, flag false) stays current with no-data tiles.
+   - **Readiness vs staleness** (review #3): `current_` gates on `windowFullyRendered()` = every window
+     tile rendered *at least once*, NOT on `needs_update`. A tide drift past `tide_invalidate_threshold_`
+     (e.g. a reservoir level changing gradually over a long survey) marks all tiles `needs_update`; serving
+     the sub-threshold-stale cached costs as current while re-rendering in the background avoids dropping the
+     costmap to not-current (and re-tripping the planner's `costmap_update_timeout`) for a full re-render.
 4. **updateCosts = blit**: map master bounds→tiles, copy cached tile char-maps into master with
    the existing max-combine (raise-only; skip NO_INFORMATION).
 5. **Tide-change invalidation**: if `|map_tide_z_ - last_tide_z_| > tide_invalidate_threshold_`,

--- a/.agent/work-plans/issue-226/plan.md
+++ b/.agent/work-plans/issue-226/plan.md
@@ -1,0 +1,38 @@
+---
+issue: 226
+---
+
+# Issue #226 — bathymetry_layer: cache static prior in world-anchored cost tiles
+
+## Root cause
+`updateCosts` re-renders the static prior per-cell every cycle over the full costmap extent:
+per cell = 1 tf transform (`worldToLatLon`→`tf_->transform(...,"earth")`) + 2 store queries
+(`bestSource`+`shallowestReliable`). ~35 µs/cell measured (local 122k→4.3s=0.23Hz). Global
+16M cells → ~9 min/pass → minutes-to-activate + control-loop misses.
+
+## Approach (mirror s57_layer's world-anchored tile cache)
+1. **Tile cache**: `std::map<TileID,TileInfo> tiles_` of world-anchored pre-rendered
+   `Costmap2D` cost tiles (fixed `x_origin_=y_origin_=0`, `resolution_`, `tile_size_=100`).
+   `worldToTile(x,y)`. Static lake → tiles computed once, reused as the rolling window scrolls.
+2. **generateTile(id)**: alloc `Costmap2D(tile_size_,tile_size_,res,wx0,wy0,NO_INFORMATION)`;
+   look up `global_frame→earth` transform **once** (hoist), then per cell apply it with
+   `tf2::doTransform` (no per-cell tf buffer lookup) → ECEF→lat/lon → `store_->cellIndex` →
+   `evaluateCell` → `setCost`. Preserve the MF1 tide gate + two-query + `unsurveyed_is_lethal`
+   semantics exactly (reuse `evaluateCell`).
+3. **Incremental generation**: `updateBounds` generates ≤ `max_tiles_per_cycle_` pending tiles
+   per cycle so the first global pass doesn't block activation; `current_` = all visible tiles
+   generated && tide valid && window valid. Serves cached (partial) tiles meanwhile.
+4. **updateCosts = blit**: map master bounds→tiles, copy cached tile char-maps into master with
+   the existing max-combine (raise-only; skip NO_INFORMATION).
+5. **Tide-change invalidation**: if `|map_tide_z_ - last_tide_z_| > tide_invalidate_threshold_`,
+   mark all tiles `needs_update` (regenerate) but keep serving cached costs (no flicker) — this
+   also resolves the stale-tide latch (#223).
+
+## Files
+- `bathymetry_layer/src/bathymetry_layer.hpp` — cache members, worldToTile/generateTile decls.
+- `bathymetry_layer/src/bathymetry_layer.cpp` — generateTile; rework updateBounds/updateCosts;
+  hoist transform.
+- `bathymetry_layer/test/test_bathymetry_layer.cpp` — tile cache + regenerate-on-tide tests.
+
+## Acceptance
+Local holds 5 Hz; planner activates in seconds; costmap clearances unchanged vs current.

--- a/.agent/work-plans/issue-226/plan.md
+++ b/.agent/work-plans/issue-226/plan.md
@@ -25,8 +25,10 @@ per cell = 1 tf transform (`worldToLatLon`→`tf_->transform(...,"earth")`) + 2 
 4. **updateCosts = blit**: map master bounds→tiles, copy cached tile char-maps into master with
    the existing max-combine (raise-only; skip NO_INFORMATION).
 5. **Tide-change invalidation**: if `|map_tide_z_ - last_tide_z_| > tide_invalidate_threshold_`,
-   mark all tiles `needs_update` (regenerate) but keep serving cached costs (no flicker) — this
-   also resolves the stale-tide latch (#223).
+   mark all tiles `needs_update` (regenerate) but keep serving cached costs (no flicker). Handles
+   a tide that *moves*; a *frozen/stale* tide is NOT detected here (separate #223 work). When
+   `max_age_ > 0`, a periodic full re-render (~max_age_/2) keeps the per-cell staleness gate honest
+   despite caching.
 
 ## Files
 - `bathymetry_layer/src/bathymetry_layer.hpp` — cache members, worldToTile/generateTile decls.

--- a/.agent/work-plans/issue-226/plan.md
+++ b/.agent/work-plans/issue-226/plan.md
@@ -56,5 +56,26 @@ per cell = 1 tf transform (`worldToLatLon`→`tf_->transform(...,"earth")`) + 2 
   hoist transform.
 - `bathymetry_layer/test/test_bathymetry_layer.cpp` — tile cache + regenerate-on-tide tests.
 
+## Live-sim finding (2026-06-27) + scale-independent fix (A+B)
+
+Instrumented sim (`bizzyboat_massabesic_launch`) showed the real blocker on the
+GLOBAL costmap was `core_rendered`(was `all_tiles_rendered`)`=0`: the first-pass
+render of the 4 km global (~1936 tiles) crept at ~8 tiles/s → ~4 min, and
+`current_` was gated on the WHOLE window → planner timed out (5 s) every cycle.
+The coverage short-circuit gave ~zero benefit at Massabesic because the chart
+store's coarse ~864 m GGGS tiles **blanket** the whole window, so every tile
+tested "covered" and took the full per-cell render. Operator rejected shrinking
+the global (size is a location/transit knob — may get BIGGER). Fix = scale-independent:
+
+- **A — robot-first render + core-region readiness.** `current_` now gates on a
+  robot-centred CORE (`ready_radius_`, default 200 m) being rendered, not the whole
+  window; tiles render nearest-vehicle-first. Core is ready in a cycle or two
+  regardless of global size; the rest fills outward in the background; the local
+  costmap covers the immediate surroundings. `all_tiles_generated_`→`core_ready_`.
+- **B — per-tile bilinear projection.** The covered-tile render interpolates each
+  cell's lat/lon from the 4 projected corners instead of an ECEF/tf round-trip per
+  cell (world→lat/lon is near-affine over ~100 m, sub-mm error). Removes the
+  dominant per-cell cost so the background fill keeps ahead of the vehicle.
+
 ## Acceptance
 Local holds 5 Hz; planner activates in seconds; costmap clearances unchanged vs current.

--- a/.agent/work-plans/issue-226/plan.md
+++ b/.agent/work-plans/issue-226/plan.md
@@ -19,9 +19,19 @@ per cell = 1 tf transform (`worldToLatLon`→`tf_->transform(...,"earth")`) + 2 
    `tf2::doTransform` (no per-cell tf buffer lookup) → ECEF→lat/lon → `store_->cellIndex` →
    `evaluateCell` → `setCost`. Preserve the MF1 tide gate + two-query + `unsurveyed_is_lethal`
    semantics exactly (reuse `evaluateCell`).
-3. **Incremental generation**: `updateBounds` generates ≤ `max_tiles_per_cycle_` pending tiles
-   per cycle so the first global pass doesn't block activation; `current_` = all visible tiles
-   generated && tide valid && window valid. Serves cached (partial) tiles meanwhile.
+3. **Incremental generation**: `updateBounds` time-boxes tile rendering to `update_timeout_`
+   (default 0.5 s, = s57_layer) per cycle so the first global pass doesn't block the costmap
+   thread; `current_` = all visible tiles generated && tide valid && window valid. Serves cached
+   (partial) tiles meanwhile.
+   - **Whole-tile coverage short-circuit** (s57-faithful, post-sim fix): a tile whose projected
+     lat/lon AABB overlaps NO resident store tile (`buildCoverage()` collects the few GGGS tiles'
+     AABBs) is filled uniformly — LETHAL when `unsurveyed_is_lethal_`, else `nullptr`/NO_INFORMATION
+     — with ZERO per-cell projection. Mirrors s57's `current_charts_.empty()` uncharted path. This
+     is what makes the time budget drain a 4 km global in ~1–2 cycles: the ~1600 out-of-lake tiles
+     become near-free, so `current_` flips true in seconds instead of ~240 s (the fixed
+     8-tiles/cycle throttle that caused `planner_server` "Costmap timed out waiting for update").
+     `tileHasCoverage()` pads the AABB by ~1e-4 deg (~11 m) so an edge-straddling tile is treated as
+     covered (full render) — never the reverse, so a covered cell is never dropped.
 4. **updateCosts = blit**: map master bounds→tiles, copy cached tile char-maps into master with
    the existing max-combine (raise-only; skip NO_INFORMATION).
 5. **Tide-change invalidation**: if `|map_tide_z_ - last_tide_z_| > tide_invalidate_threshold_`,

--- a/.agent/work-plans/issue-226/progress.md
+++ b/.agent/work-plans/issue-226/progress.md
@@ -43,8 +43,8 @@ gating, the "never drop a covered tile" margin property, eviction, and the MF1 t
 regression. Static analysis clean via colcon test (41 tests).
 
 ### Findings
-- [ ] (suggestion) README param table omits update_timeout + tide_invalidate_threshold — `bathymetry_layer/README.md:59`
-- [ ] (suggestion) empty store window + unsurveyed_is_lethal_ → whole costmap LETHAL reported current_; add throttled WARN / hold current_ false — `bathymetry_layer.cpp` generateTile/updateCosts
-- [ ] (suggestion, generalization) tide-change invalidation drops current_ for full-window re-render → can re-trip planner 5s timeout on large OPEN-WATER surveys (not the lake) — `bathymetry_layer.cpp:603`
-- [ ] (suggestion) budget loop + uniform-fill (LETHAL vs nullptr) decision not directly unit-tested (seam test deferred to sim) — `test_bathymetry_layer.cpp`
-- [ ] (suggestion) generateTile always returns true though header doc says false-on-failure; return is vestigial — `bathymetry_layer.cpp:384`, `.hpp:208`
+- [x] (suggestion) README param table omits update_timeout + tide_invalidate_threshold — `bathymetry_layer/README.md:59`
+- [x] (suggestion) empty store window + unsurveyed_is_lethal_ → whole costmap LETHAL reported current_; add throttled WARN / hold current_ false — `bathymetry_layer.cpp` generateTile/updateCosts
+- [x] (suggestion, generalization) tide-change invalidation drops current_ for full-window re-render → can re-trip planner 5s timeout on large OPEN-WATER surveys (not the lake) — `bathymetry_layer.cpp:603`
+- [ ] (suggestion, follow-up) budget-loop timing + uniform-fill (LETHAL vs nullptr) paths still need the earth-frame + disk-store fixture; gating decisions (#2 empty-coverage, #3 stale-vs-rendered) now ARE unit-tested — `test_bathymetry_layer.cpp`
+- [x] (suggestion) generateTile always returns true though header doc says false-on-failure; return is vestigial — `bathymetry_layer.cpp:384`, `.hpp:208`

--- a/.agent/work-plans/issue-226/progress.md
+++ b/.agent/work-plans/issue-226/progress.md
@@ -1,0 +1,25 @@
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-26 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8)
+**Verdict**: approved (must-fixes addressed)
+**Branch**: feature/issue-226 at `408c2ab`
+**Mode**: pre-push
+**Depth**: Deep (reason: ~470-line costmap-layer refactor, lifecycle/threading/safety)
+**Must-fix**: 4 (all fixed) | **Suggestions**: several (key ones applied)
+**Round**: 1 | **Ship**: recommended — must-fixes resolved; sim-verify owed (blocked on cube#69)
+
+Static analysis (cpplint/cppcheck/uncrustify/lint_cmake/xmllint) clean. Two disjoint-lens
+adversarial passes (scoped to diff + changed files + s57 reference). Lens A confirmed the blit
+index math correct (equivalent to s57; std::floor worldToTile improves on s57's truncation).
+
+### Findings
+- [x] (must-fix) staleness (max_age_) gate defeated by caching — added periodic re-render every ~max_age_/2 when max_age_>0 — `bathymetry_layer.cpp` updateBounds
+- [x] (must-fix) generateTile aborted whole tile on one cell's projection throw → could pin current_=false — now skips the cell + continues — `bathymetry_layer.cpp` generateTile
+- [x] (must-fix) updateCosts early-return left stale current_=true — set current_=false — `bathymetry_layer.cpp` updateCosts
+- [x] (must-fix) overstated "#223 resolved" claim — corrected comments + plan (tide-MOVED only; frozen tide = open #223) — `bathymetry_layer.cpp`, `plan.md`
+- [x] (suggestion) misleading perf-test comment (no store loaded) — corrected — `test_bathymetry_layer.cpp`
+- [x] (suggestion) documented incremental-fill coverage-gap contract (current_=false gates consumers) — `bathymetry_layer.cpp`
+- [ ] (suggestion, follow-up) tile_size_/max_tiles_per_cycle_/tide_invalidate_threshold_ hardcoded — s57 exposes tile_size as a param; consider parameterizing
+- [ ] (suggestion, follow-up) integration tests for generateTile + tide-invalidation + incremental gen need an earth-frame + disk-store fixture — owed; blit is covered, sim validates the rest

--- a/.agent/work-plans/issue-226/progress.md
+++ b/.agent/work-plans/issue-226/progress.md
@@ -23,3 +23,28 @@ index math correct (equivalent to s57; std::floor worldToTile improves on s57's 
 - [x] (suggestion) documented incremental-fill coverage-gap contract (current_=false gates consumers) — `bathymetry_layer.cpp`
 - [ ] (suggestion, follow-up) tile_size_/max_tiles_per_cycle_/tide_invalidate_threshold_ hardcoded — s57 exposes tile_size as a param; consider parameterizing
 - [ ] (suggestion, follow-up) integration tests for generateTile + tide-invalidation + incremental gen need an earth-frame + disk-store fixture — owed; blit is covered, sim validates the rest
+
+## Local Review
+**Status**: complete
+**When**: 2026-06-26 20:53 -0400
+**By**: Claude Code Agent (claude-opus-4-8)
+**Verdict**: approved
+
+**PR**: #227 at `832567c`
+**Mode**: post-PR
+**Depth**: Deep (reason: costmap current_ lifecycle + cross-layer nav consumers, >500 LOC C++)
+**Must-fix**: 0 | **Suggestions**: 5
+
+Covers the latest commit (832567c): time-budget generation (update_timeout, replacing
+max_tiles_per_cycle) + whole-tile no-coverage short-circuit (buildCoverage/tileHasCoverage),
+fixing planner_server "Costmap timed out" (current_ stuck false ~240s on the 4km global).
+Lens A (logic) + Lens B (systemic) both cleared blit index math, time-budget/all_tiles_generated_
+gating, the "never drop a covered tile" margin property, eviction, and the MF1 tide gate. No
+regression. Static analysis clean via colcon test (41 tests).
+
+### Findings
+- [ ] (suggestion) README param table omits update_timeout + tide_invalidate_threshold — `bathymetry_layer/README.md:59`
+- [ ] (suggestion) empty store window + unsurveyed_is_lethal_ → whole costmap LETHAL reported current_; add throttled WARN / hold current_ false — `bathymetry_layer.cpp` generateTile/updateCosts
+- [ ] (suggestion, generalization) tide-change invalidation drops current_ for full-window re-render → can re-trip planner 5s timeout on large OPEN-WATER surveys (not the lake) — `bathymetry_layer.cpp:603`
+- [ ] (suggestion) budget loop + uniform-fill (LETHAL vs nullptr) decision not directly unit-tested (seam test deferred to sim) — `test_bathymetry_layer.cpp`
+- [ ] (suggestion) generateTile always returns true though header doc says false-on-failure; return is vestigial — `bathymetry_layer.cpp:384`, `.hpp:208`

--- a/bathymetry_layer/README.md
+++ b/bathymetry_layer/README.md
@@ -68,7 +68,10 @@ unsurveyed cell. Treating it as unsurveyed would be a safety regression.
 | `max_age` | double | `0.0` | Staleness window (s). `0` disables the gate (D1 chart priors have timestamp 0). A cell whose freshest sample is older than `now − max_age` is LETHAL. |
 | `unsurveyed_is_lethal` | bool | `false` | When `true`, a truly-unsurveyed (no-data) cell is `LETHAL_OBSTACLE` instead of left untouched. Blanket rule — suits a closed basin whose prior fills the whole interior (no-data = land). Still gated by the tide (no cost before a valid `map_tide`). |
 | `map_tide_frame` | string | `map_tide` | Frame whose z-origin is the current water-surface ellipsoidal height. Prefix per platform (`<tf_prefix>/map_tide`). |
+| `map_frame` | string | `map` | Ellipsoid-referenced world frame (REP-105 `map`, z=0 at the WGS84 ellipsoid). The water-surface height is read as `map_tide_frame`'s z in this frame. **Must** be set and distinct from both `map_tide_frame` and the costmap's own global frame — otherwise the tide lookup self-references and reads 0, flooding the survey LETHAL (#220). Prefix per platform (`<tf_prefix>/map`). |
 | `buffer_fraction` | double | `0.05` | Fractional margin around the costmap window for `loadWindow` / `evictOutside`. |
+| `tide_invalidate_threshold` | double | `0.1` | Re-render the cached cost tiles only when the water surface moves more than this (m) from the value they were rendered against. Above realistic sea-surface-estimate jitter (~±0.02 m) so noise doesn't constantly re-render and defeat the cache, while still tracking a real (e.g. reservoir) level change. |
+| `update_timeout` | double | `0.5` | Per-cycle wall-clock budget (s) for tile (re)rendering. The window fills over a few cycles instead of blocking the costmap thread; with the no-coverage short-circuit most tiles are cheap, so a large global drains in ~1–2 cycles. |
 
 ## Layer coexistence
 

--- a/bathymetry_layer/README.md
+++ b/bathymetry_layer/README.md
@@ -71,7 +71,8 @@ unsurveyed cell. Treating it as unsurveyed would be a safety regression.
 | `map_frame` | string | `map` | Ellipsoid-referenced world frame (REP-105 `map`, z=0 at the WGS84 ellipsoid). The water-surface height is read as `map_tide_frame`'s z in this frame. **Must** be set and distinct from both `map_tide_frame` and the costmap's own global frame — otherwise the tide lookup self-references and reads 0, flooding the survey LETHAL (#220). Prefix per platform (`<tf_prefix>/map`). |
 | `buffer_fraction` | double | `0.05` | Fractional margin around the costmap window for `loadWindow` / `evictOutside`. |
 | `tide_invalidate_threshold` | double | `0.1` | Re-render the cached cost tiles only when the water surface moves more than this (m) from the value they were rendered against. Above realistic sea-surface-estimate jitter (~±0.02 m) so noise doesn't constantly re-render and defeat the cache, while still tracking a real (e.g. reservoir) level change. |
-| `update_timeout` | double | `0.5` | Per-cycle wall-clock budget (s) for tile (re)rendering. The window fills over a few cycles instead of blocking the costmap thread; with the no-coverage short-circuit most tiles are cheap, so a large global drains in ~1–2 cycles. |
+| `update_timeout` | double | `0.5` | Per-cycle wall-clock budget (s) for tile (re)rendering. The window fills over a few cycles (robot-first) instead of blocking the costmap thread. |
+| `ready_radius` | double | `200.0` | Radius (m) around the vehicle whose tiles must be rendered before the layer reports `current_`. Decouples readiness from the full window so a large global (which can take minutes to render fully) doesn't stall the planner: the robot-centred core is ready in seconds, the rest fills outward in the background, and the local costmap covers the immediate surroundings meanwhile. Scale-independent — enlarging the global for longer transits doesn't change time-to-ready. |
 
 ## Layer coexistence
 

--- a/bathymetry_layer/src/bathymetry_layer.cpp
+++ b/bathymetry_layer/src/bathymetry_layer.cpp
@@ -935,6 +935,24 @@ void BathymetryLayer::updateCosts(
   // staleness monitor sees a not-yet-complete costmap.
   current_ = map_tide_valid_ && window_valid_ && all_tiles_generated_ &&
     !coverage_empty_lethal_;
+
+  // Diagnostic breadcrumb: while the layer withholds readiness, say WHICH gate is
+  // responsible, so a "planner can't plan / costmap timed out waiting for update"
+  // symptom maps to a cause (no tide TF, store window not loaded, first-pass tile
+  // fill still in progress, or empty-coverage-lethal #2) without re-running blind.
+  // Only fires when not current; in steady state the layer is current and silent.
+  // clock_ guard: unit tests drive updateCosts without onInitialize (no clock_),
+  // and RCLCPP_WARN_THROTTLE dereferences the clock.
+  if (!current_ && clock_) {
+    RCLCPP_WARN_THROTTLE(
+      logger_, *clock_, 5000,
+      "bathymetry_layer '%s' NOT current: map_tide_valid=%d window_valid=%d "
+      "all_tiles_rendered=%d coverage_empty_lethal=%d (resident tiles=%zu)",
+      name_.c_str(),
+      static_cast<int>(map_tide_valid_), static_cast<int>(window_valid_),
+      static_cast<int>(all_tiles_generated_),
+      static_cast<int>(coverage_empty_lethal_), tiles_.size());
+  }
 }
 
 }  // namespace bathymetry_layer

--- a/bathymetry_layer/src/bathymetry_layer.cpp
+++ b/bathymetry_layer/src/bathymetry_layer.cpp
@@ -234,6 +234,17 @@ geographic_msgs::msg::GeoPoint BathymetryLayer::worldToLatLon(
   return geodesy::toMsg(ecef_point);
 }
 
+void BathymetryLayer::injectTile(
+  int ti, int tj, std::shared_ptr<nav2_costmap_2d::Costmap2D> tile)
+{
+  TileInfo info;
+  info.costmap = std::move(tile);
+  info.generated = true;
+  info.needs_update = false;
+  tiles_[std::make_pair(ti, tj)] = std::move(info);
+  all_tiles_generated_ = true;
+}
+
 BathymetryLayer::TileID BathymetryLayer::worldToTile(double x, double y) const
 {
   const double tile_meters = resolution_ * tile_size_;

--- a/bathymetry_layer/src/bathymetry_layer.cpp
+++ b/bathymetry_layer/src/bathymetry_layer.cpp
@@ -162,6 +162,10 @@ void BathymetryLayer::reset()
   current_ = false;
   window_valid_ = false;
   map_tide_valid_ = false;
+  // Drop the rendered-cost cache so it is rebuilt against the next tide/window.
+  tiles_.clear();
+  tide_rendered_ = false;
+  all_tiles_generated_ = false;
 }
 
 void BathymetryLayer::openStore()
@@ -192,10 +196,14 @@ void BathymetryLayer::matchSize()
   resolution_ = parent->getResolution();
 
   // Resolution may have changed; rebuild the store at the new default level and
-  // force a fresh window load on the next updateBounds.
+  // force a fresh window load on the next updateBounds. The cost tiles are sized
+  // to the old resolution, so drop them too — they are rebuilt on the next pass.
   openStore();
   window_valid_ = false;
   current_ = false;
+  tiles_.clear();
+  tide_rendered_ = false;
+  all_tiles_generated_ = false;
 }
 
 geographic_msgs::msg::GeoPoint BathymetryLayer::worldToLatLon(double x, double y)
@@ -208,6 +216,87 @@ geographic_msgs::msg::GeoPoint BathymetryLayer::worldToLatLon(double x, double y
   tf_->transform(world, ecef, "earth");
   geodesy::ECEFPoint ecef_point(ecef.point);
   return geodesy::toMsg(ecef_point);
+}
+
+geographic_msgs::msg::GeoPoint BathymetryLayer::worldToLatLon(
+  double x, double y, const geometry_msgs::msg::TransformStamped & to_earth) const
+{
+  // Hoisted-transform path: apply a pre-looked-up global_frame->earth transform
+  // instead of a per-cell tf buffer query. Used by generateTile so a tile's cells
+  // share one transform lookup rather than tile_size_^2 of them (#226).
+  geometry_msgs::msg::PointStamped world;
+  world.point.x = x;
+  world.point.y = y;
+  world.header.frame_id = global_frame_id_;
+  geometry_msgs::msg::PointStamped ecef;
+  tf2::doTransform(world, ecef, to_earth);
+  geodesy::ECEFPoint ecef_point(ecef.point);
+  return geodesy::toMsg(ecef_point);
+}
+
+BathymetryLayer::TileID BathymetryLayer::worldToTile(double x, double y) const
+{
+  const double tile_meters = resolution_ * tile_size_;
+  return std::make_pair(
+    static_cast<int>(std::floor((x - x_origin_) / tile_meters)),
+    static_cast<int>(std::floor((y - y_origin_) / tile_meters)));
+}
+
+bool BathymetryLayer::generateTile(
+  const TileID & id, const geometry_msgs::msg::TransformStamped & to_earth)
+{
+  const double tile_meters = resolution_ * tile_size_;
+  const double world_min_x = x_origin_ + id.first * tile_meters;
+  const double world_min_y = y_origin_ + id.second * tile_meters;
+
+  // World-anchored tile in the costmap global frame, NO_INFORMATION until a cell
+  // resolves. Same shape as s57_layer::generateTile.
+  auto tile = std::make_shared<nav2_costmap_2d::Costmap2D>(
+    tile_size_, tile_size_, resolution_, world_min_x, world_min_y,
+    nav2_costmap_2d::NO_INFORMATION);
+
+  const int64_t now_ns = clock_->now().nanoseconds();
+
+  for (int ty = 0; ty < tile_size_; ++ty) {
+    for (int tx = 0; tx < tile_size_; ++tx) {
+      double wx;
+      double wy;
+      tile->mapToWorld(
+        static_cast<unsigned int>(tx), static_cast<unsigned int>(ty), wx, wy);
+
+      gggs::CellIndex cell;
+      try {
+        const auto geo = worldToLatLon(wx, wy, to_earth);
+        cell = store_->cellIndex(geo.latitude, geo.longitude);
+      } catch (const tf2::TransformException & e) {
+        // A projection failure here is a transform problem, not a per-cell one
+        // (the transform is fixed for the pass); abort the tile so it is retried
+        // next cycle rather than caching a half-rendered grid.
+        RCLCPP_WARN_THROTTLE(
+          logger_, *clock_, 10000,
+          "bathymetry_layer '%s': cannot project tile cell to lat/lon: %s",
+          name_.c_str(), e.what());
+        return false;
+      }
+
+      // Reuse the exact per-cell decision (MF1 tide gate, two-query no-data
+      // policy, unsurveyed_is_lethal, staleness) — only WHEN it runs changes
+      // (once per tile generation, not every costmap cycle).
+      const std::optional<unsigned char> evaluated = evaluateCell(cell, now_ns);
+      if (evaluated) {
+        tile->setCost(
+          static_cast<unsigned int>(tx), static_cast<unsigned int>(ty), *evaluated);
+      }
+      // else: truly unsurveyed / left untouched — keep NO_INFORMATION so the blit
+      // skips it and another prior (e.g. s57_layer) can contribute.
+    }
+  }
+
+  auto & info = tiles_[id];
+  info.costmap = tile;
+  info.generated = true;
+  info.needs_update = false;
+  return true;
 }
 
 void BathymetryLayer::refreshWindow()
@@ -350,13 +439,94 @@ void BathymetryLayer::updateBounds(
 
   refreshWindow();
 
-  // This layer contributes data over the whole parent window; expand the update
-  // bounds to the parent costmap extent so updateCosts is invoked across it.
   auto parent = layered_costmap_->getCostmap();
   const double world_min_x = parent->getOriginX();
   const double world_min_y = parent->getOriginY();
   const double world_max_x = world_min_x + parent->getSizeInMetersX();
   const double world_max_y = world_min_y + parent->getSizeInMetersY();
+
+  // --- Cost-tile cache management (#226) ---
+  // Render the static prior into world-anchored tiles HERE (once per tile), so
+  // updateCosts is a cheap blit instead of a per-cell store query every cycle.
+  all_tiles_generated_ = false;
+  if (store_ && window_valid_ && map_tide_valid_) {
+    const double buffer =
+      std::max(world_max_x - world_min_x, world_max_y - world_min_y) * buffer_fraction_;
+
+    // Tide-change invalidation: re-render only when the surface moved materially.
+    // Cached costs keep being served until each tile is regenerated (no flicker;
+    // also resolves the stale-tide latch, #223).
+    if (!tide_rendered_ ||
+      std::abs(map_tide_z_ - last_tide_z_) > tide_invalidate_threshold_)
+    {
+      for (auto & entry : tiles_) {
+        entry.second.needs_update = true;
+      }
+      last_tide_z_ = map_tide_z_;
+      tide_rendered_ = true;
+    }
+
+    // Tiles overlapping the buffered window.
+    const TileID lo = worldToTile(world_min_x - buffer, world_min_y - buffer);
+    const TileID hi = worldToTile(world_max_x + buffer, world_max_y + buffer);
+
+    // Evict cached tiles fully outside the window (bound memory on long surveys).
+    for (auto it = tiles_.begin(); it != tiles_.end(); ) {
+      const TileID & t = it->first;
+      if (t.first < lo.first || t.first > hi.first ||
+        t.second < lo.second || t.second > hi.second)
+      {
+        it = tiles_.erase(it);
+      } else {
+        ++it;
+      }
+    }
+
+    // Hoist the global_frame->earth transform: one lookup for the whole pass,
+    // not one per cell (the costly part of the old per-cell path).
+    geometry_msgs::msg::TransformStamped to_earth;
+    bool have_xf = false;
+    try {
+      to_earth = tf_->lookupTransform("earth", global_frame_id_, tf2::TimePointZero);
+      have_xf = true;
+    } catch (const tf2::TransformException & e) {
+      RCLCPP_WARN_THROTTLE(
+        logger_, *clock_, 10000,
+        "bathymetry_layer '%s': cannot look up earth<-%s: %s",
+        name_.c_str(), global_frame_id_.c_str(), e.what());
+    }
+
+    // Render pending tiles, bounded per cycle so the first pass over a large
+    // (e.g. 4000x4000) global costmap is spread across cycles instead of blocking
+    // activation. all_tiles_generated_ gates current_ (MF2) below.
+    bool all_done = have_xf;
+    if (have_xf) {
+      int budget = max_tiles_per_cycle_;
+      for (int ti = lo.first; ti <= hi.first; ++ti) {
+        for (int tj = lo.second; tj <= hi.second; ++tj) {
+          const TileID id(ti, tj);
+          auto it = tiles_.find(id);
+          const bool needs =
+            (it == tiles_.end()) || !it->second.generated || it->second.needs_update;
+          if (!needs) {
+            continue;
+          }
+          if (budget > 0) {
+            generateTile(id, to_earth);
+            --budget;
+            it = tiles_.find(id);
+          }
+          if (it == tiles_.end() || !it->second.generated || it->second.needs_update) {
+            all_done = false;
+          }
+        }
+      }
+    }
+    all_tiles_generated_ = all_done;
+  }
+
+  // This layer contributes data over the whole parent window; expand the update
+  // bounds to the parent costmap extent so updateCosts is invoked across it.
   *min_x = std::min(*min_x, world_min_x);
   *min_y = std::min(*min_y, world_min_y);
   *max_x = std::max(*max_x, world_max_x);
@@ -459,49 +629,74 @@ void BathymetryLayer::updateCosts(
     return;
   }
 
-  const int64_t now_ns = clock_->now().nanoseconds();
+  // Blit the pre-rendered cost tiles into the master grid (#226). The expensive
+  // store query + projection already happened once per tile in
+  // updateBounds::generateTile; here it is a bounded memory copy with this
+  // layer's max-combine semantics (raise-only; skip NO_INFORMATION). Mirrors
+  // s57_layer::updateCosts (tile_offset_* index convention).
+  double world_min_x;
+  double world_min_y;
+  double world_max_x;
+  double world_max_y;
+  master_grid.mapToWorld(
+    static_cast<unsigned int>(min_i), static_cast<unsigned int>(min_j),
+    world_min_x, world_min_y);
+  master_grid.mapToWorld(
+    static_cast<unsigned int>(max_i), static_cast<unsigned int>(max_j),
+    world_max_x, world_max_y);
 
-  for (int j = min_j; j < max_j; ++j) {
-    for (int i = min_i; i < max_i; ++i) {
-      double wx;
-      double wy;
-      master_grid.mapToWorld(static_cast<unsigned int>(i), static_cast<unsigned int>(j), wx, wy);
+  const TileID start_tile = worldToTile(world_min_x, world_min_y);
+  const TileID end_tile = worldToTile(world_max_x, world_max_y);
 
-      gggs::CellIndex cell;
-      try {
-        const auto geo = worldToLatLon(wx, wy);
-        cell = store_->cellIndex(geo.latitude, geo.longitude);
-      } catch (const tf2::TransformException & e) {
-        RCLCPP_WARN_THROTTLE(
-          logger_, *clock_, 10000,
-          "bathymetry_layer '%s': cannot project cell to lat/lon: %s", name_.c_str(), e.what());
-        continue;
+  unsigned char * const master = master_grid.getCharMap();
+  const double inv_res = 1.0 / resolution_;
+
+  for (int ti = start_tile.first; ti <= end_tile.first; ++ti) {
+    // Offset from tile-local x to master-local x (costmap origins are
+    // resolution-aligned; lround absorbs sub-cell TF round-trip jitter).
+    const int tile_offset_x =
+      -ti * tile_size_ +
+      static_cast<int>(std::lround((master_grid.getOriginX() - x_origin_) * inv_res));
+    const int start_i = std::max(min_i, -tile_offset_x);
+    const int stop_i = std::min(max_i, tile_size_ - tile_offset_x);
+    if (start_i >= stop_i) {
+      continue;
+    }
+    for (int tj = start_tile.second; tj <= end_tile.second; ++tj) {
+      const auto entry = tiles_.find(std::make_pair(ti, tj));
+      if (entry == tiles_.end() || !entry->second.costmap) {
+        continue;  // not generated yet (or fully unsurveyed) — leave master as-is
       }
+      const int tile_offset_y =
+        -tj * tile_size_ +
+        static_cast<int>(std::lround((master_grid.getOriginY() - y_origin_) * inv_res));
+      const unsigned char * const src = entry->second.costmap->getCharMap();
 
-      const std::optional<unsigned char> evaluated = evaluateCell(cell, now_ns);
-      if (!evaluated) {
-        // Truly unsurveyed: leave the master cost untouched (NO_INFORMATION) so
-        // another prior (e.g. s57_layer) can contribute. Never WRITE NO_INFORMATION.
-        continue;
-      }
-      const unsigned char cost = *evaluated;
-
-      // Max-cost combine: only raise the master cost (or fill NO_INFORMATION).
-      const unsigned char existing =
-        master_grid.getCost(static_cast<unsigned int>(i), static_cast<unsigned int>(j));
-      if (existing == nav2_costmap_2d::NO_INFORMATION || cost > existing) {
-        master_grid.setCost(
-          static_cast<unsigned int>(i), static_cast<unsigned int>(j), cost);
+      for (int j = std::max(min_j, -tile_offset_y);
+        j < max_j && j + tile_offset_y < tile_size_; ++j)
+      {
+        const unsigned int target_row = master_grid.getIndex(0, static_cast<unsigned int>(j));
+        const unsigned int source_row =
+          entry->second.costmap->getIndex(0, static_cast<unsigned int>(j + tile_offset_y));
+        for (int i = start_i; i < stop_i; ++i) {
+          const unsigned char cost = src[source_row + i + tile_offset_x];
+          if (cost == nav2_costmap_2d::NO_INFORMATION) {
+            continue;
+          }
+          unsigned char & dst = master[target_row + i];
+          if (dst == nav2_costmap_2d::NO_INFORMATION || cost > dst) {
+            dst = cost;
+          }
+        }
       }
     }
   }
 
-  // MF2: only report this cycle as "current" when all prerequisites held:
-  // - a valid tide was received (map_tide_valid_) — MF1 safety gate
-  // - the store window was successfully loaded (window_valid_) — S2 gate
-  // A degraded cycle (no tide yet, or loadWindow failed) must not appear fresh
-  // to Nav2's staleness monitor; leave current_=false so Nav2 can detect it.
-  current_ = map_tide_valid_ && window_valid_;
+  // MF2: only report this cycle "current" when the MF1 tide gate and the store
+  // window gate held AND every tile in the window has been rendered against the
+  // current tide. While the first pass is still filling tiles in, current_=false
+  // so Nav2's staleness monitor sees a not-yet-complete costmap.
+  current_ = map_tide_valid_ && window_valid_ && all_tiles_generated_;
 }
 
 }  // namespace bathymetry_layer

--- a/bathymetry_layer/src/bathymetry_layer.cpp
+++ b/bathymetry_layer/src/bathymetry_layer.cpp
@@ -736,7 +736,9 @@ void BathymetryLayer::updateBounds(
         name_.c_str());
     }
 
-    // The vehicle sits at the centre of the rolling window; render ROBOT-FIRST.
+    // Render ROBOT-FIRST: order pending tiles by distance to the vehicle's tile.
+    // (For a rolling costmap the vehicle is near the window centre; the core
+    // readiness region below is clamped to the window regardless.)
     const TileID robot_tile = worldToTile(robot_x, robot_y);
 
     // Render pending tiles nearest-the-vehicle first, time-boxed per cycle

--- a/bathymetry_layer/src/bathymetry_layer.cpp
+++ b/bathymetry_layer/src/bathymetry_layer.cpp
@@ -14,6 +14,7 @@
 #include "geodesy/wgs84.h"
 #include "geometry_msgs/msg/point_stamped.hpp"
 #include "marine_autonomy/gggs.h"
+#include "marine_bathymetry_store/bathy_cell.hpp"
 #include "marine_bathymetry_store/query.hpp"
 #include "marine_bathymetry_store/tile_io.hpp"
 #include "nav2_costmap_2d/cost_values.hpp"
@@ -130,14 +131,17 @@ void BathymetryLayer::onInitialize()
     tide_invalidate_threshold_ = 0.1;
   }
 
-  // How many cost tiles to (re)render per costmap cycle. Bounds first-pass work
-  // so a large global costmap fills incrementally instead of blocking.
-  declareParameter("max_tiles_per_cycle", rclcpp::ParameterValue(max_tiles_per_cycle_));
-  node->get_parameter(name_ + ".max_tiles_per_cycle", max_tiles_per_cycle_);
-  if (max_tiles_per_cycle_ < 1) {
+  // Per-cycle wall-clock budget for tile (re)rendering (seconds), mirroring
+  // s57_layer's update_timeout. updateBounds renders as many pending tiles as fit
+  // in this budget each cycle, so a large global costmap fills over a few cycles
+  // instead of blocking the costmap thread, yet drains fast because the
+  // no-coverage short-circuit makes most tiles cheap. Default 0.5 s (= s57_layer).
+  declareParameter("update_timeout", rclcpp::ParameterValue(update_timeout_));
+  node->get_parameter(name_ + ".update_timeout", update_timeout_);
+  if (!std::isfinite(update_timeout_) || update_timeout_ <= 0.0) {
     RCLCPP_WARN_STREAM(
-      logger_, "Invalid max_tiles_per_cycle " << max_tiles_per_cycle_ << "; using 8 instead.");
-    max_tiles_per_cycle_ = 8;
+      logger_, "Invalid update_timeout " << update_timeout_ << "; using 0.5 instead.");
+    update_timeout_ = 0.5;
   }
 
   global_frame_id_ = layered_costmap_->getGlobalFrameID();
@@ -275,12 +279,113 @@ BathymetryLayer::TileID BathymetryLayer::worldToTile(double x, double y) const
     static_cast<int>(std::floor((y - y_origin_) / tile_meters)));
 }
 
+bool BathymetryLayer::tileHasCoverage(
+  double min_lat, double min_lon, double max_lat, double max_lon,
+  const std::vector<CoverageBox> & coverage) const
+{
+  // ~1e-4 deg (~11 m) margin: a generous superset so a tile straddling the
+  // coverage edge is treated as covered (full render) rather than skipped —
+  // never the reverse, so no covered cell is ever dropped.
+  constexpr double kMargin = 1e-4;
+  const double lo_lat = min_lat - kMargin;
+  const double lo_lon = min_lon - kMargin;
+  const double hi_lat = max_lat + kMargin;
+  const double hi_lon = max_lon + kMargin;
+  for (const auto & box : coverage) {
+    const bool lat_overlap = (hi_lat >= box.min_lat) && (lo_lat <= box.max_lat);
+    const bool lon_overlap = (hi_lon >= box.min_lon) && (lo_lon <= box.max_lon);
+    if (lat_overlap && lon_overlap) {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::vector<BathymetryLayer::CoverageBox> BathymetryLayer::buildCoverage() const
+{
+  std::vector<CoverageBox> coverage;
+  if (!store_) {
+    return coverage;
+  }
+  // The store holds only the windowed coverage (a handful of GGGS tiles for a
+  // lake), so this is cheap. One AABB per resident tile across all source layers.
+  for (const auto layer : marine_bathymetry_store::source_layers_by_priority) {
+    for (const auto & entry : store_->tiles(layer)) {
+      const gggs::GridIndex & grid = entry.first;
+      coverage.push_back(
+        CoverageBox{
+          grid.southLatitude(), grid.westLongitude(),
+          grid.northLatitude(), grid.eastLongitude()});
+    }
+  }
+  return coverage;
+}
+
 bool BathymetryLayer::generateTile(
-  const TileID & id, const geometry_msgs::msg::TransformStamped & to_earth)
+  const TileID & id, const geometry_msgs::msg::TransformStamped & to_earth,
+  const std::vector<CoverageBox> & coverage)
 {
   const double tile_meters = resolution_ * tile_size_;
   const double world_min_x = x_origin_ + id.first * tile_meters;
   const double world_min_y = y_origin_ + id.second * tile_meters;
+  const double world_max_x = world_min_x + tile_meters;
+  const double world_max_y = world_min_y + tile_meters;
+
+  // Whole-tile coverage short-circuit (mirrors s57_layer testing a tile against
+  // its loaded chart grids before sampling). Project the four corners to lat/lon:
+  // a convex rectangle's lat/lon extent is bounded by the min/max of its corner
+  // images (Earth curvature over a ~100 m tile edge is sub-mm), so this AABB is a
+  // superset of the tile's true extent. If it overlaps NONE of the store's
+  // resident-tile AABBs, the tile has no store data and is filled uniformly —
+  // skipping the 10,000-cell projection+query that dominates a large global
+  // costmap's first pass (the bulk of tiles on a 4 km global over a small lake).
+  bool corners_ok = true;
+  double min_lat = 0.0;
+  double min_lon = 0.0;
+  double max_lat = 0.0;
+  double max_lon = 0.0;
+  const double corners_x[4] = {world_min_x, world_max_x, world_min_x, world_max_x};
+  const double corners_y[4] = {world_min_y, world_min_y, world_max_y, world_max_y};
+  for (int c = 0; c < 4; ++c) {
+    try {
+      const auto geo = worldToLatLon(corners_x[c], corners_y[c], to_earth);
+      if (c == 0) {
+        min_lat = max_lat = geo.latitude;
+        min_lon = max_lon = geo.longitude;
+      } else {
+        min_lat = std::min(min_lat, geo.latitude);
+        max_lat = std::max(max_lat, geo.latitude);
+        min_lon = std::min(min_lon, geo.longitude);
+        max_lon = std::max(max_lon, geo.longitude);
+      }
+    } catch (const tf2::TransformException &) {
+      corners_ok = false;
+      break;
+    }
+  }
+
+  if (corners_ok) {
+    if (!tileHasCoverage(min_lat, min_lon, max_lat, max_lon, coverage)) {
+      // No store data anywhere in this tile. generateTile only runs once
+      // map_tide_valid_ (MF1), so for a closed basin whose prior fills the
+      // interior a no-data cell is land: LETHAL when unsurveyed_is_lethal_, else
+      // left fully NO_INFORMATION (nullptr, which updateCosts fast-skips so
+      // another prior can fill it). Either path does zero per-cell projection.
+      auto & info = tiles_[id];
+      if (unsurveyed_is_lethal_) {
+        info.costmap = std::make_shared<nav2_costmap_2d::Costmap2D>(
+          tile_size_, tile_size_, resolution_, world_min_x, world_min_y,
+          nav2_costmap_2d::LETHAL_OBSTACLE);
+      } else {
+        info.costmap = nullptr;
+      }
+      info.generated = true;
+      info.needs_update = false;
+      return true;
+    }
+  }
+  // corners_ok == false falls through to the per-cell path, which itself skips
+  // unprojectable cells (continue) rather than failing the whole tile.
 
   // World-anchored tile in the costmap global frame, NO_INFORMATION until a cell
   // resolves. Same shape as s57_layer::generateTile.
@@ -551,12 +656,21 @@ void BathymetryLayer::updateBounds(
         name_.c_str(), global_frame_id_.c_str(), e.what());
     }
 
-    // Render pending tiles, bounded per cycle so the first pass over a large
-    // (e.g. 4000x4000) global costmap is spread across cycles instead of blocking
-    // activation. all_tiles_generated_ gates current_ (MF2) below.
+    // The store holds only the windowed coverage (a handful of GGGS tiles for a
+    // lake); collect their lat/lon AABBs once so generateTile can cheaply skip the
+    // per-cell projection on tiles that fall entirely outside coverage.
+    const std::vector<CoverageBox> coverage = buildCoverage();
+
+    // Render pending tiles, time-boxed per cycle (mirrors s57_layer) so the first
+    // pass over a large (e.g. 4000x4000) global costmap is spread across cycles
+    // instead of blocking the costmap thread. all_tiles_generated_ gates current_
+    // (MF2) below. With the no-coverage short-circuit, the whole window typically
+    // drains in ~1-2 cycles, so current_ goes true promptly.
     bool all_done = have_xf;
     if (have_xf) {
-      int budget = max_tiles_per_cycle_;
+      const rclcpp::Time gen_start = clock_->now();
+      const rclcpp::Duration budget = rclcpp::Duration::from_seconds(update_timeout_);
+      bool time_up = false;
       for (int ti = lo.first; ti <= hi.first; ++ti) {
         for (int tj = lo.second; tj <= hi.second; ++tj) {
           const TileID id(ti, tj);
@@ -566,10 +680,12 @@ void BathymetryLayer::updateBounds(
           if (!needs) {
             continue;
           }
-          if (budget > 0) {
-            generateTile(id, to_earth);
-            --budget;
+          if (!time_up) {
+            generateTile(id, to_earth, coverage);
             it = tiles_.find(id);
+            if (clock_->now() - gen_start > budget) {
+              time_up = true;
+            }
           }
           if (it == tiles_.end() || !it->second.generated || it->second.needs_update) {
             all_done = false;

--- a/bathymetry_layer/src/bathymetry_layer.cpp
+++ b/bathymetry_layer/src/bathymetry_layer.cpp
@@ -144,6 +144,18 @@ void BathymetryLayer::onInitialize()
     update_timeout_ = 0.5;
   }
 
+  // Radius (m) around the vehicle whose tiles must be rendered before the layer
+  // reports current_ (review A). Decouples readiness from the full window so a
+  // large global doesn't stall the planner. Default 200 m (~the local-planning
+  // neighbourhood); the rest of the global fills outward in the background.
+  declareParameter("ready_radius", rclcpp::ParameterValue(ready_radius_));
+  node->get_parameter(name_ + ".ready_radius", ready_radius_);
+  if (!std::isfinite(ready_radius_) || ready_radius_ < 0.0) {
+    RCLCPP_WARN_STREAM(
+      logger_, "Invalid ready_radius " << ready_radius_ << "; using 200.0 instead.");
+    ready_radius_ = 200.0;
+  }
+
   global_frame_id_ = layered_costmap_->getGlobalFrameID();
 
   if (store_path_.empty()) {
@@ -191,7 +203,7 @@ void BathymetryLayer::reset()
   // Drop the rendered-cost cache so it is rebuilt against the next tide/window.
   tiles_.clear();
   tide_rendered_ = false;
-  all_tiles_generated_ = false;
+  core_ready_ = false;
 }
 
 void BathymetryLayer::openStore()
@@ -229,7 +241,7 @@ void BathymetryLayer::matchSize()
   current_ = false;
   tiles_.clear();
   tide_rendered_ = false;
-  all_tiles_generated_ = false;
+  core_ready_ = false;
 }
 
 geographic_msgs::msg::GeoPoint BathymetryLayer::worldToLatLon(double x, double y)
@@ -268,7 +280,7 @@ void BathymetryLayer::injectTile(
   info.generated = true;
   info.needs_update = false;
   tiles_[std::make_pair(ti, tj)] = std::move(info);
-  all_tiles_generated_ = true;
+  core_ready_ = true;
 }
 
 void BathymetryLayer::markTileNeedsUpdate(int ti, int tj)
@@ -365,24 +377,15 @@ void BathymetryLayer::generateTile(
   // skipping the 10,000-cell projection+query that dominates a large global
   // costmap's first pass (the bulk of tiles on a 4 km global over a small lake).
   bool corners_ok = true;
-  double min_lat = 0.0;
-  double min_lon = 0.0;
-  double max_lat = 0.0;
-  double max_lon = 0.0;
+  double clat[4];
+  double clon[4];
   const double corners_x[4] = {world_min_x, world_max_x, world_min_x, world_max_x};
   const double corners_y[4] = {world_min_y, world_min_y, world_max_y, world_max_y};
   for (int c = 0; c < 4; ++c) {
     try {
       const auto geo = worldToLatLon(corners_x[c], corners_y[c], to_earth);
-      if (c == 0) {
-        min_lat = max_lat = geo.latitude;
-        min_lon = max_lon = geo.longitude;
-      } else {
-        min_lat = std::min(min_lat, geo.latitude);
-        max_lat = std::max(max_lat, geo.latitude);
-        min_lon = std::min(min_lon, geo.longitude);
-        max_lon = std::max(max_lon, geo.longitude);
-      }
+      clat[c] = geo.latitude;
+      clon[c] = geo.longitude;
     } catch (const tf2::TransformException &) {
       corners_ok = false;
       break;
@@ -390,6 +393,11 @@ void BathymetryLayer::generateTile(
   }
 
   if (corners_ok) {
+    const double min_lat = std::min(std::min(clat[0], clat[1]), std::min(clat[2], clat[3]));
+    const double max_lat = std::max(std::max(clat[0], clat[1]), std::max(clat[2], clat[3]));
+    const double min_lon = std::min(std::min(clon[0], clon[1]), std::min(clon[2], clon[3]));
+    const double max_lon = std::max(std::max(clon[0], clon[1]), std::max(clon[2], clon[3]));
+
     if (!tileHasCoverage(min_lat, min_lon, max_lat, max_lon, coverage)) {
       // No store data anywhere in this tile. generateTile only runs once
       // map_tide_valid_ (MF1), so for a closed basin whose prior fills the
@@ -408,54 +416,75 @@ void BathymetryLayer::generateTile(
       info.needs_update = false;
       return;
     }
-  }
-  // corners_ok == false falls through to the per-cell path, which itself skips
-  // unprojectable cells (continue) rather than failing the whole tile.
 
-  // World-anchored tile in the costmap global frame, NO_INFORMATION until a cell
-  // resolves. Same shape as s57_layer::generateTile.
+    // Covered: full render with per-cell lat/lon BILINEARLY interpolated from the
+    // four corner geos (review B). The world->lat/lon map is near-affine over a
+    // ~100 m tile (sub-mm curvature, <<1 store cell), so this drops the dominant
+    // per-cell cost — an ECEF/tf round-trip per cell — that made a large global's
+    // first pass take minutes. cellIndex + the two-query evaluateCell decision
+    // still run per cell (the actual store lookup). All four corners projected,
+    // so no per-cell tf throw is possible here.
+    auto tile = std::make_shared<nav2_costmap_2d::Costmap2D>(
+      tile_size_, tile_size_, resolution_, world_min_x, world_min_y,
+      nav2_costmap_2d::NO_INFORMATION);
+    const int64_t now_ns = clock_->now().nanoseconds();
+    const double inv = 1.0 / static_cast<double>(tile_size_);
+    for (int ty = 0; ty < tile_size_; ++ty) {
+      const double fy = (static_cast<double>(ty) + 0.5) * inv;
+      for (int tx = 0; tx < tile_size_; ++tx) {
+        const double fx = (static_cast<double>(tx) + 0.5) * inv;
+        const double w00 = (1.0 - fx) * (1.0 - fy);
+        const double w10 = fx * (1.0 - fy);
+        const double w01 = (1.0 - fx) * fy;
+        const double w11 = fx * fy;
+        const double lat = w00 * clat[0] + w10 * clat[1] + w01 * clat[2] + w11 * clat[3];
+        const double lon = w00 * clon[0] + w10 * clon[1] + w01 * clon[2] + w11 * clon[3];
+        const gggs::CellIndex cell = store_->cellIndex(lat, lon);
+        const std::optional<unsigned char> evaluated = evaluateCell(cell, now_ns);
+        if (evaluated) {
+          tile->setCost(
+            static_cast<unsigned int>(tx), static_cast<unsigned int>(ty), *evaluated);
+        }
+      }
+    }
+    auto & info = tiles_[id];
+    info.costmap = tile;
+    info.generated = true;
+    info.needs_update = false;
+    return;
+  }
+
+  // corners_ok == false (a corner is unprojectable): fall back to the per-cell
+  // worldToLatLon path, which skips individual unprojectable cells (continue)
+  // rather than failing the whole tile. Rare (a TF gap at a tile corner).
   auto tile = std::make_shared<nav2_costmap_2d::Costmap2D>(
     tile_size_, tile_size_, resolution_, world_min_x, world_min_y,
     nav2_costmap_2d::NO_INFORMATION);
-
   const int64_t now_ns = clock_->now().nanoseconds();
-
   for (int ty = 0; ty < tile_size_; ++ty) {
     for (int tx = 0; tx < tile_size_; ++tx) {
       double wx;
       double wy;
       tile->mapToWorld(
         static_cast<unsigned int>(tx), static_cast<unsigned int>(ty), wx, wy);
-
       gggs::CellIndex cell;
       try {
         const auto geo = worldToLatLon(wx, wy, to_earth);
         cell = store_->cellIndex(geo.latitude, geo.longitude);
       } catch (const tf2::TransformException & e) {
-        // Skip this cell (leave NO_INFORMATION) and keep rendering, matching the
-        // old per-cell path's continue-on-unprojectable-cell. Aborting the whole
-        // tile would leave it permanently ungenerated — pinning current_=false
-        // (a safety layer reading perpetually stale) on a single bad cell.
         RCLCPP_WARN_THROTTLE(
           logger_, *clock_, 10000,
           "bathymetry_layer '%s': cannot project tile cell to lat/lon: %s",
           name_.c_str(), e.what());
         continue;
       }
-
-      // Reuse the exact per-cell decision (MF1 tide gate, two-query no-data
-      // policy, unsurveyed_is_lethal, staleness) — only WHEN it runs changes
-      // (once per tile generation, not every costmap cycle).
       const std::optional<unsigned char> evaluated = evaluateCell(cell, now_ns);
       if (evaluated) {
         tile->setCost(
           static_cast<unsigned int>(tx), static_cast<unsigned int>(ty), *evaluated);
       }
-      // else: truly unsurveyed / left untouched — keep NO_INFORMATION so the blit
-      // skips it and another prior (e.g. s57_layer) can contribute.
     }
   }
-
   auto & info = tiles_[id];
   info.costmap = tile;
   info.generated = true;
@@ -554,7 +583,8 @@ void BathymetryLayer::refreshWindow()
 }
 
 void BathymetryLayer::updateBounds(
-  double, double, double, double * min_x, double * min_y, double * max_x, double * max_y)
+  double robot_x, double robot_y, double, double * min_x, double * min_y,
+  double * max_x, double * max_y)
 {
   if (!enabled_) {
     return;
@@ -611,7 +641,7 @@ void BathymetryLayer::updateBounds(
   // --- Cost-tile cache management (#226) ---
   // Render the static prior into world-anchored tiles HERE (once per tile), so
   // updateCosts is a cheap blit instead of a per-cell store query every cycle.
-  all_tiles_generated_ = false;
+  core_ready_ = false;
   coverage_empty_lethal_ = false;
   if (store_ && window_valid_ && map_tide_valid_) {
     const double buffer =
@@ -706,46 +736,66 @@ void BathymetryLayer::updateBounds(
         name_.c_str());
     }
 
-    // Render pending tiles, time-boxed per cycle (mirrors s57_layer) so the first
-    // pass over a large (e.g. 4000x4000) global costmap is spread across cycles
-    // instead of blocking the costmap thread. Skipped when empty-lethal (#2):
-    // no point allocating ~1600 uniform-LETHAL tiles for a grid we will report
-    // not-current. A tile is (re)rendered when never generated OR stale
-    // (needs_update after a tide move); a stale-but-generated tile keeps serving
-    // its cached costs until it regenerates (no flicker).
+    // The vehicle sits at the centre of the rolling window; render ROBOT-FIRST.
+    const TileID robot_tile = worldToTile(robot_x, robot_y);
+
+    // Render pending tiles nearest-the-vehicle first, time-boxed per cycle
+    // (#226 review A+B). Robot-first ordering means the planning-relevant
+    // neighbourhood is correct within a cycle or two; the rest of a large global
+    // fills outward in the background. Skipped when empty-lethal (#2). A tile is
+    // (re)rendered when never generated OR stale (needs_update after a tide move);
+    // a stale-but-generated tile keeps serving its cached costs until it
+    // regenerates (no flicker).
     if (have_xf && !coverage_empty_lethal_) {
-      const rclcpp::Time gen_start = clock_->now();
-      const rclcpp::Duration budget = rclcpp::Duration::from_seconds(update_timeout_);
-      bool time_up = false;
+      std::vector<TileID> pending;
       for (int ti = lo.first; ti <= hi.first; ++ti) {
         for (int tj = lo.second; tj <= hi.second; ++tj) {
-          const TileID id(ti, tj);
-          auto it = tiles_.find(id);
-          const bool needs =
-            (it == tiles_.end()) || !it->second.generated || it->second.needs_update;
-          if (needs && !time_up) {
-            generateTile(id, to_earth, coverage);
-            if (clock_->now() - gen_start > budget) {
-              time_up = true;
-            }
+          const auto it = tiles_.find(std::make_pair(ti, tj));
+          if (it == tiles_.end() || !it->second.generated || it->second.needs_update) {
+            pending.emplace_back(ti, tj);
           }
+        }
+      }
+      std::sort(
+        pending.begin(), pending.end(),
+        [robot_tile](const TileID & a, const TileID & b) {
+          const int64_t ax = a.first - robot_tile.first;
+          const int64_t ay = a.second - robot_tile.second;
+          const int64_t bx = b.first - robot_tile.first;
+          const int64_t by = b.second - robot_tile.second;
+          return (ax * ax + ay * ay) < (bx * bx + by * by);
+        });
+      const rclcpp::Time gen_start = clock_->now();
+      const rclcpp::Duration budget = rclcpp::Duration::from_seconds(update_timeout_);
+      for (const TileID & id : pending) {
+        generateTile(id, to_earth, coverage);
+        if (clock_->now() - gen_start > budget) {
+          break;
         }
       }
     }
 
-    // #3: current_ readiness is "every window tile has been rendered at least
-    // once" — NOT "no tile needs re-rendering". A tide that drifts past
-    // tide_invalidate_threshold_ (e.g. a reservoir level changing gradually over
-    // a long survey) marks every tile needs_update; gating current_ on that would
-    // drop the whole costmap to not-current for a full-window re-render (seconds
-    // on a 4 km global) and re-trip the planner's costmap_update_timeout — even
-    // though the cached costs are only sub-threshold (<0.1 m, well inside the
-    // ~1.5 m clearance ramp) stale. So serve the cached costs as current while the
-    // re-render proceeds in the background; only a genuinely never-rendered tile
-    // (first fill, or a freshly scrolled-in window region) holds current_ false.
-    all_tiles_generated_ =
-      have_xf && !coverage_empty_lethal_ &&
-      windowFullyRendered(lo.first, lo.second, hi.first, hi.second);
+    // current_ readiness (#226 review A): gate on a robot-CENTRED CORE region
+    // being rendered, NOT the whole window. Rendering an entire large global
+    // (e.g. 4 km ~= 1900 tiles) takes far longer than the planner's
+    // costmap_update_timeout, so gating readiness on the full window stalls the
+    // planner. With robot-first rendering the core (within ready_radius_ of the
+    // vehicle) is ready within a cycle or two: the planner can plan, the rest
+    // fills outward before the vehicle reaches it, and the (small, fast) local
+    // costmap covers the immediate surroundings meanwhile. Scale-independent — a
+    // bigger global for longer transits does not change time-to-ready.
+    // Also #3: a generated-but-stale (needs_update) tile still counts as rendered,
+    // so a tide drift does not drop current_ for a full re-render.
+    const int core_r = std::max(
+      0, static_cast<int>(std::ceil(ready_radius_ / (resolution_ * tile_size_))));
+    const int core_lo_i = std::max(lo.first, robot_tile.first - core_r);
+    const int core_hi_i = std::min(hi.first, robot_tile.first + core_r);
+    const int core_lo_j = std::max(lo.second, robot_tile.second - core_r);
+    const int core_hi_j = std::min(hi.second, robot_tile.second + core_r);
+    const bool core_in_window = (core_lo_i <= core_hi_i) && (core_lo_j <= core_hi_j);
+    core_ready_ =
+      have_xf && !coverage_empty_lethal_ && core_in_window &&
+      windowFullyRendered(core_lo_i, core_lo_j, core_hi_i, core_hi_j);
   }
 
   // This layer contributes data over the whole parent window; expand the update
@@ -895,7 +945,7 @@ void BathymetryLayer::updateCosts(
         // unsurveyed: leave the master untouched. COVERAGE-GAP CONTRACT: while the
         // first pass fills in, an un-generated tile contributes nothing — under
         // unsurveyed_is_lethal a land cell here is NOT yet lethal. current_ is
-        // held false (all_tiles_generated_ below) for exactly this window, so a
+        // held false (core_ready_ below) for exactly this window, so a
         // consumer that respects costmap currentness will not plan on it. Nav2's
         // controller/planner gate on costmap currentness, so the gap is not acted
         // on; it self-closes within a few cycles for the (small) local costmap.
@@ -927,13 +977,13 @@ void BathymetryLayer::updateCosts(
   }
 
   // MF2: only report this cycle "current" when the MF1 tide gate and the store
-  // window gate held AND every window tile has been rendered at least once
-  // (all_tiles_generated_; see updateBounds for the #3 stale-vs-rendered
-  // distinction). coverage_empty_lethal_ (#2) also forces not-current so an
-  // all-LETHAL grid from an empty store window is never asserted as usable.
-  // While the first pass is still filling tiles in, current_=false so Nav2's
-  // staleness monitor sees a not-yet-complete costmap.
-  current_ = map_tide_valid_ && window_valid_ && all_tiles_generated_ &&
+  // window gate held AND the robot-centred CORE region has been rendered
+  // (core_ready_; see updateBounds for the #3 stale-vs-rendered distinction and
+  // the review-A core-readiness rationale). coverage_empty_lethal_ (#2) also
+  // forces not-current so an all-LETHAL grid from an empty store window is never
+  // asserted as usable. While the core is still filling in, current_=false so
+  // Nav2's staleness monitor sees a not-yet-ready costmap.
+  current_ = map_tide_valid_ && window_valid_ && core_ready_ &&
     !coverage_empty_lethal_;
 
   // Diagnostic breadcrumb: while the layer withholds readiness, say WHICH gate is
@@ -947,10 +997,10 @@ void BathymetryLayer::updateCosts(
     RCLCPP_WARN_THROTTLE(
       logger_, *clock_, 5000,
       "bathymetry_layer '%s' NOT current: map_tide_valid=%d window_valid=%d "
-      "all_tiles_rendered=%d coverage_empty_lethal=%d (resident tiles=%zu)",
+      "core_rendered=%d coverage_empty_lethal=%d (resident tiles=%zu)",
       name_.c_str(),
       static_cast<int>(map_tide_valid_), static_cast<int>(window_valid_),
-      static_cast<int>(all_tiles_generated_),
+      static_cast<int>(core_ready_),
       static_cast<int>(coverage_empty_lethal_), tiles_.size());
   }
 }

--- a/bathymetry_layer/src/bathymetry_layer.cpp
+++ b/bathymetry_layer/src/bathymetry_layer.cpp
@@ -271,6 +271,14 @@ void BathymetryLayer::injectTile(
   all_tiles_generated_ = true;
 }
 
+void BathymetryLayer::markTileNeedsUpdate(int ti, int tj)
+{
+  const auto it = tiles_.find(std::make_pair(ti, tj));
+  if (it != tiles_.end()) {
+    it->second.needs_update = true;
+  }
+}
+
 BathymetryLayer::TileID BathymetryLayer::worldToTile(double x, double y) const
 {
   const double tile_meters = resolution_ * tile_size_;
@@ -301,6 +309,23 @@ bool BathymetryLayer::tileHasCoverage(
   return false;
 }
 
+bool BathymetryLayer::windowFullyRendered(
+  int ti_lo, int tj_lo, int ti_hi, int tj_hi) const
+{
+  // "Rendered at least once" = the tile is resident and generated. needs_update
+  // (a stale-but-serving tile awaiting re-render) does NOT count as un-rendered:
+  // its cached costs are valid to serve, so it must not hold current_ false (#3).
+  for (int ti = ti_lo; ti <= ti_hi; ++ti) {
+    for (int tj = tj_lo; tj <= tj_hi; ++tj) {
+      const auto it = tiles_.find(std::make_pair(ti, tj));
+      if (it == tiles_.end() || !it->second.generated) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
 std::vector<BathymetryLayer::CoverageBox> BathymetryLayer::buildCoverage() const
 {
   std::vector<CoverageBox> coverage;
@@ -321,7 +346,7 @@ std::vector<BathymetryLayer::CoverageBox> BathymetryLayer::buildCoverage() const
   return coverage;
 }
 
-bool BathymetryLayer::generateTile(
+void BathymetryLayer::generateTile(
   const TileID & id, const geometry_msgs::msg::TransformStamped & to_earth,
   const std::vector<CoverageBox> & coverage)
 {
@@ -381,7 +406,7 @@ bool BathymetryLayer::generateTile(
       }
       info.generated = true;
       info.needs_update = false;
-      return true;
+      return;
     }
   }
   // corners_ok == false falls through to the per-cell path, which itself skips
@@ -435,7 +460,6 @@ bool BathymetryLayer::generateTile(
   info.costmap = tile;
   info.generated = true;
   info.needs_update = false;
-  return true;
 }
 
 void BathymetryLayer::refreshWindow()
@@ -588,6 +612,7 @@ void BathymetryLayer::updateBounds(
   // Render the static prior into world-anchored tiles HERE (once per tile), so
   // updateCosts is a cheap blit instead of a per-cell store query every cycle.
   all_tiles_generated_ = false;
+  coverage_empty_lethal_ = false;
   if (store_ && window_valid_ && map_tide_valid_) {
     const double buffer =
       std::max(world_max_x - world_min_x, world_max_y - world_min_y) * buffer_fraction_;
@@ -661,13 +686,34 @@ void BathymetryLayer::updateBounds(
     // per-cell projection on tiles that fall entirely outside coverage.
     const std::vector<CoverageBox> coverage = buildCoverage();
 
+    // #2 safety: an EMPTY store window under unsurveyed_is_lethal_ would make
+    // every tile short-circuit to LETHAL — the whole costmap, including the
+    // vehicle's own cell, reads as obstacle. Rather than assert that fabricated
+    // all-lethal grid as a usable ("current") costmap, flag it so updateCosts
+    // holds current_ false, and warn so the operator sees a misconfig (wrong/empty
+    // store_path) or the vehicle being outside the surveyed extent, instead of a
+    // silent box-in. When unsurveyed_is_lethal_ is false, empty coverage just
+    // means "no data here" — tiles stay NO_INFORMATION for other priors to fill,
+    // so this does not fire and exploration is not frozen.
+    coverage_empty_lethal_ = unsurveyed_is_lethal_ && coverage.empty();
+    if (coverage_empty_lethal_) {
+      RCLCPP_WARN_THROTTLE(
+        logger_, *clock_, 10000,
+        "bathymetry_layer '%s': no store coverage in the current window and "
+        "unsurveyed_is_lethal is set; the whole costmap would read LETHAL. "
+        "Reporting NOT current instead of an all-lethal grid — check store_path "
+        "and that the vehicle is within the store's surveyed extent.",
+        name_.c_str());
+    }
+
     // Render pending tiles, time-boxed per cycle (mirrors s57_layer) so the first
     // pass over a large (e.g. 4000x4000) global costmap is spread across cycles
-    // instead of blocking the costmap thread. all_tiles_generated_ gates current_
-    // (MF2) below. With the no-coverage short-circuit, the whole window typically
-    // drains in ~1-2 cycles, so current_ goes true promptly.
-    bool all_done = have_xf;
-    if (have_xf) {
+    // instead of blocking the costmap thread. Skipped when empty-lethal (#2):
+    // no point allocating ~1600 uniform-LETHAL tiles for a grid we will report
+    // not-current. A tile is (re)rendered when never generated OR stale
+    // (needs_update after a tide move); a stale-but-generated tile keeps serving
+    // its cached costs until it regenerates (no flicker).
+    if (have_xf && !coverage_empty_lethal_) {
       const rclcpp::Time gen_start = clock_->now();
       const rclcpp::Duration budget = rclcpp::Duration::from_seconds(update_timeout_);
       bool time_up = false;
@@ -677,23 +723,29 @@ void BathymetryLayer::updateBounds(
           auto it = tiles_.find(id);
           const bool needs =
             (it == tiles_.end()) || !it->second.generated || it->second.needs_update;
-          if (!needs) {
-            continue;
-          }
-          if (!time_up) {
+          if (needs && !time_up) {
             generateTile(id, to_earth, coverage);
-            it = tiles_.find(id);
             if (clock_->now() - gen_start > budget) {
               time_up = true;
             }
           }
-          if (it == tiles_.end() || !it->second.generated || it->second.needs_update) {
-            all_done = false;
-          }
         }
       }
     }
-    all_tiles_generated_ = all_done;
+
+    // #3: current_ readiness is "every window tile has been rendered at least
+    // once" — NOT "no tile needs re-rendering". A tide that drifts past
+    // tide_invalidate_threshold_ (e.g. a reservoir level changing gradually over
+    // a long survey) marks every tile needs_update; gating current_ on that would
+    // drop the whole costmap to not-current for a full-window re-render (seconds
+    // on a 4 km global) and re-trip the planner's costmap_update_timeout — even
+    // though the cached costs are only sub-threshold (<0.1 m, well inside the
+    // ~1.5 m clearance ramp) stale. So serve the cached costs as current while the
+    // re-render proceeds in the background; only a genuinely never-rendered tile
+    // (first fill, or a freshly scrolled-in window region) holds current_ false.
+    all_tiles_generated_ =
+      have_xf && !coverage_empty_lethal_ &&
+      windowFullyRendered(lo.first, lo.second, hi.first, hi.second);
   }
 
   // This layer contributes data over the whole parent window; expand the update
@@ -875,10 +927,14 @@ void BathymetryLayer::updateCosts(
   }
 
   // MF2: only report this cycle "current" when the MF1 tide gate and the store
-  // window gate held AND every tile in the window has been rendered against the
-  // current tide. While the first pass is still filling tiles in, current_=false
-  // so Nav2's staleness monitor sees a not-yet-complete costmap.
-  current_ = map_tide_valid_ && window_valid_ && all_tiles_generated_;
+  // window gate held AND every window tile has been rendered at least once
+  // (all_tiles_generated_; see updateBounds for the #3 stale-vs-rendered
+  // distinction). coverage_empty_lethal_ (#2) also forces not-current so an
+  // all-LETHAL grid from an empty store window is never asserted as usable.
+  // While the first pass is still filling tiles in, current_=false so Nav2's
+  // staleness monitor sees a not-yet-complete costmap.
+  current_ = map_tide_valid_ && window_valid_ && all_tiles_generated_ &&
+    !coverage_empty_lethal_;
 }
 
 }  // namespace bathymetry_layer

--- a/bathymetry_layer/src/bathymetry_layer.cpp
+++ b/bathymetry_layer/src/bathymetry_layer.cpp
@@ -118,6 +118,28 @@ void BathymetryLayer::onInitialize()
     buffer_fraction_ = default_buffer_fraction;
   }
 
+  // Re-render the cost-tile cache only when the tide moves more than this (m).
+  // Default 0.1 m clears realistic sea-surface-estimate jitter (~+/-0.02 m) so
+  // noise doesn't constantly re-render and defeat the cache (#226 review).
+  declareParameter("tide_invalidate_threshold", rclcpp::ParameterValue(tide_invalidate_threshold_));
+  node->get_parameter(name_ + ".tide_invalidate_threshold", tide_invalidate_threshold_);
+  if (!std::isfinite(tide_invalidate_threshold_) || tide_invalidate_threshold_ < 0.0) {
+    RCLCPP_WARN_STREAM(
+      logger_, "Invalid tide_invalidate_threshold " << tide_invalidate_threshold_ <<
+        "; using 0.1 instead.");
+    tide_invalidate_threshold_ = 0.1;
+  }
+
+  // How many cost tiles to (re)render per costmap cycle. Bounds first-pass work
+  // so a large global costmap fills incrementally instead of blocking.
+  declareParameter("max_tiles_per_cycle", rclcpp::ParameterValue(max_tiles_per_cycle_));
+  node->get_parameter(name_ + ".max_tiles_per_cycle", max_tiles_per_cycle_);
+  if (max_tiles_per_cycle_ < 1) {
+    RCLCPP_WARN_STREAM(
+      logger_, "Invalid max_tiles_per_cycle " << max_tiles_per_cycle_ << "; using 8 instead.");
+    max_tiles_per_cycle_ = 8;
+  }
+
   global_frame_id_ = layered_costmap_->getGlobalFrameID();
 
   if (store_path_.empty()) {

--- a/bathymetry_layer/src/bathymetry_layer.cpp
+++ b/bathymetry_layer/src/bathymetry_layer.cpp
@@ -280,14 +280,15 @@ bool BathymetryLayer::generateTile(
         const auto geo = worldToLatLon(wx, wy, to_earth);
         cell = store_->cellIndex(geo.latitude, geo.longitude);
       } catch (const tf2::TransformException & e) {
-        // A projection failure here is a transform problem, not a per-cell one
-        // (the transform is fixed for the pass); abort the tile so it is retried
-        // next cycle rather than caching a half-rendered grid.
+        // Skip this cell (leave NO_INFORMATION) and keep rendering, matching the
+        // old per-cell path's continue-on-unprojectable-cell. Aborting the whole
+        // tile would leave it permanently ungenerated — pinning current_=false
+        // (a safety layer reading perpetually stale) on a single bad cell.
         RCLCPP_WARN_THROTTLE(
           logger_, *clock_, 10000,
           "bathymetry_layer '%s': cannot project tile cell to lat/lon: %s",
           name_.c_str(), e.what());
-        return false;
+        continue;
       }
 
       // Reuse the exact per-cell decision (MF1 tide gate, two-query no-data
@@ -464,9 +465,14 @@ void BathymetryLayer::updateBounds(
     const double buffer =
       std::max(world_max_x - world_min_x, world_max_y - world_min_y) * buffer_fraction_;
 
-    // Tide-change invalidation: re-render only when the surface moved materially.
-    // Cached costs keep being served until each tile is regenerated (no flicker;
-    // also resolves the stale-tide latch, #223).
+    const int64_t now_ns = clock_->now().nanoseconds();
+
+    // Tide-CHANGE invalidation: re-render when the surface MOVED materially.
+    // Cached costs keep being served until each tile regenerates (no flicker).
+    // NOTE: this handles a tide that *moves*, not a tide that *freezes/stops*
+    // (lookupTransform(TimePointZero) returns the latest regardless of age, and
+    // map_tide_valid_ is a latch) — detecting a stale/absent tide is the separate
+    // #223 work, NOT resolved here.
     if (!tide_rendered_ ||
       std::abs(map_tide_z_ - last_tide_z_) > tide_invalidate_threshold_)
     {
@@ -475,6 +481,22 @@ void BathymetryLayer::updateBounds(
       }
       last_tide_z_ = map_tide_z_;
       tide_rendered_ = true;
+    }
+
+    // Staleness vs caching: a tile is rendered once, so without this a cell that
+    // ages past max_age_ would keep its cached (possibly non-lethal) cost instead
+    // of flipping to stale-LETHAL like the old per-cycle evaluation did. When the
+    // staleness gate is on (max_age_ > 0), force a full re-render every
+    // ~max_age_/2 so a cell goes stale-LETHAL within ~max_age_ of when it should.
+    // max_age_ == 0 (default) disables the gate, keeping the full caching benefit.
+    if (max_age_ > 0.0) {
+      const int64_t interval_ns = static_cast<int64_t>(max_age_ * 5e8);
+      if (now_ns - last_full_render_ns_ >= interval_ns) {
+        for (auto & entry : tiles_) {
+          entry.second.needs_update = true;
+        }
+        last_full_render_ns_ = now_ns;
+      }
     }
 
     // Tiles overlapping the buffered window.
@@ -637,6 +659,9 @@ void BathymetryLayer::updateCosts(
   nav2_costmap_2d::Costmap2D & master_grid, int min_i, int min_j, int max_i, int max_j)
 {
   if (!enabled_ || !store_) {
+    // A disabled or store-less cycle contributes nothing; it must not leave a
+    // stale current_=true behind for Nav2's staleness monitor (MF2).
+    current_ = false;
     return;
   }
 
@@ -676,7 +701,15 @@ void BathymetryLayer::updateCosts(
     for (int tj = start_tile.second; tj <= end_tile.second; ++tj) {
       const auto entry = tiles_.find(std::make_pair(ti, tj));
       if (entry == tiles_.end() || !entry->second.costmap) {
-        continue;  // not generated yet (or fully unsurveyed) — leave master as-is
+        // Not generated yet (incremental fill / post-invalidation), or fully
+        // unsurveyed: leave the master untouched. COVERAGE-GAP CONTRACT: while the
+        // first pass fills in, an un-generated tile contributes nothing — under
+        // unsurveyed_is_lethal a land cell here is NOT yet lethal. current_ is
+        // held false (all_tiles_generated_ below) for exactly this window, so a
+        // consumer that respects costmap currentness will not plan on it. Nav2's
+        // controller/planner gate on costmap currentness, so the gap is not acted
+        // on; it self-closes within a few cycles for the (small) local costmap.
+        continue;
       }
       const int tile_offset_y =
         -tj * tile_size_ +

--- a/bathymetry_layer/src/bathymetry_layer.hpp
+++ b/bathymetry_layer/src/bathymetry_layer.hpp
@@ -262,11 +262,19 @@ private:
   double y_origin_ = 0.0;
   int tile_size_ = 100;
   double update_timeout_ = 0.5;
-  // True when every tile overlapping the current window is generated and
-  // up to date (no pending render work). Gates current_ (MF2) alongside the
-  // tide/window flags so Nav2 sees a "not yet current" costmap while the first
-  // pass is still filling tiles in, then "current" once complete.
-  bool all_tiles_generated_ = false;
+  // Readiness radius (metres) around the vehicle for the current_ gate (review A).
+  // current_ is reported once the tiles within this radius of the vehicle are
+  // rendered — NOT the whole window — so a large global (which takes far longer
+  // than the planner's costmap_update_timeout to render fully) does not stall the
+  // planner. Robot-first rendering fills the core first; the rest fills outward in
+  // the background. Scale-independent: a bigger global does not change time-to-ready.
+  double ready_radius_ = 200.0;
+  // True when the robot-centred CORE region (within ready_radius_) has been
+  // rendered at least once. Gates current_ (MF2) alongside the tide/window flags
+  // and coverage_empty_lethal_ (#2), so Nav2 sees "not yet current" only until the
+  // vehicle's neighbourhood is ready — seconds, regardless of total global size —
+  // rather than until the entire window is rendered (minutes on a 4 km global).
+  bool core_ready_ = false;
 
   // Tide-change invalidation: re-render tiles only when the water surface moves
   // more than this (metres) from the value the cache was rendered against.

--- a/bathymetry_layer/src/bathymetry_layer.hpp
+++ b/bathymetry_layer/src/bathymetry_layer.hpp
@@ -205,9 +205,13 @@ private:
 
   // Tide-change invalidation: re-render tiles only when the water surface moves
   // more than this (metres) from the value the cache was rendered against.
+  // Default 0.1 m: above realistic sea-surface estimate jitter (~+/-0.01-0.02 m
+  // in sim, from averaging odom z) so normal noise does not constantly re-render
+  // and defeat the cache, while still re-rendering when the tide moves enough to
+  // shift cost (the clearance ramp spans ~1.5 m). Parameterized (tunable).
   double last_tide_z_ = 0.0;
   bool tide_rendered_ = false;
-  double tide_invalidate_threshold_ = 0.02;
+  double tide_invalidate_threshold_ = 0.1;
 
   // Staleness vs caching: a tile is rendered once, so a cell that ages past
   // max_age_ would keep its cached (possibly non-lethal) cost rather than

--- a/bathymetry_layer/src/bathymetry_layer.hpp
+++ b/bathymetry_layer/src/bathymetry_layer.hpp
@@ -9,6 +9,7 @@
 #include <optional>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "geographic_msgs/msg/geo_point.hpp"
 #include "geometry_msgs/msg/point_stamped.hpp"
@@ -108,6 +109,28 @@ protected:
   void injectTile(int ti, int tj, std::shared_ptr<nav2_costmap_2d::Costmap2D> tile);
   int tileSize() const {return tile_size_;}
 
+  // A lat/lon axis-aligned bounding box of one store tile, used as a cheap
+  // whole-tile coverage test in generateTile (mirrors s57_layer testing a tile
+  // against its loaded chart grids before sampling). Built once per generation
+  // pass by buildCoverage() from the store's resident tiles across all layers.
+  struct CoverageBox
+  {
+    double min_lat;
+    double min_lon;
+    double max_lat;
+    double max_lon;
+  };
+
+  // Whether a tile's projected lat/lon AABB (@p min_lat..@p max_lat,
+  // @p min_lon..@p max_lon) overlaps any store coverage box, after padding by a
+  // safety margin so a tile straddling the coverage edge counts as covered
+  // (full render) — never the reverse, so a covered cell is never classified
+  // no-coverage and dropped. Exposed for unit testing the generateTile
+  // no-coverage short-circuit decision.
+  bool tileHasCoverage(
+    double min_lat, double min_lon, double max_lat, double max_lon,
+    const std::vector<CoverageBox> & coverage) const;
+
   // Test seams: the store and the cached water-surface height, so a test fixture
   // can populate a synthetic store and drive cost evaluation without TF.
   std::unique_ptr<marine_bathymetry_store::BathymetryStore> store_;
@@ -170,10 +193,23 @@ private:
   };
 
   TileID worldToTile(double x, double y) const;
+
+  // Collect the lat/lon AABBs of every tile currently resident in the store
+  // (all source layers). Cheap: the store holds only the windowed coverage (a
+  // handful of GGGS tiles for a lake). Empty when the store has no data.
+  std::vector<CoverageBox> buildCoverage() const;
+
   // Render (or re-render) a tile's costs from the store using @p to_earth (the
-  // hoisted global_frame->earth transform). Returns false if rendering failed
-  // (e.g. a per-cell projection threw); the tile is left ungenerated.
-  bool generateTile(const TileID & id, const geometry_msgs::msg::TransformStamped & to_earth);
+  // hoisted global_frame->earth transform). @p coverage is the store's resident
+  // tile AABBs (buildCoverage()): a tile whose projected lat/lon extent overlaps
+  // none of them has no store data, so it is filled uniformly without the
+  // per-cell projection+query (LETHAL_OBSTACLE when unsurveyed_is_lethal_, else
+  // left fully NO_INFORMATION) — the bulk of tiles on a large global costmap.
+  // Returns false if rendering failed (e.g. a per-cell projection threw); the
+  // tile is left ungenerated.
+  bool generateTile(
+    const TileID & id, const geometry_msgs::msg::TransformStamped & to_earth,
+    const std::vector<CoverageBox> & coverage);
 
   std::string store_path_;
   std::string map_tide_frame_ = "map_tide";
@@ -189,14 +225,17 @@ private:
   // Cost-tile cache + its fixed world anchor (cells, metres). x_origin_/y_origin_
   // stay 0 so tile boundaries are stable in the global frame across cycles (a
   // rolling window then reuses the same tiles). tile_size_ is the tile edge in
-  // cells. max_tiles_per_cycle_ bounds how many tiles are rendered per
-  // updateBounds call so the first full pass over a large (e.g. 4000x4000) global
-  // costmap is spread across cycles instead of blocking activation for minutes.
+  // cells. update_timeout_ time-boxes tile generation per updateBounds call
+  // (mirrors s57_layer): as many pending tiles as fit in this wall-clock budget
+  // (seconds) are rendered each cycle, so the first full pass over a large
+  // (e.g. 4000x4000) global costmap is spread across cycles instead of blocking
+  // the costmap thread. With the no-coverage short-circuit (most tiles cheap),
+  // the whole window drains in ~1-2 cycles so current_ goes true promptly.
   std::map<TileID, TileInfo> tiles_;
   double x_origin_ = 0.0;
   double y_origin_ = 0.0;
   int tile_size_ = 100;
-  int max_tiles_per_cycle_ = 8;
+  double update_timeout_ = 0.5;
   // True when every tile overlapping the current window is generated and
   // up to date (no pending render work). Gates current_ (MF2) alongside the
   // tide/window flags so Nav2 sees a "not yet current" costmap while the first

--- a/bathymetry_layer/src/bathymetry_layer.hpp
+++ b/bathymetry_layer/src/bathymetry_layer.hpp
@@ -101,6 +101,13 @@ protected:
   // are returned unchanged. Exposed for unit testing.
   static std::string expandUserPath(const std::string & path);
 
+  // Test seam (test_bathymetry_layer.cpp): inject a pre-rendered cost tile at
+  // grid coordinate (ti, tj) and mark the cache complete, so the updateCosts
+  // blit can be unit-tested without the store/TF/projection pipeline. tileSize()
+  // exposes the tile edge (cells) so a test can size a matching tile.
+  void injectTile(int ti, int tj, std::shared_ptr<nav2_costmap_2d::Costmap2D> tile);
+  int tileSize() const {return tile_size_;}
+
   // Test seams: the store and the cached water-surface height, so a test fixture
   // can populate a synthetic store and drive cost evaluation without TF.
   std::unique_ptr<marine_bathymetry_store::BathymetryStore> store_;

--- a/bathymetry_layer/src/bathymetry_layer.hpp
+++ b/bathymetry_layer/src/bathymetry_layer.hpp
@@ -109,6 +109,15 @@ protected:
   void injectTile(int ti, int tj, std::shared_ptr<nav2_costmap_2d::Costmap2D> tile);
   int tileSize() const {return tile_size_;}
 
+  // Test seam: force window_valid_ (normally set by refreshWindow on a
+  // successful loadWindow) so the current_ gate can be unit-tested without TF.
+  void setWindowValidForTest(bool v) {window_valid_ = v;}
+
+  // Test seam: mark an already-injected tile stale (needs_update) without a tide
+  // move, so windowFullyRendered's "stale-but-rendered still counts as ready"
+  // property (#3) can be unit-tested. No-op if the tile is not resident.
+  void markTileNeedsUpdate(int ti, int tj);
+
   // A lat/lon axis-aligned bounding box of one store tile, used as a cheap
   // whole-tile coverage test in generateTile (mirrors s57_layer testing a tile
   // against its loaded chart grids before sampling). Built once per generation
@@ -131,6 +140,14 @@ protected:
     double min_lat, double min_lon, double max_lat, double max_lon,
     const std::vector<CoverageBox> & coverage) const;
 
+  // Whether every tile in the inclusive grid range [ (ti_lo,tj_lo) .. (ti_hi,tj_hi) ]
+  // has been rendered at least once (resident and `generated`). This is the
+  // current_ readiness signal: a tile that is generated but `needs_update`
+  // (stale-but-serving after a tide move) still counts as rendered, so a tide
+  // drift does not drop the costmap to not-current (#3). A never-rendered tile
+  // (first fill / freshly scrolled-in region) returns false. Exposed for testing.
+  bool windowFullyRendered(int ti_lo, int tj_lo, int ti_hi, int tj_hi) const;
+
   // Test seams: the store and the cached water-surface height, so a test fixture
   // can populate a synthetic store and drive cost evaluation without TF.
   std::unique_ptr<marine_bathymetry_store::BathymetryStore> store_;
@@ -140,6 +157,14 @@ protected:
   // is not a valid water-surface datum and would produce arbitrary clearance
   // values. updateCosts() also gates current_=true on this flag (MF1/MF2).
   bool map_tide_valid_ = false;
+
+  // #2 safety latch (set each updateBounds pass): the current window has NO store
+  // coverage AND unsurveyed_is_lethal_ is set, so every tile would short-circuit
+  // to LETHAL — an all-obstacle grid including the vehicle's own cell. updateCosts
+  // gates current_=false on this so that fabricated all-lethal grid is never
+  // asserted as a usable costmap (the layer warns instead). Protected so the test
+  // fixture can drive the gate directly.
+  bool coverage_empty_lethal_ = false;
 
   // Parameters (protected so the test fixture can configure them directly).
   double minimum_depth_ = 1.0;
@@ -205,9 +230,10 @@ private:
   // none of them has no store data, so it is filled uniformly without the
   // per-cell projection+query (LETHAL_OBSTACLE when unsurveyed_is_lethal_, else
   // left fully NO_INFORMATION) — the bulk of tiles on a large global costmap.
-  // Returns false if rendering failed (e.g. a per-cell projection threw); the
-  // tile is left ungenerated.
-  bool generateTile(
+  // Always marks the tile generated: a cell whose projection throws is skipped
+  // (left NO_INFORMATION) rather than failing the tile, so a single bad cell
+  // cannot pin the tile ungenerated and hold current_ false forever.
+  void generateTile(
     const TileID & id, const geometry_msgs::msg::TransformStamped & to_earth,
     const std::vector<CoverageBox> & coverage);
 

--- a/bathymetry_layer/src/bathymetry_layer.hpp
+++ b/bathymetry_layer/src/bathymetry_layer.hpp
@@ -209,6 +209,14 @@ private:
   bool tide_rendered_ = false;
   double tide_invalidate_threshold_ = 0.02;
 
+  // Staleness vs caching: a tile is rendered once, so a cell that ages past
+  // max_age_ would keep its cached (possibly non-lethal) cost rather than
+  // flipping to stale-LETHAL the way the old per-cycle evaluation did. When the
+  // staleness gate is enabled (max_age_ > 0) the cache is fully re-rendered on
+  // this interval so a cell goes stale-LETHAL within ~max_age_ of when it should.
+  // last_full_render_ns_ is the time of the last such forced re-render.
+  int64_t last_full_render_ns_ = 0;
+
   // Last buffered geographic window passed to loadWindow/evictOutside. Used to
   // skip redundant reloads when the costmap has not scrolled past the buffer.
   geographic_msgs::msg::GeoPoint window_min_;

--- a/bathymetry_layer/src/bathymetry_layer.hpp
+++ b/bathymetry_layer/src/bathymetry_layer.hpp
@@ -4,14 +4,18 @@
 #ifndef BATHYMETRY_LAYER_HPP_
 #define BATHYMETRY_LAYER_HPP_
 
+#include <map>
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 
 #include "geographic_msgs/msg/geo_point.hpp"
 #include "geometry_msgs/msg/point_stamped.hpp"
+#include "geometry_msgs/msg/transform_stamped.hpp"
 #include "marine_autonomy/gggs.h"
 #include "marine_bathymetry_store/bathymetry_store.hpp"
+#include "nav2_costmap_2d/costmap_2d.hpp"
 #include "nav2_costmap_2d/layer.hpp"
 #include "nav2_costmap_2d/layered_costmap.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -120,8 +124,16 @@ protected:
 
 private:
   // Convert a costmap world coordinate to WGS84 lat/lon via the `earth` TF frame
-  // (mirrors s57_layer::worldToLatLon).
+  // (mirrors s57_layer::worldToLatLon). Per-cell tf buffer lookup — used only for
+  // the buffered-window AABB; tile rendering uses the hoisted transform below.
   geographic_msgs::msg::GeoPoint worldToLatLon(double x, double y);
+
+  // Apply a cached global_frame->earth transform to a world point and convert to
+  // lat/lon — the hoisted-transform inner loop of generateTile(). No per-cell tf
+  // buffer lookup (the costly part of worldToLatLon); the transform is looked up
+  // once per generation pass and reused for every cell.
+  geographic_msgs::msg::GeoPoint worldToLatLon(
+    double x, double y, const geometry_msgs::msg::TransformStamped & to_earth) const;
 
   // Recompute the buffered geographic window from the parent costmap bounds and
   // (re)load / evict store tiles to keep memory bounded. Returns false if the
@@ -130,6 +142,31 @@ private:
 
   // Open the on-disk store at store_path_ with the parent costmap's resolution.
   void openStore();
+
+  // World-anchored cost-tile cache (mirrors s57_layer). The prior is static in
+  // world space, so a tile is rendered once and reused as the rolling window
+  // scrolls — turning per-cycle O(cells x (tf + store query)) into an O(cells)
+  // blit in updateCosts. TileID is the integer tile grid coordinate; a tile
+  // covers tile_size_ x tile_size_ cells of resolution_ metres, anchored at
+  // (x_origin_, y_origin_) in the costmap global frame.
+  typedef std::pair<int, int> TileID;
+  struct TileInfo
+  {
+    // Pre-rendered costs for this tile (nullptr until generated). NO_INFORMATION
+    // where the cell is unsurveyed/untouched; otherwise the bathymetry cost.
+    std::shared_ptr<nav2_costmap_2d::Costmap2D> costmap;
+    // True once the tile has been rendered against the current tide.
+    bool generated = false;
+    // Marked when the tide moved past the threshold; the tile keeps serving its
+    // cached costs until it is regenerated, so the costmap never flickers.
+    bool needs_update = false;
+  };
+
+  TileID worldToTile(double x, double y) const;
+  // Render (or re-render) a tile's costs from the store using @p to_earth (the
+  // hoisted global_frame->earth transform). Returns false if rendering failed
+  // (e.g. a per-cell projection threw); the tile is left ungenerated.
+  bool generateTile(const TileID & id, const geometry_msgs::msg::TransformStamped & to_earth);
 
   std::string store_path_;
   std::string map_tide_frame_ = "map_tide";
@@ -141,6 +178,29 @@ private:
 
   std::string global_frame_id_;
   double resolution_ = 1.0;
+
+  // Cost-tile cache + its fixed world anchor (cells, metres). x_origin_/y_origin_
+  // stay 0 so tile boundaries are stable in the global frame across cycles (a
+  // rolling window then reuses the same tiles). tile_size_ is the tile edge in
+  // cells. max_tiles_per_cycle_ bounds how many tiles are rendered per
+  // updateBounds call so the first full pass over a large (e.g. 4000x4000) global
+  // costmap is spread across cycles instead of blocking activation for minutes.
+  std::map<TileID, TileInfo> tiles_;
+  double x_origin_ = 0.0;
+  double y_origin_ = 0.0;
+  int tile_size_ = 100;
+  int max_tiles_per_cycle_ = 8;
+  // True when every tile overlapping the current window is generated and
+  // up to date (no pending render work). Gates current_ (MF2) alongside the
+  // tide/window flags so Nav2 sees a "not yet current" costmap while the first
+  // pass is still filling tiles in, then "current" once complete.
+  bool all_tiles_generated_ = false;
+
+  // Tide-change invalidation: re-render tiles only when the water surface moves
+  // more than this (metres) from the value the cache was rendered against.
+  double last_tide_z_ = 0.0;
+  bool tide_rendered_ = false;
+  double tide_invalidate_threshold_ = 0.02;
 
   // Last buffered geographic window passed to loadWindow/evictOutside. Used to
   // skip redundant reloads when the costmap has not scrolled past the buffer.

--- a/bathymetry_layer/test/test_bathymetry_layer.cpp
+++ b/bathymetry_layer/test/test_bathymetry_layer.cpp
@@ -738,7 +738,7 @@ TEST(BathymetryLayer, EmptyCoverageWithUnsurveyedLethalHoldsNotCurrent)
   const int ts = layer.tileSize();
   auto tile = std::make_shared<nav2_costmap_2d::Costmap2D>(
     ts, ts, 1.0, 0.0, 0.0, nav2_costmap_2d::NO_INFORMATION);
-  layer.injectTile(0, 0, tile);   // marks all_tiles_generated_ true
+  layer.injectTile(0, 0, tile);   // marks core_ready_ true
   layer.setMapTideValid(true);
   layer.setWindowValid(true);
 

--- a/bathymetry_layer/test/test_bathymetry_layer.cpp
+++ b/bathymetry_layer/test/test_bathymetry_layer.cpp
@@ -63,6 +63,8 @@ public:
   void setMaxUncertainty(double v) {max_uncertainty_ = v;}
   void setMaxAge(double v) {max_age_ = v;}
   void setUnsurveyedIsLethal(bool v) {unsurveyed_is_lethal_ = v;}
+  void setWindowValid(bool v) {setWindowValidForTest(v);}
+  void setCoverageEmptyLethal(bool v) {coverage_empty_lethal_ = v;}
   // enabled_ is set from the "enabled" param in onInitialize(); the blit tests
   // skip initialize(), so set it directly.
   void setEnabled(bool v) {enabled_ = v;}
@@ -75,6 +77,8 @@ public:
   using BathymetryLayer::tileSize;
   using BathymetryLayer::CoverageBox;
   using BathymetryLayer::tileHasCoverage;
+  using BathymetryLayer::windowFullyRendered;
+  using BathymetryLayer::markTileNeedsUpdate;
 };
 
 // ---------------------------------------------------------------------------
@@ -717,4 +721,72 @@ TEST(BathymetryLayer, TileCoverageOverlapDecision)
   // Empty store (no data loaded) → nothing is covered, so every tile takes the
   // short-circuit (uniform lethal land / NO_INFORMATION).
   EXPECT_FALSE(layer.tileHasCoverage(42.985, -71.395, 42.990, -71.390, {}));
+}
+
+// #2 safety gate: when the store window has NO coverage and unsurveyed_is_lethal
+// is set, the whole costmap would read LETHAL (incl. the boat's own cell). The
+// layer must report NOT current in that case rather than asserting the fabricated
+// all-lethal grid as a usable costmap. Drives the gate through updateCosts (which
+// sets current_) + isCurrent().
+TEST(BathymetryLayer, EmptyCoverageWithUnsurveyedLethalHoldsNotCurrent)
+{
+  BathymetryLayerForTest layer;
+  layer.setStore(std::make_unique<BathymetryStore>(10));  // non-null for the guard
+  layer.setEnabled(true);
+  layer.setUnsurveyedIsLethal(true);
+
+  const int ts = layer.tileSize();
+  auto tile = std::make_shared<nav2_costmap_2d::Costmap2D>(
+    ts, ts, 1.0, 0.0, 0.0, nav2_costmap_2d::NO_INFORMATION);
+  layer.injectTile(0, 0, tile);   // marks all_tiles_generated_ true
+  layer.setMapTideValid(true);
+  layer.setWindowValid(true);
+
+  nav2_costmap_2d::Costmap2D master(ts, ts, 1.0, 0.0, 0.0, nav2_costmap_2d::FREE_SPACE);
+
+  // Coverage present (flag false): all gates satisfied → current.
+  layer.setCoverageEmptyLethal(false);
+  layer.updateCosts(master, 0, 0, ts, ts);
+  EXPECT_TRUE(layer.isCurrent())
+    << "tide + window valid and tiles rendered → costmap is current";
+
+  // Empty-coverage-lethal: must drop to not-current even though every other gate
+  // still holds, so the planner does not act on an all-lethal grid.
+  layer.setCoverageEmptyLethal(true);
+  layer.updateCosts(master, 0, 0, ts, ts);
+  EXPECT_FALSE(layer.isCurrent())
+    << "empty store window + unsurveyed_is_lethal must report NOT current";
+}
+
+// #3: a tide drift past the invalidation threshold marks every tile needs_update;
+// gating current_ on that would drop the costmap to not-current for a full-window
+// re-render (and re-trip the planner timeout) even though the cached costs are
+// only sub-threshold stale. windowFullyRendered must therefore treat a
+// generated-but-needs_update tile as STILL rendered (ready), and only a
+// never-rendered (absent) tile as not-ready.
+TEST(BathymetryLayer, WindowReadyTreatsStaleTileAsRendered)
+{
+  BathymetryLayerForTest layer;
+  layer.setStore(std::make_unique<BathymetryStore>(10));
+  const int ts = layer.tileSize();
+  auto make_tile = [ts]() {
+      return std::make_shared<nav2_costmap_2d::Costmap2D>(
+        ts, ts, 1.0, 0.0, 0.0, nav2_costmap_2d::NO_INFORMATION);
+    };
+  layer.injectTile(0, 0, make_tile());
+  layer.injectTile(0, 1, make_tile());
+  layer.injectTile(1, 0, make_tile());
+  layer.injectTile(1, 1, make_tile());
+
+  EXPECT_TRUE(layer.windowFullyRendered(0, 0, 1, 1))
+    << "every window tile generated → ready";
+
+  // Mark one tile stale (as a tide move would): still rendered, still ready.
+  layer.markTileNeedsUpdate(1, 1);
+  EXPECT_TRUE(layer.windowFullyRendered(0, 0, 1, 1))
+    << "a generated-but-stale (needs_update) tile must NOT hold current_ false (#3)";
+
+  // A window region with a never-rendered (absent) tile is not ready.
+  EXPECT_FALSE(layer.windowFullyRendered(0, 0, 2, 2))
+    << "an absent (never-rendered) tile → not ready";
 }

--- a/bathymetry_layer/test/test_bathymetry_layer.cpp
+++ b/bathymetry_layer/test/test_bathymetry_layer.cpp
@@ -569,9 +569,11 @@ TEST(BathymetryLayer, TileBlitIsCheapOverLargeGrid)
   const auto dt = std::chrono::duration_cast<std::chrono::milliseconds>(
     std::chrono::steady_clock::now() - t0).count();
 
-  // A memory-copy blit of 250k cells is sub-ms to a few ms; the old per-cell path
-  // (~35 us/cell) would be ~8.75 s. A 1 s bound flags a regression to per-cell
-  // work without being flaky on a loaded CI host.
+  // A memory-copy blit of 250k cells is sub-ms to a few ms. This guards the blit
+  // staying O(cells) — no per-cell projection/tf creeping back into the copy. It
+  // does NOT exercise the store (none is loaded; generateTile owns the store
+  // query), so it cannot catch a per-cell *store-query* regression — that path is
+  // covered end to end in sim. The 1 s bound is generous against CI noise.
   std::cout << "[ PERF     ] tile blit over " << (n * n) << " cells: "
             << dt << " ms" << std::endl;
   EXPECT_LT(dt, 1000)

--- a/bathymetry_layer/test/test_bathymetry_layer.cpp
+++ b/bathymetry_layer/test/test_bathymetry_layer.cpp
@@ -5,11 +5,13 @@
 
 #include <unistd.h>
 
+#include <chrono>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <filesystem>
+#include <iostream>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -61,11 +63,16 @@ public:
   void setMaxUncertainty(double v) {max_uncertainty_ = v;}
   void setMaxAge(double v) {max_age_ = v;}
   void setUnsurveyedIsLethal(bool v) {unsurveyed_is_lethal_ = v;}
+  // enabled_ is set from the "enabled" param in onInitialize(); the blit tests
+  // skip initialize(), so set it directly.
+  void setEnabled(bool v) {enabled_ = v;}
 
   using BathymetryLayer::computeCost;
   using BathymetryLayer::evaluateCell;
   using BathymetryLayer::isStale;
   using BathymetryLayer::expandUserPath;
+  using BathymetryLayer::injectTile;
+  using BathymetryLayer::tileSize;
 };
 
 // ---------------------------------------------------------------------------
@@ -461,6 +468,118 @@ TEST(BathymetryLayer, WindowedResidencyStaysBounded)
     << "eviction must actually free the out-of-window tiles";
 
   fs::remove_all(dir);
+}
+
+// ---------------------------------------------------------------------------
+// Cost-tile cache / blit (#226). updateCosts no longer queries the store per
+// cell every cycle; it blits pre-rendered, world-anchored tiles into the master
+// grid. These exercise the blit (mapping + max-combine + cheapness) directly via
+// the injectTile seam, without the store/TF/projection pipeline (generateTile's
+// projection reuses the already-tested worldToLatLon + evaluateCell).
+// ---------------------------------------------------------------------------
+
+TEST(BathymetryLayer, TileBlitMaxCombineAndOffsets)
+{
+  BathymetryLayerForTest layer;
+  layer.setStore(std::make_unique<BathymetryStore>(10));  // non-null for the guard
+  layer.setEnabled(true);
+
+  const int ts = layer.tileSize();
+  // Tile at grid (0,0): world origin (0,0), 1 m cells, NO_INFORMATION default.
+  auto tile = std::make_shared<nav2_costmap_2d::Costmap2D>(
+    ts, ts, 1.0, 0.0, 0.0, nav2_costmap_2d::NO_INFORMATION);
+  tile->setCost(5, 5, 100);
+  tile->setCost(10, 20, 200);
+  tile->setCost(7, 7, 80);
+  tile->setCost(50, 50, nav2_costmap_2d::FREE_SPACE);
+  // (40, 40) left NO_INFORMATION.
+  layer.injectTile(0, 0, tile);
+
+  nav2_costmap_2d::Costmap2D master(60, 60, 1.0, 0.0, 0.0, nav2_costmap_2d::FREE_SPACE);
+  master.setCost(5, 5, 150);   // higher than the tile's 100 -> keep existing
+  master.setCost(10, 20, 50);  // lower than the tile's 200 -> tile wins
+  master.setCost(50, 50, nav2_costmap_2d::NO_INFORMATION);  // tile FREE fills it
+
+  layer.updateCosts(master, 0, 0, 60, 60);
+
+  EXPECT_EQ(static_cast<int>(master.getCost(5, 5)), 150)
+    << "max-combine must keep the higher existing master cost";
+  EXPECT_EQ(static_cast<int>(master.getCost(10, 20)), 200)
+    << "tile raises a lower master cost (and the (10,20) offset maps correctly)";
+  EXPECT_EQ(static_cast<int>(master.getCost(7, 7)), 80)
+    << "tile cost fills over FREE_SPACE";
+  EXPECT_EQ(
+    static_cast<int>(master.getCost(40, 40)),
+    static_cast<int>(nav2_costmap_2d::FREE_SPACE))
+    << "tile NO_INFORMATION is skipped -- master left unchanged";
+  EXPECT_EQ(
+    static_cast<int>(master.getCost(50, 50)),
+    static_cast<int>(nav2_costmap_2d::FREE_SPACE))
+    << "tile cost fills a NO_INFORMATION master cell";
+}
+
+TEST(BathymetryLayer, TileBlitTracksRollingMasterOrigin)
+{
+  BathymetryLayerForTest layer;
+  layer.setStore(std::make_unique<BathymetryStore>(10));
+  layer.setEnabled(true);
+
+  const int ts = layer.tileSize();
+  auto tile = std::make_shared<nav2_costmap_2d::Costmap2D>(
+    ts, ts, 1.0, 0.0, 0.0, nav2_costmap_2d::NO_INFORMATION);
+  tile->setCost(35, 25, 170);
+  layer.injectTile(0, 0, tile);
+
+  // Master origin shifted to (30, 10): master cell (5, 15) is world ~(35.5,25.5),
+  // i.e. tile cell (35, 25). Exercises the tile_offset_* index math (#226).
+  nav2_costmap_2d::Costmap2D master(40, 40, 1.0, 30.0, 10.0, nav2_costmap_2d::FREE_SPACE);
+  layer.updateCosts(master, 0, 0, 40, 40);
+
+  EXPECT_EQ(static_cast<int>(master.getCost(5, 15)), 170)
+    << "tile cell (35,25) must blit to master cell (5,15) under a (30,10) origin";
+  EXPECT_EQ(
+    static_cast<int>(master.getCost(6, 15)),
+    static_cast<int>(nav2_costmap_2d::FREE_SPACE))
+    << "the neighbouring master cell maps to an un-set tile cell";
+}
+
+TEST(BathymetryLayer, TileBlitIsCheapOverLargeGrid)
+{
+  BathymetryLayerForTest layer;
+  layer.setStore(std::make_unique<BathymetryStore>(10));
+  layer.setEnabled(true);
+
+  const int ts = layer.tileSize();
+  const int n = 500;  // 500x500 = 250k master cells
+  const int tiles_per_side = (n + ts - 1) / ts;
+  for (int ti = 0; ti < tiles_per_side; ++ti) {
+    for (int tj = 0; tj < tiles_per_side; ++tj) {
+      auto tile = std::make_shared<nav2_costmap_2d::Costmap2D>(
+        ts, ts, 1.0,
+        static_cast<double>(ti) * ts, static_cast<double>(tj) * ts,
+        nav2_costmap_2d::FREE_SPACE);
+      layer.injectTile(ti, tj, tile);
+    }
+  }
+
+  nav2_costmap_2d::Costmap2D master(n, n, 1.0, 0.0, 0.0, nav2_costmap_2d::NO_INFORMATION);
+
+  const auto t0 = std::chrono::steady_clock::now();
+  layer.updateCosts(master, 0, 0, n, n);
+  const auto dt = std::chrono::duration_cast<std::chrono::milliseconds>(
+    std::chrono::steady_clock::now() - t0).count();
+
+  // A memory-copy blit of 250k cells is sub-ms to a few ms; the old per-cell path
+  // (~35 us/cell) would be ~8.75 s. A 1 s bound flags a regression to per-cell
+  // work without being flaky on a loaded CI host.
+  std::cout << "[ PERF     ] tile blit over " << (n * n) << " cells: "
+            << dt << " ms" << std::endl;
+  EXPECT_LT(dt, 1000)
+    << "updateCosts must be an O(cells) blit, not a per-cell store query";
+  EXPECT_EQ(
+    static_cast<int>(master.getCost(250, 250)),
+    static_cast<int>(nav2_costmap_2d::FREE_SPACE))
+    << "interior master cell got the tile's cost";
 }
 
 // ---------------------------------------------------------------------------

--- a/bathymetry_layer/test/test_bathymetry_layer.cpp
+++ b/bathymetry_layer/test/test_bathymetry_layer.cpp
@@ -73,6 +73,8 @@ public:
   using BathymetryLayer::expandUserPath;
   using BathymetryLayer::injectTile;
   using BathymetryLayer::tileSize;
+  using BathymetryLayer::CoverageBox;
+  using BathymetryLayer::tileHasCoverage;
 };
 
 // ---------------------------------------------------------------------------
@@ -682,4 +684,37 @@ TEST_F(TideFrameTest, DegenerateTideFrameConfigRejected)
   EXPECT_FALSE(layer.isMapTideValid())
     << "map_frame == map_tide_frame is a degenerate identity lookup and must be "
        "rejected as an invalid tide";
+}
+
+// ---------------------------------------------------------------------------
+// generateTile's whole-tile coverage short-circuit (#226 perf fix part 2):
+// a tile whose projected lat/lon AABB overlaps no resident store tile is filled
+// uniformly without the per-cell projection+query. The safety-critical property
+// is that a tile is NEVER wrongly classified no-coverage (which would drop real
+// bathymetry when unsurveyed_is_lethal is false), so the test pins the margin
+// behaviour: straddling/within-margin tiles count as covered; only clearly
+// disjoint tiles are skipped.
+TEST(BathymetryLayer, TileCoverageOverlapDecision)
+{
+  BathymetryLayerForTest layer;
+  using Box = BathymetryLayerForTest::CoverageBox;
+  // One resident store tile, roughly a Lake Massabesic patch.
+  const std::vector<BathymetryLayerForTest::CoverageBox> coverage{
+    Box{42.98, -71.40, 43.00, -71.38}};
+
+  // Fully inside coverage → covered (full per-cell render).
+  EXPECT_TRUE(layer.tileHasCoverage(42.985, -71.395, 42.990, -71.390, coverage));
+  // Straddling the coverage edge → covered (conservative).
+  EXPECT_TRUE(layer.tileHasCoverage(42.995, -71.385, 43.005, -71.375, coverage));
+  // Just outside the top edge but within the ~11 m (1e-4 deg) margin → still
+  // covered: a covered cell must never be dropped.
+  EXPECT_TRUE(layer.tileHasCoverage(43.00005, -71.390, 43.00010, -71.385, coverage));
+  // Clearly beyond the margin (~22 m above) → no coverage (eligible for the
+  // uniform-fill short-circuit).
+  EXPECT_FALSE(layer.tileHasCoverage(43.00030, -71.390, 43.00040, -71.385, coverage));
+  // Far away → no coverage.
+  EXPECT_FALSE(layer.tileHasCoverage(42.000, -72.000, 42.001, -71.999, coverage));
+  // Empty store (no data loaded) → nothing is covered, so every tile takes the
+  // short-circuit (uniform lethal land / NO_INFORMATION).
+  EXPECT_FALSE(layer.tileHasCoverage(42.985, -71.395, 42.990, -71.390, {}));
 }


### PR DESCRIPTION
## Problem

`bathymetry_layer` re-rendered the **static** prior **per cell, every costmap cycle**, over the
full extent: per cell a tf2 transform (`worldToLatLon`→`earth`) + two store queries
(`bestSource` + `shallowestReliable`). Measured ~**35 µs/cell** — local costmap (122k cells)
ran at **0.23 Hz** vs 5 Hz, and the **16M-cell global** costmap took ~**9 min** for one pass, so
`planner_server` spent **minutes** activating (pegged at 99% CPU = computing) and the controller
loop missed its rate. It only surfaced once the tide gate opened (before, the loop early-returned).

## Fix — adopt the `s57_layer` world-anchored tile-cache pattern

The prior is static in world space, so render it once and reuse as the rolling window scrolls:

- **World-anchored cost-tile cache** (`std::map<TileID, TileInfo>` of pre-rendered `Costmap2D`
  tiles). `generateTile` renders a tile from the store with the `global_frame→earth` transform
  **hoisted** (one lookup per pass, applied per cell via `tf2::doTransform`), reusing the exact
  `evaluateCell` decision so every safety gate (MF1 tide / two-query no-data / `unsurveyed_is_lethal`
  / staleness) is preserved.
- `updateCosts` is now a **bounded blit** (max-combine; skip `NO_INFORMATION`), mirroring
  `s57_layer`.
- **Incremental generation** (`max_tiles_per_cycle_`) so the first pass over a large global costmap
  doesn't block activation; `current_` (MF2) gates on all tiles being generated.
- **Tide-change invalidation** re-renders tiles when the surface moves, serving cached costs
  meanwhile.

Steady state: `O(cells × (tf + 2 queries))` per cycle → `O(cells)` copy.

## Review (pre-push, Deep) — findings addressed

Two disjoint-lens adversarial passes. Lens A confirmed the blit index math correct. Lens B found
safety-relevant caching gaps vs the old per-cycle path, all fixed in `408c2ab`:

- **Staleness (`max_age_`) gate** was defeated by caching → added a periodic full re-render
  (~`max_age_`/2) when the gate is on; `max_age_==0` keeps full caching.
- **`generateTile`** aborted the whole tile on one cell's projection throw (could pin
  `current_=false`) → skip the cell, keep rendering.
- **`updateCosts`** early-return left a stale `current_=true` → cleared.
- Corrected an overstated **"#223 resolved"** claim — tide-change invalidation handles a tide that
  *moves*, not one that *freezes* (still #223).

## Tests

All **17 tests + plugin load + lint** pass. New tests cover the perf-critical blit: cell mapping +
max-combine, the rolling-origin offset math, and cheapness (**250k-cell blit <1 ms** vs the old
~8.75 s for the same count).

## Not yet done (follow-up)

- **Live-sim activation/control-loop measurement** is owed but **blocked on cube#69**: #221 removed
  `epoch.hpp` and `cube_bathymetry` (which the sim launches) won't build until that lands. `core`
  builds clean at #221. I'll post the sim number once unblocked.
- Integration tests for `generateTile` / tide-invalidation / incremental gen need an `earth`-frame +
  disk-store fixture (owed; the blit is covered, sim validates the rest).
- `tile_size_` / `max_tiles_per_cycle_` / `tide_invalidate_threshold_` are hardcoded; consider
  parameterizing (s57 exposes `tile_size`).

Reference implementation: `s57_tools/s57_layer`.

Closes #226

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8`
