### PR TITLE
feat(gggs): add parent()/children() quadtree index-math helpers

### DIFF
--- a/.agent/work-plans/issue-249/progress.md
+++ b/.agent/work-plans/issue-249/progress.md
@@ -1,0 +1,27 @@
+---
+issue: 249
+---
+
+# Issue #249 — feat(gggs): add parent()/children() quadtree index-math helpers
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-01 02:12 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-249 at `e93eaa0`
+**Mode**: pre-push
+**Depth**: Deep (reason: 222 lines added ≥ 200-line threshold)
+**Must-fix**: 0 | **Suggestions**: 2
+**Round**: 1 | **Ship**: recommended — no must-fix; math verified sound (compiled+ran probe against real headers), only two low-severity test/doc suggestions
+
+### Findings
+- [ ] (suggestion) Polar "band" round-trip tests (75°/85°) exercise column-scaling only, not the ±90° latitude-clamp path; add a northernmost/southernmost-row test asserting child count + coverage — `test/test_gggs.cpp:1287`
+- [ ] (suggestion) `children(parent(g)) ⊇ {g}` technically fails for degenerate ≥90° phantom grids, but those are unreachable via `Level::gridIndex` (verified) so not an operational bug; add a one-line doc note on exact-pole grid degeneracy — `include/marine_autonomy/gggs/index_math.h:47`
+
+### Notes
+- Static analysis: `cppcheck` clean; `ament_cpplint` header_guard/include_subdir hits on `index_math.h` dropped — `CMakeLists.txt:66` excludes `ament_cmake_cpplint`, and the new file matches the package-wide `PROJECT11_GGGS_*` convention of all sibling headers.
+- Adversarial: Lens A (logic) + Lens B (systemic) fresh-context passes. Lens B found no exception-safety / concurrency / ODR issues. Lens A's polar "must-fix" was empirically refuted (probe: `Level(1).gridIndex` max row = 46, phantom row 47 unreachable; polar children fully tile parent's reachable extent and round-trip).
+- Governance: Standards Compliance, Modularity, Iterative-Validated-Evolution all Pass. New header ships via existing `install(DIRECTORY include/)`; tests auto-register via existing `ament_add_gtest(test_gggs ...)`. No ADR or consequence-map triggers.
+- No work plan at `.agent/work-plans/issue-249/plan.md` — Plan Drift skipped.

--- a/marine_autonomy/include/marine_autonomy/gggs.h
+++ b/marine_autonomy/include/marine_autonomy/gggs.h
@@ -65,5 +65,6 @@
 #include "gggs/level.h"
 #include "gggs/grid_area_iterator.h"
 #include "gggs/cell_area_iterator.h"
+#include "gggs/index_math.h"
 
 #endif

