### PR TITLE
feat(marine_interfaces): SonarVisualizationTile transport messages (PR1 of #230)

### DIFF
--- a/.agent/work-plans/issue-230/plan.md
+++ b/.agent/work-plans/issue-230/plan.md
@@ -23,9 +23,12 @@ touches.
 
 **Messages** (six `.msg`, helper types embedded for reuse):
 
-1. **`GridIndex.msg`** — `uint8 level`, `uint32 row`, `uint32 col`. The ROS
-   mirror of `gggs::GridIndex`; embedded in tile, catalog entry, and request so
-   the index format is defined once.
+1. **`TileIndex.msg`** — `uint8 level`, `uint32 row`, `uint32 col`. Addresses a
+   whole GGGS tile (mirrors `gggs::GridIndex {level,row,col}`, noted in the
+   message comment); named `TileIndex` rather than `GridIndex` for consistency
+   with the `Tile*` family and to avoid the `grid_map` cell-index reading
+   (decided 2026-06-27). Embedded in tile, catalog entry, and request so the
+   index format is defined once.
 2. **`VisualizationBand.msg`** — one self-describing quantized band:
    `string name`, `uint8 dtype`, `float64 scale/offset/nodata`, `uint8[] data`
    (row-major raw bytes for the **dirty window**, length `=
@@ -34,24 +37,25 @@ touches.
    `sensor_msgs/PointField`** (INT16=3, UINT8=2, …) rather than inventing a new
    enum (precedent-reuse — [[feedback_sensor_msg_conventions_tf_trademarks]]).
 3. **`SonarVisualizationTile.msg`** — `std_msgs/Header header` (`stamp` = tile
-   version time on the boat clock; `frame_id` = display-CRS tag), `GridIndex
+   version time on the boat clock; `frame_id` = display-CRS tag), `TileIndex
    index`, `uint16 width/height` (cells per side), dirty sub-window `uint16
    window_col/window_row/window_width/window_height`, `VisualizationBand[]
    bands`. Band data covers **only the dirty window** (incremental patch — the
    bandwidth win on top of quantization+zlib, matching cube#70's incremental
    `~/tiles`); a full-tile update sets the window to the whole tile.
-4. **`TileCatalogEntry.msg`** — `GridIndex index`, `builtin_interfaces/Time
+4. **`TileCatalogEntry.msg`** — `TileIndex index`, `builtin_interfaces/Time
    version` (per-tile version = latest-cell timestamp, ADR-0008 D3).
 5. **`TileCatalog.msg`** — `std_msgs/Header header` (`stamp` = catalog
    generation-time, the prune gate), `TileCatalogEntry[] entries` (a
    **complete** snapshot — prune-on-absence depends on completeness, D4).
-6. **`TileRequest.msg`** — `std_msgs/Header header`, `GridIndex[] tiles` (the
+6. **`TileRequest.msg`** — `std_msgs/Header header`, `TileIndex[] tiles` (the
    operator's "need" list).
 
 **Anti-entropy reconciler** (the testable heart of acceptance #2): a **ROS-free**
-pure-logic library (proposed package `marine_tile_sync`) so the protocol is
-proven deterministically without a GUI and is reusable by both `camp` (#121) and
-the web viewer (#166):
+pure-logic library in a **new in-repo package `marine_tile_sync`** (inside
+`unh_marine_autonomy`, so no `.repos` change — decided 2026-06-27) so the
+protocol is proven deterministically without a GUI and is reusable by both
+`camp` (#121) and the web viewer (#166):
 
 7. **`TileCatalogBuilder`** (boat side) — snapshot a dirty/known set → catalog.
 8. **`TileCatalogReconciler`** (operator side) — given local cache `{index →
@@ -70,7 +74,7 @@ update the package's message inventory.
 
 | File | Change |
 |------|--------|
-| `marine_interfaces/msg/GridIndex.msg` | New |
+| `marine_interfaces/msg/TileIndex.msg` | New |
 | `marine_interfaces/msg/VisualizationBand.msg` | New (with PointField-mirrored dtype constants) |
 | `marine_interfaces/msg/SonarVisualizationTile.msg` | New |
 | `marine_interfaces/msg/TileCatalogEntry.msg` | New |
@@ -93,7 +97,7 @@ update the package's message inventory.
 
 | ADR | Triggered | How addressed |
 |---|---|---|
-| 0008 (this companion) | Yes | D1 named bands; D2 dense-quantized, **no compression fields** in msg; D3 `builtin_interfaces/Time` version; D4 complete catalog + gen-time + timestamp-gated prune; D7 level in `GridIndex`; D8 no `source_index` |
+| 0008 (this companion) | Yes | D1 named bands; D2 dense-quantized, **no compression fields** in msg; D3 `builtin_interfaces/Time` version; D4 complete catalog + gen-time + timestamp-gated prune; D7 level in `TileIndex`; D8 no `source_index` |
 | 0001 (colormap) | No | Bands are scalar fields; colormap is operator-side render (camp#121), not in the message |
 | 0002 (bathy store) | Indirect | Tile identity = GGGS index matches the store's tiling |
 | 0007 (MBES backscatter) | Indirect | `backscatter` band is display-grade (D10); durable home stays the store |
@@ -107,23 +111,23 @@ update the package's message inventory.
 | New `marine_tile_sync` package | Workspace build order / `.repos` if standalone | Decided in Open Q (in-repo pkg = no `.repos` change) |
 | Package gains messages | `marine_interfaces` has **no `.agents/README.md`** — gap, not created here | No — separate doc task |
 
+## Resolved Decisions (2026-06-27)
+
+- **Reconciler in scope.** #230 = messages (PR1) **+** the ROS-free
+  `marine_tile_sync` reconciler/builder lib with simulated-loss tests (PR2,
+  stacked) — satisfies acceptance #2 and gives cube#78/camp#121 a tested
+  protocol to depend on.
+- **Package home.** `marine_tile_sync` is a new package **inside
+  `unh_marine_autonomy`** — no `.repos` change.
+- **Index naming.** `TileIndex` (not `GridIndex`) — consistent with the `Tile*`
+  family and avoids the `grid_map` cell-index reading; mirrors
+  `gggs::GridIndex` in fields, noted in the message comment.
+
 ## Open Questions
 
-- [ ] **Reconciler scope.** Recommend #230 = messages (PR1) **+** ROS-free
-  `marine_tile_sync` reconciler/builder lib with simulated-loss tests (PR2,
-  stacked) — this is what satisfies acceptance #2 and gives cube#78/camp#121 a
-  tested protocol to depend on. Alternative: ship messages-only here and put the
-  reconciler in camp#121 (leaves acceptance #2 unmet in this issue). **Pick one.**
-- [ ] **New package name/home.** If we build the lib: `marine_tile_sync` as a new
-  package **inside `unh_marine_autonomy`** (no `.repos` change; recommended) vs.
-  standalone repo. Confirm the name.
-- [ ] **`GridIndex` naming.** Reusing the gggs type name as `marine_interfaces/GridIndex`
-  is intentional (ROS mirror) — flag only if a different name is preferred to
-  avoid confusion with `grid_map`.
+- [ ] No open questions — plan is review-plan-ready.
 
 ## Estimated Scope
 
-**Two stacked PRs** (if reconciler in scope): PR1 = six messages + CMakeLists +
-docs (small, low-risk); PR2 = `marine_tile_sync` lib + GTest (medium), stacked on
-PR1. Collapses to a single messages-only PR if the reconciler is deferred to
-camp#121.
+**Two stacked PRs**: PR1 = six messages + CMakeLists + docs (small, low-risk);
+PR2 = `marine_tile_sync` lib + GTest (medium), stacked on PR1.

--- a/.agent/work-plans/issue-230/plan.md
+++ b/.agent/work-plans/issue-230/plan.md
@@ -101,6 +101,7 @@ ADR-0008 D3 supersedes it with timestamp/version.
 | `marine_interfaces/msg/TileRequest.msg` | New |
 | `marine_interfaces/CMakeLists.txt` | Append 6 entries to `set(MSG_FILES …)`; `builtin_interfaces` already in rosidl DEPENDENCIES |
 | `marine_interfaces/package.xml` | **Add `<depend>builtin_interfaces</depend>`** — new msgs use `builtin_interfaces/Time`; it is in CMakeLists DEPENDENCIES but **not** the manifest |
+| `docs/interfaces.md` | Add a "Live sonar coverage transport" message-reference note for the new family (PR1) |
 | `marine_tiled_raster_store/include|src/.../tile_catalog*.{hpp,cpp}` | New: payload-agnostic `TileCatalogBuilder` / `TileCatalogReconciler` (PR2) |
 | `marine_tiled_raster_store/test/test_tile_catalog.cpp` | New GTest: loss/reorder/cold-start/reset convergence (PR2) |
 | `marine_tiled_raster_store/CMakeLists.txt` | Register the new lib sources + GTest |

--- a/.agent/work-plans/issue-230/plan.md
+++ b/.agent/work-plans/issue-230/plan.md
@@ -34,8 +34,10 @@ touches.
    (row-major raw bytes for the **dirty window**, length `=
    window_w·window_h·sizeof(dtype)`). Consumer dequantizes generically
    (`value = raw·scale + offset`). `dtype` constants **mirror
-   `sensor_msgs/PointField`** (INT16=3, UINT8=2, …) rather than inventing a new
-   enum (precedent-reuse — [[feedback_sensor_msg_conventions_tf_trademarks]]).
+   `sensor_msgs/PointField` numeric values** (INT16=3, UINT8=2, …) as **local
+   `uint8` constants in this `.msg`** — no `sensor_msgs` build dep (keeps the
+   "no new deps" property); precedent-reuse without coupling
+   ([[feedback_sensor_msg_conventions_tf_trademarks]]).
 3. **`SonarVisualizationTile.msg`** — `std_msgs/Header header` (`stamp` = tile
    version time on the boat clock; `frame_id` = display-CRS tag), `TileIndex
    index`, `uint16 width/height` (cells per side), dirty sub-window `uint16
@@ -51,24 +53,41 @@ touches.
 6. **`TileRequest.msg`** — `std_msgs/Header header`, `TileIndex[] tiles` (the
    operator's "need" list).
 
-**Anti-entropy reconciler** (the testable heart of acceptance #2): a **ROS-free**
-pure-logic library in a **new in-repo package `marine_tile_sync`** (inside
-`unh_marine_autonomy`, so no `.repos` change — decided 2026-06-27) so the
-protocol is proven deterministically without a GUI and is reusable by both
-`camp` (#121) and the web viewer (#166):
+Message split by concern: `SonarVisualizationTile` + `VisualizationBand` are the
+**light/quantized display payload**; `TileIndex` / `TileCatalogEntry` /
+`TileCatalog` / `TileRequest` are **payload-agnostic sync-protocol** messages
+(indices + versions, no pixels) — so a future full-tile store-to-store sync can
+reuse the same catalog/request shape.
+
+**Anti-entropy reconciler** (the testable heart of acceptance #2): a **ROS-free,
+payload-agnostic** pure-logic library added to the existing **`marine_tiled_raster_store`**
+package — the #172 shared GGGS tiling/persistence core whose own header
+(`tile_io.hpp`) designates it the home where "the #86-Phase-6 … sync will build."
+The reconciler operates on `gggs::GridIndex` + a version + plain catalog structs
+and knows **nothing about full vs light tiles**, so it is reused by *both* the
+light-tile display sync (now, #230) and a future full-tile store-to-store sync —
+the reuse Roland asked for (2026-06-27), written once. No new package
+(`marine_tile_sync` rejected — it would fork the contract #172 was built to
+share), and **no `marine_interfaces` dependency** in the store core (it stays
+ROS-message-free; cube#78/camp#121 adapt msgs↔structs at the node boundary):
 
 7. **`TileCatalogBuilder`** (boat side) — snapshot a dirty/known set → catalog.
 8. **`TileCatalogReconciler`** (operator side) — given local cache `{index →
    version}` + a received catalog, compute `{request-list, prune-list}`:
    request missing/stale; **prune-on-absence** but **timestamp-gated** (prune an
    absent tile only if older than the catalog's generation-time, D4 condition b).
-9. **Unit tests** simulating loss / reorder / cold-start / **boat reset** (fresh
-   boat → small catalog → operator prunes the rest), asserting convergence to
-   exactly the catalog set and that a late/reordered catalog cannot delete a
-   just-pushed fresh tile.
+9. **Unit tests** (extend `marine_tiled_raster_store`'s GTest suite) simulating
+   loss / reorder / cold-start / **boat reset** (fresh boat → small catalog →
+   operator prunes the rest), asserting convergence to exactly the catalog set
+   and that a late/reordered catalog cannot delete a just-pushed fresh tile. This
+   is a **pure-logic + deterministic-sim** realization of acceptance #2; the real
+   ROS publisher/subscriber wiring is deferred to cube#78 (producer) / camp#121
+   (consumer).
 
-**Docs**: a `marine_interfaces` message-reference note for the new family, and
-update the package's message inventory.
+**Docs**: a `marine_interfaces` message-reference note for the new family; update
+`marine_tiled_raster_store/README.md` (sync section); and **fix the stale
+`tile_io.hpp` comment** that still says "manifest/**content-hash** sync" —
+ADR-0008 D3 supersedes it with timestamp/version.
 
 ## Files to Change
 
@@ -80,9 +99,13 @@ update the package's message inventory.
 | `marine_interfaces/msg/TileCatalogEntry.msg` | New |
 | `marine_interfaces/msg/TileCatalog.msg` | New |
 | `marine_interfaces/msg/TileRequest.msg` | New |
-| `marine_interfaces/CMakeLists.txt` | Append 6 entries to `set(MSG_FILES …)`; `builtin_interfaces` already in DEPENDENCIES |
-| `marine_interfaces/package.xml` | No new deps (std_msgs/builtin_interfaces already present) — verify |
-| `marine_tile_sync/` (new pkg) | Reconciler + builder lib + GTest (PR2) |
+| `marine_interfaces/CMakeLists.txt` | Append 6 entries to `set(MSG_FILES …)`; `builtin_interfaces` already in rosidl DEPENDENCIES |
+| `marine_interfaces/package.xml` | **Add `<depend>builtin_interfaces</depend>`** — new msgs use `builtin_interfaces/Time`; it is in CMakeLists DEPENDENCIES but **not** the manifest |
+| `marine_tiled_raster_store/include|src/.../tile_catalog*.{hpp,cpp}` | New: payload-agnostic `TileCatalogBuilder` / `TileCatalogReconciler` (PR2) |
+| `marine_tiled_raster_store/test/test_tile_catalog.cpp` | New GTest: loss/reorder/cold-start/reset convergence (PR2) |
+| `marine_tiled_raster_store/CMakeLists.txt` | Register the new lib sources + GTest |
+| `marine_tiled_raster_store/include/.../tile_io.hpp` | Fix stale "manifest/content-hash sync" comment → timestamp/version (ADR-0008 D3) |
+| `marine_tiled_raster_store/README.md` | Document the sync/reconciler addition |
 
 ## Principles Self-Check
 
@@ -108,17 +131,25 @@ update the package's message inventory.
 |---|---|---|
 | `set(MSG_FILES …)` in CMakeLists | Rebase against #167/PR#169 if it lands first (same list) | Yes — sequence/rebase noted |
 | New message family | Producer cube#78, consumer camp#121 build against these | No — downstream issues |
-| New `marine_tile_sync` package | Workspace build order / `.repos` if standalone | Decided in Open Q (in-repo pkg = no `.repos` change) |
-| Package gains messages | `marine_interfaces` has **no `.agents/README.md`** — gap, not created here | No — separate doc task |
+| Add reconciler to `marine_tiled_raster_store` | `tile_io.hpp` stale "content-hash sync" comment (D3 supersedes) + README sync section | Yes — both in Files table |
+| `marine_interfaces` msgs use `builtin_interfaces/Time` | `package.xml` must declare `<depend>builtin_interfaces</depend>` | Yes — in Files table |
+| Package gains messages | `marine_interfaces` + `marine_tiled_raster_store` have **no `.agents/README.md`** — gap, not created here | No — separate doc task |
 
 ## Resolved Decisions (2026-06-27)
 
-- **Reconciler in scope.** #230 = messages (PR1) **+** the ROS-free
-  `marine_tile_sync` reconciler/builder lib with simulated-loss tests (PR2,
-  stacked) — satisfies acceptance #2 and gives cube#78/camp#121 a tested
-  protocol to depend on.
-- **Package home.** `marine_tile_sync` is a new package **inside
-  `unh_marine_autonomy`** — no `.repos` change.
+- **Reconciler in scope.** #230 = messages (PR1) **+** a ROS-free reconciler/builder
+  lib with simulated-loss tests (PR2, stacked) — satisfies acceptance #2 (as a
+  pure-logic + deterministic-sim realization; real ROS nodes deferred to
+  cube#78/camp#121).
+- **Reconciler home (revised after plan review).** Added to the existing
+  **`marine_tiled_raster_store`** package, **not** a new `marine_tile_sync`. That
+  package is the #172 shared GGGS tiling/persistence core explicitly built to be
+  the sync home (`tile_io.hpp`); a new package would fork the contract it was
+  built to share. The reconciler is **payload-agnostic** (`gggs::GridIndex` +
+  version + plain structs, no `marine_interfaces` dep), so it is reused by both
+  the light display-tile sync and a future full-tile store-to-store sync — the
+  reuse Roland asked for. The light/quantized `SonarVisualizationTile` payload
+  stays distinct in `marine_interfaces`.
 - **Index naming.** `TileIndex` (not `GridIndex`) — consistent with the `Tile*`
   family and avoids the `grid_map` cell-index reading; mirrors
   `gggs::GridIndex` in fields, noted in the message comment.
@@ -129,5 +160,6 @@ update the package's message inventory.
 
 ## Estimated Scope
 
-**Two stacked PRs**: PR1 = six messages + CMakeLists + docs (small, low-risk);
-PR2 = `marine_tile_sync` lib + GTest (medium), stacked on PR1.
+**Two stacked PRs**: PR1 = six messages + CMakeLists + `package.xml` dep + docs
+(small, low-risk); PR2 = `marine_tiled_raster_store` reconciler lib + GTest +
+`tile_io.hpp` comment fix (medium), stacked on PR1.

--- a/.agent/work-plans/issue-230/plan.md
+++ b/.agent/work-plans/issue-230/plan.md
@@ -1,0 +1,129 @@
+# Plan: SonarVisualizationTile transport + anti-entropy tile-sync (ADR-0008)
+
+## Issue
+
+https://github.com/rolker/unh_marine_autonomy/issues/230 (Part of #171; realizes I3 / #86 Phase 6; companion to ADR-0008)
+
+## Context
+
+ADR-0008 (merged) ratified the boat→operator live tile transport for GGGS-tiled
+sonar coverage. This issue delivers its **contract artifacts** in
+`marine_interfaces`: the quantized display-grade tile message plus the
+anti-entropy catalog/request protocol. The producer (`cube_bathymetry` #78) and
+the operator render/cache (`camp` #121) are separate downstream issues that
+depend on these messages.
+
+`marine_interfaces` is a pure `rosidl` package — `msg/` files registered in an
+explicit `set(MSG_FILES …)` in `CMakeLists.txt` (not a glob), so new messages
+must be added to that list. No existing GGGS/tile/`GridIndex` message exists;
+these are net-new in a domain none of the in-flight churn (#158/#162/#167)
+touches.
+
+## Approach
+
+**Messages** (six `.msg`, helper types embedded for reuse):
+
+1. **`GridIndex.msg`** — `uint8 level`, `uint32 row`, `uint32 col`. The ROS
+   mirror of `gggs::GridIndex`; embedded in tile, catalog entry, and request so
+   the index format is defined once.
+2. **`VisualizationBand.msg`** — one self-describing quantized band:
+   `string name`, `uint8 dtype`, `float64 scale/offset/nodata`, `uint8[] data`
+   (row-major raw bytes for the **dirty window**, length `=
+   window_w·window_h·sizeof(dtype)`). Consumer dequantizes generically
+   (`value = raw·scale + offset`). `dtype` constants **mirror
+   `sensor_msgs/PointField`** (INT16=3, UINT8=2, …) rather than inventing a new
+   enum (precedent-reuse — [[feedback_sensor_msg_conventions_tf_trademarks]]).
+3. **`SonarVisualizationTile.msg`** — `std_msgs/Header header` (`stamp` = tile
+   version time on the boat clock; `frame_id` = display-CRS tag), `GridIndex
+   index`, `uint16 width/height` (cells per side), dirty sub-window `uint16
+   window_col/window_row/window_width/window_height`, `VisualizationBand[]
+   bands`. Band data covers **only the dirty window** (incremental patch — the
+   bandwidth win on top of quantization+zlib, matching cube#70's incremental
+   `~/tiles`); a full-tile update sets the window to the whole tile.
+4. **`TileCatalogEntry.msg`** — `GridIndex index`, `builtin_interfaces/Time
+   version` (per-tile version = latest-cell timestamp, ADR-0008 D3).
+5. **`TileCatalog.msg`** — `std_msgs/Header header` (`stamp` = catalog
+   generation-time, the prune gate), `TileCatalogEntry[] entries` (a
+   **complete** snapshot — prune-on-absence depends on completeness, D4).
+6. **`TileRequest.msg`** — `std_msgs/Header header`, `GridIndex[] tiles` (the
+   operator's "need" list).
+
+**Anti-entropy reconciler** (the testable heart of acceptance #2): a **ROS-free**
+pure-logic library (proposed package `marine_tile_sync`) so the protocol is
+proven deterministically without a GUI and is reusable by both `camp` (#121) and
+the web viewer (#166):
+
+7. **`TileCatalogBuilder`** (boat side) — snapshot a dirty/known set → catalog.
+8. **`TileCatalogReconciler`** (operator side) — given local cache `{index →
+   version}` + a received catalog, compute `{request-list, prune-list}`:
+   request missing/stale; **prune-on-absence** but **timestamp-gated** (prune an
+   absent tile only if older than the catalog's generation-time, D4 condition b).
+9. **Unit tests** simulating loss / reorder / cold-start / **boat reset** (fresh
+   boat → small catalog → operator prunes the rest), asserting convergence to
+   exactly the catalog set and that a late/reordered catalog cannot delete a
+   just-pushed fresh tile.
+
+**Docs**: a `marine_interfaces` message-reference note for the new family, and
+update the package's message inventory.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `marine_interfaces/msg/GridIndex.msg` | New |
+| `marine_interfaces/msg/VisualizationBand.msg` | New (with PointField-mirrored dtype constants) |
+| `marine_interfaces/msg/SonarVisualizationTile.msg` | New |
+| `marine_interfaces/msg/TileCatalogEntry.msg` | New |
+| `marine_interfaces/msg/TileCatalog.msg` | New |
+| `marine_interfaces/msg/TileRequest.msg` | New |
+| `marine_interfaces/CMakeLists.txt` | Append 6 entries to `set(MSG_FILES …)`; `builtin_interfaces` already in DEPENDENCIES |
+| `marine_interfaces/package.xml` | No new deps (std_msgs/builtin_interfaces already present) — verify |
+| `marine_tile_sync/` (new pkg) | Reconciler + builder lib + GTest (PR2) |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Don't invent message conventions; read precedent | `dtype` mirrors `sensor_msgs/PointField`; `Header`-carried version/gen-time, not bespoke fields |
+| Robustness / do it with tests | Reconciler is ROS-free + unit-tested under loss/reorder/reset (acceptance #2) |
+| Quality Standard — complete the lifecycle transition | Timestamp-gated prune handles the reorder/late-catalog edge case, not just the happy path |
+| No trademarks / display-vs-store separation | Tile message carries no provenance — it is the display projection, never a store schema |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0008 (this companion) | Yes | D1 named bands; D2 dense-quantized, **no compression fields** in msg; D3 `builtin_interfaces/Time` version; D4 complete catalog + gen-time + timestamp-gated prune; D7 level in `GridIndex`; D8 no `source_index` |
+| 0001 (colormap) | No | Bands are scalar fields; colormap is operator-side render (camp#121), not in the message |
+| 0002 (bathy store) | Indirect | Tile identity = GGGS index matches the store's tiling |
+| 0007 (MBES backscatter) | Indirect | `backscatter` band is display-grade (D10); durable home stays the store |
+
+## Consequences
+
+| If we change... | Also update... | Included? |
+|---|---|---|
+| `set(MSG_FILES …)` in CMakeLists | Rebase against #167/PR#169 if it lands first (same list) | Yes — sequence/rebase noted |
+| New message family | Producer cube#78, consumer camp#121 build against these | No — downstream issues |
+| New `marine_tile_sync` package | Workspace build order / `.repos` if standalone | Decided in Open Q (in-repo pkg = no `.repos` change) |
+| Package gains messages | `marine_interfaces` has **no `.agents/README.md`** — gap, not created here | No — separate doc task |
+
+## Open Questions
+
+- [ ] **Reconciler scope.** Recommend #230 = messages (PR1) **+** ROS-free
+  `marine_tile_sync` reconciler/builder lib with simulated-loss tests (PR2,
+  stacked) — this is what satisfies acceptance #2 and gives cube#78/camp#121 a
+  tested protocol to depend on. Alternative: ship messages-only here and put the
+  reconciler in camp#121 (leaves acceptance #2 unmet in this issue). **Pick one.**
+- [ ] **New package name/home.** If we build the lib: `marine_tile_sync` as a new
+  package **inside `unh_marine_autonomy`** (no `.repos` change; recommended) vs.
+  standalone repo. Confirm the name.
+- [ ] **`GridIndex` naming.** Reusing the gggs type name as `marine_interfaces/GridIndex`
+  is intentional (ROS mirror) — flag only if a different name is preferred to
+  avoid confusion with `grid_map`.
+
+## Estimated Scope
+
+**Two stacked PRs** (if reconciler in scope): PR1 = six messages + CMakeLists +
+docs (small, low-risk); PR2 = `marine_tile_sync` lib + GTest (medium), stacked on
+PR1. Collapses to a single messages-only PR if the reconciler is deferred to
+camp#121.

--- a/.agent/work-plans/issue-230/progress.md
+++ b/.agent/work-plans/issue-230/progress.md
@@ -17,3 +17,19 @@ issue: 230
 - [x] Reconciler scope — **resolved**: messages (PR1) + ROS-free `marine_tile_sync` reconciler lib (PR2). Satisfies acceptance #2.
 - [x] Package home — **resolved**: `marine_tile_sync` as a new package inside `unh_marine_autonomy` (no `.repos` change).
 - [x] Index message naming — **resolved**: `TileIndex` (not `GridIndex`); mirrors `gggs::GridIndex` in fields, avoids `grid_map` cell-index confusion.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-06-27 15:58 -04:00
+**By**: Claude Code Agent (Claude Opus) (in-context — author self-review)
+
+**Plan**: `.agent/work-plans/issue-230/plan.md` at `3314434`
+**PR**: PR-less (`--issue` mode)
+**Verdict**: changes-requested
+
+### Findings
+- [ ] (must-fix) Plan ignores existing `marine_tiled_raster_store`, whose README ("share one tiling + persistence (and, later, **sync**) contract") and `tile_io.hpp:39` ("the #86-Phase-6 … sync will build on here") designate it the home for this Phase-6 sync — house the reconciler there or record an explicit decision for a separate `marine_tile_sync` — `plan.md:56`
+- [ ] (must-fix) Consequences table misses reconciling the stale content-hash wording in `marine_tiled_raster_store/include/marine_tiled_raster_store/tile_io.hpp:39` ("manifest/content-hash sync"), which ADR-0008 D3 supersedes with timestamp/version — `plan.md:106`
+- [ ] (suggestion) Make acceptance-#2 reinterpretation explicit: pure-logic reconciler + deterministic loss/reorder tests (real ROS publisher/subscriber nodes deferred to cube#78 / camp#121) — `plan.md:116`
+- [ ] (suggestion) `package.xml` does **not** declare `builtin_interfaces` (only in CMakeLists DEPENDENCIES); new msgs use `builtin_interfaces/Time` — add `<depend>builtin_interfaces</depend>`, correct the "already present" claim — `plan.md:84`
+- [ ] (suggestion) Confirm PointField dtype constants are copied as local `uint8` constants (no `sensor_msgs` build dep), consistent with "No new deps" — `plan.md:38`

--- a/.agent/work-plans/issue-230/progress.md
+++ b/.agent/work-plans/issue-230/progress.md
@@ -1,0 +1,19 @@
+---
+issue: 230
+---
+
+# Issue #230 — I3 / #86 Phase 6: SonarVisualizationTile transport + anti-entropy tile-sync (ADR-0008)
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-27 15:40 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8)
+
+**Plan**: `.agent/work-plans/issue-230/plan.md` at `839c412`
+**Branch**: feature/issue-230 at `839c412`
+**Phases**: two stacked PRs (messages; then ROS-free reconciler lib) — collapses to one if reconciler deferred
+
+### Open questions
+- [ ] Reconciler scope: messages-only here vs. messages + ROS-free `marine_tile_sync` reconciler lib (PR2) that satisfies acceptance #2 — recommend the latter.
+- [ ] New package name/home if lib is in scope: `marine_tile_sync` inside `unh_marine_autonomy` (recommended) vs. standalone repo.
+- [ ] `GridIndex` message naming: reuse the gggs type name (intentional ROS mirror) vs. a distinct name to avoid `grid_map` confusion.

--- a/.agent/work-plans/issue-230/progress.md
+++ b/.agent/work-plans/issue-230/progress.md
@@ -33,3 +33,17 @@ issue: 230
 - [ ] (suggestion) Make acceptance-#2 reinterpretation explicit: pure-logic reconciler + deterministic loss/reorder tests (real ROS publisher/subscriber nodes deferred to cube#78 / camp#121) — `plan.md:116`
 - [ ] (suggestion) `package.xml` does **not** declare `builtin_interfaces` (only in CMakeLists DEPENDENCIES); new msgs use `builtin_interfaces/Time` — add `<depend>builtin_interfaces</depend>`, correct the "already present" claim — `plan.md:84`
 - [ ] (suggestion) Confirm PointField dtype constants are copied as local `uint8` constants (no `sensor_msgs` build dep), consistent with "No new deps" — `plan.md:38`
+
+## Plan Revised
+**Status**: complete
+**When**: 2026-06-27 16:10 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8)
+
+All five plan-review findings folded into the plan (commit below):
+- [x] (must-fix) Reconciler home → **`marine_tiled_raster_store`** (the #172 sync home), not a new `marine_tile_sync`. Payload-agnostic (`gggs::GridIndex` + version + structs), reused by both light display-tile sync and a future full-tile sync. Confirmed with Roland: store = full tiles, messages = light tiles, share generic code.
+- [x] (must-fix) `tile_io.hpp` stale "content-hash sync" comment → fix to timestamp/version (ADR-0008 D3); now in Files table + Consequences.
+- [x] (suggestion) Acceptance-#2 reinterpretation made explicit (pure-logic + deterministic sim; real ROS nodes deferred to cube#78/camp#121).
+- [x] (suggestion) `package.xml` → add `<depend>builtin_interfaces</depend>`; corrected the "already present" claim.
+- [x] (suggestion) PointField dtype constants → **local `uint8` constants**, no `sensor_msgs` dep; made explicit.
+
+Plan now review-plan-ready; no open questions.

--- a/.agent/work-plans/issue-230/progress.md
+++ b/.agent/work-plans/issue-230/progress.md
@@ -47,3 +47,24 @@ All five plan-review findings folded into the plan (commit below):
 - [x] (suggestion) PointField dtype constants → **local `uint8` constants**, no `sensor_msgs` dep; made explicit.
 
 Plan now review-plan-ready; no open questions.
+
+## Implementation
+**Status**: PR1 complete (messages); PR2 (reconciler lib) not started
+**When**: 2026-06-27 16:30 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8)
+
+**Commit**: `c686bcc` — feat(marine_interfaces): SonarVisualizationTile transport messages (#230)
+**Branch**: feature/issue-230
+
+PR1 delivered:
+- Six `.msg` files: `TileIndex`, `VisualizationBand`, `SonarVisualizationTile`, `TileCatalogEntry`, `TileCatalog`, `TileRequest`.
+- Registered in `CMakeLists.txt` `MSG_FILES`; added `<depend>builtin_interfaces</depend>` to `package.xml`.
+- Documented the family in `docs/interfaces.md` (ADR-0008 section).
+- **Build-verified**: `colcon build` clean (36.6s); `ros2 interface show` confirms all six generate and compose correctly (embedded `TileIndex`, dtype constants, `builtin_interfaces/Time`).
+
+Notes:
+- No pre-commit config/hooks wired in this project repo (onboarding gap, not addressed here).
+
+### Next
+- [ ] `/review-code` (pre-push) on the PR1 diff before pushing.
+- [ ] PR2: payload-agnostic reconciler in `marine_tiled_raster_store` + GTest + `tile_io.hpp` comment fix.

--- a/.agent/work-plans/issue-230/progress.md
+++ b/.agent/work-plans/issue-230/progress.md
@@ -68,3 +68,22 @@ Notes:
 ### Next
 - [ ] `/review-code` (pre-push) on the PR1 diff before pushing.
 - [ ] PR2: payload-agnostic reconciler in `marine_tiled_raster_store` + GTest + `tile_io.hpp` comment fix.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-27 20:42 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-230 at `8f5745e`
+**Mode**: pre-push
+**Depth**: Standard (reason: project-level `plan.md` override-trigger + shared cross-repo message wire contract; 11-file count inflated by plan/progress workflow docs — substantive surface is 9 files)
+**Must-fix**: 0 | **Suggestions**: 5
+**Round**: 1 | **Ship**: recommended — no Must-fix; ADR-0008-faithful additive messages, build + both adversarial passes confirm a sound, implementable wire contract
+
+### Findings
+- [ ] (suggestion) Patch-application ordering under reorder underspecified: per-tile `header.stamp` (D3) + incremental disjoint sub-windows (D1) gives no rule for a reordered older patch; per-tile catalog can't detect a missing sub-window — document in ADR-0008 D3 / camp #121 — `marine_interfaces/msg/SonarVisualizationTile.msg:12`
+- [ ] (suggestion) State the window extent bound (`window_col+window_width ≤ width`, `window_row+window_height ≤ height`); current comment bounds only the origin — `marine_interfaces/msg/SonarVisualizationTile.msg:21`
+- [ ] (suggestion) Comment "only the types v1 quantizes to are listed" contradicts the defined `UINT16=4` (no v1 band uses it) — reconcile prose with constant set — `marine_interfaces/msg/VisualizationBand.msg:12`
+- [ ] (suggestion) Tie `width`/`height` to `index.level` (GGGS grid edge, derivable/checkable) or note they are advisory — `marine_interfaces/msg/SonarVisualizationTile.msg:16`
+- [ ] (suggestion) Optionally document each dtype's byte width so `data` length is derivable without the PointField size table — `marine_interfaces/msg/VisualizationBand.msg:11`

--- a/.agent/work-plans/issue-230/progress.md
+++ b/.agent/work-plans/issue-230/progress.md
@@ -14,6 +14,6 @@ issue: 230
 **Phases**: two stacked PRs (messages; then ROS-free reconciler lib) — collapses to one if reconciler deferred
 
 ### Open questions
-- [ ] Reconciler scope: messages-only here vs. messages + ROS-free `marine_tile_sync` reconciler lib (PR2) that satisfies acceptance #2 — recommend the latter.
-- [ ] New package name/home if lib is in scope: `marine_tile_sync` inside `unh_marine_autonomy` (recommended) vs. standalone repo.
-- [ ] `GridIndex` message naming: reuse the gggs type name (intentional ROS mirror) vs. a distinct name to avoid `grid_map` confusion.
+- [x] Reconciler scope — **resolved**: messages (PR1) + ROS-free `marine_tile_sync` reconciler lib (PR2). Satisfies acceptance #2.
+- [x] Package home — **resolved**: `marine_tile_sync` as a new package inside `unh_marine_autonomy` (no `.repos` change).
+- [x] Index message naming — **resolved**: `TileIndex` (not `GridIndex`); mirrors `gggs::GridIndex` in fields, avoids `grid_map` cell-index confusion.

--- a/.agent/work-plans/issue-230/progress.md
+++ b/.agent/work-plans/issue-230/progress.md
@@ -87,3 +87,20 @@ Notes:
 - [ ] (suggestion) Comment "only the types v1 quantizes to are listed" contradicts the defined `UINT16=4` (no v1 band uses it) — reconcile prose with constant set — `marine_interfaces/msg/VisualizationBand.msg:12`
 - [ ] (suggestion) Tie `width`/`height` to `index.level` (GGGS grid edge, derivable/checkable) or note they are advisory — `marine_interfaces/msg/SonarVisualizationTile.msg:16`
 - [ ] (suggestion) Optionally document each dtype's byte width so `data` length is derivable without the PointField size table — `marine_interfaces/msg/VisualizationBand.msg:11`
+
+## Review Triage (Pre-Push)
+**Status**: complete
+**When**: 2026-06-27 16:50 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8)
+
+Verdict **approved**, 0 must-fix. All 5 suggestions applied as `.msg` comment
+clarifications (no wire-layout change — generated code unchanged, no rebuild):
+- [x] Patch-ordering under reorder → added best-effort/heal-via-full-resend note + pointer to camp #121; deeper patch-application semantics owned by the consumer.
+- [x] Window extent bound (`window_col+window_width ≤ width`, etc.) stated.
+- [x] dtype prose reconciled with `UINT16` (reserved for sidescan source rasters, not a v1 bathy band).
+- [x] `width`/`height` tied to `index.level` GGGS grid edge (convenience + consistency check).
+- [x] Per-dtype byte widths documented so `data` length is derivable.
+
+Follow-up (not PR1): consumer patch-application ordering rule is camp #121's to specify; optional ADR-0008 D3 clarification can ride that work.
+
+PR1 clear to push.

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -205,6 +205,41 @@ This document describes all ROS communication interfaces (topics, services, acti
 - `TaskInformation current_navigation_task`: Active task
 - `TaskInformation[] tasks`: Full task list with status
 
+### Live sonar coverage transport (ADR-0008)
+
+Boat→operator transport of GGGS-tiled sonar coverage for live display in CAMP
+and the web viewer. The tile message is a lossy, quantized **display
+projection** of the durable stores (bathy ADR-0002, backscatter ADR-0006/0007),
+never a storage schema. A catalog/request pair drives anti-entropy
+reconciliation (push + periodic complete catalog → request-missing/stale +
+prune-on-absence). See [ADR-0008](decisions/0008-live-sonar-coverage-transport-and-render.md).
+
+#### `marine_interfaces/TileIndex`
+- `uint8 level`, `uint32 row`, `uint32 col`: GGGS tile address (mirrors `gggs::GridIndex`)
+
+#### `marine_interfaces/VisualizationBand`
+- `string name`: band identity (`depth` / `uncertainty` / `backscatter` / `intensity`)
+- `uint8 dtype`: element type (`UINT8`/`INT16`/`UINT16`; values mirror `sensor_msgs/PointField`)
+- `float64 scale`, `float64 offset`, `float64 nodata`: generic dequantization (`value = raw·scale + offset`); `nodata` in raw units
+- `uint8[] data`: row-major raw cells of the dirty window, little-endian
+
+#### `marine_interfaces/SonarVisualizationTile`
+- `std_msgs/Header header`: `stamp` = tile version time (newest-wins); `frame_id` = display CRS tag
+- `TileIndex index`, `uint16 width`/`height`: which tile, and its full cell size
+- `uint16 window_col`/`window_row`/`window_width`/`window_height`: dirty sub-window the bands cover
+- `VisualizationBand[] bands`: one entry per present band
+
+#### `marine_interfaces/TileCatalogEntry`
+- `TileIndex index`, `builtin_interfaces/Time version`: a tile's identity + version
+
+#### `marine_interfaces/TileCatalog`
+- `std_msgs/Header header`: `stamp` = catalog generation-time (the prune gate)
+- `TileCatalogEntry[] entries`: **complete** snapshot of the source's tiles
+
+#### `marine_interfaces/TileRequest`
+- `std_msgs/Header header`
+- `TileIndex[] tiles`: consumer's missing/stale "need" list
+
 ## Related Documentation
 - [Data Flows](data_flows.md) - System-level data flow diagrams
 - [Autonomy Modes](autonomy_modes.md) - State machine documentation

--- a/marine_interfaces/CMakeLists.txt
+++ b/marine_interfaces/CMakeLists.txt
@@ -56,6 +56,13 @@ set(MSG_FILES
   msg/OccupancyPolygon.msg
   msg/OccupancyVectorMap.msg
   msg/RobotState.msg
+  # Live sonar coverage transport + anti-entropy tile-sync (ADR-0008, #230)
+  msg/TileIndex.msg
+  msg/VisualizationBand.msg
+  msg/SonarVisualizationTile.msg
+  msg/TileCatalogEntry.msg
+  msg/TileCatalog.msg
+  msg/TileRequest.msg
 )
 
 rosidl_generate_interfaces(

--- a/marine_interfaces/msg/SonarVisualizationTile.msg
+++ b/marine_interfaces/msg/SonarVisualizationTile.msg
@@ -6,7 +6,11 @@
 #
 # Incremental update: bands carry only the DIRTY SUB-WINDOW of the tile (the
 # region that changed), which the consumer patches into its tile at the window
-# offset. A full-tile update sets the window to the whole tile.
+# offset. A full-tile update sets the window to the whole tile. Live push is
+# best-effort: a lost or reordered sub-window patch is healed by the
+# catalog/TileRequest path, which re-sends the affected tile in full. The
+# consumer orders patches by header.stamp (ADR-0008 D3); detailed
+# patch-application semantics live in the consumer (camp #121).
 
 # stamp = this tile's version time (boat clock; drives newest-wins ordering,
 #         ADR-0008 D3). frame_id = display CRS tag (e.g. "gggs").
@@ -14,13 +18,19 @@ std_msgs/Header header
 
 TileIndex index          # which GGGS tile
 
-uint16 width             # tile size in cells (full tile, e.g. 960)
+# Full tile size in cells. For GGGS this is the grid edge for index.level
+# (e.g. 960x960), derivable from the GGGS spec; carried here as a convenience
+# and a consistency check.
+uint16 width
 uint16 height
 
-# Dirty sub-window in cell coordinates within [0,width) x [0,height). The band
-# data arrays cover exactly this window, row-major. Cell (r,c) of the window is
-# GGGS cell (window_row + r, window_col + c) -- rows/cols follow GGGS cell index
-# order (the renderer georeferences via GGGS; no display orientation is implied).
+# Dirty sub-window in cell coordinates, bounded by the tile:
+#   window_col + window_width  <= width
+#   window_row + window_height <= height
+# The band data arrays cover exactly this window, row-major. Cell (r,c) of the
+# window is GGGS cell (window_row + r, window_col + c) -- rows/cols follow GGGS
+# cell index order (the renderer georeferences via GGGS; no display orientation
+# is implied).
 uint16 window_col
 uint16 window_row
 uint16 window_width

--- a/marine_interfaces/msg/SonarVisualizationTile.msg
+++ b/marine_interfaces/msg/SonarVisualizationTile.msg
@@ -1,0 +1,29 @@
+# A GGGS-tiled sonar DISPLAY product: one tile's worth of quantized, named
+# bands for live operator visualization (boat -> CAMP / web viewer). This is a
+# lossy display projection of the durable stores (bathy ADR-0002, backscatter
+# ADR-0006/0007), never a competing storage schema -- it carries no provenance
+# and is always rebuildable from the stores. See ADR-0008.
+#
+# Incremental update: bands carry only the DIRTY SUB-WINDOW of the tile (the
+# region that changed), which the consumer patches into its tile at the window
+# offset. A full-tile update sets the window to the whole tile.
+
+# stamp = this tile's version time (boat clock; drives newest-wins ordering,
+#         ADR-0008 D3). frame_id = display CRS tag (e.g. "gggs").
+std_msgs/Header header
+
+TileIndex index          # which GGGS tile
+
+uint16 width             # tile size in cells (full tile, e.g. 960)
+uint16 height
+
+# Dirty sub-window in cell coordinates within [0,width) x [0,height). The band
+# data arrays cover exactly this window, row-major. Cell (r,c) of the window is
+# GGGS cell (window_row + r, window_col + c) -- rows/cols follow GGGS cell index
+# order (the renderer georeferences via GGGS; no display orientation is implied).
+uint16 window_col
+uint16 window_row
+uint16 window_width
+uint16 window_height
+
+VisualizationBand[] bands   # one entry per band present (depth/uncertainty/...)

--- a/marine_interfaces/msg/TileCatalog.msg
+++ b/marine_interfaces/msg/TileCatalog.msg
@@ -1,0 +1,12 @@
+# A COMPLETE periodic snapshot of every tile a source currently holds, each
+# with its version. Drives anti-entropy reconciliation: the consumer converges
+# its cache to exactly this set -- requesting tiles it is missing or stale on,
+# and pruning (on absence) tiles not listed. Completeness is required:
+# prune-on-absence is invalid against a partial/paged catalog. See ADR-0008 D4.
+
+# stamp = catalog generation-time. Prune is timestamp-gated against this: an
+#         absent tile is pruned only if older than this time, so a late or
+#         reordered catalog cannot delete a just-pushed fresh tile.
+std_msgs/Header header
+
+TileCatalogEntry[] entries   # the complete tile set (may be empty = source holds none)

--- a/marine_interfaces/msg/TileCatalogEntry.msg
+++ b/marine_interfaces/msg/TileCatalogEntry.msg
@@ -1,0 +1,6 @@
+# One entry in a TileCatalog: a tile's identity plus its current version.
+
+TileIndex index
+builtin_interfaces/Time version   # per-tile version = its latest-cell timestamp
+                                  # (ADR-0008 D3); monotonic per source so two
+                                  # versions order for newest-wins.

--- a/marine_interfaces/msg/TileIndex.msg
+++ b/marine_interfaces/msg/TileIndex.msg
@@ -1,0 +1,8 @@
+# Addresses a whole GGGS tile (a level/row/col cell block in the Global
+# Geographic Grid System). The ROS mirror of gggs::GridIndex {level,row,col};
+# named TileIndex (not GridIndex) for consistency with the Tile* message family
+# and to avoid the grid_map cell-index reading. See ADR-0008.
+
+uint8  level   # GGGS level (cell-size-derived); e.g. bathy L10, sidescan L13
+uint32 row     # GGGS tile row
+uint32 col     # GGGS tile column

--- a/marine_interfaces/msg/TileRequest.msg
+++ b/marine_interfaces/msg/TileRequest.msg
@@ -1,0 +1,7 @@
+# Consumer -> source "need" list: the tiles the consumer is missing or stale on
+# and wants (re)sent. Derived from reconciling a received TileCatalog against
+# the local cache. See ADR-0008 D4.
+
+std_msgs/Header header    # stamp = request time
+
+TileIndex[] tiles         # the tiles being requested

--- a/marine_interfaces/msg/VisualizationBand.msg
+++ b/marine_interfaces/msg/VisualizationBand.msg
@@ -1,0 +1,23 @@
+# One named, self-describing quantized band of a SonarVisualizationTile.
+# The consumer dequantizes generically -- value = raw * scale + offset -- with
+# no hardcoded per-band knowledge. `data` holds the raw quantized cells of the
+# tile's dirty sub-window (see SonarVisualizationTile), row-major in GGGS cell
+# order, length = window_width * window_height * <sizeof dtype>. See ADR-0008 D1.
+
+string name    # band identity: "depth" | "uncertainty" | "backscatter" | "intensity"
+
+# Element type of the packed `data` bytes, little-endian. Values mirror
+# sensor_msgs/PointField numeric datatypes, kept as local constants so this
+# package takes no sensor_msgs dependency. Only the types v1 quantizes to are
+# listed (depth -> INT16; uncertainty/backscatter/intensity -> UINT8).
+uint8 UINT8  = 2
+uint8 INT16  = 3
+uint8 UINT16 = 4
+uint8 dtype
+
+float64 scale    # dequantization gain  (value = raw * scale + offset)
+float64 offset   # dequantization bias
+float64 nodata   # raw sentinel marking an empty/unknown cell, in RAW units
+                 # (compared before dequantization), e.g. -32768 for INT16 depth
+
+uint8[] data     # row-major raw cells of the dirty window, little-endian

--- a/marine_interfaces/msg/VisualizationBand.msg
+++ b/marine_interfaces/msg/VisualizationBand.msg
@@ -8,8 +8,11 @@ string name    # band identity: "depth" | "uncertainty" | "backscatter" | "inten
 
 # Element type of the packed `data` bytes, little-endian. Values mirror
 # sensor_msgs/PointField numeric datatypes, kept as local constants so this
-# package takes no sensor_msgs dependency. Only the types v1 quantizes to are
-# listed (depth -> INT16; uncertainty/backscatter/intensity -> UINT8).
+# package takes no sensor_msgs dependency. The byte width sizes `data`
+# (= window_width * window_height * width_bytes):
+#   UINT8  (2) -> 1 byte   : uncertainty / backscatter / intensity bands
+#   INT16  (3) -> 2 bytes  : depth band
+#   UINT16 (4) -> 2 bytes  : reserved for sidescan source rasters (no v1 bathy band)
 uint8 UINT8  = 2
 uint8 INT16  = 3
 uint8 UINT16 = 4

--- a/marine_interfaces/package.xml
+++ b/marine_interfaces/package.xml
@@ -11,6 +11,7 @@
 
   <build_depend>rosidl_default_generators</build_depend>
 
+  <depend>builtin_interfaces</depend>
   <depend>geographic_msgs</depend>
   <depend>marine_acoustic_msgs</depend>
   <depend>std_msgs</depend>


### PR DESCRIPTION
**Part of #230** — first of two PRs (PR1: messages; PR2: the payload-agnostic
reconciler lib in `marine_tiled_raster_store`). Does **not** close #230.

Implements the six live-sonar-coverage transport messages from
[ADR-0008](https://github.com/rolker/unh_marine_autonomy/blob/jazzy/docs/decisions/0008-live-sonar-coverage-transport-and-render.md):

- **`TileIndex`** — GGGS tile address (mirrors `gggs::GridIndex`)
- **`VisualizationBand`** — named, self-describing quantized band; generic
  dequantization (`value = raw·scale + offset`); dtype constants mirror
  `sensor_msgs/PointField` as **local `uint8` constants** (no `sensor_msgs` dep)
- **`SonarVisualizationTile`** — light/lossy display tile carrying a dirty
  sub-window of named bands (incremental; no compression fields — `udp_bridge`
  zlib rides the wire per D2)
- **`TileCatalogEntry`** / **`TileCatalog`** — complete per-source snapshot for
  anti-entropy reconciliation
- **`TileRequest`** — consumer missing/stale need list

Light/quantized payload (`SonarVisualizationTile` + `VisualizationBand`) is kept
distinct from the payload-agnostic sync-protocol messages
(`TileIndex`/`TileCatalog`/`TileCatalogEntry`/`TileRequest`), so a future
full-tile sync can reuse the catalog/request shape.

Registered in `CMakeLists.txt` `MSG_FILES`; added the `builtin_interfaces`
manifest dependency; documented the family in `docs/interfaces.md`.

**Verification**: `colcon build` clean; `ros2 interface show` confirms all six
generate and compose. Pre-push self-review (dual adversarial lens): approved,
0 must-fix; 5 suggestions applied as comment clarifications.

Part of #171.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8`
