### PR TITLE
feat(marine_contacts): lightweight Qt-free home for the Contact builder (#243)

### DIFF
--- a/marine_contacts/CMakeLists.txt
+++ b/marine_contacts/CMakeLists.txt
@@ -1,0 +1,60 @@
+cmake_minimum_required(VERSION 3.8)
+project(marine_contacts)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(marine_interfaces REQUIRED)
+find_package(rclcpp REQUIRED)
+
+# Qt-free Contact builder + manual-curation store. Built with position-independent
+# code so this static library can be linked into SHARED consumers transitively —
+# the rqt_sonar_waterfall plugin (rqt_operator_tools#86) is a shared object that
+# links it. Without PIC the plugin link fails (R_X86_64_PC32).
+add_library(${PROJECT_NAME}
+  src/contact_store.cpp
+)
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+set_target_properties(${PROJECT_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include>"
+)
+
+# marine_interfaces is the public (header) dependency; rclcpp is used only inside
+# ContactStore::save/load for the CDR round-trip. Both are exported below: this is a
+# static library, so CMake propagates even the implementation-only link to consumers.
+ament_target_dependencies(${PROJECT_NAME} marine_interfaces rclcpp)
+
+# Headers are laid out as include/${PROJECT_NAME}/*.hpp, so install the include/ tree
+# to `include` (matching the $<INSTALL_INTERFACE:include> above).
+install(DIRECTORY include/ DESTINATION include)
+install(TARGETS ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_dependencies(marine_interfaces rclcpp)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+  find_package(ament_cmake_gtest REQUIRED)
+
+  # Box->Contact build, in-box query, CDR save/load round-trip, GeoJSON export.
+  ament_add_gtest(test_contact_store test/test_contact_store.cpp)
+  target_link_libraries(test_contact_store ${PROJECT_NAME})
+endif()
+
+ament_package()

--- a/marine_contacts/README.md
+++ b/marine_contacts/README.md
@@ -1,0 +1,39 @@
+# marine_contacts
+
+A lightweight, **Qt-free** home for building and curating
+`marine_interfaces/msg/Contact` records. Depends only on `marine_interfaces` and
+`rclcpp`, so any Contact producer can link it without pulling in a UI or
+perception toolchain.
+
+## What it provides (`marine_contacts::marine_contacts`)
+
+- **`make_box_contact(points, id, source, frame, stamp_s)`** — build a human-origin
+  (`ORIGIN_HUMAN`, `STATUS_PROPOSED`) `BOX` Contact from a map-frame footprint. The
+  pose is the points' centroid, the BOX dimensions their extent. `geo_pose` is left
+  unresolved (NaN latitude) — geodetic resolution is the caller's job.
+- **`ContactStore`** — an in-memory set of contacts with a map-frame bounding-box
+  query (`inBox`) and CDR `ContactArray` persistence (`save`/`load`), forward-
+  compatible with the standalone contact-manager store (`unh_marine_autonomy#167`).
+- **`export_contacts_geojson(contacts, path)`** — write geo-resolved contacts as an
+  RFC 7946 GeoJSON `FeatureCollection` (skips contacts with no geo reference).
+
+All of it is Qt-free and unit-tested without a display (`test_contact_store`).
+
+## Linking it
+
+```cmake
+find_package(marine_contacts REQUIRED)
+# ...
+target_link_libraries(your_target marine_contacts::marine_contacts)
+```
+
+```cpp
+#include "marine_contacts/contact_store.hpp"
+```
+
+## History
+
+Extracted from `marine_perception_tools` so consumers (the live waterfall target
+marker `rqt_operator_tools#86`, and future automated detectors) get the builder
+without the offline sidescan-tuner dependency chain. See `marine_perception_tools`
+for the original extraction (`#13`).

--- a/marine_contacts/include/marine_contacts/contact_store.hpp
+++ b/marine_contacts/include/marine_contacts/contact_store.hpp
@@ -1,0 +1,94 @@
+// Copyright 2026 Roland Arsenault
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MARINE_CONTACTS__CONTACT_STORE_HPP_
+#define MARINE_CONTACTS__CONTACT_STORE_HPP_
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "marine_interfaces/msg/contact.hpp"
+
+// Qt-free Contact builder + manual-curation store. Builds human-drawn contacts as
+// the unified marine_interfaces/msg/Contact, persists them as a CDR ContactArray
+// file, and answers a map-frame bounding-box query for the cross-pass overlay.
+// Qt-free so the box geometry + serialization round-trip are unit-tested without a
+// display. Deps are intentionally tiny (marine_interfaces + rclcpp) so any Contact
+// producer — the operator UI today, an automated detector tomorrow — can link it
+// without pulling a UI/perception toolchain. The CDR ContactArray format is
+// forward-compatible with the contact_manager standalone store
+// (unh_marine_autonomy#167).
+
+namespace marine_contacts
+{
+
+// A 2D point in the map (bizzy/map ENU) plane, metres.
+struct MapPoint
+{
+  double x = 0.0;
+  double y = 0.0;
+};
+
+// Build a human-origin BOX Contact from the map-frame footprint of a drawn box.
+// `points` are the box corners (or any point set) in map metres; the contact's
+// kinematics pose is their centroid, the BOX dimensions their extent. The contact
+// is STATUS_PROPOSED, existence_probability 1.0, frame_id `frame`. `geo_pose` is
+// left unresolved (latitude = NaN) — lat/lon resolution is a follow-up; same-datum
+// overlay uses the map-frame pose directly.
+marine_interfaces::msg::Contact make_box_contact(
+  const std::vector<MapPoint> & points, const std::string & id,
+  const std::string & source, const std::string & frame, double stamp_s);
+
+// Outcome of a GeoJSON export: whether the file wrote, and how many contacts were
+// written vs skipped (skipped = no resolved geo_pose, i.e. NaN latitude).
+struct GeoJsonExportResult
+{
+  bool ok = false;
+  std::size_t written = 0;
+  std::size_t skipped = 0;
+};
+
+// Write the contacts as an RFC 7946 GeoJSON FeatureCollection to `path`: one Point
+// feature per contact with a resolved geo_pose (finite latitude), geometry
+// [lon, lat], properties { id, width_m, height_m, stamp }. Contacts with no geo
+// reference (NaN latitude) are skipped and counted. Hand-written JSON (no new dep);
+// Qt-free so it is unit-tested without a display. Returns ok=false on a file error.
+GeoJsonExportResult export_contacts_geojson(
+  const std::vector<marine_interfaces::msg::Contact> & contacts, const std::string & path);
+
+class ContactStore
+{
+public:
+  void add(const marine_interfaces::msg::Contact & contact) {contacts_.push_back(contact);}
+  void clear() {contacts_.clear();}
+  const std::vector<marine_interfaces::msg::Contact> & contacts() const {return contacts_;}
+  std::size_t size() const {return contacts_.size();}
+
+  // Contacts whose map-frame position lies within [min_x, max_x] x [min_y, max_y].
+  std::vector<const marine_interfaces::msg::Contact *> inBox(
+    double min_x, double min_y, double max_x, double max_y) const;
+
+  // Persist / load all contacts as a CDR-serialized ContactArray. Returns false on
+  // any file or (de)serialization error.
+  bool save(const std::string & path) const;
+  bool load(const std::string & path);
+
+private:
+  std::vector<marine_interfaces::msg::Contact> contacts_;
+};
+
+}  // namespace marine_contacts
+
+#endif  // MARINE_CONTACTS__CONTACT_STORE_HPP_

--- a/marine_contacts/package.xml
+++ b/marine_contacts/package.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>marine_contacts</name>
+  <version>0.0.0</version>
+  <description>
+    Qt-free builder + manual-curation store for marine_interfaces/Contact: build a
+    BOX Contact from a map-frame footprint, query a contact set by bounding box,
+    persist as a CDR ContactArray, and export GeoJSON. Deps are intentionally tiny
+    (marine_interfaces + rclcpp) so any Contact producer — the operator UI today,
+    an automated detector tomorrow — can link it without pulling a UI/perception
+    toolchain. Extracted from marine_perception_tools (see rqt_operator_tools#86).
+  </description>
+  <maintainer email="roland@ccom.unh.edu">Roland Arsenault</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>marine_interfaces</depend>
+  <depend>rclcpp</depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/marine_contacts/src/contact_store.cpp
+++ b/marine_contacts/src/contact_store.cpp
@@ -1,0 +1,206 @@
+// Copyright 2026 Roland Arsenault
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "marine_contacts/contact_store.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <fstream>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "marine_interfaces/msg/contact_array.hpp"
+#include "rclcpp/serialization.hpp"
+#include "rclcpp/serialized_message.hpp"
+
+namespace marine_contacts
+{
+
+marine_interfaces::msg::Contact make_box_contact(
+  const std::vector<MapPoint> & points, const std::string & id,
+  const std::string & source, const std::string & frame, double stamp_s)
+{
+  marine_interfaces::msg::Contact c;
+  c.header.frame_id = frame;
+  const double t = std::max(0.0, stamp_s);   // guard negative -> nanosec wraparound
+  c.header.stamp.sec = static_cast<int32_t>(t);
+  c.header.stamp.nanosec =
+    static_cast<uint32_t>((t - static_cast<double>(c.header.stamp.sec)) * 1e9);
+  c.id = id;
+  c.source = source;
+  c.existence_probability = 1.0f;            // human-drawn
+  c.origin_kind = marine_interfaces::msg::Contact::ORIGIN_HUMAN;
+  c.status = marine_interfaces::msg::Contact::STATUS_PROPOSED;
+
+  // BOX shape + centroid pose from the drawn footprint.
+  c.shape.type = marine_interfaces::msg::Shape::BOX;
+  c.kinematics.orientation_availability =
+    marine_interfaces::msg::Kinematics::ORIENTATION_UNAVAILABLE;
+  c.kinematics.pose.pose.orientation.w = 1.0;
+
+  if (!points.empty()) {
+    double min_x = points.front().x;
+    double max_x = min_x;
+    double min_y = points.front().y;
+    double max_y = min_y;
+    for (const auto & p : points) {
+      min_x = std::min(min_x, p.x);
+      max_x = std::max(max_x, p.x);
+      min_y = std::min(min_y, p.y);
+      max_y = std::max(max_y, p.y);
+    }
+    c.kinematics.pose.pose.position.x = 0.5 * (min_x + max_x);
+    c.kinematics.pose.pose.position.y = 0.5 * (min_y + max_y);
+    c.shape.dimensions.x = max_x - min_x;
+    c.shape.dimensions.y = max_y - min_y;
+    c.shape.dimensions.z = 0.0;
+  }
+
+  // geo_pose unresolved (lat/lon resolution is a follow-up): NaN latitude marks it.
+  c.geo_pose.position.latitude = std::numeric_limits<double>::quiet_NaN();
+  return c;
+}
+
+std::vector<const marine_interfaces::msg::Contact *> ContactStore::inBox(
+  double min_x, double min_y, double max_x, double max_y) const
+{
+  std::vector<const marine_interfaces::msg::Contact *> out;
+  for (const auto & c : contacts_) {
+    const double x = c.kinematics.pose.pose.position.x;
+    const double y = c.kinematics.pose.pose.position.y;
+    if (x >= min_x && x <= max_x && y >= min_y && y <= max_y) {
+      out.push_back(&c);
+    }
+  }
+  return out;
+}
+
+bool ContactStore::save(const std::string & path) const
+{
+  marine_interfaces::msg::ContactArray arr;
+  arr.contacts = contacts_;
+  rclcpp::SerializedMessage serialized;
+  try {
+    rclcpp::Serialization<marine_interfaces::msg::ContactArray>().serialize_message(
+      &arr, &serialized);
+  } catch (const std::exception &) {
+    return false;
+  }
+  std::ofstream out(path, std::ios::binary | std::ios::trunc);
+  if (!out) {return false;}
+  const auto & rcl = serialized.get_rcl_serialized_message();
+  out.write(reinterpret_cast<const char *>(rcl.buffer),
+    static_cast<std::streamsize>(rcl.buffer_length));
+  return out.good();
+}
+
+bool ContactStore::load(const std::string & path)
+{
+  std::ifstream in(path, std::ios::binary | std::ios::ate);
+  if (!in) {return false;}
+  const std::streamsize n = in.tellg();
+  if (n < 0) {return false;}
+  in.seekg(0);
+  rclcpp::SerializedMessage serialized(static_cast<size_t>(n));
+  auto & rcl = serialized.get_rcl_serialized_message();
+  if (n > 0 && !in.read(reinterpret_cast<char *>(rcl.buffer), n)) {return false;}
+  rcl.buffer_length = static_cast<size_t>(n);
+
+  marine_interfaces::msg::ContactArray arr;
+  try {
+    rclcpp::Serialization<marine_interfaces::msg::ContactArray>().deserialize_message(
+      &serialized, &arr);
+  } catch (const std::exception &) {
+    return false;
+  }
+  contacts_ = arr.contacts;
+  return true;
+}
+
+namespace
+{
+// Escape a string for a JSON string literal (RFC 8259): quotes, backslash, controls.
+std::string json_escape(const std::string & s)
+{
+  std::string out;
+  out.reserve(s.size() + 2);
+  for (char c : s) {
+    switch (c) {
+      case '"': out += "\\\""; break;
+      case '\\': out += "\\\\"; break;
+      case '\b': out += "\\b"; break;
+      case '\f': out += "\\f"; break;
+      case '\n': out += "\\n"; break;
+      case '\r': out += "\\r"; break;
+      case '\t': out += "\\t"; break;
+      default:
+        if (static_cast<unsigned char>(c) < 0x20) {
+          char u[8];
+          std::snprintf(u, sizeof(u), "\\u%04x", static_cast<unsigned char>(c));
+          out += u;
+        } else {
+          out += c;
+        }
+    }
+  }
+  return out;
+}
+}  // namespace
+
+GeoJsonExportResult export_contacts_geojson(
+  const std::vector<marine_interfaces::msg::Contact> & contacts, const std::string & path)
+{
+  GeoJsonExportResult result;
+  std::ofstream f(path);
+  if (!f) {return result;}   // ok stays false
+
+  f << "{\n  \"type\": \"FeatureCollection\",\n  \"features\": [";
+  bool first = true;
+  for (const auto & c : contacts) {
+    const double lat = c.geo_pose.position.latitude;
+    const double lon = c.geo_pose.position.longitude;
+    if (!std::isfinite(lat) || !std::isfinite(lon)) {
+      ++result.skipped;   // no resolved geo reference -> not exportable as a point
+      continue;
+    }
+    // Sanitize non-finite numeric properties to 0 — `export` takes arbitrary
+    // Contacts (e.g. loaded from a .cdr), and a bare nan/inf token is invalid JSON.
+    // Buffers are sized for the worst-case finite double (%f ~ 320 chars) so a
+    // mis-resolved huge value can't truncate mid-number into malformed JSON.
+    const auto fin = [](double v) {return std::isfinite(v) ? v : 0.0;};
+    const double stamp = fin(
+      static_cast<double>(c.header.stamp.sec) +
+      static_cast<double>(c.header.stamp.nanosec) * 1e-9);
+    char coords[768];
+    std::snprintf(coords, sizeof(coords), "[%.8f, %.8f]", lon, lat);
+    char props[1024];
+    std::snprintf(
+      props, sizeof(props), "\"width_m\": %.3f, \"height_m\": %.3f, \"stamp\": %.3f",
+      fin(c.shape.dimensions.x), fin(c.shape.dimensions.y), stamp);
+    f << (first ? "" : ",")
+      << "\n    {\"type\": \"Feature\", \"geometry\": {\"type\": \"Point\", "
+      << "\"coordinates\": " << coords << "}, \"properties\": {\"id\": \""
+      << json_escape(c.id) << "\", " << props << "}}";
+    first = false;
+    ++result.written;
+  }
+  f << "\n  ]\n}\n";
+  result.ok = f.good();
+  return result;
+}
+
+}  // namespace marine_contacts

--- a/marine_contacts/test/test_contact_store.cpp
+++ b/marine_contacts/test/test_contact_store.cpp
@@ -1,0 +1,152 @@
+// Copyright 2026 Roland Arsenault
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <fstream>
+#include <limits>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "marine_contacts/contact_store.hpp"
+#include "marine_interfaces/msg/contact.hpp"
+
+using marine_contacts::ContactStore;
+using marine_contacts::MapPoint;
+using marine_contacts::make_box_contact;
+using marine_contacts::export_contacts_geojson;
+using Contact = marine_interfaces::msg::Contact;
+
+TEST(ContactStore, BoxContactCentroidAndExtent)
+{
+  const std::vector<MapPoint> box{{10.0, 20.0}, {14.0, 26.0}};
+  const Contact c = make_box_contact(box, "T-001", "sidescan.port", "bizzy/map", 1234.5);
+  EXPECT_EQ(c.header.frame_id, "bizzy/map");
+  EXPECT_EQ(c.id, "T-001");
+  EXPECT_EQ(c.source, "sidescan.port");
+  EXPECT_FLOAT_EQ(c.existence_probability, 1.0f);
+  EXPECT_EQ(c.origin_kind, Contact::ORIGIN_HUMAN);
+  EXPECT_EQ(c.status, Contact::STATUS_PROPOSED);
+  EXPECT_EQ(c.shape.type, marine_interfaces::msg::Shape::BOX);
+  EXPECT_NEAR(c.kinematics.pose.pose.position.x, 12.0, 1e-9);  // centroid
+  EXPECT_NEAR(c.kinematics.pose.pose.position.y, 23.0, 1e-9);
+  EXPECT_NEAR(c.shape.dimensions.x, 4.0, 1e-9);                // extent
+  EXPECT_NEAR(c.shape.dimensions.y, 6.0, 1e-9);
+  EXPECT_TRUE(std::isnan(c.geo_pose.position.latitude));       // unresolved
+  EXPECT_EQ(c.header.stamp.sec, 1234);
+}
+
+TEST(ContactStore, InBoxQuery)
+{
+  ContactStore s;
+  s.add(make_box_contact({{0.0, 0.0}}, "a", "src", "bizzy/map", 0.0));
+  s.add(make_box_contact({{100.0, 100.0}}, "b", "src", "bizzy/map", 0.0));
+  EXPECT_EQ(s.size(), 2u);
+  const auto hits = s.inBox(-5.0, -5.0, 5.0, 5.0);
+  ASSERT_EQ(hits.size(), 1u);
+  EXPECT_EQ(hits.front()->id, "a");
+}
+
+TEST(ContactStore, SaveLoadRoundTrip)
+{
+  ContactStore s;
+  s.add(make_box_contact({{10.0, 20.0}, {14.0, 26.0}}, "T-001", "sidescan.port",
+    "bizzy/map", 1234.5));
+  s.add(make_box_contact({{-3.0, 7.0}}, "T-002", "sidescan.starboard", "bizzy/map", 9.0));
+
+  const std::string path = std::string(testing::TempDir()) + "mc_contacts_test.cdr";
+  ASSERT_TRUE(s.save(path));
+
+  ContactStore loaded;
+  ASSERT_TRUE(loaded.load(path));
+  ASSERT_EQ(loaded.size(), 2u);
+  EXPECT_EQ(loaded.contacts()[0].id, "T-001");
+  EXPECT_NEAR(loaded.contacts()[0].kinematics.pose.pose.position.x, 12.0, 1e-9);
+  EXPECT_NEAR(loaded.contacts()[0].shape.dimensions.y, 6.0, 1e-9);
+  EXPECT_EQ(loaded.contacts()[1].id, "T-002");
+  EXPECT_EQ(loaded.contacts()[1].source, "sidescan.starboard");
+}
+
+TEST(ContactStore, LoadMissingFileFails)
+{
+  ContactStore s;
+  EXPECT_FALSE(s.load(std::string(testing::TempDir()) + "does_not_exist_mc.cdr"));
+}
+
+TEST(ContactStore, GeoJsonExportWritesResolvedSkipsUnreferenced)
+{
+  // One geo-resolved contact + one with no geo reference (NaN latitude by default).
+  Contact resolved = make_box_contact(
+    {{10.0, 20.0}, {14.0, 26.0}}, "T-001", "sidescan", "bizzy/map", 1234.5);
+  resolved.geo_pose.position.latitude = 43.05;
+  resolved.geo_pose.position.longitude = -71.40;
+  resolved.geo_pose.position.altitude = 52.3;
+
+  std::vector<Contact> contacts{
+    resolved,
+    make_box_contact({{-3.0, 7.0}}, "T-002", "sidescan", "bizzy/map", 9.0)};
+
+  const std::string path = std::string(testing::TempDir()) + "mc_contacts_test.geojson";
+  const auto r = export_contacts_geojson(contacts, path);
+  EXPECT_TRUE(r.ok);
+  EXPECT_EQ(r.written, 1u);   // only the geo-resolved one
+  EXPECT_EQ(r.skipped, 1u);   // the NaN-latitude one
+
+  std::ifstream f(path);
+  ASSERT_TRUE(f.good());
+  std::stringstream ss;
+  ss << f.rdbuf();
+  const std::string text = ss.str();
+  EXPECT_NE(text.find("\"FeatureCollection\""), std::string::npos);
+  EXPECT_NE(text.find("\"id\": \"T-001\""), std::string::npos);
+  EXPECT_EQ(text.find("T-002"), std::string::npos);   // skipped, not present
+  EXPECT_NE(text.find("-71.40"), std::string::npos);  // lon first (GeoJSON order)
+  EXPECT_NE(text.find("43.05"), std::string::npos);
+}
+
+TEST(ContactStore, GeoJsonExportSanitizesNonFiniteProperties)
+{
+  // A geo-resolved contact with a non-finite dimension (e.g. from a corrupt load)
+  // must still produce valid JSON — no bare nan/inf token.
+  Contact c = make_box_contact({{0.0, 0.0}}, "T-001", "sidescan", "bizzy/map", 1.0);
+  c.geo_pose.position.latitude = 43.0;
+  c.geo_pose.position.longitude = -71.0;
+  c.shape.dimensions.x = std::numeric_limits<double>::quiet_NaN();
+  c.shape.dimensions.y = std::numeric_limits<double>::infinity();
+
+  const std::string path = std::string(testing::TempDir()) + "mc_contacts_nonfinite.geojson";
+  const auto r = export_contacts_geojson({c}, path);
+  EXPECT_TRUE(r.ok);
+  EXPECT_EQ(r.written, 1u);
+
+  std::ifstream f(path);
+  std::stringstream ss;
+  ss << f.rdbuf();
+  const std::string text = ss.str();
+  EXPECT_EQ(text.find("nan"), std::string::npos);
+  EXPECT_EQ(text.find("inf"), std::string::npos);
+}
+
+TEST(ContactStore, GeoJsonExportEmptyOnNoGeo)
+{
+  std::vector<Contact> contacts{
+    make_box_contact({{0.0, 0.0}}, "T-001", "sidescan", "bizzy/map", 1.0)};
+  const std::string path = std::string(testing::TempDir()) + "mc_contacts_nogeo.geojson";
+  const auto r = export_contacts_geojson(contacts, path);
+  EXPECT_TRUE(r.ok);          // valid (empty) FeatureCollection still written
+  EXPECT_EQ(r.written, 0u);
+  EXPECT_EQ(r.skipped, 1u);
+}


### PR DESCRIPTION
## Summary

Adds **`marine_contacts`**, a lightweight Qt-free package next to `marine_interfaces`
that holds the Contact builder + manual-curation store, moved out of
`marine_perception_tools`.

**Why:** the builder's real deps are tiny (`marine_interfaces` + `rclcpp`), but it
lived inside `marine_perception_tools`, whose package pulls the whole offline
sidescan-tuner chain (`sea_surface_segmentation` → depthai, nav2, grid_map, ...).
CMake can only `find_package` a package whole, so every consumer inherited that
chain. This broke the live waterfall target marker's per-repo CI
(https://github.com/rolker/rqt_operator_tools/pull/89). Giving the builder a
lightweight home fixes that for the operator UI today and for any future automated
Contact producer.

## What's here

- `make_box_contact()` — map-frame footprint → human-origin (`ORIGIN_HUMAN`,
  `STATUS_PROPOSED`) `BOX` Contact (centroid pose, extent dimensions, NaN geo_pose).
- `ContactStore` — in-memory set + map-frame bounding-box query + CDR `ContactArray`
  `save`/`load`.
- `export_contacts_geojson()` — RFC 7946 `FeatureCollection` of geo-resolved
  contacts (skips ungeoreferenced ones).

Namespace renamed `marine_perception_tools` → `marine_contacts`; header at
`include/marine_contacts/contact_store.hpp`; exported as
`marine_contacts::marine_contacts` (idiom mirrors `marine_tiled_raster_store`).
Tests ported verbatim — **7 unit tests green**, uncrustify/cpplint/xmllint clean.

## Stacked follow-ups (land after this merges)

1. `rolker/marine_perception_tools` — drop the moved files + `contact_builder`
   target, `<depend>marine_contacts</depend>`, relink the viewer + test (supersedes
   the export added by `rolker/marine_perception_tools#13`).
2. `rolker/rqt_operator_tools#86` — switch `find_package`/link/`#include` to
   `marine_contacts`; its CI then builds only `marine_interfaces` + `marine_contacts`
   (light), no heavy chain.

Closes #243

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8`
