### PR TITLE
Publish structured TaskFeedback for operator stations (P1 boat-side of camp#123)

### DIFF
--- a/.agent/work-plans/issue-236/plan.md
+++ b/.agent/work-plans/issue-236/plan.md
@@ -1,0 +1,88 @@
+# Plan: Publish structured TaskFeedback for operator stations (P1 boat-side of camp#123)
+
+## Issue
+
+https://github.com/rolker/unh_marine_autonomy/issues/236
+
+## Context
+
+CAMP's running-task display is being redesigned (umbrella rolker/camp#123) to consume
+the boat's *structured* task model instead of the flattened `marine_interfaces/Heartbeat`
+key/value dump it gets today. The information is lost **on the boat**:
+`mission_manager/mission_manager/camp_interface.py::navigatorFeedback()` already holds the
+raw `marine_nav_interfaces/TaskFeedback` (`current_navigation_task` + `tasks[]`) as
+`feedback_msg.feedback.feedback`, then flattens it via `listTasks()` into the Heartbeat
+before anything leaves the boat.
+
+This is the **P1 boat-side** half: publish that `TaskFeedback` as-is on a dedicated topic,
+periodically, leaving the existing Heartbeat untouched. The CAMP-side read-only tree view
+is tracked separately under camp#123.
+
+## Approach
+
+1. **New publisher in `on_configure()`** — create a second lifecycle publisher
+   `task_feedback_publisher_` of type `marine_nav_interfaces/TaskFeedback` on topic
+   `marine/status/mission_tasks` (sibling of the existing `marine/status/mission_manager`).
+   Default QoS, depth 10 (volatile) — see ADR note on transport below.
+2. **`navigatorFeedback()`** — when `feedback_msg is not None`, publish
+   `feedback_msg.feedback.feedback` (already a `TaskFeedback`) directly on the new topic,
+   alongside the existing Heartbeat. When `feedback_msg is None`, skip the structured
+   publish (no task data to send); the Heartbeat path is unchanged.
+3. **`navigatorDone()`** — construct a `TaskFeedback` with `current_navigation_task = ''`
+   and `tasks = result.tasks` (or empty when `result is None`) and publish it, so a
+   completed/cleared mission still reflects final state on the new topic.
+4. **Import** `TaskFeedback` in `camp_interface.py` (currently only `TaskInformation` is
+   imported from `marine_nav_interfaces.msg`).
+5. **Tests** — extend `test/test_camp_interface.py`: assert the new publisher is created in
+   `on_configure()`, that `navigatorFeedback()` publishes the raw `TaskFeedback` (and does
+   not when `feedback_msg is None`), and that `navigatorDone()` publishes a `TaskFeedback`
+   with empty `current_navigation_task` + the result tasks. Follows the existing
+   MagicMock-based harness (all ROS deps mocked).
+6. **Bridge entry (separate follow-up, flagged not blocking)** — add
+   `mission_tasks: {source: marine/status/mission_tasks}` to
+   `unh_echoboats_project11/bizzyboat_project11/config/bizzyboat.yaml`, mirroring the
+   existing `heartbeat_nav` entry across its VPN/cell variant blocks. That config lives in
+   the **separate `unh_echoboats_project11` platform repo**, so it is its own small PR; the
+   boat-side publisher does not depend on it to land.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `mission_manager/mission_manager/mission_manager/camp_interface.py` | Import `TaskFeedback`; create `task_feedback_publisher_` in `on_configure()`; publish structured `TaskFeedback` in `navigatorFeedback()` + `navigatorDone()` |
+| `mission_manager/mission_manager/test/test_camp_interface.py` | Tests for publisher creation + structured publish on feedback/done |
+| `unh_echoboats_project11/.../config/bizzyboat.yaml` | **Follow-up PR (separate repo)** — bridge `mission_tasks` mirroring `heartbeat_nav` |
+
+`marine_nav_interfaces` is already a `<depend>` in `package.xml` — no manifest change.
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Robustness (open-water quality standard) | Delivery survives a lossy UDP link via **periodic re-publish** (same mechanism the Heartbeat relies on), not `transient_local` — which does not tunnel through `udp_bridge`. Tests cover the `None`-feedback edge case so a completed/idle mission can't emit a malformed message. |
+| Additive / no regression | Existing Heartbeat on `marine/status/mission_manager` is untouched; the new topic is purely additive, so current CAMP keeps working during the CAMP-side migration. |
+| Interface clarity (`docs/interfaces.md`) | New topic name is a sibling of the existing status topic and carries an existing message type (`TaskFeedback`) — no new message definitions. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0008 (live sonar coverage transport & render) | No (referenced) | That ADR governs **heavy** tiled-raster transport that saturated `udp_bridge` (#250) and needs metering. `TaskFeedback` is a small, low-rate status message published like the existing Heartbeat — it is the light-status case, not the bounded-raster case, so no tile-sync/metering machinery applies. |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| Add `marine/status/mission_tasks` publisher | Bridge config in `unh_echoboats_project11` so it reaches shore | No — flagged as separate follow-up PR (different repo) |
+| Add `marine/status/mission_tasks` publisher | CAMP-side consumer (read-only tree view) | No — tracked under umbrella camp#123 (next phase) |
+| New publisher behavior | `test_camp_interface.py` | Yes |
+
+## Open Questions
+
+- Topic name `marine/status/mission_tasks` — proposed; confirm during review-plan if a
+  different convention is preferred (e.g. `marine/status/tasks`).
+
+## Estimated Scope
+
+Single small PR (publisher + tests) on `unh_marine_autonomy`. Bridge config is a separate
+one-line follow-up PR in the platform repo. CAMP-side view is a separate effort under camp#123.

--- a/.agent/work-plans/issue-236/progress.md
+++ b/.agent/work-plans/issue-236/progress.md
@@ -1,0 +1,17 @@
+---
+issue: 236
+---
+
+# Issue #236 — Publish structured TaskFeedback for operator stations (P1 boat-side of camp#123)
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-28 08:20 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Plan**: `.agent/work-plans/issue-236/plan.md` at `6760606`
+**Branch**: feature/issue-236 at `6760606`
+**Phases**: single
+
+### Open questions
+- [ ] Topic name `marine/status/mission_tasks` — confirm convention in review-plan (vs e.g. `marine/status/tasks`).

--- a/.agent/work-plans/issue-236/progress.md
+++ b/.agent/work-plans/issue-236/progress.md
@@ -15,3 +15,21 @@ issue: 236
 
 ### Open questions
 - [ ] Topic name `marine/status/mission_tasks` — confirm convention in review-plan (vs e.g. `marine/status/tasks`).
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-28 08:51 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved
+
+**Branch**: feature/issue-236 at `b47dd86`
+**Mode**: pre-push
+**Depth**: Standard (reason: adds a new published topic interface)
+**Must-fix**: 0 | **Suggestions**: 4
+**Round**: 1 | **Ship**: recommended — no must-fix; cadence suggestions point opposite ways, tune after measuring bridge budget
+
+### Findings
+- [ ] (suggestion) Structured TaskFeedback (with poses) on Heartbeat cadence may strain cell link — consider decimate/publish-on-change; measure on bridge — `camp_interface.py:178,202`
+- [ ] (suggestion) Lifecycle publishers not destroyed on on_cleanup → reconfigure leak (parity w/ existing status_publisher) — `camp_interface.py:135`
+- [ ] (suggestion) navigatorDone terminal message is one-shot; dropped UDP packet leaves CAMP on stale in-progress state (parity w/ Heartbeat-done) — `camp_interface.py:202`
+- [ ] (suggestion) task_feedback.tasks = result.tasks aliases result list — benign today, guard if future code mutates before publish — `camp_interface.py:198`

--- a/mission_manager/mission_manager/mission_manager/camp_interface.py
+++ b/mission_manager/mission_manager/mission_manager/camp_interface.py
@@ -38,7 +38,7 @@ from typing import Optional
 from geometry_msgs.msg import PoseStamped, Quaternion
 from marine_autonomy import nav
 from marine_interfaces.msg import BehaviorInformation, Heartbeat, KeyValue
-from marine_nav_interfaces.msg import TaskInformation
+from marine_nav_interfaces.msg import TaskFeedback, TaskInformation
 from rclpy.lifecycle import Node, Publisher
 from rclpy.subscription import Subscription
 from std_msgs.msg import String
@@ -107,6 +107,7 @@ class CampInterface:
         self.mission_manager = mission_manager
         self.command_subscriber: Optional[Subscription] = None
         self.status_publisher: Optional[Publisher] = None
+        self.task_feedback_publisher: Optional[Publisher] = None
         self.earth: Optional[nav.EarthTransforms] = None
 
     def on_configure(self):
@@ -119,6 +120,22 @@ class CampInterface:
             self.mission_manager.create_lifecycle_publisher(
                 Heartbeat,
                 'marine/status/mission_manager',
+                10
+            )
+        )
+
+        # Structured task state for operator stations (CAMP). The Heartbeat
+        # above flattens tasks into key/value strings for at-a-glance status;
+        # this publishes the unflattened TaskFeedback (current task + full task
+        # list) so CAMP can render a structured running-task view. Published on
+        # the same periodic cadence as the Heartbeat (in navigatorFeedback /
+        # navigatorDone) rather than relying on transient_local, because the
+        # udp_bridge to shore is best-effort UDP and does not tunnel DDS
+        # durability — periodic re-publish is what survives the link.
+        self.task_feedback_publisher = (
+            self.mission_manager.create_lifecycle_publisher(
+                TaskFeedback,
+                'marine/status/mission_tasks',
                 10
             )
         )
@@ -157,6 +174,8 @@ class CampInterface:
                 KeyValue(key='Current Nav Task',
                          value=task_feedback.current_navigation_task))
             listTasks(task_feedback.tasks, hb)