--- a/marine_autonomy/include/marine_autonomy/gggs/index_math.h
+++ b/marine_autonomy/include/marine_autonomy/gggs/index_math.h
@@ -1,0 +1,101 @@
+// Copyright 2026 Roland Arsenault
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Roland Arsenault nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef PROJECT11_GGGS_INDEX_MATH_H
+#define PROJECT11_GGGS_INDEX_MATH_H
+
+#include <cstddef>
+#include <vector>
+
+#include "grid_index.h"
+#include "level.h"
+#include "grid_area_iterator.h"
+
+namespace gggs
+{
+
+/// @brief The coarser-level grid (at `level - 1`) that contains @p child.
+///
+/// GGGS is a quadtree: each grid at level `L` lies within exactly one grid at
+/// level `L-1`. This resolves that parent by looking up the child cell's centre
+/// at the coarser level. Going through `Level::gridIndex` (rather than halving
+/// row/column directly) keeps the polar `latitudeScaleFactor` (1/3/9) column
+/// scaling correct across the latitude-band boundaries.
+///
+/// @param child A valid grid at level >= 1.
+/// @return The containing grid at `child.level() - 1`, or an invalid GridIndex
+///         when @p child is invalid or already at level 0 (the coarsest level,
+///         which has no parent).
+inline GridIndex parent(const GridIndex& child)
+{
+  if (!child.valid() || child.level() == 0)
+    return GridIndex();
+
+  const double center_latitude = 0.5 * (child.southLatitude() + child.northLatitude());
+  const double center_longitude = 0.5 * (child.westLongitude() + child.eastLongitude());
+  return Level(child.level() - 1).gridIndex(center_latitude, center_longitude);
+}
+
+/// @brief The finer-level grids (at `level + 1`) that tile @p parent_grid.
+///
+/// The inverse of parent(): every returned child satisfies `parent(c) ==
+/// parent_grid`. In temperate latitude bands this is the expected 2x2 = 4
+/// children; where the polar `latitudeScaleFactor` changes the column count
+/// between bands, the count differs accordingly. GridAreaIterator computes the
+/// per-row column range from longitudes, so the polar case is handled without
+/// manual column arithmetic.
+///
+/// @param parent_grid A valid grid coarser than the finest level.
+/// @return The child grids at `parent_grid.level() + 1`, or an empty vector when
+///         @p parent_grid is invalid or already at the finest level.
+inline std::vector<GridIndex> children(const GridIndex& parent_grid)
+{
+  std::vector<GridIndex> result;
+  if (!parent_grid.valid() ||
+      static_cast<std::size_t>(parent_grid.level()) + 1 >= levels.size())
+    return result;
+
+  const Level child_level(parent_grid.level() + 1);
+
+  // Sample just inside each corner so the lookup lands within the parent's
+  // half-open extent rather than on a neighbouring grid across a shared edge.
+  // The inset is far smaller than a child cell span at every level.
+  constexpr double kCornerInset = 1e-9;
+  const GridIndex south_west = child_level.gridIndex(
+    parent_grid.southLatitude() + kCornerInset, parent_grid.westLongitude() + kCornerInset);
+  const GridIndex north_east = child_level.gridIndex(
+    parent_grid.northLatitude() - kCornerInset, parent_grid.eastLongitude() - kCornerInset);
+
+  for (GridAreaIterator it(south_west, north_east); it.valid(); it.next())
+    result.push_back(*it);
+  return result;
+}
+
+}  // namespace gggs
+
+#endif

--- a/marine_autonomy/include/marine_autonomy/gggs/index_math.h
+++ b/marine_autonomy/include/marine_autonomy/gggs/index_math.h
@@ -51,6 +51,11 @@ namespace gggs
 /// @return The containing grid at `child.level() - 1`, or an invalid GridIndex
 ///         when @p child is invalid or already at level 0 (the coarsest level,
 ///         which has no parent).
+/// @note Grids sitting exactly on a pole (+/-90 deg) are geometrically
+///       degenerate and are never produced by `Level::gridIndex`, so they lie
+///       outside the supported input domain. For every grid reachable through
+///       the normal geographic lookups the `children(parent(g))` set contains
+///       `g` (the round-trip invariant the tests check).
 inline GridIndex parent(const GridIndex& child)
 {
   if (!child.valid() || child.level() == 0)

--- a/marine_autonomy/test/test_gggs.cpp
+++ b/marine_autonomy/test/test_gggs.cpp
@@ -1189,3 +1189,123 @@ TEST(GGGSGridBounds, PerRowColumnCount)
       << "Column count should be uniform in same band at row " << r;
   }
 }
