### PR TITLE
Packaging: valid nlohmann-json-dev rosdep key + dependencies.repos for CI (#228)

### DIFF
--- a/.agent/work-plans/issue-228/plan.md
+++ b/.agent/work-plans/issue-228/plan.md
@@ -1,0 +1,71 @@
+# Plan: Packaging: invalid nlohmann_json rosdep key + undeclared marine_nav source deps break whole-monorepo CI
+
+## Issue
+
+https://github.com/rolker/unh_marine_autonomy/issues/228
+
+## Context
+
+Two packaging gaps break a clean whole-monorepo `rosdep install` + build:
+
+1. **Bug**: `marine_bathymetry_store/package.xml:19` and
+   `marine_mbes_backscatter_store/package.xml:23` both declare
+   `<depend>nlohmann_json</depend>`. `nlohmann_json` is not a valid rosdep
+   key — the correct key is `nlohmann-json-dev` (resolves to
+   `nlohmann-json3-dev` via apt).
+
+2. **Gap**: `mission_manager`, `mission_manager_interfaces`, and
+   `marine_autonomy_integration_tests` depend on `marine_nav_interfaces` /
+   `marine_nav_tasks` (from `unh_marine_navigation`). The repo's
+   `config/repos/core.repos` already lists `unh_marine_navigation`, but that
+   path is not a standard CI entry point. No root-level `dependencies.repos`
+   exists for CI consumers to `vcs import`.
+
+`cube_bathymetry` carries workarounds for both (ROSDEP_SKIP_KEYS,
+ADDITIONAL_DEBS, COLCON_IGNORE on mission_manager*). Both fixes land in one PR.
+
+## Approach
+
+1. **Fix `nlohmann_json` rosdep key** — change the invalid key to the correct
+   one in both affected `package.xml` files.
+
+2. **Add `dependencies.repos`** — create a root-level `dependencies.repos`
+   listing only `unh_marine_navigation` (not all of `config/repos/core.repos`).
+   This is the `industrial_ci` convention for upstream source deps.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `marine_bathymetry_store/package.xml` | Line 19: `nlohmann_json` → `nlohmann-json-dev` |
+| `marine_mbes_backscatter_store/package.xml` | Line 23: `nlohmann_json` → `nlohmann-json-dev` |
+| `dependencies.repos` (new) | Root-level vcs repos file listing `unh_marine_navigation` |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Standards Compliance | Using the correct rosdep key (`nlohmann-json-dev`) aligns with ROS 2 packaging conventions. |
+| Only what's needed | Two targeted edits + one new file. No refactoring, no behavior change. |
+| A change includes its consequences | PR description will note the cube_bathymetry workarounds that can drop afterward. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0008 — Follow ROS 2 Official Conventions | Yes | Fix brings `package.xml` declarations into compliance with valid rosdep keys. |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `package.xml` nlohmann key | `cube_bathymetry` drops `ROSDEP_SKIP_KEYS: nlohmann_json` + `ADDITIONAL_DEBS` | No — cube_bathymetry follow-up PR; note in description |
+| Add `dependencies.repos` | `cube_bathymetry` drops `COLCON_IGNORE` on `mission_manager*` | No — cube_bathymetry follow-up PR; note in description |
+
+## Open Questions
+
+- [ ] No open questions — plan is review-plan-ready.
+
+## Estimated Scope
+
+Single PR. Three file changes (two edits, one new file).

--- a/.agent/work-plans/issue-228/progress.md
+++ b/.agent/work-plans/issue-228/progress.md
@@ -67,3 +67,15 @@ Both fixes are correctly described in the issue. The `cube_bathymetry` repo curr
 
 ### Actions
 - [ ] No actions — issue is plan-task-ready.
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-27 12:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Plan**: `.agent/work-plans/issue-228/plan.md` at `34854ef`
+**Branch**: feature/issue-228 at `34854ef`
+**Phases**: single
+
+### Open questions
+- [ ] No open questions — plan is review-plan-ready.

--- a/.agent/work-plans/issue-228/progress.md
+++ b/.agent/work-plans/issue-228/progress.md
@@ -79,3 +79,16 @@ Both fixes are correctly described in the issue. The `cube_bathymetry` repo curr
 
 ### Open questions
 - [ ] No open questions — plan is review-plan-ready.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-06-27 14:00 +00:00
+**By**: Claude Sonnet (in-context — author self-review)
+
+**Plan**: `.agent/work-plans/issue-228/plan.md` at `34854ef`
+**PR**: PR-less (--issue mode)
+**Verdict**: approve-with-suggestions
+
+### Findings
+- [ ] (suggestion) Consequences table describes the cube_bathymetry follow-up as "drops `COLCON_IGNORE` on `mission_manager*`" — but depending on how cube_bathymetry's current `UPSTREAM_WORKSPACE` is wired, the follow-up may also need to add/update an `UPSTREAM_WORKSPACE` reference to `unh_marine_autonomy`'s new `dependencies.repos` (so `unh_marine_navigation` is pulled automatically rather than ignored). Consider noting this nuance in the PR description so the cube_bathymetry follow-up scope is accurately understood. — `plan.md:63`
+- [ ] (suggestion) `dependencies.repos` content is not specified in the plan. The implementer should follow the vcstools YAML format used in `config/repos/core.repos` and include `version: jazzy` on the `unh_marine_navigation` entry. This is a minor implementation detail but worth making explicit to avoid a stale-branch mistake. — `plan.md:41`

--- a/.agent/work-plans/issue-228/progress.md
+++ b/.agent/work-plans/issue-228/progress.md
@@ -1,0 +1,69 @@
+---
+issue: 228
+---
+
+# Issue #228 — Packaging: invalid nlohmann_json rosdep key + undeclared marine_nav source deps break whole-monorepo CI
+
+## Issue Review
+**Status**: complete
+**When**: 2026-06-27 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Issue**: #228
+**Comment**: (best-effort post follows this entry; not recorded inline)
+**Scope verdict**: well-scoped
+
+### Summary
+
+Issue #228 identifies two packaging gaps in the `unh_marine_autonomy` monorepo:
+
+1. **Bug**: `marine_bathymetry_store` and `marine_mbes_backscatter_store` both declare `<depend>nlohmann_json</depend>`, which is not a valid rosdep key. The correct key is `nlohmann-json-dev` (resolves to `nlohmann-json3-dev` via apt). This is confirmed by inspecting the package.xml files in the worktree.
+
+2. **Gap**: Packages `mission_manager`, `mission_manager_interfaces`, and `marine_autonomy_integration_tests` depend on `marine_nav_interfaces` and `marine_nav_tasks` (from `unh_marine_navigation`). The repo's `config/repos/core.repos` already lists `unh_marine_navigation`, but this manifest lives under `config/repos/`, not at the repo root — so a fresh CI consumer doing `vcs import` from the root won't find it. The fix is to add a root-level `dependencies.repos` (or CI `upstream.repos`) pointing to `unh_marine_navigation`.
+
+Both fixes are correctly described in the issue. The `cube_bathymetry` repo currently carries workarounds for both (`ROSDEP_SKIP_KEYS`, `ADDITIONAL_DEBS`, `COLCON_IGNORE`), confirming the pain is real and the fixes unblock a downstream consumer.
+
+### Scope Assessment
+
+**Well-scoped**: Yes. Both fixes are mechanical and self-contained:
+- Item 1: two-line change (two `package.xml` files).
+- Item 2: add one `dependencies.repos` at the repo root (or promote/symlink `config/repos/core.repos`).
+- No behavior changes; no API changes; no message interface changes.
+- Both fit in a single PR.
+
+**Right repo**: Yes. `marine_bathymetry_store` and `marine_mbes_backscatter_store` live in this repo; the `mission_manager` and integration-test packages are also here. The manifest gap is the repo's own responsibility to document.
+
+**Dependencies**: The fix is a prerequisite for `cube_bathymetry` to drop its workarounds (PR #72 / issue cube_bathymetry#72 carries the skip-keys). No ordering constraint within this repo; both items can land in one PR.
+
+### Principle Alignment
+
+| Principle | Status | Notes |
+|---|---|---|
+| A change includes its consequences | OK | Fix is narrow — `package.xml` edits and a new manifest. No tests, docs, or message interfaces affected. The issue explicitly notes what downstream workarounds can drop afterward. |
+| Improve incrementally | OK | Two focused, reviewable changes in one PR. |
+| Standards Compliance (project) | OK | Correcting to the proper rosdep key aligns with ROS 2 community packaging standards (ADR-0008). |
+| Only what's needed | OK | Issue scope is minimal — no new packages, no refactoring. |
+| Modularity and Decoupling (project) | Watch | Adding `dependencies.repos` at the root makes the self-describing dependency graph explicit. This is hygiene, not a structural change. |
+
+### ADR Applicability
+
+| ADR | Triggered | Notes |
+|---|---|---|
+| 0008 — Follow ROS 2 Official Conventions | Yes | `package.xml` dependency declarations must use valid rosdep keys. The fix brings both packages into compliance. |
+| 0001 — Adopt ADRs | No | No design decision is being made; this is a bug fix and packaging hygiene. |
+| 0002 — Worktree isolation | Yes (process) | Already satisfied — branch `feature/issue-228` exists and work will proceed in the worktree. |
+
+### Consequences
+
+- After Item 1 lands, `cube_bathymetry` can drop `ROSDEP_SKIP_KEYS: nlohmann_json` and `ADDITIONAL_DEBS: nlohmann-json3-dev` from its CI config. That is cube_bathymetry's own PR to make; not required in this PR but worth noting in the PR description.
+- After Item 2 lands, `cube_bathymetry` can drop the `COLCON_IGNORE`-on-`mission_manager*` workaround.
+- No other packages in the workspace declare `nlohmann_json` (with the wrong key) — only these two.
+- The `config/repos/core.repos` already lists `unh_marine_navigation`, so the source is not missing from the workspace manifest layer — only from a repo-root CI entry point.
+
+### Recommendations
+
+- For Item 2: prefer a new `dependencies.repos` at the repo root (following `industrial_ci` convention for `upstream.repos`) rather than a symlink to `config/repos/core.repos`. The workspace manifest (`config/repos/core.repos`) includes many other repos beyond `unh_marine_navigation`; a targeted `dependencies.repos` listing only unresolved source deps is cleaner for CI consumers.
+- PR description should note the downstream cube_bathymetry workarounds that can be dropped, so that work is visible and can be tracked.
+
+### Actions
+- [ ] No actions — issue is plan-task-ready.

--- a/.agent/work-plans/issue-228/progress.md
+++ b/.agent/work-plans/issue-228/progress.md
@@ -92,3 +92,18 @@ Both fixes are correctly described in the issue. The `cube_bathymetry` repo curr
 ### Findings
 - [ ] (suggestion) Consequences table describes the cube_bathymetry follow-up as "drops `COLCON_IGNORE` on `mission_manager*`" — but depending on how cube_bathymetry's current `UPSTREAM_WORKSPACE` is wired, the follow-up may also need to add/update an `UPSTREAM_WORKSPACE` reference to `unh_marine_autonomy`'s new `dependencies.repos` (so `unh_marine_navigation` is pulled automatically rather than ignored). Consider noting this nuance in the PR description so the cube_bathymetry follow-up scope is accurately understood. — `plan.md:63`
 - [ ] (suggestion) `dependencies.repos` content is not specified in the plan. The implementer should follow the vcstools YAML format used in `config/repos/core.repos` and include `version: jazzy` on the `unh_marine_navigation` entry. This is a minor implementation detail but worth making explicit to avoid a stale-branch mistake. — `plan.md:41`
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-27 12:28 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-228 at `a25fa26`
+**Mode**: pre-push
+**Depth**: Standard (reason: 5 files / 183 lines in the 50–199 band; `plan.md` is a project-repo override-trigger)
+**Must-fix**: 0 | **Suggestions**: 1
+**Round**: 1 | **Ship**: recommended — no must-fix; one optional documentation suggestion
+
+### Findings
+- [ ] (suggestion) `dependencies.repos` header comment overstates completeness — implies `unh_marine_navigation` is the only unreleased source dep, but `config/repos/underlay.repos` carries branch-pinned forks too; scope the comment to the #228 marine_nav gap — `dependencies.repos:1-8`

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -1,14 +1,13 @@
 # Source dependencies for CI consumers (vcstool / industrial_ci
-# UPSTREAM_WORKSPACE convention). Lists the unreleased source repos this
-# monorepo depends on but does not vendor, so a downstream `vcs import` can
-# obtain them before a whole-workspace rosdep resolve + build.
+# UPSTREAM_WORKSPACE convention): source repos a downstream `vcs import` needs
+# to resolve build deps that this monorepo references but does not vendor.
 #
-# Currently only unh_marine_navigation (provides marine_nav_interfaces /
-# marine_nav_tasks, depended on by mission_manager*, mission_manager_interfaces,
-# and marine_autonomy_integration_tests). See #228.
-#
-# This is intentionally minimal — config/repos/core.repos lists the full
-# development manifest (many repos beyond what a CI source-dep import needs).
+# Scoped to the #228 marine_nav gap — unh_marine_navigation provides
+# marine_nav_interfaces / marine_nav_tasks, depended on by mission_manager*,
+# mission_manager_interfaces, and marine_autonomy_integration_tests. This is
+# NOT an exhaustive list of every unreleased dep (config/repos/*.repos carry
+# the full development manifest, incl. branch-pinned forks); add entries here
+# only as concrete CI source-dep gaps surface.
 repositories:
   unh_marine_navigation:
     type: git

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -1,0 +1,16 @@
+# Source dependencies for CI consumers (vcstool / industrial_ci
+# UPSTREAM_WORKSPACE convention). Lists the unreleased source repos this
+# monorepo depends on but does not vendor, so a downstream `vcs import` can
+# obtain them before a whole-workspace rosdep resolve + build.
+#
+# Currently only unh_marine_navigation (provides marine_nav_interfaces /
+# marine_nav_tasks, depended on by mission_manager*, mission_manager_interfaces,
+# and marine_autonomy_integration_tests). See #228.
+#
+# This is intentionally minimal — config/repos/core.repos lists the full
+# development manifest (many repos beyond what a CI source-dep import needs).
+repositories:
+  unh_marine_navigation:
+    type: git
+    url: https://github.com/rolker/unh_marine_navigation.git
+    version: jazzy

--- a/marine_bathymetry_store/package.xml
+++ b/marine_bathymetry_store/package.xml
@@ -16,7 +16,7 @@
   <depend>marine_autonomy</depend>
   <depend>marine_tiled_raster_store</depend>
   <depend>geographic_msgs</depend>
-  <depend>nlohmann_json</depend>
+  <depend>nlohmann-json-dev</depend>
   <depend>libgdal-dev</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>

--- a/marine_mbes_backscatter_store/package.xml
+++ b/marine_mbes_backscatter_store/package.xml
@@ -20,7 +20,7 @@
   <depend>marine_tiled_raster_store</depend>
   <depend>marine_backscatter</depend>
   <depend>geographic_msgs</depend>
-  <depend>nlohmann_json</depend>
+  <depend>nlohmann-json-dev</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
Closes #228.

## What

Fixes two packaging gaps that break a clean whole-monorepo rosdep resolve +
build (latent under per-package CI, surfaced by `cube_bathymetry`'s
`industrial_ci` migration):

1. **Invalid `nlohmann_json` rosdep key → `nlohmann-json-dev`** in
   `marine_bathymetry_store/package.xml` and
   `marine_mbes_backscatter_store/package.xml`. `nlohmann_json` does not resolve
   (`rosdep resolve nlohmann_json` → no rule); `nlohmann-json-dev` resolves to
   apt `nlohmann-json3-dev`.
2. **New root-level `dependencies.repos`** listing `unh_marine_navigation`
   (provides `marine_nav_interfaces` / `marine_nav_tasks`, depended on by
   `mission_manager*`, `mission_manager_interfaces`,
   `marine_autonomy_integration_tests`). Gives CI consumers a standard
   `vcs import` entry point for the source dep instead of `COLCON_IGNORE`-ing
   the dependent packages. Intentionally minimal vs. `config/repos/core.repos`
   (the full dev manifest); `url`/`version` mirror that file.

## Verification

- `rosdep resolve nlohmann-json-dev` → `nlohmann-json3-dev` ✓; old key → no rule ✓
- Repo-wide grep: no remaining `nlohmann_json` in any `package.xml` ✓
- `dependencies.repos` valid vcstool YAML; `unh_marine_navigation` `version: jazzy`
  matches `config/repos/core.repos` ✓

Pure packaging metadata — no behavior, interface, or test changes.

## Downstream follow-up (cube_bathymetry)

After this lands and `cube_bathymetry`'s `upstream.repos` picks up the fixed
`unh_marine_autonomy`, the cube CI workarounds can drop:

- `ROSDEP_SKIP_KEYS: nlohmann_json` + `ADDITIONAL_DEBS: nlohmann-json3-dev` — gone (key now resolves).
- `COLCON_IGNORE` on `mission_manager*` / integration-tests / backscatter — gone
  (the `marine_nav` source dep is now resolvable via `dependencies.repos`).
  **Nuance**: cube's CI may need its `UPSTREAM_WORKSPACE` to also import this
  `dependencies.repos` (or add `unh_marine_navigation` to cube's own
  `upstream.repos`) so the source dep is actually cloned — verify when wiring the
  cube follow-up.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8`
