### PR TITLE
docs: broaden bathy-store Processed layer to include off-boat CUBE re-run (ADR-0002)

### DIFF
--- a/docs/decisions/0002-bathymetric-data-store.md
+++ b/docs/decisions/0002-bathymetric-data-store.md
@@ -134,9 +134,14 @@ Each cell stores at minimum **depth** (ellipsoidal height, WGS84),
 **uncertainty**, **source layer**, and **timestamp**. Three source layers,
 queried by descending priority:
 
-1. **Processed** — externally produced grids (bathy-BAG / GeoTIFF), highest
-   confidence.
-2. **Draft** — real-time CUBE output, valuable but potentially noisy.
+1. **Processed** — the authoritative product, highest confidence: externally
+   produced grids (bathy-BAG / GeoTIFF) **or the off-boat CUBE re-run** (the
+   full-bag offline replay via `cube_bathymetry`'s `import_bag`,
+   [cube_bathymetry#85](https://github.com/rolker/cube_bathymetry/issues/85)).
+   Mirrors the backscatter store's `Processed` (ADR-0007): off-boat re-processing
+   is authoritative regardless of source. The *live* node writes Draft, not
+   Processed.
+2. **Draft** — real-time (on-boat, live) CUBE output, valuable but potentially noisy.
 3. **Chart** — S57-derived depths (after datum correction), broad but coarse.
 
 Default query returns the highest-priority source present per cell. A separate
@@ -152,6 +157,15 @@ supersedes draft without data loss.
 [ADR-0005](0005-multi-platform-provenance-registry.md) D2/D8; see D5. The
 navigation-safety **shallowest-reliable** query deliberately ignores the
 provenance axis (ADR-0005 D5 carve-out): it selects on depth + uncertainty only.)
+
+(Amended 2026-06-28, [#241](https://github.com/rolker/unh_marine_autonomy/issues/241):
+the **Processed** layer is broadened from "externally produced grids" to "the
+authoritative product" — externally-processed grids **or the off-boat CUBE re-run**
+(`cube_bathymetry`'s `import_bag`, which now writes Processed by default,
+[cube_bathymetry#85](https://github.com/rolker/cube_bathymetry/issues/85)). This
+aligns with the backscatter store's `Processed` (ADR-0007): off-boat re-processing
+is authoritative regardless of whether it came from an external package or our own
+CUBE replay. The live node still writes Draft.)
 
 ### D4 — All depths on the WGS84 ellipsoid; datum conversion happens at import
 

--- a/marine_bathymetry_store/include/marine_bathymetry_store/bathy_cell.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/bathy_cell.hpp
@@ -46,8 +46,12 @@ namespace marine_bathymetry_store
 /// construction flag the importer opts into.
 enum class SourceLayer : uint8_t
 {
-  Processed = 0,  ///< Externally produced grids (bathy-BAG / GeoTIFF). Highest confidence.
-  Draft = 1,      ///< Real-time CUBE output. Valuable but potentially noisy.
+  Processed = 0,  ///< The authoritative product: externally-processed grids
+                  ///< (bathy-BAG / GeoTIFF) OR the off-boat CUBE re-run (the full-bag
+                  ///< replay via cube_bathymetry `import_bag`, cube_bathymetry#85).
+                  ///< Highest confidence. Mirrors the backscatter store's Processed
+                  ///< (ADR-0007). The *live* node writes Draft, not Processed.
+  Draft = 1,      ///< Real-time (on-boat, live) CUBE output. Valuable but potentially noisy.
   Chart = 2,      ///< Contour / S57-derived prior. Broad, coarse, read-only.
 };
 


### PR DESCRIPTION
## Summary

Broaden the `marine_bathymetry_store` **`SourceLayer::Processed`** semantics from
"externally produced grids (bathy-BAG / GeoTIFF)" to **"the authoritative product:
external grids OR the off-boat CUBE re-run"**, and update the doc comment + ADR-0002
(with an amendment note) to match.

## Why

[rolker/cube_bathymetry#85](https://github.com/rolker/cube_bathymetry/issues/85)
makes the offline `import_bag` write bathy tiles to the `Processed` layer by default
(the off-boat full-bag CUBE replay is authoritative; the live node writes `Draft`).
The old "externally produced grids" wording no longer matches. This mirrors the
backscatter store's `Processed` (ADR-0007): off-boat re-processing is authoritative
regardless of whether it came from an external package or our own CUBE replay.

## Changes (doc-only)

- `marine_bathymetry_store/.../bathy_cell.hpp`: `SourceLayer::Processed` doc comment.
- `docs/decisions/0002-bathymetric-data-store.md`: D3 definition + an amendment note.

Closes #241
Part of rolker/cube_bathymetry#85

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