+
+// ============================================================================
+// index_math.h — parent() / children() quadtree navigation
+// ============================================================================
+
+TEST(GGGSIndexMath, ParentIsOneLevelCoarser)
+{
+  gggs::Level level(10);
+  auto child = level.gridIndex(43.0, -70.5);  // New Hampshire coast
+  auto parent = gggs::parent(child);
+  ASSERT_TRUE(parent.valid());
+  EXPECT_EQ(parent.level(), 9);
+}
+
+TEST(GGGSIndexMath, ParentContainsChildCentre)
+{
+  gggs::Level level(10);
+  auto child = level.gridIndex(43.0, -70.5);
+  auto parent = gggs::parent(child);
+  ASSERT_TRUE(parent.valid());
+
+  const double child_center_lat = 0.5 * (child.southLatitude() + child.northLatitude());
+  const double child_center_lon = 0.5 * (child.westLongitude() + child.eastLongitude());
+  EXPECT_LE(parent.southLatitude(), child_center_lat);
+  EXPECT_GE(parent.northLatitude(), child_center_lat);
+  EXPECT_LE(parent.westLongitude(), child_center_lon);
+  EXPECT_GE(parent.eastLongitude(), child_center_lon);
+}
+
+TEST(GGGSIndexMath, ParentAtLevelZeroIsInvalid)
+{
+  gggs::Level level(0);
+  auto grid = level.gridIndex(43.0, -70.5);
+  ASSERT_EQ(grid.level(), 0);
+  EXPECT_FALSE(gggs::parent(grid).valid());
+}
+
+TEST(GGGSIndexMath, ParentOfInvalidIsInvalid)
+{
+  gggs::GridIndex invalid;
+  ASSERT_FALSE(invalid.valid());
+  EXPECT_FALSE(gggs::parent(invalid).valid());
+}
+
+TEST(GGGSIndexMath, ChildrenTemperateBandAreFour)
+{
+  gggs::Level level(9);
+  auto parent = level.gridIndex(43.0, -70.5);
+  auto kids = gggs::children(parent);
+  EXPECT_EQ(kids.size(), 4u);
+}
+
+TEST(GGGSIndexMath, ChildrenAllMapBackToParent)
+{
+  gggs::Level level(9);
+  auto parent = level.gridIndex(43.0, -70.5);
+  auto kids = gggs::children(parent);
+  ASSERT_FALSE(kids.empty());
+  for (const auto& kid : kids)
+  {
+    EXPECT_EQ(kid.level(), parent.level() + 1);
+    EXPECT_EQ(gggs::parent(kid), parent);
+  }
+}
+
+TEST(GGGSIndexMath, SiblingsShareTheSameParent)
+{
+  gggs::Level level(10);
+  auto child = level.gridIndex(43.0, -70.5);
+  auto parent = gggs::parent(child);
+  ASSERT_TRUE(parent.valid());
+  auto siblings = gggs::children(parent);
+  ASSERT_GE(siblings.size(), 2u);
+  // The original child is among the siblings, and every sibling shares the parent.
+  bool found_child = false;
+  for (const auto& sibling : siblings)
+  {
+    EXPECT_EQ(gggs::parent(sibling), parent);
+    if (sibling == child)
+      found_child = true;
+  }
+  EXPECT_TRUE(found_child);
+}
+
+TEST(GGGSIndexMath, ChildrenAtFinestLevelIsEmpty)
+{
+  gggs::Level level(20);  // finest level — no children
+  auto grid = level.gridIndex(43.0, -70.5);
+  ASSERT_EQ(grid.level(), 20);
+  EXPECT_TRUE(gggs::children(grid).empty());
+}
+
+TEST(GGGSIndexMath, ChildrenOfInvalidIsEmpty)
+{
+  gggs::GridIndex invalid;
+  ASSERT_FALSE(invalid.valid());
+  EXPECT_TRUE(gggs::children(invalid).empty());
+}
+
+TEST(GGGSIndexMath, ParentChildrenRoundTripSubPolarBand)
+{
+  // ~75 deg latitude — a higher polar column scale-factor band.
+  gggs::Level level(9);
+  auto parent = level.gridIndex(75.0, 10.0);
+  auto kids = gggs::children(parent);
+  ASSERT_FALSE(kids.empty());
+  for (const auto& kid : kids)
+    EXPECT_EQ(gggs::parent(kid), parent);
+}
+
+TEST(GGGSIndexMath, ParentChildrenRoundTripPolarBand)
+{
+  // ~85 deg latitude — the highest polar column scale-factor band.
+  gggs::Level level(9);
+  auto parent = level.gridIndex(85.0, 10.0);
+  auto kids = gggs::children(parent);
+  ASSERT_FALSE(kids.empty());
+  for (const auto& kid : kids)
+    EXPECT_EQ(gggs::parent(kid), parent);
+}

