### PR TITLE
docs: refresh sonar ecosystem map to current status (#237)

### DIFF
--- a/docs/sonar_ecosystem.md
+++ b/docs/sonar_ecosystem.md
@@ -7,7 +7,7 @@ current; when an umbrella closes or a frontier shifts, update the relevant row.
 
 > Status legend: ✅ done · 🔨 in progress · 📋 designed, not built · ⚠️ blocked/degraded
 
-_Last verified: 2026-06-27._
+_Last verified: 2026-06-28 (full status audit against PR/merge state)._
 
 ## The two arcs
 
@@ -38,18 +38,18 @@ looked.
 
 | Stage | What | Owning umbrella(s) | ADR | Status |
 |-------|------|--------------------|-----|--------|
-| **Acquire — MBES** | M3 multibeam driver (`kongsberg_em_bridge`) | — | — | ✅ functional, ⚠️ data-quality bugs: timing [echoboats#338], gyro/roll [echoboats#337]/[echoboats#339] |
+| **Acquire — MBES** | M3 multibeam driver (`kongsberg_em_bridge`) | — | — | ✅ functional; ⚠️ open data-quality bugs: gyro health [echoboats#337], time-sync [echoboats#338] (mru_transform SBG-primary [echoboats#339] ✅ closed) |
 | **Acquire — sidescan** | Garmin GCV driver + platform integration | [#185](https://github.com/rolker/unh_marine_autonomy/issues/185) | — | 🔨 protocol cracked; driver/platform in flight |
 | **Acquire — other** | DeltaT sonar driver | [#111](https://github.com/rolker/unh_marine_autonomy/issues/111) | — | 📋 |
 | **Estimate — bathy** | CUBE draft tiles (live), backscatter co-estimation, slope correction | — | 0007 | ✅ mature ([cube#54], [cube#70] closed); slope-correction merged but dormant (needs [cube#59]) |
 | **Estimate — sidescan** | `marine_sidescan_mosaic` live mosaic (L13, uint16) | [#171](https://github.com/rolker/unh_marine_autonomy/issues/171) (I2), [#185](https://github.com/rolker/unh_marine_autonomy/issues/185) | — | 📋 design locked, not built |
 | **Store — core** | Generic band/dtype tiled-GeoTIFF store core | [#172](https://github.com/rolker/unh_marine_autonomy/issues/172) | 0002 | ✅ closed (`marine_tiled_raster_store`) |
-| **Store — bathy** | Multi-source bathy store; layers (draft/processed/chart), priority query | [#86](https://github.com/rolker/unh_marine_autonomy/issues/86) | 0002 | ✅ readiness arc complete; sub-features open: [#151] levels, [#163]/[cube#44] chart, [#188] pyramids, [#189] atomic write |
-| **Store — backscatter** | Two-tier backscatter store (GeoCoder, draft/processed) | [#180](https://github.com/rolker/unh_marine_autonomy/issues/180) | 0006 / 0007 | 📋 core supports it; sidescan/MBES specifics not built |
+| **Store — bathy** | Multi-source bathy store; layers (draft/processed/chart), priority query | [#86](https://github.com/rolker/unh_marine_autonomy/issues/86) | 0002 | ✅ readiness arc complete; sub-features: [cube#44] chart prior 🔨 implemented (PR#45); [#151] levels / [#188] pyramids / [#189] atomic write 📋 |
+| **Store — backscatter** | Two-tier backscatter store (GeoCoder, draft/processed) | [#180](https://github.com/rolker/unh_marine_autonomy/issues/180) | 0006 / 0007 | 🔨 **M3/MBES half ✅ done**: [cube#80] offline producer merged → `marine_mbes_backscatter_store`; sidescan half 📋 |
 | **Store — provenance** | Cross-store multi-platform source-id + registry | [#179](https://github.com/rolker/unh_marine_autonomy/issues/179) | 0005 | 📋 deferred (multi-platform later tier) |
-| **Live transport** | `SonarVisualizationTile` + anti-entropy tile-sync | [#230](https://github.com/rolker/unh_marine_autonomy/issues/230) (= #86-Phase-6 / #171-I3) | 0008 | 🔨 **current** — PR1 messages done; reconciler + [cube#78] producer + [camp#121] consumer next |
-| **Costmap** | Bathy → Nav2 costmap layer | [#127](https://github.com/rolker/unh_marine_autonomy/issues/127) | — | ⚠️ built but **unusable** until the tide-frame fix [uma#220] + cost-model rework (midpoint+uncertainty) |
-| **Render — CAMP** | Unified band-select + colormap raster render + live cache | [#175](https://github.com/rolker/unh_marine_autonomy/issues/175) (I4), [camp#121], [camp#108], [camp#63] | 0001 / 0008 | 🔨 file-store display works; unified render + live cache not built |
+| **Live transport** | `SonarVisualizationTile` + anti-entropy tile-sync | [#230](https://github.com/rolker/unh_marine_autonomy/issues/230) (= #86-Phase-6 / #171-I3) | 0008 | ✅ **#230 transport closed + [cube#78] producer merged**; only [camp#121] consumer (live cache) remains |
+| **Costmap** | Bathy → Nav2 costmap layer | [#127](https://github.com/rolker/unh_marine_autonomy/issues/127) | — | ✅ **usable** — tide-frame fix [uma#220] + latch-hardening [uma#223] merged (PR#222). Midpoint+uncertainty cost-model rework is a separate enhancement, not a blocker |
+| **Render — CAMP** | Unified band-select + colormap raster render + live cache | [#175](https://github.com/rolker/unh_marine_autonomy/issues/175) (I4), [camp#121], [camp#108], [camp#63] | 0001 / 0008 | 🔨 file-store display + GPU raster ([camp#90]) ✅; band-select [camp#108] in PR review ([camp#124]); live cache [camp#121] 📋 |
 | **Render — web** | Browser SA viewer (contacts + bathy + sidescan) | [#166](https://github.com/rolker/unh_marine_autonomy/issues/166) | — | 📋 |
 | **Reprocess** | Offline M3 bag → store tiles; PINGMapper offline sidescan EGN | [#171](https://github.com/rolker/unh_marine_autonomy/issues/171) (C1) | — | ✅ M3 import landed ([cube#63] closed); 📋 sidescan offline pipeline to validate; ⚠️ draft→**processed** promotion workflow thin |
 | **Metering** | Per-topic priority on the `udp_bridge` rate-limiter | [udp_bridge#19](https://github.com/rolker/udp_bridge/issues/19) | 0008 (D9) | 📋 |
@@ -62,12 +62,15 @@ looked.
 [cube#70]: https://github.com/rolker/cube_bathymetry/issues/70
 [cube#78]: https://github.com/rolker/cube_bathymetry/issues/78
 [cube#80]: https://github.com/rolker/cube_bathymetry/issues/80
+[cube#81]: https://github.com/rolker/cube_bathymetry/issues/81
 [camp#63]: https://github.com/rolker/camp/issues/63
 [camp#90]: https://github.com/rolker/camp/issues/90
 [camp#108]: https://github.com/rolker/camp/issues/108
 [camp#121]: https://github.com/rolker/camp/issues/121
+[camp#124]: https://github.com/rolker/camp/pull/124
 [rqt#58]: https://github.com/rolker/rqt_operator_tools/issues/58
 [uma#220]: https://github.com/rolker/unh_marine_autonomy/issues/220
+[uma#223]: https://github.com/rolker/unh_marine_autonomy/issues/223
 [echoboats#337]: https://github.com/rolker/unh_echoboats_project11/issues/337
 [echoboats#338]: https://github.com/rolker/unh_echoboats_project11/issues/338
 [echoboats#339]: https://github.com/rolker/unh_echoboats_project11/issues/339
@@ -87,8 +90,8 @@ topic), intentionally *not* the Arc-1 raster tile-sync.
 
 | Stage | What | Owning issue(s) | ADR | Status |
 |-------|------|-----------------|-----|--------|
-| **Explore** | `rqt` sonar review tools: waterfall over sidescan **and now MBES**, echogram, target views | [rqt#53] (echogram), [rqt#40] (MBES backscatter extractor), [rqt#50]/[rqt#69]/[rqt#73]/[rqt#82] (waterfall) | — | 🔨 waterfall + echogram active; MBES extractor 📋 |
-| **Mark** | draw-a-box target marking in the live view → `TargetAnnotation` | [rqt#59] | — | 📋 |
+| **Explore** | `rqt` sonar review tools: waterfall over sidescan **and now MBES**, echogram, target views | [rqt#53] (echogram), [rqt#40] (MBES backscatter extractor), [rqt#50]/[rqt#69]/[rqt#73]/[rqt#82] (waterfall) | — | ✅ waterfall + echogram modernized ([rqt#53] done: PR#52/#55/#64/#80 merged); MBES backscatter extractor [rqt#40] 📋 |
+| **Mark** | draw-a-box target marking in the live view → `TargetAnnotation` | [rqt#59] | — | 📋 (gated on the `TargetAnnotation` msg); **near-term subset [rqt#86]** publishes a `Contact` to the bag instead |
 | **Mark → Contact** | live-view marking publishes into `contact_manager` | [rqt#81] | 0004 | 📋 — the load-bearing link between the arcs |
 | **Contact** | unified `Contact` CRUD store + curate/confirm + distribution | [#157](https://github.com/rolker/unh_marine_autonomy/issues/157) / [#167](https://github.com/rolker/unh_marine_autonomy/issues/167) (+#156) | 0004 | 🔨 v1 core in flight |
 | **Device control** | bridgeable settings for the review tools / CA tuning | [#168](https://github.com/rolker/unh_marine_autonomy/issues/168) | 0003 | 🔨 |
@@ -102,6 +105,7 @@ topic), intentionally *not* the Arc-1 raster tile-sync.
 [rqt#73]: https://github.com/rolker/rqt_operator_tools/issues/73
 [rqt#81]: https://github.com/rolker/rqt_operator_tools/issues/81
 [rqt#82]: https://github.com/rolker/rqt_operator_tools/issues/82
+[rqt#86]: https://github.com/rolker/rqt_operator_tools/issues/86
 
 > **Tracking gap (follow-up):** unlike Arc 1 (which has #86 / #171 / ADR-0008),
 > the explore→mark→contact→display arc has **no unifying umbrella** tying the
@@ -132,41 +136,40 @@ the final surveying days. Coverage (Tools 1–2) is **band-selectable** — the
 operator views it as **depth / uncertainty / backscatter** through one CAMP
 band-picker + colormap (ADR-0008 D6; [camp#108]/[camp#121]).
 
-1. **Display existing coverage, especially multibeam.** The M3 bathy is already
-   in the GGGS store ([cube#63] closed); CAMP's GGGS raster layer ([camp#90],
-   closed) renders it. Shortest path: point CAMP at the Massabesic store + a
-   colormap. **Closest of the three**, and the render foundation Tool 2 reuses.
-   - **Bands:** depth + uncertainty come from the bathy store today. **Backscatter
-     is added by [cube#80]** — the offline M3 import also writes a float32
-     backscatter store layer (float32 tiles already persist in
-     `marine_tiled_raster_store`; ADR-0007 producer). First cut = beam-angle-vs-nadir;
-     GeoCoder-grade incidence ([cube#15]/[cube#59]) is a follow-up.
-2. **Display new coverage as it's collected.** The [#230] chain (messages +
-   reconciler ✅ merged) → [cube#78] producer → [camp#121] live cache, **feeding
-   the same band-generic render as Tool 1**. [cube#78] already carries the live
-   3-band tile (depth/uncertainty/backscatter; co-estimation [cube#54] done).
-   Farthest, but the live cache is the only new display piece.
+1. **Display existing coverage, especially multibeam — essentially DONE.** M3 bathy
+   is in the GGGS store ([cube#63] closed); CAMP's GGGS raster layer ([camp#90])
+   renders it; the offline backscatter producer [cube#80] ✅ **merged**
+   (`marine_mbes_backscatter_store`). The band picker (depth/uncertainty/backscatter
+   + colormap, [camp#108]) is **in PR review ([camp#124])** — once it lands, Tool 1
+   is complete. Remaining = land [camp#124].
+2. **Display new coverage as it's collected — producers DONE, consumer is the gap.**
+   The [#230] transport ✅ closed and the [cube#78] producer ✅ **merged** (3-band
+   live tile, sim-verified on Massabesic M3). The one remaining piece is
+   **[camp#121]** — the CAMP consumer + disk-backed live cache, reusing Tool 1's
+   band-generic render. **Untouched; this is the real bottleneck for Tool 2.**
 3. **Mark a target on the live sidescan view → save a contact to the operator bag.**
-   The waterfall's slant→ground geometry ([rqt#58]) is closed; add the draw-box
-   marking ([rqt#59]'s UI half) and **publish a `marine_interfaces/Contact`**
-   (already defined, `ORIGIN_HUMAN`) on a bag-recorded topic. **Sidesteps two
-   blockers**: the unsettled `TargetAnnotation` message gating [rqt#59], and the
-   `contact_manager` backend (#157/#167) — neither is needed to record a contact.
+   The waterfall's slant→ground geometry ([rqt#58]) is closed; **[rqt#86]** adds the
+   draw-box marking and **publishes a `marine_interfaces/Contact`** (`ORIGIN_HUMAN`)
+   on a bag-recorded topic — sidestepping the unsettled `TargetAnnotation` ([rqt#59])
+   and the `contact_manager` backend (#157/#167). **Untouched.**
 
-**Producer symmetry:** existing coverage's backscatter comes from the offline
-import ([cube#80], durable store layer); live coverage's from [cube#78] (display
-tile). One band-generic CAMP renderer shows either.
+**Producer symmetry:** both backscatter producers are merged — existing coverage
+from the offline import ([cube#80], durable store layer), live coverage from
+[cube#78] (display tile). **Both surface the co-estimated value UNCORRECTED**; the
+nadir-stripe angle-correction is a separate gated issue ([cube#81], now an
+empirical angular-response/ARA approach) that, once landed, corrects both at once.
 
-**Sequence:** Tool 1 first (closest; shared render foundation; [cube#80] gives it
-backscatter) ‖ Tool 3 in parallel (independent rqt track, unblocked) → Tool 2
-(live cache on Tool 1's render).
+**Sequence now:** land [camp#124] (finishes Tool 1) → build **[camp#121]** (the
+Tool 2 consumer — top priority) ‖ **[rqt#86]** in parallel (independent rqt track).
 
 ### Longer-term / supporting
 
-- **Make the costmap usable** ([uma#220] tide-frame fix + cost-model rework) —
-  built but 100% lethal today; best ratio of "unlocks autonomy" to work remaining.
-- **Land acquisition data-quality bugs** ([echoboats#337]/[echoboats#338]/[echoboats#339])
-  — corrupt every downstream product in *both* arcs; cheap, foundational.
+- **Costmap cost-model rework** (midpoint-depth + per-band-uncertainty, worst-case
+  clearance) — an *enhancement* for shore-keepoff / unknown-lake generalization. The
+  tide-frame blocker ([uma#220]/[uma#223]) is already fixed, so the layer is **usable
+  today**; this is quality, not a blocker.
+- **Land acquisition data-quality bugs** ([echoboats#337] gyro health, [echoboats#338]
+  time-sync) — corrupt every downstream product in *both* arcs; cheap, foundational.
 - The **sidescan track** ([#171]/[#185]) and the **draft→processed + coverage-QC
   loop** (the gap between "collected data" and "finished survey") — [cube#80] is
   a first step, producing an authoritative backscatter layer off-boat.


### PR DESCRIPTION
Closes #237.

Refreshes `docs/sonar_ecosystem.md` after a full 2026-06-28 audit of every non-✅
item — the map (verified 06-27) had multiple stale rows because issue *state*
lagged actual *PR/merge* state.

**Re-marked as resolved:** uma#230 (transport) closed; cube#78 + cube#80 producers
merged; costmap usable (uma#220/#223, PR#222); echoboats#339 closed; rqt#53
echogram modernization done (4 merged PRs).

**Re-marked as active (open + PR/worktree):** camp#108 band-select in PR review
(camp#124); cube#44 chart prior implemented; cube#81 → empirical angular-response (ARA).

**Clarified:** both backscatter producers surface the value UNCORRECTED (correction
deferred to cube#81); the genuine remaining three-tools gaps are **camp#121** (Tool 2
consumer) and **rqt#86** (Tool 3); the costmap cost-model rework is an enhancement,
not a blocker.

All reference links validated.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8`
