### PR TITLE
feat(marine_tiled_raster_store): anti-entropy tile-sync reconciler (PR2 of #230)

### DIFF
--- a/.agent/work-plans/issue-230/progress.md
+++ b/.agent/work-plans/issue-230/progress.md
@@ -154,3 +154,18 @@ Static analysis: ament_cpplint clean; independent `g++ -fsyntax-only -Wall -Wext
 - [ ] (suggestion) `reconcile()` `to_request` carries bare `GridIndex`; returning `TileCatalogEntry` (index+version) resists markHave-on-ack desync — `tile_catalog.hpp:76-77`
 - [ ] (suggestion) Validate `index.valid()` at ingestion (invalid GridIndices collapse to one map key; untested path) — `tile_catalog.cpp:28,67,103`
 - [ ] (suggestion) Note `markHave`-after-`drop` resurrection + cache-growth bound for the node author; minor: `reserve` reconcile result vectors — `tile_catalog.cpp:66-79`
+
+## Review Triage (PR2)
+**Status**: complete
+**When**: 2026-06-27 17:50 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8)
+
+Container review-code verdict **approved**, 0 must-fix, 5 suggestions (all
+docs/API-hardening, no defects). All 5 folded in pre-push:
+- [x] Single-monotonic-clock / `generation_time`=0-disables-prune invariant documented prominently (file note + struct doc).
+- [x] Thread-safety contract documented ("not thread-safe; serialize externally").
+- [x] `to_request` bare-index rationale documented (mirrors `TileRequest.msg`; delivered tile self-describes version) — kept as-is, intentional.
+- [x] **Invalid-index guard** added at ingestion (`update`/`markHave` ignore invalid; `reconcile` skips invalid catalog entries) + new test `InvalidIndexIgnored`.
+- [x] `markHave`-after-`drop` resurrection noted as intentional + cache-bound note for node author; `reserve()` on reconcile result vectors.
+
+**Verified**: rebuild clean; `colcon test` → 14/14 catalog tests pass; cpplint clean.

--- a/.agent/work-plans/issue-230/progress.md
+++ b/.agent/work-plans/issue-230/progress.md
@@ -133,3 +133,24 @@ lines / trailing whitespace.
 
 ### Next
 - [ ] `/review-code` (container) on the PR2 diff, then push + PR (Part of #230 — closes it).
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-27 21:36 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-230 at `d03bb94`
+**Mode**: pre-push
+**Depth**: Standard (reason: ~640 LOC new correctness-critical reconciliation logic, single package)
+**Must-fix**: 0 | **Suggestions**: 5
+**Round**: 2 | **Ship**: recommended — first review of the PR2 diff (round-1 entry was the merged PR1); 0 must-fix, core newest-wins/timestamp-gated-prune/convergence logic independently confirmed correct by two adversarial passes, cpplint + independent compile clean, matches plan & ADR-0008 D3/D4
+
+Static analysis: ament_cpplint clean; independent `g++ -fsyntax-only -Wall -Wextra -Wpedantic` clean for the new TU (only pre-existing `gz4d_geo.h` dep warnings). All findings are docs/API-hardening suggestions for the future ROS node boundary (deferred to cube#78/camp#121), not defects in the delivered pure-logic library.
+
+### Findings
+- [ ] (suggestion) Single-monotonic-clock invariant for `generation_time` is unenforced; sim-time-0 → `buildCatalog(0)` silently disables pruning, cross-clock skew could over-prune — document prominently / debug-assert — `tile_catalog.cpp:125`, `tile_catalog.hpp:99-101`
+- [ ] (suggestion) Document thread-safety contract ("not thread-safe; external sync required") — reader+writer node usage — `tile_catalog.hpp` class decls
+- [ ] (suggestion) `reconcile()` `to_request` carries bare `GridIndex`; returning `TileCatalogEntry` (index+version) resists markHave-on-ack desync — `tile_catalog.hpp:76-77`
+- [ ] (suggestion) Validate `index.valid()` at ingestion (invalid GridIndices collapse to one map key; untested path) — `tile_catalog.cpp:28,67,103`
+- [ ] (suggestion) Note `markHave`-after-`drop` resurrection + cache-growth bound for the node author; minor: `reserve` reconcile result vectors — `tile_catalog.cpp:66-79`

--- a/.agent/work-plans/issue-230/progress.md
+++ b/.agent/work-plans/issue-230/progress.md
@@ -104,3 +104,32 @@ clarifications (no wire-layout change — generated code unchanged, no rebuild):
 Follow-up (not PR1): consumer patch-application ordering rule is camp #121's to specify; optional ADR-0008 D3 clarification can ride that work.
 
 PR1 clear to push.
+
+## Implementation (PR2)
+**Status**: complete (local) — reconciler lib + tests
+**When**: 2026-06-27 17:25 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8)
+
+**Branch**: feature/issue-230 (off merged jazzy `e372718`)
+
+PR2 delivered — payload-agnostic anti-entropy tile-sync in `marine_tiled_raster_store`:
+- `include/marine_tiled_raster_store/tile_catalog.hpp` + `src/tile_catalog.cpp`:
+  `TileVersion`/`TileCatalogEntry`/`TileCatalog`/`ReconcileResult` types,
+  `TileCatalogBuilder` (source registry → complete snapshot), `TileCatalogReconciler`
+  (pure `reconcile()` → request missing/stale + timestamp-gated prune-on-absence;
+  `markHave`/`drop` for async state). ROS-free, no `marine_interfaces` dep — over
+  `gggs::GridIndex` + `TileVersion` only, so reusable by full- and light-tile sync.
+- `test/test_tile_catalog.cpp`: 13 GTests — builder snapshot/newest-wins/remove;
+  reconciler cold-start/up-to-date/stale/missing/prune/**timestamp-gated prune
+  (fresh tile survives stale catalog)**/reordered-stale-ignored/**boat-reset
+  convergence**/**convergence under loss+reorder**.
+- `tile_io.hpp`: stale "content-hash sync" comment → timestamp/version (ADR-0008 D3) — review finding #2.
+- `CMakeLists.txt`: source added to lib + `test_tile_catalog` gtest registered.
+- `README.md`: documented the sync facility + the new test.
+
+**Verified**: `colcon build` clean (-Wall -Wextra -Wpedantic, no warnings);
+`colcon test` → test_tile_catalog 13/13 pass; `ament_cpplint` clean; no long
+lines / trailing whitespace.
+
+### Next
+- [ ] `/review-code` (container) on the PR2 diff, then push + PR (Part of #230 — closes it).

--- a/marine_tiled_raster_store/CMakeLists.txt
+++ b/marine_tiled_raster_store/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(GDAL CONFIG REQUIRED)
 
 add_library(${PROJECT_NAME}
   src/tile_io.cpp
+  src/tile_catalog.cpp
 )
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
@@ -63,6 +64,9 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_tile_io test/test_tile_io.cpp)
   target_link_libraries(test_tile_io ${PROJECT_NAME})
+
+  ament_add_gtest(test_tile_catalog test/test_tile_catalog.cpp)
+  target_link_libraries(test_tile_catalog ${PROJECT_NAME})
 endif()
 
 ament_package()

--- a/marine_tiled_raster_store/README.md
+++ b/marine_tiled_raster_store/README.md
@@ -21,6 +21,22 @@ originates in [ADR-0002](../docs/decisions/0002-bathymetric-data-store.md) §D5/
   WGS84-georeferenced from its GGGS grid corners, written north-up; `loadTile`
   recovers the `GridIndex` from the geotransform and **rejects** a tile written
   at a different level or a non-WGS84 raster.
+- **Anti-entropy tile-sync** (`tile_catalog.hpp`) — the `#86`-Phase-6 sync logic
+  this package was always meant to host. **Payload-agnostic** (reasons over tile
+  `GridIndex` + `TileVersion` only, never tile contents) and **ROS-free**, so it
+  serves both the light display-tile transport ([ADR-0008]) and a future
+  full-tile store-to-store sync:
+  - **`TileCatalogBuilder`** (source/boat) — a tile→version registry that emits a
+    **complete** `TileCatalog` snapshot.
+  - **`TileCatalogReconciler`** (consumer/operator) — `reconcile(catalog)` returns
+    the tiles to **request** (missing/stale) and to **prune** (held but absent,
+    **timestamp-gated** so a late/reordered catalog can't delete a just-pushed
+    fresh tile). Pure (no mutation); converges to the catalog under loss/reorder.
+
+  The node boundary adapts the `marine_interfaces` wire messages
+  (`TileCatalog` / `TileRequest` / `SonarVisualizationTile`) to/from these types.
+
+[ADR-0008]: ../docs/decisions/0008-live-sonar-coverage-transport-and-render.md
 
 ## Element types
 
@@ -48,7 +64,11 @@ colcon test --packages-select marine_tiled_raster_store
 
 `test_tile_io` (headless GTest) covers the uint16 single-band and double 3-band
 round-trips, level-mismatch rejection, the `band_nodata`-size guard, and
-dirty-only `saveTiles` / `loadTiles`.
+dirty-only `saveTiles` / `loadTiles`. `test_tile_catalog` covers the
+builder/reconciler: complete-snapshot emission, newest-wins, request of
+missing/stale tiles, prune-on-absence with the timestamp gate (fresh tile
+survives a stale catalog), and convergence under simulated loss/reorder + boat
+reset.
 
 ## Dependencies
 

--- a/marine_tiled_raster_store/include/marine_tiled_raster_store/tile_catalog.hpp
+++ b/marine_tiled_raster_store/include/marine_tiled_raster_store/tile_catalog.hpp
@@ -1,0 +1,152 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef MARINE_TILED_RASTER_STORE__TILE_CATALOG_HPP_
+#define MARINE_TILED_RASTER_STORE__TILE_CATALOG_HPP_
+
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <vector>
+
+#include "marine_autonomy/gggs.h"
+
+namespace marine_tiled_raster_store
+{
+
+/// @file
+/// @brief Payload-agnostic anti-entropy tile-sync: the catalog/reconcile logic
+///        a source uses to advertise its tiles and a consumer uses to converge
+///        its cache to exactly the source's set. ROS-free and tile-content-free
+///        — it reasons over tile **indices + versions only**, so it serves both
+///        the light display-tile transport (ADR-0008) and a future full-tile
+///        store-to-store sync. The node boundary adapts the `marine_interfaces`
+///        wire messages (`TileCatalog` / `TileRequest` / `SonarVisualizationTile`)
+///        to/from these types.
+
+/// @brief A per-tile version stamp — monotonic per source, newest-wins.
+///
+/// Nanoseconds-since-epoch is the natural carrier (cells already carry
+/// timestamps; ADR-0008 D3), but any source-monotonic integer works. Kept a
+/// plain integer so this logic stays ROS-free: the node boundary flattens
+/// `builtin_interfaces/Time` to/from this.
+using TileVersion = std::int64_t;
+
+/// @brief One catalog entry: a tile's GGGS index plus its current version.
+struct TileCatalogEntry
+{
+  gggs::GridIndex index;
+  TileVersion version{0};
+};
+
+/// @brief A **complete** snapshot of every tile a source holds, plus the time
+///        it was generated.
+///
+/// Completeness is a contract: prune-on-absence is only valid against a full
+/// snapshot (ADR-0008 D4a). `generation_time` is the prune gate (D4b) — a held
+/// tile absent from the catalog is pruned only if older than this time.
+struct TileCatalog
+{
+  TileVersion generation_time{0};
+  std::vector<TileCatalogEntry> entries;
+};
+
+/// @brief The two action lists a reconcile produces.
+struct ReconcileResult
+{
+  std::vector<gggs::GridIndex> to_request;  ///< missing or stale on the consumer
+  std::vector<gggs::GridIndex> to_prune;    ///< held but absent from the catalog (gated)
+};
+
+/// @brief Source-side (boat) authoritative tile→version registry that emits
+///        complete catalog snapshots. ROS-free.
+class TileCatalogBuilder
+{
+public:
+  /// @brief Record (or bump) a tile's version. Newest-wins: an older version is
+  ///        ignored, so an out-of-order update cannot roll a tile back.
+  void update(const gggs::GridIndex & index, TileVersion version);
+
+  /// @brief Forget a tile (it left the source). It is then absent from future
+  ///        catalogs, which drives prune-on-absence downstream.
+  void remove(const gggs::GridIndex & index);
+
+  /// @brief The current version of @p index, or std::nullopt if unknown.
+  std::optional<TileVersion> versionOf(const gggs::GridIndex & index) const;
+
+  /// @brief Number of tiles currently held.
+  std::size_t size() const noexcept {return versions_.size();}
+
+  /// @brief Build a **complete** catalog snapshot stamped @p generation_time.
+  ///        Pass a time at least as new as every held tile's version.
+  TileCatalog buildCatalog(TileVersion generation_time) const;
+
+private:
+  std::map<gggs::GridIndex, TileVersion> versions_;
+};
+
+/// @brief Consumer-side (operator) anti-entropy reconciler.
+///
+/// Holds what the consumer currently has and at what version, and computes —
+/// against a received complete catalog — which tiles to **request** (missing or
+/// stale) and which to **prune** (held but absent, timestamp-gated).
+///
+/// `reconcile()` is **pure**: it does not mutate state. The consumer acts on the
+/// returned lists (sends requests, deletes pruned tiles) and reports completion
+/// back via `markHave()` / `drop()`, modelling the real async flow. Repeated
+/// reconciles converge the cache to exactly the catalog set under loss/reorder.
+class TileCatalogReconciler
+{
+public:
+  /// @brief Record that the consumer now holds @p index at @p version (e.g. a
+  ///        tile was received and applied). Newest-wins: an older version is
+  ///        ignored, so a reordered stale arrival cannot lower the held version.
+  void markHave(const gggs::GridIndex & index, TileVersion version);
+
+  /// @brief Forget @p index (the consumer deleted it, e.g. after a prune).
+  void drop(const gggs::GridIndex & index);
+
+  /// @brief Whether the consumer currently holds @p index.
+  bool has(const gggs::GridIndex & index) const;
+
+  /// @brief The held version of @p index, or std::nullopt if absent.
+  std::optional<TileVersion> versionOf(const gggs::GridIndex & index) const;
+
+  /// @brief Number of tiles currently cached.
+  std::size_t size() const noexcept {return cache_.size();}
+
+  /// @brief Compute the request + prune lists against a **complete** @p catalog.
+  ///
+  /// Request: every catalog tile the consumer is missing or holds at an older
+  /// version. Prune: every held tile **absent** from the catalog whose held
+  /// version predates @p catalog.generation_time — the timestamp gate
+  /// (ADR-0008 D4b) that stops a late/reordered catalog from deleting a
+  /// just-pushed fresh tile. Pure: does not mutate this reconciler.
+  ReconcileResult reconcile(const TileCatalog & catalog) const;
+
+private:
+  std::map<gggs::GridIndex, TileVersion> cache_;
+};
+
+}  // namespace marine_tiled_raster_store
+
+#endif  // MARINE_TILED_RASTER_STORE__TILE_CATALOG_HPP_

--- a/marine_tiled_raster_store/include/marine_tiled_raster_store/tile_catalog.hpp
+++ b/marine_tiled_raster_store/include/marine_tiled_raster_store/tile_catalog.hpp
@@ -42,6 +42,15 @@ namespace marine_tiled_raster_store
 ///        store-to-store sync. The node boundary adapts the `marine_interfaces`
 ///        wire messages (`TileCatalog` / `TileRequest` / `SonarVisualizationTile`)
 ///        to/from these types.
+///
+/// @note **Not thread-safe.** Builder/reconciler hold plain `std::map` state; a
+///   node touching one from multiple threads (e.g. a subscription callback and a
+///   timer) must serialize access externally.
+/// @note **Single monotonic source clock.** Versions and `generation_time` must
+///   come from one monotonically-increasing source (the boat). The prune gate
+///   compares held versions against a catalog's `generation_time`, so cross-clock
+///   skew can over-/under-prune. Invalid `gggs::GridIndex` values are ignored at
+///   ingestion (they are not real tiles).
 
 /// @brief A per-tile version stamp — monotonic per source, newest-wins.
 ///
@@ -63,7 +72,10 @@ struct TileCatalogEntry
 ///
 /// Completeness is a contract: prune-on-absence is only valid against a full
 /// snapshot (ADR-0008 D4a). `generation_time` is the prune gate (D4b) — a held
-/// tile absent from the catalog is pruned only if older than this time.
+/// tile absent from the catalog is pruned only if older than this time. It must
+/// be at least as new as every entry's version (the source stamps "now"); a
+/// `generation_time` of 0 (e.g. an un-stamped or sim-time-0 catalog) disables
+/// pruning entirely, since no held version can be strictly older than 0.
 struct TileCatalog
 {
   TileVersion generation_time{0};
@@ -73,8 +85,13 @@ struct TileCatalog
 /// @brief The two action lists a reconcile produces.
 struct ReconcileResult
 {
-  std::vector<gggs::GridIndex> to_request;  ///< missing or stale on the consumer
-  std::vector<gggs::GridIndex> to_prune;    ///< held but absent from the catalog (gated)
+  /// Missing or stale on the consumer. Bare indices (no version) — this mirrors
+  /// the `marine_interfaces/TileRequest` wire shape, and the requested version
+  /// is unnecessary: the delivered `SonarVisualizationTile` self-describes its
+  /// version, which the consumer passes to `markHave`.
+  std::vector<gggs::GridIndex> to_request;
+  /// Held but absent from the catalog and older than its generation_time (gated).
+  std::vector<gggs::GridIndex> to_prune;
 };
 
 /// @brief Source-side (boat) authoritative tile→version registry that emits
@@ -120,6 +137,9 @@ public:
   /// @brief Record that the consumer now holds @p index at @p version (e.g. a
   ///        tile was received and applied). Newest-wins: an older version is
   ///        ignored, so a reordered stale arrival cannot lower the held version.
+  ///        Calling this after `drop()` re-adds the tile — intentional, so a
+  ///        re-received tile returns. An invalid @p index is ignored. The node
+  ///        author bounds cache growth (e.g. evict by area/recency).
   void markHave(const gggs::GridIndex & index, TileVersion version);
 
   /// @brief Forget @p index (the consumer deleted it, e.g. after a prune).

--- a/marine_tiled_raster_store/include/marine_tiled_raster_store/tile_io.hpp
+++ b/marine_tiled_raster_store/include/marine_tiled_raster_store/tile_io.hpp
@@ -36,7 +36,9 @@
 ///
 /// The format-agnostic generalization of `marine_bathymetry_store/tile_io`
 /// (ADR-0002 §D5/§D6 in `unh_marine_autonomy` is the origin and the contract
-/// the #86-Phase-6 manifest/content-hash sync will build on here). Each tile is
+/// the #86-Phase-6 timestamp/version anti-entropy sync builds on here — see
+/// `tile_catalog.hpp` and ADR-0008 D3/D4, which supersede the earlier
+/// content-hash manifest idea). Each tile is
 /// one GeoTIFF with @c bandCount() bands of `T`, WGS84-georeferenced from its
 /// GGGS grid corners and written **north-up** (raster row 0 = north), so a row
 /// flip separates on-disk order from the in-memory GGGS cell order

--- a/marine_tiled_raster_store/src/tile_catalog.cpp
+++ b/marine_tiled_raster_store/src/tile_catalog.cpp
@@ -28,6 +28,9 @@ namespace marine_tiled_raster_store
 
 void TileCatalogBuilder::update(const gggs::GridIndex & index, TileVersion version)
 {
+  if (!index.valid()) {
+    return;  // not a real tile; all invalid indices collapse to one map key
+  }
   auto it = versions_.find(index);
   if (it == versions_.end()) {
     versions_.emplace(index, version);
@@ -65,6 +68,9 @@ TileCatalog TileCatalogBuilder::buildCatalog(TileVersion generation_time) const
 
 void TileCatalogReconciler::markHave(const gggs::GridIndex & index, TileVersion version)
 {
+  if (!index.valid()) {
+    return;  // not a real tile; all invalid indices collapse to one map key
+  }
   auto it = cache_.find(index);
   if (it == cache_.end()) {
     cache_.emplace(index, version);
@@ -95,12 +101,17 @@ std::optional<TileVersion> TileCatalogReconciler::versionOf(const gggs::GridInde
 ReconcileResult TileCatalogReconciler::reconcile(const TileCatalog & catalog) const
 {
   ReconcileResult result;
+  result.to_request.reserve(catalog.entries.size());
+  result.to_prune.reserve(cache_.size());
 
   // Index the catalog for lookup of held tiles below. A well-formed catalog has
   // unique indices; if one repeats (malformed source), keep the newest version
   // so the request/prune decisions stay conservative.
   std::map<gggs::GridIndex, TileVersion> catalog_versions;
   for (const auto & entry : catalog.entries) {
+    if (!entry.index.valid()) {
+      continue;  // ignore a malformed catalog's invalid entries
+    }
     auto it = catalog_versions.find(entry.index);
     if (it == catalog_versions.end()) {
       catalog_versions.emplace(entry.index, entry.version);

--- a/marine_tiled_raster_store/src/tile_catalog.cpp
+++ b/marine_tiled_raster_store/src/tile_catalog.cpp
@@ -1,0 +1,134 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "marine_tiled_raster_store/tile_catalog.hpp"
+
+namespace marine_tiled_raster_store
+{
+
+// ---- TileCatalogBuilder ----------------------------------------------------
+
+void TileCatalogBuilder::update(const gggs::GridIndex & index, TileVersion version)
+{
+  auto it = versions_.find(index);
+  if (it == versions_.end()) {
+    versions_.emplace(index, version);
+  } else if (version > it->second) {
+    it->second = version;  // newest-wins; an older update is ignored
+  }
+}
+
+void TileCatalogBuilder::remove(const gggs::GridIndex & index)
+{
+  versions_.erase(index);
+}
+
+std::optional<TileVersion> TileCatalogBuilder::versionOf(const gggs::GridIndex & index) const
+{
+  auto it = versions_.find(index);
+  if (it == versions_.end()) {
+    return std::nullopt;
+  }
+  return it->second;
+}
+
+TileCatalog TileCatalogBuilder::buildCatalog(TileVersion generation_time) const
+{
+  TileCatalog catalog;
+  catalog.generation_time = generation_time;
+  catalog.entries.reserve(versions_.size());
+  for (const auto & [index, version] : versions_) {
+    catalog.entries.push_back(TileCatalogEntry{index, version});
+  }
+  return catalog;
+}
+
+// ---- TileCatalogReconciler -------------------------------------------------
+
+void TileCatalogReconciler::markHave(const gggs::GridIndex & index, TileVersion version)
+{
+  auto it = cache_.find(index);
+  if (it == cache_.end()) {
+    cache_.emplace(index, version);
+  } else if (version > it->second) {
+    it->second = version;  // newest-wins; a reordered older arrival is ignored
+  }
+}
+
+void TileCatalogReconciler::drop(const gggs::GridIndex & index)
+{
+  cache_.erase(index);
+}
+
+bool TileCatalogReconciler::has(const gggs::GridIndex & index) const
+{
+  return cache_.find(index) != cache_.end();
+}
+
+std::optional<TileVersion> TileCatalogReconciler::versionOf(const gggs::GridIndex & index) const
+{
+  auto it = cache_.find(index);
+  if (it == cache_.end()) {
+    return std::nullopt;
+  }
+  return it->second;
+}
+
+ReconcileResult TileCatalogReconciler::reconcile(const TileCatalog & catalog) const
+{
+  ReconcileResult result;
+
+  // Index the catalog for lookup of held tiles below. A well-formed catalog has
+  // unique indices; if one repeats (malformed source), keep the newest version
+  // so the request/prune decisions stay conservative.
+  std::map<gggs::GridIndex, TileVersion> catalog_versions;
+  for (const auto & entry : catalog.entries) {
+    auto it = catalog_versions.find(entry.index);
+    if (it == catalog_versions.end()) {
+      catalog_versions.emplace(entry.index, entry.version);
+    } else if (entry.version > it->second) {
+      it->second = entry.version;
+    }
+  }
+
+  // Request: catalog tiles we are missing or hold at an older version.
+  for (const auto & [index, version] : catalog_versions) {
+    auto held = cache_.find(index);
+    if (held == cache_.end() || held->second < version) {
+      result.to_request.push_back(index);
+    }
+  }
+
+  // Prune: held tiles absent from the catalog, but only if older than the
+  // catalog's generation time — so a late/reordered catalog cannot delete a
+  // just-pushed fresh tile (ADR-0008 D4b).
+  for (const auto & [index, version] : cache_) {
+    if (catalog_versions.find(index) == catalog_versions.end() &&
+      version < catalog.generation_time)
+    {
+      result.to_prune.push_back(index);
+    }
+  }
+
+  return result;
+}
+
+}  // namespace marine_tiled_raster_store

--- a/marine_tiled_raster_store/test/test_tile_catalog.cpp
+++ b/marine_tiled_raster_store/test/test_tile_catalog.cpp
@@ -1,0 +1,297 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <map>
+#include <set>
+#include <vector>
+
+#include "marine_autonomy/gggs.h"
+#include "marine_tiled_raster_store/tile_catalog.hpp"
+
+namespace mtrs = marine_tiled_raster_store;
+
+namespace
+{
+
+// Distinct GGGS grids near Lake Massabesic. Level 13 grids span ~0.001 deg, so
+// 0.01-deg spacing yields well-separated, distinct tiles away from the polar
+// scaling boundaries.
+const gggs::Level kLevel(13);
+
+gggs::GridIndex gridAt(int i)
+{
+  return kLevel.gridIndex(43.00 + 0.01 * i, -71.40);
+}
+
+bool contains(const std::vector<gggs::GridIndex> & v, const gggs::GridIndex & g)
+{
+  return std::find(v.begin(), v.end(), g) != v.end();
+}
+
+}  // namespace
+
+// Sanity: the test grid generator yields distinct, valid indices.
+TEST(TileCatalogGrids, DistinctAndValid)
+{
+  std::set<gggs::GridIndex> seen;
+  for (int i = 0; i < 5; ++i) {
+    const gggs::GridIndex g = gridAt(i);
+    EXPECT_TRUE(g.valid());
+    EXPECT_TRUE(seen.insert(g).second) << "grid " << i << " collided";
+  }
+}
+
+// ---- TileCatalogBuilder ----------------------------------------------------
+
+TEST(TileCatalogBuilder, EmitsCompleteSnapshot)
+{
+  mtrs::TileCatalogBuilder builder;
+  builder.update(gridAt(0), 100);
+  builder.update(gridAt(1), 200);
+  builder.update(gridAt(2), 150);
+
+  const mtrs::TileCatalog catalog = builder.buildCatalog(300);
+
+  EXPECT_EQ(catalog.generation_time, 300);
+  ASSERT_EQ(catalog.entries.size(), 3u);
+
+  std::map<gggs::GridIndex, mtrs::TileVersion> by_index;
+  for (const auto & e : catalog.entries) {
+    by_index[e.index] = e.version;
+  }
+  EXPECT_EQ(by_index[gridAt(0)], 100);
+  EXPECT_EQ(by_index[gridAt(1)], 200);
+  EXPECT_EQ(by_index[gridAt(2)], 150);
+}
+
+TEST(TileCatalogBuilder, NewestWins)
+{
+  mtrs::TileCatalogBuilder builder;
+  builder.update(gridAt(0), 100);
+  builder.update(gridAt(0), 50);   // older -> ignored
+  ASSERT_TRUE(builder.versionOf(gridAt(0)).has_value());
+  EXPECT_EQ(*builder.versionOf(gridAt(0)), 100);
+
+  builder.update(gridAt(0), 200);  // newer -> applied
+  EXPECT_EQ(*builder.versionOf(gridAt(0)), 200);
+  EXPECT_EQ(builder.size(), 1u);
+}
+
+TEST(TileCatalogBuilder, RemoveDropsFromSnapshot)
+{
+  mtrs::TileCatalogBuilder builder;
+  builder.update(gridAt(0), 100);
+  builder.update(gridAt(1), 100);
+  builder.remove(gridAt(0));
+
+  EXPECT_FALSE(builder.versionOf(gridAt(0)).has_value());
+  const mtrs::TileCatalog catalog = builder.buildCatalog(200);
+  ASSERT_EQ(catalog.entries.size(), 1u);
+  EXPECT_EQ(catalog.entries.front().index, gridAt(1));
+}
+
+// ---- TileCatalogReconciler: request -----------------------------------------
+
+TEST(TileCatalogReconciler, ColdStartRequestsAll)
+{
+  mtrs::TileCatalogBuilder builder;
+  for (int i = 0; i < 3; ++i) {
+    builder.update(gridAt(i), 100 + i);
+  }
+  const mtrs::TileCatalog catalog = builder.buildCatalog(300);
+
+  mtrs::TileCatalogReconciler reconciler;  // empty
+  const mtrs::ReconcileResult res = reconciler.reconcile(catalog);
+
+  EXPECT_EQ(res.to_request.size(), 3u);
+  EXPECT_TRUE(res.to_prune.empty());
+}
+
+TEST(TileCatalogReconciler, UpToDateIsNoOp)
+{
+  mtrs::TileCatalogBuilder builder;
+  for (int i = 0; i < 3; ++i) {
+    builder.update(gridAt(i), 100 + i);
+  }
+  const mtrs::TileCatalog catalog = builder.buildCatalog(300);
+
+  mtrs::TileCatalogReconciler reconciler;
+  for (int i = 0; i < 3; ++i) {
+    reconciler.markHave(gridAt(i), 100 + i);
+  }
+  const mtrs::ReconcileResult res = reconciler.reconcile(catalog);
+
+  EXPECT_TRUE(res.to_request.empty());
+  EXPECT_TRUE(res.to_prune.empty());
+}
+
+TEST(TileCatalogReconciler, StaleTileRequested)
+{
+  mtrs::TileCatalogBuilder builder;
+  builder.update(gridAt(0), 200);
+  const mtrs::TileCatalog catalog = builder.buildCatalog(300);
+
+  mtrs::TileCatalogReconciler reconciler;
+  reconciler.markHave(gridAt(0), 100);  // stale: held 100 < catalog 200
+  const mtrs::ReconcileResult res = reconciler.reconcile(catalog);
+
+  ASSERT_EQ(res.to_request.size(), 1u);
+  EXPECT_EQ(res.to_request.front(), gridAt(0));
+  EXPECT_TRUE(res.to_prune.empty());
+}
+
+TEST(TileCatalogReconciler, MissingTileRequested)
+{
+  mtrs::TileCatalogBuilder builder;
+  builder.update(gridAt(0), 100);
+  builder.update(gridAt(1), 100);
+  const mtrs::TileCatalog catalog = builder.buildCatalog(300);
+
+  mtrs::TileCatalogReconciler reconciler;
+  reconciler.markHave(gridAt(0), 100);  // has g0; missing g1
+  const mtrs::ReconcileResult res = reconciler.reconcile(catalog);
+
+  ASSERT_EQ(res.to_request.size(), 1u);
+  EXPECT_EQ(res.to_request.front(), gridAt(1));
+}
+
+// ---- TileCatalogReconciler: prune ------------------------------------------
+
+TEST(TileCatalogReconciler, PruneOnAbsence)
+{
+  mtrs::TileCatalogBuilder builder;
+  builder.update(gridAt(0), 100);
+  const mtrs::TileCatalog catalog = builder.buildCatalog(300);
+
+  mtrs::TileCatalogReconciler reconciler;
+  reconciler.markHave(gridAt(0), 100);
+  reconciler.markHave(gridAt(1), 100);  // absent from catalog, old (100 < 300)
+  const mtrs::ReconcileResult res = reconciler.reconcile(catalog);
+
+  EXPECT_TRUE(res.to_request.empty());
+  ASSERT_EQ(res.to_prune.size(), 1u);
+  EXPECT_EQ(res.to_prune.front(), gridAt(1));
+}
+
+// The load-bearing invariant: a late/reordered catalog must not delete a
+// just-pushed fresh tile (held version >= catalog generation_time).
+TEST(TileCatalogReconciler, PruneIsTimestampGated)
+{
+  mtrs::TileCatalogBuilder builder;  // empty source view at this (stale) catalog
+  const mtrs::TileCatalog stale_catalog = builder.buildCatalog(300);
+
+  mtrs::TileCatalogReconciler reconciler;
+  reconciler.markHave(gridAt(0), 500);  // fresh: pushed after the catalog's time
+  reconciler.markHave(gridAt(1), 100);  // old: predates the catalog
+
+  const mtrs::ReconcileResult res = reconciler.reconcile(stale_catalog);
+
+  // g0 (500 >= gen 300) survives; only g1 (100 < 300) is pruned.
+  EXPECT_TRUE(res.to_request.empty());
+  ASSERT_EQ(res.to_prune.size(), 1u);
+  EXPECT_EQ(res.to_prune.front(), gridAt(1));
+  EXPECT_FALSE(contains(res.to_prune, gridAt(0)));
+}
+
+TEST(TileCatalogReconciler, ReorderedStalePushIgnored)
+{
+  mtrs::TileCatalogReconciler reconciler;
+  reconciler.markHave(gridAt(0), 200);
+  reconciler.markHave(gridAt(0), 100);  // reordered older arrival -> ignored
+
+  ASSERT_TRUE(reconciler.versionOf(gridAt(0)).has_value());
+  EXPECT_EQ(*reconciler.versionOf(gridAt(0)), 200);
+}
+
+// ---- Convergence -----------------------------------------------------------
+
+// A fresh boat advertises a small catalog with a new generation time; the
+// operator prunes its stale tiles and converges to exactly the new set.
+TEST(TileCatalogReconciler, BoatResetConverges)
+{
+  // Operator holds five old tiles.
+  mtrs::TileCatalogReconciler reconciler;
+  for (int i = 0; i < 5; ++i) {
+    reconciler.markHave(gridAt(i), 100 + i);
+  }
+
+  // Boat reset: a small fresh catalog (just g0) at a much newer time.
+  mtrs::TileCatalogBuilder fresh;
+  fresh.update(gridAt(0), 1000);
+  const mtrs::TileCatalog catalog = fresh.buildCatalog(2000);
+
+  mtrs::ReconcileResult res = reconciler.reconcile(catalog);
+  // g1..g4 pruned (old, absent); g0 requested (held 100 < 1000).
+  EXPECT_EQ(res.to_prune.size(), 4u);
+  ASSERT_EQ(res.to_request.size(), 1u);
+  EXPECT_EQ(res.to_request.front(), gridAt(0));
+
+  // Apply the actions, then re-reconcile: converged, no further work.
+  for (const auto & g : res.to_prune) {
+    reconciler.drop(g);
+  }
+  reconciler.markHave(gridAt(0), 1000);
+
+  res = reconciler.reconcile(catalog);
+  EXPECT_TRUE(res.to_request.empty());
+  EXPECT_TRUE(res.to_prune.empty());
+  EXPECT_EQ(reconciler.size(), 1u);
+}
+
+// Anti-entropy under loss/reorder: even if only one requested tile arrives per
+// round and arrivals are reordered, repeated reconciles converge to the catalog.
+TEST(TileCatalogReconciler, ConvergesUnderLossAndReorder)
+{
+  mtrs::TileCatalogBuilder builder;
+  const int n = 6;
+  for (int i = 0; i < n; ++i) {
+    builder.update(gridAt(i), 500 + i);
+  }
+  const mtrs::TileCatalog catalog = builder.buildCatalog(1000);
+
+  mtrs::TileCatalogReconciler reconciler;  // starts empty
+
+  int rounds = 0;
+  const int max_rounds = n + 5;  // generous bound; should converge in ~n
+  while (rounds++ < max_rounds) {
+    const mtrs::ReconcileResult res = reconciler.reconcile(catalog);
+    if (res.to_request.empty() && res.to_prune.empty()) {
+      break;
+    }
+    EXPECT_TRUE(res.to_prune.empty());  // nothing to prune: catalog is the truth
+    ASSERT_FALSE(res.to_request.empty());
+
+    // Lossy + reordered link: deliver only the LAST requested tile this round.
+    const gggs::GridIndex & arrived = res.to_request.back();
+    auto v = builder.versionOf(arrived);
+    ASSERT_TRUE(v.has_value());
+    reconciler.markHave(arrived, *v);
+  }
+
+  EXPECT_LE(rounds, max_rounds);
+  EXPECT_EQ(reconciler.size(), static_cast<std::size_t>(n));
+  const mtrs::ReconcileResult final_res = reconciler.reconcile(catalog);
+  EXPECT_TRUE(final_res.to_request.empty());
+  EXPECT_TRUE(final_res.to_prune.empty());
+}

--- a/marine_tiled_raster_store/test/test_tile_catalog.cpp
+++ b/marine_tiled_raster_store/test/test_tile_catalog.cpp
@@ -224,6 +224,32 @@ TEST(TileCatalogReconciler, ReorderedStalePushIgnored)
   EXPECT_EQ(*reconciler.versionOf(gridAt(0)), 200);
 }
 
+// Invalid (default/sentinel) indices are ignored at ingestion, so they cannot
+// collapse together into one bogus map key on either side.
+TEST(TileCatalogBuilderReconciler, InvalidIndexIgnored)
+{
+  const gggs::GridIndex invalid;  // default-constructed -> invalid sentinel
+  ASSERT_FALSE(invalid.valid());
+
+  mtrs::TileCatalogBuilder builder;
+  builder.update(invalid, 100);
+  EXPECT_EQ(builder.size(), 0u);
+  EXPECT_FALSE(builder.versionOf(invalid).has_value());
+
+  mtrs::TileCatalogReconciler reconciler;
+  reconciler.markHave(invalid, 100);
+  EXPECT_EQ(reconciler.size(), 0u);
+  EXPECT_FALSE(reconciler.has(invalid));
+
+  // A malformed catalog carrying an invalid entry does not request/prune it.
+  mtrs::TileCatalog catalog;
+  catalog.generation_time = 300;
+  catalog.entries.push_back(mtrs::TileCatalogEntry{invalid, 100});
+  const mtrs::ReconcileResult res = reconciler.reconcile(catalog);
+  EXPECT_TRUE(res.to_request.empty());
+  EXPECT_TRUE(res.to_prune.empty());
+}
+
 // ---- Convergence -----------------------------------------------------------
 
 // A fresh boat advertises a small catalog with a new generation time; the


### PR DESCRIPTION
**Closes #230** — PR2 of 2 (PR1, the six transport messages, merged via #234).

Adds the `#86`-Phase-6 anti-entropy tile-sync to `marine_tiled_raster_store` —
the package [ADR-0008] / its own `tile_io.hpp` designated as the sync home:

- **`tile_catalog.{hpp,cpp}`** — `TileCatalogBuilder` (source tile→version
  registry → **complete** snapshot) and `TileCatalogReconciler` (pure
  `reconcile()` → **request** missing/stale + **timestamp-gated prune**-on-absence;
  `markHave`/`drop` for async state). **Payload-agnostic & ROS-free** — reasons
  over `gggs::GridIndex` + `TileVersion` only, no `marine_interfaces` dep — so it
  serves both the light display-tile transport and a future full-tile sync. The
  node boundary (cube#78 / camp#121) adapts the wire messages to/from these types.
- **`test_tile_catalog.cpp`** — 14 GTests: builder snapshot/newest-wins/remove;
  reconciler cold-start / up-to-date / stale / missing / prune-on-absence /
  **timestamp-gated prune (fresh tile survives a stale catalog)** /
  reordered-stale-ignored / invalid-index-ignored / **boat-reset convergence** /
  **convergence under simulated loss + reorder**.
- **`tile_io.hpp`** — fixed the stale "content-hash sync" comment to
  timestamp/version (ADR-0008 D3).
- README + CMakeLists updated.

**Verification**: `colcon build` clean (`-Wall -Wextra -Wpedantic`, no warnings);
`colcon test` → 14/14 catalog tests pass; `ament_cpplint` clean. Two pre-push
adversarial review passes (container): approved, 0 must-fix; all 5 hardening
suggestions folded in.

[ADR-0008]: https://github.com/rolker/unh_marine_autonomy/blob/jazzy/docs/decisions/0008-live-sonar-coverage-transport-and-render.md

Part of #171.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8`