--- a/marine_autonomy/test/test_gggs.cpp
+++ b/marine_autonomy/test/test_gggs.cpp
@@ -1309,3 +1309,33 @@ TEST(GGGSIndexMath, ParentChildrenRoundTripPolarBand)
   for (const auto& kid : kids)
     EXPECT_EQ(gggs::parent(kid), parent);
 }
+
+TEST(GGGSIndexMath, ChildrenNearNorthPole)
+{
+  // Northernmost row: northLatitude() clamps to +90, so this exercises the
+  // latitude-clamp path (distinct from mid-band column scaling). Children must
+  // still tile the parent and every child must map back.
+  gggs::Level level(9);
+  auto parent = level.gridIndex(89.9, 10.0);
+  auto kids = gggs::children(parent);
+  ASSERT_FALSE(kids.empty());
+  for (const auto& kid : kids)
+  {
+    EXPECT_EQ(kid.level(), parent.level() + 1);
+    EXPECT_EQ(gggs::parent(kid), parent);
+  }
+}
+
+TEST(GGGSIndexMath, ChildrenNearSouthPole)
+{
+  // Southernmost row: southLatitude() clamps to -90 — the mirror clamp path.
+  gggs::Level level(9);
+  auto parent = level.gridIndex(-89.9, 10.0);
+  auto kids = gggs::children(parent);
+  ASSERT_FALSE(kids.empty());
+  for (const auto& kid : kids)
+  {
+    EXPECT_EQ(kid.level(), parent.level() + 1);
+    EXPECT_EQ(gggs::parent(kid), parent);
+  }
+}


### PR DESCRIPTION
## Summary

Adds two GGGS quadtree index-math helpers so callers can navigate the level hierarchy
directly:

- `gggs::parent(const GridIndex& child)` — the coarser-level (`level-1`) grid containing a
  grid. Resolves it via the child cell centre and `Level::gridIndex`, so the polar
  `latitudeScaleFactor` (1/3/9) column scaling is handled without manual column arithmetic.
  Returns an invalid `GridIndex` for a level-0 or invalid input.
- `gggs::children(const GridIndex& parent)` — the finer-level (`level+1`) grids that tile a
  grid. Reuses `GridAreaIterator` (already polar-correct) over the parent's extent. Returns
  empty at the finest level or for an invalid input.

Header-only, purely additive — no existing API touched. Wired into the `gggs.h` umbrella so
callers get both with the existing single include.

## Motivation

Part of **rolker/camp#160** (consumer-side live-coverage overview pyramid + bounded
eviction): camp folds an evicted fine tile into its coarse parent before dropping it, which
needs `parent(GridIndex)`. Placing the primitive in GGGS keeps it reusable — the boat can
use the same helper for a future producer-side overview product. `children()` is not
consumed by camp yet but is added for completeness and that future reuse (operator-sanctioned
at the camp#160 plan checkpoint).

## Tests

13 `GGGSIndexMath` tests added to the existing `test_gggs` binary (no new target — matches
the repo's single consolidated GGGS test file):

- `parent()` is one level coarser and geographically contains the child centre.
- `parent()` at level 0 / of an invalid grid returns invalid.
- `children()` in a temperate band is exactly 4; every child maps back via `parent()`.
- Siblings share the same parent (and the original child is among `children(parent(child))`).
- `children()` at the finest level / of an invalid grid is empty.
- Sub-polar (75 deg) and polar (85 deg) column-scale bands round-trip.
- Near-north-pole (89.9 deg) and near-south-pole (-89.9 deg) exercise the +/-90 deg
  latitude-clamp path.

`colcon test marine_autonomy`: 147 tests, 0 failures (13 new + prior suite green).

## Review

Pre-push `/review-code` returned 2 suggestions, both applied: the near-pole clamp-path
tests and a doc note that exact-pole (+/-90 deg) grids are degenerate and never produced by
`Level::gridIndex` (outside the supported input domain).

Closes #249

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