+            # Structured mirror of the same feedback for CAMP.
+            self.task_feedback_publisher.publish(task_feedback)
         self.status_publisher.publish(hb)
 
     def navigatorDone(self, state, result):
@@ -170,11 +189,17 @@ class CampInterface:
                 key='T',
                 value=now.isoformat(timespec='milliseconds')))
         hb.values.append(KeyValue(key='Navigator', value='done'))
+        task_feedback = TaskFeedback()
+        task_feedback.current_navigation_task = ''
         if result is None:
             listTasks(None, hb)
         else:
             listTasks(result.tasks, hb)
+            task_feedback.tasks = result.tasks
         self.status_publisher.publish(hb)
+        # Structured final state for CAMP: no current task (navigator done),
+        # carrying the result task list (with their done flags) when present.
+        self.task_feedback_publisher.publish(task_feedback)
 
     def commandCallback(self, msg):
         """Receive ROS command String.

--- a/mission_manager/mission_manager/test/test_camp_interface.py
+++ b/mission_manager/mission_manager/test/test_camp_interface.py
@@ -79,6 +79,21 @@ class TestCampInterfaceInit(unittest.TestCase):
         ci = CampInterface(mm)
         self.assertIsNone(ci.command_subscriber)
         self.assertIsNone(ci.status_publisher)
+        self.assertIsNone(ci.task_feedback_publisher)
+
+    def test_on_configure_creates_task_feedback_publisher(self):
+        """on_configure() creates the structured TaskFeedback publisher."""
+        mm = MagicMock()
+        ci = CampInterface(mm)
+        with patch('mission_manager.camp_interface.nav'):
+            ci.on_configure()
+        topics = [
+            call.args[1]
+            for call in mm.create_lifecycle_publisher.call_args_list
+        ]
+        self.assertIn('marine/status/mission_tasks', topics)
+        self.assertIn('marine/status/mission_manager', topics)
+        self.assertIsNotNone(ci.task_feedback_publisher)
 
 
 class TestCommandCallback(unittest.TestCase):
@@ -470,6 +485,7 @@ class TestNavigatorFeedback(unittest.TestCase):
 
         self.ci = CampInterface(self.mm)
         self.ci.status_publisher = MagicMock()
+        self.ci.task_feedback_publisher = MagicMock()
 
     def test_feedback_none_publishes_heartbeat(self):
         """Even with None feedback, a heartbeat should be published."""
@@ -479,6 +495,15 @@ class TestNavigatorFeedback(unittest.TestCase):
                        return_value=MagicMock(values=[])):
                 self.ci.navigatorFeedback(None)
         self.ci.status_publisher.publish.assert_called_once()
+
+    def test_feedback_none_skips_task_feedback(self):
+        """No feedback means no structured TaskFeedback is published."""
+        with patch('mission_manager.camp_interface.KeyValue',
+                   side_effect=MagicMock):
+            with patch('mission_manager.camp_interface.Heartbeat',
+                       return_value=MagicMock(values=[])):
+                self.ci.navigatorFeedback(None)
+        self.ci.task_feedback_publisher.publish.assert_not_called()
 
     def test_feedback_with_tasks_publishes_heartbeat(self):
         """Feedback with task info should publish a heartbeat."""
@@ -491,6 +516,20 @@ class TestNavigatorFeedback(unittest.TestCase):
                        return_value=MagicMock(values=[])):
                 self.ci.navigatorFeedback(feedback_msg)
         self.ci.status_publisher.publish.assert_called_once()
+
+    def test_feedback_with_tasks_publishes_structured_feedback(self):
+        """The raw TaskFeedback is published unflattened for CAMP."""
+        feedback_msg = MagicMock()
+        task_feedback = feedback_msg.feedback.feedback
+        task_feedback.current_navigation_task = 'task_1'
+        task_feedback.tasks = []
+        with patch('mission_manager.camp_interface.KeyValue',
+                   side_effect=MagicMock):
+            with patch('mission_manager.camp_interface.Heartbeat',
+                       return_value=MagicMock(values=[])):
+                self.ci.navigatorFeedback(feedback_msg)
+        self.ci.task_feedback_publisher.publish.assert_called_once_with(
+            task_feedback)
 
 
 class TestNavigatorDone(unittest.TestCase):
@@ -509,6 +548,7 @@ class TestNavigatorDone(unittest.TestCase):
 
         self.ci = CampInterface(self.mm)
         self.ci.status_publisher = MagicMock()
+        self.ci.task_feedback_publisher = MagicMock()
 
     def test_done_with_none_result(self):
         """Handle None result by still publishing a heartbeat."""
@@ -518,6 +558,17 @@ class TestNavigatorDone(unittest.TestCase):
                        return_value=MagicMock(values=[])):
                 self.ci.navigatorDone(None, None)
         self.ci.status_publisher.publish.assert_called_once()
+
+    def test_done_none_result_publishes_empty_task_feedback(self):
+        """Done with no result publishes a current-task-less TaskFeedback."""
+        with patch('mission_manager.camp_interface.KeyValue',
+                   side_effect=MagicMock):
+            with patch('mission_manager.camp_interface.Heartbeat',
+                       return_value=MagicMock(values=[])):
+                self.ci.navigatorDone(None, None)
+        self.ci.task_feedback_publisher.publish.assert_called_once()
+        published = self.ci.task_feedback_publisher.publish.call_args.args[0]
+        self.assertEqual(published.current_navigation_task, '')
 
     def test_done_with_result(self):
         """Publish heartbeat with tasks when a result is provided."""
@@ -529,6 +580,20 @@ class TestNavigatorDone(unittest.TestCase):
                        return_value=MagicMock(values=[])):
                 self.ci.navigatorDone(None, result)
         self.ci.status_publisher.publish.assert_called_once()
+
+    def test_done_result_publishes_structured_task_feedback(self):
+        """Done with a result carries the result task list for CAMP."""
+        result = MagicMock()
+        result.tasks = [MagicMock(id='t1', type='goto', done=True, status='')]
+        with patch('mission_manager.camp_interface.KeyValue',
+                   side_effect=MagicMock):
+            with patch('mission_manager.camp_interface.Heartbeat',
+                       return_value=MagicMock(values=[])):
+                self.ci.navigatorDone(None, result)
+        self.ci.task_feedback_publisher.publish.assert_called_once()
+        published = self.ci.task_feedback_publisher.publish.call_args.args[0]
+        self.assertEqual(published.current_navigation_task, '')
+        self.assertEqual(published.tasks, result.tasks)
 
 
 class TestAlignPoses(unittest.TestCase):


### PR DESCRIPTION
Closes #236

## Summary

`CampInterface` flattened the navigator's `TaskFeedback` into a `Heartbeat`
key/value dump before anything left the boat, so the operator station (CAMP)
could only render a text blob. This adds a second lifecycle publisher on
`marine/status/mission_tasks` that emits the **unflattened** `TaskFeedback`
(`current_navigation_task` + full `tasks[]`) alongside the existing Heartbeat,
in both `navigatorFeedback()` and `navigatorDone()`. The existing
`marine/status/mission_manager` Heartbeat is unchanged.

P1 boat-side of the CAMP running-task display redesign (umbrella rolker/camp#123).

## Why periodic, not transient_local

CAMP runs off-boat over `udp_bridge`, which is best-effort UDP with bounded
packet-resend and does **not** tunnel DDS durability. So `transient_local`
(latched) doesn't survive the link. Delivery robustness comes from **periodic
re-publish** — exactly how the existing Heartbeat already stays current. Default
volatile QoS, depth 10.

## Changes

- `camp_interface.py`: import `TaskFeedback`; create `task_feedback_publisher`
  in `on_configure()`; publish structured `TaskFeedback` in `navigatorFeedback()`
  (when feedback is present) and `navigatorDone()` (terminal state, no current task).
- `test_camp_interface.py`: 5 new tests — publisher creation, structured publish
  on feedback, skip-when-no-feedback, structured publish on done with/without result.

## Testing

Full package Python suite: **101 passed**. flake8 clean on changed files.

## Follow-ups (not blocking)

- **Bridge entry** (separate PR, platform repo `unh_echoboats_project11`): add
  `mission_tasks: {source: marine/status/mission_tasks}` to `bizzyboat.yaml`
  mirroring `heartbeat_nav`, so the topic reaches shore.
- **CAMP-side read-only tree view**: tracked under rolker/camp#123.
- **Cadence/bandwidth**: pre-push review flagged that the structured payload
  (with task poses) on Heartbeat cadence may strain the cell link — measure on
  the bridge during bring-up; decimate or publish-on-change if needed.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
