### PR TITLE
Simplify bathy + backscatter store formats: reference/survey layers, sufficient-statistic backscatter, drop source/time (#248)

### DIFF
--- a/.agent/work-plans/issue-248/plan.md
+++ b/.agent/work-plans/issue-248/plan.md
@@ -1,0 +1,167 @@
+# Plan: Greenfield store-format simplification (bathy + MBES backscatter)
+
+## Issue
+
+https://github.com/rolker/unh_marine_autonomy/issues/248
+
+## Context
+
+Both stores carry per-cell `time` and `source` rasters that are redundant once the
+stores are treated as regenerable caches over raw bags. Three bathy source layers
+(`chart`/`draft`/`processed`) collapse to two (`pre-existing` / `cube`), and two
+MBES layers (`draft`/`processed`) collapse to one (`cube`). The MBES value-band
+schema changes from `{intensity, intensity_variance}` (2-band) to
+`{mean, standard_error, sample_sd}` (3-band), encoding the Welford sufficient stats
+for lossless reload. The `registry.json` sidecar is repurposed from a per-cell
+source-index interning table to store-level coarse metadata (survey, sensor, date).
+No migration — stores are re-derivable from bags; start from scratch.
+
+Operator decisions (issue Resolutions, 2026-06-30):
+1. ADR scope widened: amend ADR-0002, ADR-0005, and ADR-0007 (not just ADR-0002).
+2. Synchronized landing with cube_bathymetry#96 — that PR must be held until #248
+   is ready; both merge together to avoid a broken build window.
+3. `registry.json` repurposed as coarse metadata (not removed).
+
+## Approach
+
+1. **Write ADR addenda (all three)** — document decisions before touching code.
+   - ADR-0002 addendum: layer taxonomy (chart/draft/processed → pre-existing/cube),
+     tile layout (drop `_time.tif`/`_source.tif`; single 2-band value tile only).
+   - ADR-0005 addendum: per-cell source-index raster dropped; `registry.json`
+     repurposed as store/layer-level coarse metadata (survey, sensor, date).
+   - ADR-0007 addendum: value-band schema (`{intensity, intensity_variance}` →
+     `{mean, standard_error, sample_sd}`) + layer collapse (draft/processed → cube).
+
+2. **Refactor `marine_bathymetry_store`:**
+   a. `bathy_cell.hpp` — replace `SourceLayer{Processed=0, Draft=1, Chart=2}`
+      with `SourceLayer{Cube=0, PreExisting=1}` (`Cube` highest priority); update
+      `source_layers_by_priority`; strip `timestamp` and `source_index` from `BathyCell`.
+   b. `bathymetry_tile.hpp` — remove `TimeRaster`/`SourceRaster` members and
+      all `_time`/`_source` band accessors; constructor becomes single-arg
+      (`gggs::GridIndex`); `set`/`get` operate on `{depth, uncertainty}` only.
+   c. `bathymetry_store.hpp/.cpp` — rename `chart_writable_` →
+      `pre_existing_writable_`; layer count 3→2; update `Chart`→`PreExisting` guards.
+   d. `tile_io.hpp/.cpp` — `layerDirName` returns `"cube"`/`"pre-existing"` (drop
+      `"draft"`/`"processed"`/`"chart"`); `saveTile`/`loadTile` write/read only the
+      2-band value GeoTIFF (no `_time.tif` or `_source.tif` companions); update
+      `save`/`load`/`loadWindow` accordingly.
+   e. `registry.hpp/.cpp` — replace per-index `SourceRecord` intern table with a
+      flat `StoreMetadata` struct (`{platform, sensor, survey, date}`) persisted to
+      `registry.json`; simpler load/save with no `by_index_`/`by_source_id_` maps.
+   f. `query.hpp/.cpp` — drop `timestamp` and `source_index` from `DepthSample`;
+      update `bestSource`/`forEachCellBestSource` accordingly.
+   g. `geotiff_import.hpp/.cpp` — remove `SourceRecord`/`SourceRegistry` parameter
+      from `GeoTiffImportOptions`; stamp no source index (coarse metadata is
+      store-level, not per-import-call); keep remaining import logic intact.
+   h. `test/test_tile_io.cpp` — update for 2-layer taxonomy and value-only tile;
+      add round-trip test for bathy: write `{depth, uncertainty}`, reload, confirm
+      `uncertainty` round-trips losslessly (no confidence-scale needed for bathy
+      since it's already stored as-is).
+   i. `test/test_store.cpp`, `test/test_query.cpp`, `test/test_geotiff_import.cpp`
+      — purge `timestamp`/`source_index` references; update layer names.
+   j. `README.md` — update store format section (layer dirs, tile files, registry schema).
+
+3. **Refactor `marine_mbes_backscatter_store`:**
+   a. `mbes_cell.hpp` — replace `SourceLayer{Processed=0, Draft=1}` with
+      `SourceLayer{Cube=0}`; update `source_layers_by_priority` to a 1-element array;
+      rename `MbesCell` fields: `intensity`→`mean`, `intensity_variance`→`standard_error`;
+      add `sample_sd`; drop `timestamp` and `source_index`.
+   b. `mbes_tile.hpp` — remove `TimeRaster`/`SourceRaster`; value raster becomes
+      3-band `{mean, standard_error, sample_sd}` (all `float`); band constants
+      `kMean=0`, `kStandardError=1`, `kSampleSd=2`.
+   c. `mbes_store.hpp/.cpp` — layer count 2→1; remove `set(Draft/Processed, ...)` distinction;
+      single `set(SourceLayer::Cube, ...)`.
+   d. `tile_io.hpp/.cpp` — `layerDirName` returns `"cube"` only; `saveTile`/`loadTile`
+      write/read 3-band `Float32` value tile only; update `save`/`load`.
+   e. `registry.hpp/.cpp` — same repurpose as bathy: `StoreMetadata` struct,
+      flat `registry.json` with `{platform, sensor, survey, date}`; the `calibration_ref`
+      field survives as a coarse store-level field (not per-cell).
+   f. `query.hpp/.cpp` — rename `IntensitySample{intensity, intensity_variance,
+      timestamp, source}` → `BackscatterSample{mean, standard_error, sample_sd, source}`;
+      `bestSource` and `forEachCellBestSource` walk the single `Cube` layer.
+   g. `test/test_tile_io.cpp` — add Welford round-trip tests:
+      - n≥2 case: set `(mean, SE*scale, SD)`, reload, reconstruct
+        `n = (SD / (SE*scale/scale))^2 = (SD/SE)^2` and `M2 = SD^2*(n-1)`, verify exact.
+      - n=1 sentinel: set `(mean_value, 0.0f, 0.0f)` (SD==0, finite mean), reload,
+        verify n=1 and M2=0 detected; distinguish from no-data (NaN mean).
+      - Confidence scale divide-out: write SE as `scale * SE_actual`, reload and
+        divide by scale, verify `(SD / SE_actual)^2` is integer.
+   h. `test/test_store.cpp`, `test/test_query.cpp` — update for single layer,
+      new field names.
+   i. `README.md` — update format section (single layer, 3-band tile, registry schema).
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `docs/decisions/0002-bathymetric-data-store.md` | Addendum: layer taxonomy + tile layout simplification |
+| `docs/decisions/0005-multi-platform-provenance-registry.md` | Addendum: per-cell source-index dropped; registry.json = coarse metadata |
+| `docs/decisions/0007-mbes-backscatter-store.md` | Addendum: value-band schema + layer collapse |
+| `marine_bathymetry_store/include/marine_bathymetry_store/bathy_cell.hpp` | SourceLayer enum (Cube/PreExisting), BathyCell (drop timestamp/source_index) |
+| `marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_tile.hpp` | Drop time/source rasters; value-only tile |
+| `marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_store.hpp` | Rename chart_writable_, layer count 3→2 |
+| `marine_bathymetry_store/src/bathymetry_store.cpp` | Chart→PreExisting guards |
+| `marine_bathymetry_store/include/marine_bathymetry_store/tile_io.hpp` | layerDirName, value-only I/O |
+| `marine_bathymetry_store/src/tile_io.cpp` | Implement simplified I/O |
+| `marine_bathymetry_store/include/marine_bathymetry_store/registry.hpp` | Repurpose as StoreMetadata |
+| `marine_bathymetry_store/src/registry.cpp` | Flat JSON schema |
+| `marine_bathymetry_store/include/marine_bathymetry_store/query.hpp` | DepthSample (drop timestamp/source_index) |
+| `marine_bathymetry_store/src/query.cpp` | Update query logic |
+| `marine_bathymetry_store/include/marine_bathymetry_store/geotiff_import.hpp` | Remove SourceRecord param |
+| `marine_bathymetry_store/src/geotiff_import.cpp` | Remove per-cell source stamping |
+| `marine_bathymetry_store/test/test_tile_io.cpp` | New layer names, bathy round-trip test |
+| `marine_bathymetry_store/test/test_store.cpp` | Layer name/field updates |
+| `marine_bathymetry_store/test/test_query.cpp` | DepthSample field updates |
+| `marine_bathymetry_store/test/test_geotiff_import.cpp` | Remove SourceRecord usage |
+| `marine_bathymetry_store/README.md` | Format section update |
+| `marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/mbes_cell.hpp` | SourceLayer (Cube only), MbesCell (mean/SE/SD, drop ts/src) |
+| `marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/mbes_tile.hpp` | 3-band value raster only |
+| `marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/mbes_store.hpp` | Single layer |
+| `marine_mbes_backscatter_store/src/mbes_store.cpp` | Single layer |
+| `marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/tile_io.hpp` | 3-band value-only I/O |
+| `marine_mbes_backscatter_store/src/tile_io.cpp` | Implement 3-band I/O |
+| `marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/registry.hpp` | Repurpose as StoreMetadata |
+| `marine_mbes_backscatter_store/src/registry.cpp` | Flat JSON schema (+ calibration_ref) |
+| `marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/query.hpp` | BackscatterSample (mean/SE/SD/source) |
+| `marine_mbes_backscatter_store/src/query.cpp` | Single-layer bestSource |
+| `marine_mbes_backscatter_store/test/test_tile_io.cpp` | Welford round-trip tests (n≥2, n=1 sentinel, scale divide-out) |
+| `marine_mbes_backscatter_store/test/test_store.cpp` | Single layer, new field names |
+| `marine_mbes_backscatter_store/test/test_query.cpp` | BackscatterSample fields |
+| `marine_mbes_backscatter_store/README.md` | Format section update |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Capture decisions, not just implementations | ADR addenda for all three affected ADRs (0002, 0005, 0007) are step 1, before any code change. |
+| A change includes its consequences | Round-trip tests, README updates, and ADR addenda are all in scope. cube_bathymetry#96 must co-land. |
+| Only what's needed | Dropping time/source rasters and collapsing layers removes redundant state; no new structure added. |
+| Improve incrementally | Greenfield rewrite is justified by the "regenerable cache" framing; no migration shim needed or appropriate. |
+| Test what breaks | Required round-trip tests: Welford `(mean,SE,SD)↔(n,mean,M2)` for n≥2 + n=1 sentinel; bathy uncertainty round-trip unchanged. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| Project ADR-0002 (Bathy store) | Yes — amended | Addendum records layer taxonomy change + tile layout simplification. |
+| Project ADR-0005 (Provenance registry) | Yes — amended | Addendum records per-cell source-index drop; registry.json repurposed as coarse metadata. |
+| Project ADR-0007 (MBES backscatter store) | Yes — amended | Addendum records value-band schema + layer collapse. |
+| Workspace ADR-0008 (ROS 2 conventions) | No | No new .msg/.srv; pure store-format change. |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| SourceLayer enum (bathy) | cube_bathymetry#96 consumption (seed precedence, import_bag) | Yes — synchronized landing constraint; #96 must be ready before merge |
+| SourceLayer enum (MBES) | Any cube_bathymetry code that writes to MBES store | Yes — synchronized landing |
+| registry.json schema | Any code that reads registry.json (currently none outside store lib) | Yes — StoreMetadata struct replaces SourceRegistry throughout |
+| BathyCell / MbesCell field removal | geotiff_import (no SourceRecord); query results | Yes — in Files to Change |
+| layerDirName constants | On-disk store directories | Yes — greenfield; no existing stores to migrate |
+
+## Open Questions
+
+- [ ] No open questions — all three resolutions from the issue review are incorporated.
+
+## Estimated Scope
+
+Single PR. Co-lands with cube_bathymetry#96 (synchronized merge; no broken window).

--- a/.agent/work-plans/issue-248/plan.md
+++ b/.agent/work-plans/issue-248/plan.md
@@ -8,8 +8,8 @@ https://github.com/rolker/unh_marine_autonomy/issues/248
 
 Both stores carry per-cell `time` and `source` rasters that are redundant once the
 stores are treated as regenerable caches over raw bags. Three bathy source layers
-(`chart`/`draft`/`processed`) collapse to two (`pre-existing` / `cube`), and two
-MBES layers (`draft`/`processed`) collapse to one (`cube`). The MBES value-band
+(`chart`/`draft`/`processed`) collapse to two (`reference` / `survey`), and two
+MBES layers (`draft`/`processed`) collapse to one (`survey`). The MBES value-band
 schema changes from `{intensity, intensity_variance}` (2-band) to
 `{mean, standard_error, sample_sd}` (3-band), encoding the Welford sufficient stats
 for lossless reload. The `registry.json` sidecar is repurposed from a per-cell
@@ -42,25 +42,25 @@ Plan Review resolutions (2026-07-01, operator-confirmed):
 ## Approach
 
 1. **Write ADR addenda (all three)** — document decisions before touching code.
-   - ADR-0002 addendum: layer taxonomy (chart/draft/processed → pre-existing/cube),
+   - ADR-0002 addendum: layer taxonomy (chart/draft/processed → reference/survey),
      tile layout (drop `_time.tif`/`_source.tif`; single 2-band value tile only),
      **and retirement of the `bathymetry_layer` per-cell staleness gate** (with
      rationale: surveyed static bottom, not a live feed).
    - ADR-0005 addendum: per-cell source-index raster dropped; `registry.json`
      repurposed as store/layer-level coarse metadata (survey, sensor, date).
    - ADR-0007 addendum: value-band schema (`{intensity, intensity_variance}` →
-     `{mean, standard_error, sample_sd}`) + layer collapse (draft/processed → cube).
+     `{mean, standard_error, sample_sd}`) + layer collapse (draft/processed → survey).
 
 2. **Refactor `marine_bathymetry_store`:**
    a. `bathy_cell.hpp` — replace `SourceLayer{Processed=0, Draft=1, Chart=2}`
-      with `SourceLayer{Cube=0, PreExisting=1}` (`Cube` highest priority); update
+      with `SourceLayer{Survey=0, Reference=1}` (`Survey` highest priority); update
       `source_layers_by_priority`; strip `timestamp` and `source_index` from `BathyCell`.
    b. `bathymetry_tile.hpp` — remove `TimeRaster`/`SourceRaster` members and
       all `_time`/`_source` band accessors; constructor becomes single-arg
       (`gggs::GridIndex`); `set`/`get` operate on `{depth, uncertainty}` only.
    c. `bathymetry_store.hpp/.cpp` — rename `chart_writable_` →
-      `pre_existing_writable_`; layer count 3→2; update `Chart`→`PreExisting` guards.
-   d. `tile_io.hpp/.cpp` — `layerDirName` returns `"cube"`/`"pre-existing"` (drop
+      `reference_writable_`; layer count 3→2; update `Chart`→`Reference` guards.
+   d. `tile_io.hpp/.cpp` — `layerDirName` returns `"survey"`/`"reference"` (drop
       `"draft"`/`"processed"`/`"chart"`); `saveTile`/`loadTile` write/read only the
       2-band value GeoTIFF (no `_time.tif` or `_source.tif` companions); update
       `save`/`load`/`loadWindow` accordingly.
@@ -93,22 +93,22 @@ Plan Review resolutions (2026-07-01, operator-confirmed):
 
 4. **Refactor `marine_mbes_backscatter_store`:**
    a. `mbes_cell.hpp` — replace `SourceLayer{Processed=0, Draft=1}` with
-      `SourceLayer{Cube=0}`; update `source_layers_by_priority` to a 1-element array;
+      `SourceLayer{Survey=0}`; update `source_layers_by_priority` to a 1-element array;
       rename `MbesCell` fields: `intensity`→`mean`, `intensity_variance`→`standard_error`;
       add `sample_sd`; drop `timestamp` and `source_index`.
    b. `mbes_tile.hpp` — remove `TimeRaster`/`SourceRaster`; value raster becomes
       3-band `{mean, standard_error, sample_sd}` (all `float`); band constants
       `kMean=0`, `kStandardError=1`, `kSampleSd=2`.
    c. `mbes_store.hpp/.cpp` — layer count 2→1; remove `set(Draft/Processed, ...)` distinction;
-      single `set(SourceLayer::Cube, ...)`.
-   d. `tile_io.hpp/.cpp` — `layerDirName` returns `"cube"` only; `saveTile`/`loadTile`
+      single `set(SourceLayer::Survey, ...)`.
+   d. `tile_io.hpp/.cpp` — `layerDirName` returns `"survey"` only; `saveTile`/`loadTile`
       write/read 3-band `Float32` value tile only; update `save`/`load`.
    e. `registry.hpp/.cpp` — same repurpose as bathy: `StoreMetadata` struct,
       flat `registry.json` with `{platform, sensor, survey, date}`; the `calibration_ref`
       field survives as a coarse store-level field (not per-cell).
    f. `query.hpp/.cpp` — rename `IntensitySample{intensity, intensity_variance,
       timestamp, source}` → `BackscatterSample{mean, standard_error, sample_sd, source}`;
-      `bestSource` and `forEachCellBestSource` walk the single `Cube` layer.
+      `bestSource` and `forEachCellBestSource` walk the single `Survey` layer.
    g. `test/test_tile_io.cpp` — add Welford round-trip tests:
       - n≥2 case: set `(mean, SE*scale, SD)`, reload, reconstruct
         `n = (SD / (SE*scale/scale))^2 = (SD/SE)^2` and `M2 = SD^2*(n-1)`, verify exact.
@@ -127,10 +127,10 @@ Plan Review resolutions (2026-07-01, operator-confirmed):
 | `docs/decisions/0002-bathymetric-data-store.md` | Addendum: layer taxonomy + tile layout simplification + staleness-gate retirement rationale |
 | `docs/decisions/0005-multi-platform-provenance-registry.md` | Addendum: per-cell source-index dropped; registry.json = coarse metadata |
 | `docs/decisions/0007-mbes-backscatter-store.md` | Addendum: value-band schema + layer collapse |
-| `marine_bathymetry_store/include/marine_bathymetry_store/bathy_cell.hpp` | SourceLayer enum (Cube/PreExisting), BathyCell (drop timestamp/source_index) |
+| `marine_bathymetry_store/include/marine_bathymetry_store/bathy_cell.hpp` | SourceLayer enum (Survey/Reference), BathyCell (drop timestamp/source_index) |
 | `marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_tile.hpp` | Drop time/source rasters; value-only tile |
 | `marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_store.hpp` | Rename chart_writable_, layer count 3→2 |
-| `marine_bathymetry_store/src/bathymetry_store.cpp` | Chart→PreExisting guards |
+| `marine_bathymetry_store/src/bathymetry_store.cpp` | Chart→Reference guards |
 | `marine_bathymetry_store/include/marine_bathymetry_store/tile_io.hpp` | layerDirName, value-only I/O |
 | `marine_bathymetry_store/src/tile_io.cpp` | Implement simplified I/O |
 | `marine_bathymetry_store/include/marine_bathymetry_store/registry.hpp` | Repurpose as StoreMetadata |
@@ -149,7 +149,7 @@ Plan Review resolutions (2026-07-01, operator-confirmed):
 | `bathymetry_layer/test/*` | Remove/adjust staleness-gate tests |
 | `bathymetry_layer/README.md` | Drop staleness-gate mention (if present) |
 | `marine_tiled_raster_store/README.md` | Refresh bathy tile-format cross-reference (old "3 bands") |
-| `marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/mbes_cell.hpp` | SourceLayer (Cube only), MbesCell (mean/SE/SD, drop ts/src) |
+| `marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/mbes_cell.hpp` | SourceLayer (Survey only), MbesCell (mean/SE/SD, drop ts/src) |
 | `marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/mbes_tile.hpp` | 3-band value raster only |
 | `marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/mbes_store.hpp` | Single layer |
 | `marine_mbes_backscatter_store/src/mbes_store.cpp` | Single layer |

--- a/.agent/work-plans/issue-248/plan.md
+++ b/.agent/work-plans/issue-248/plan.md
@@ -22,11 +22,30 @@ Operator decisions (issue Resolutions, 2026-06-30):
    is ready; both merge together to avoid a broken build window.
 3. `registry.json` repurposed as coarse metadata (not removed).
 
+Plan Review resolutions (2026-07-01, operator-confirmed):
+4. **Retire the `bathymetry_layer` staleness gate.** The Nav2 costmap layer's
+   per-cell staleness gate (`bathymetry_layer.cpp:842,885`) reads
+   `DepthSample::timestamp`, which this change drops. Operator decision: **retire
+   the gate** rather than keep per-cell bathy time. Rationale: bathy is a surveyed
+   *static* bottom (not a live sensor feed), so per-cell staleness is not a
+   meaningful costmap hazard. Retirement is **explicit, not silent**: remove the
+   gate code + its tests + any README mention, and record the decision + rationale
+   in the ADR-0002 addendum.
+5. **`import_geotiff` CLI** (`marine_bathymetry_store/src/import_geotiff_main.cpp`)
+   uses `SourceRecord`/`SourceRegistry` and `--source-id`/`--datum` — a build break
+   otherwise. Drop the per-cell provenance path + its help text (coarse metadata is
+   store-level now). This CLI is a `registry.json` reader — corrects the plan's
+   earlier "no readers outside the lib" claim.
+6. Refresh `marine_tiled_raster_store/README.md` bathy-tile-format cross-reference
+   (it references the old "3 bands" layout).
+
 ## Approach
 
 1. **Write ADR addenda (all three)** — document decisions before touching code.
    - ADR-0002 addendum: layer taxonomy (chart/draft/processed → pre-existing/cube),
-     tile layout (drop `_time.tif`/`_source.tif`; single 2-band value tile only).
+     tile layout (drop `_time.tif`/`_source.tif`; single 2-band value tile only),
+     **and retirement of the `bathymetry_layer` per-cell staleness gate** (with
+     rationale: surveyed static bottom, not a live feed).
    - ADR-0005 addendum: per-cell source-index raster dropped; `registry.json`
      repurposed as store/layer-level coarse metadata (survey, sensor, date).
    - ADR-0007 addendum: value-band schema (`{intensity, intensity_variance}` →
@@ -60,8 +79,19 @@ Operator decisions (issue Resolutions, 2026-06-30):
    i. `test/test_store.cpp`, `test/test_query.cpp`, `test/test_geotiff_import.cpp`
       — purge `timestamp`/`source_index` references; update layer names.
    j. `README.md` — update store format section (layer dirs, tile files, registry schema).
+   k. `import_geotiff_main.cpp` (built `import_geotiff` CLI) — remove the
+      `SourceRecord`/`SourceRegistry` usage and the `--source-id`/`--datum`
+      provenance flags + help text; keep the core geotiff→store import path.
 
-3. **Refactor `marine_mbes_backscatter_store`:**
+3. **Retire the `bathymetry_layer` staleness gate:**
+   a. `bathymetry_layer/src/bathymetry_layer.cpp` — remove the per-cell staleness
+      gate (the `DepthSample::timestamp` reads at ~`:842,885` and the surrounding
+      gate logic/params).
+   b. `bathymetry_layer/test/*` — remove/adjust staleness-gate tests.
+   c. `bathymetry_layer/README.md` (if it documents the gate) — drop the mention.
+   d. Rationale recorded in the ADR-0002 addendum (step 1).
+
+4. **Refactor `marine_mbes_backscatter_store`:**
    a. `mbes_cell.hpp` — replace `SourceLayer{Processed=0, Draft=1}` with
       `SourceLayer{Cube=0}`; update `source_layers_by_priority` to a 1-element array;
       rename `MbesCell` fields: `intensity`→`mean`, `intensity_variance`→`standard_error`;
@@ -94,7 +124,7 @@ Operator decisions (issue Resolutions, 2026-06-30):
 
 | File | Change |
 |------|--------|
-| `docs/decisions/0002-bathymetric-data-store.md` | Addendum: layer taxonomy + tile layout simplification |
+| `docs/decisions/0002-bathymetric-data-store.md` | Addendum: layer taxonomy + tile layout simplification + staleness-gate retirement rationale |
 | `docs/decisions/0005-multi-platform-provenance-registry.md` | Addendum: per-cell source-index dropped; registry.json = coarse metadata |
 | `docs/decisions/0007-mbes-backscatter-store.md` | Addendum: value-band schema + layer collapse |
 | `marine_bathymetry_store/include/marine_bathymetry_store/bathy_cell.hpp` | SourceLayer enum (Cube/PreExisting), BathyCell (drop timestamp/source_index) |
@@ -114,6 +144,11 @@ Operator decisions (issue Resolutions, 2026-06-30):
 | `marine_bathymetry_store/test/test_query.cpp` | DepthSample field updates |
 | `marine_bathymetry_store/test/test_geotiff_import.cpp` | Remove SourceRecord usage |
 | `marine_bathymetry_store/README.md` | Format section update |
+| `marine_bathymetry_store/src/import_geotiff_main.cpp` | Drop `--source-id`/`--datum` + SourceRegistry provenance path + help text (build-break fix) |
+| `bathymetry_layer/src/bathymetry_layer.cpp` | Retire per-cell staleness gate (remove `DepthSample::timestamp` reads ~`:842,885` + gate logic/params) |
+| `bathymetry_layer/test/*` | Remove/adjust staleness-gate tests |
+| `bathymetry_layer/README.md` | Drop staleness-gate mention (if present) |
+| `marine_tiled_raster_store/README.md` | Refresh bathy tile-format cross-reference (old "3 bands") |
 | `marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/mbes_cell.hpp` | SourceLayer (Cube only), MbesCell (mean/SE/SD, drop ts/src) |
 | `marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/mbes_tile.hpp` | 3-band value raster only |
 | `marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/mbes_store.hpp` | Single layer |
@@ -154,7 +189,8 @@ Operator decisions (issue Resolutions, 2026-06-30):
 |---|---|---|
 | SourceLayer enum (bathy) | cube_bathymetry#96 consumption (seed precedence, import_bag) | Yes — synchronized landing constraint; #96 must be ready before merge |
 | SourceLayer enum (MBES) | Any cube_bathymetry code that writes to MBES store | Yes — synchronized landing |
-| registry.json schema | Any code that reads registry.json (currently none outside store lib) | Yes — StoreMetadata struct replaces SourceRegistry throughout |
+| registry.json schema | `import_geotiff` CLI reads/writes it (a registry.json reader — earlier "none outside lib" claim was wrong); StoreMetadata replaces SourceRegistry throughout | Yes |
+| Drop `DepthSample::timestamp` | `bathymetry_layer` staleness gate consumes it → **retire the gate** (layer + tests + README + ADR-0002 rationale) | Yes — step 3 |
 | BathyCell / MbesCell field removal | geotiff_import (no SourceRecord); query results | Yes — in Files to Change |
 | layerDirName constants | On-disk store directories | Yes — greenfield; no existing stores to migrate |
 

--- a/.agent/work-plans/issue-248/progress.md
+++ b/.agent/work-plans/issue-248/progress.md
@@ -104,3 +104,89 @@ Per the consequences map and ADR cross-references:
 - [ ] (must-fix) `marine_bathymetry_store/src/import_geotiff_main.cpp` (built `import_geotiff` CLI) uses `SourceRecord`/`SourceRegistry` and passes `registry` to load/save/import — not in Files to Change; build break. Redesign/remove its `--source-id`/`--datum` provenance path + help text. — `plan.md:110`
 - [ ] (suggestion) Consequences table claims no registry.json readers outside the store lib; `import_geotiff_main.cpp` is a counterexample. — `plan.md:157`
 - [ ] (suggestion) `marine_tiled_raster_store/README.md` cross-references the bathy tile format ("3 bands"); refresh or note out-of-scope. — `plan.md:116`
+
+## Implementation
+**Status**: complete (bathy + MBES built & green in-container; bathymetry_layer edited, not buildable in-container)
+**When**: 2026-07-01 02:45 +00:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Branch**: feature/issue-248 at `d68bc44`
+**Commits** (atomic, agent identity, hooks passing, no `--no-verify`):
+- `af5189c` docs(adr): amend ADR-0002/0005/0007
+- `8c23003` feat(marine_bathymetry_store): greenfield store-format simplification
+- `09aed92` feat(bathymetry_layer): retire per-cell staleness gate + cube/pre-existing
+- `844ef82` feat(marine_mbes_backscatter_store): 3-band Welford value tile + single cube layer
+- `d68bc44` docs(marine_tiled_raster_store): refresh bathy/mbes tile-format cross-references
+
+### What was implemented (all plan steps)
+
+1. **ADR addenda** (step 1, before code): ADR-0002 Amendment A2 (layer taxonomy
+   chart/draft/processed → cube/pre-existing; drop `_time`/`_source` tiles →
+   single 2-band value tile; registry.json → coarse StoreMetadata; **staleness-gate
+   retirement rationale** — surveyed static bottom, not a live feed); ADR-0005
+   amendment (per-cell source index dropped for single-platform stores; registry
+   repurposed; multi-platform contract retained); ADR-0007 amendment A.1–A.4
+   (value bands `{intensity,intensity_variance}` → `{mean,standard_error,sample_sd}`
+   Welford stats + confidence-scaled SE; draft/processed → single cube; `_time`/
+   `_source` dropped; safety non-goal unchanged).
+
+2. **marine_bathymetry_store**: `SourceLayer{Cube,PreExisting}`; `BathyCell` /
+   `BathymetryTile` value-only 2-band tile (dropped timestamp/source_index and
+   companion tiles); `registry.hpp/.cpp` `SourceRegistry` → flat `StoreMetadata`;
+   persistence free fns take `StoreMetadata*`; `DepthSample` slimmed; `geotiff_import`
+   drops registry/timestamp/source stamping; `import_geotiff` CLI drops
+   `--source-id`/`--datum`/`--timestamp` + SourceRegistry, layer names
+   `cube|pre-existing`, added optional coarse `--platform/--sensor/--survey/--date`.
+   Tests + README updated; bathy uncertainty round-trip + StoreMetadata round-trip
+   added.
+
+3. **bathymetry_layer staleness-gate retirement** (operator-approved, explicit):
+   removed `max_age` param, `isStale()`, `evaluateCell`'s `now_ns` arg, the forced
+   re-render interval + `last_full_render_ns_`; `evaluateCell` LETHALs an
+   over-uncertain/unreliable cell purely on the uncertainty gate. Removed the
+   `StaleCellIsLethal` test and the staleness arm of test 7; dropped the `max_age`
+   README row/param/yaml. Adopted `cube/pre-existing` naming in the store
+   construction + tests.
+
+4. **marine_mbes_backscatter_store**: single `cube` layer; 3-band `Float32`
+   `{mean,standard_error,sample_sd}` value tile; dropped companions; registry →
+   `StoreMetadata{...,calibration_ref}`; `IntensitySample` → `BackscatterSample`.
+   Tests + README updated.
+
+5. **Load-bearing tests** (all present & passing): backscatter Welford round-trip
+   for n≥2 (`n=(sample_sd/SE)^2`, `M2=sample_sd^2*(n-1)`); the **n=1 sentinel**
+   (`sample_sd==0`, finite mean → n=1, M2=0; distinct from NaN no-data); the
+   **confidence-scale divide-out** (integer n); bathy uncertainty round-trip; the
+   layer-name/field updates across all touched tests.
+
+6. **marine_tiled_raster_store/README.md** bathy tile-format cross-reference
+   refreshed (2-band bathy + 3-band MBES consumer).
+
+### Per-package build/test status
+- **marine_bathymetry_store**: **green** in-container — `colcon build` + `colcon test`
+  → 138 tests, 0 failures (58 gtest cases across store/query/tile_io/geotiff_import,
+  plus linters incl. uncrustify).
+- **marine_mbes_backscatter_store**: **green** in-container — 84 tests, 0 failures.
+- **bathymetry_layer**: **NOT built/tested in-container** — depends on the
+  lower-layer `geodesy` package (`geodesy/ecef.h`), which is absent in this
+  container (nav2/geodesy underlay not provided). Code edits are complete and
+  self-consistent (stale-symbol sweep clean; no dangling `max_age_`/`isStale`/
+  `now_ns`/`last_full_render_ns_`). **Host must `colcon build` + `colcon test`
+  bathymetry_layer** once geodesy/nav2 are available.
+
+### Deviations from the plan
+- **Legacy 3-band `loadTile` guard dropped** (bathy). The pre-#178 rejection guard
+  and its test were removed rather than kept: greenfield, no on-disk migration, and
+  the value tile is now 2-band, so the guard has no legacy to protect against.
+- **import_geotiff CLI gained coarse metadata flags** (`--platform/--sensor/
+  --survey/--date`) writing `StoreMetadata` — a small, natural replacement for the
+  dropped per-cell provenance path (plan said "drop the provenance path"; this keeps
+  provenance at the new store-level granularity). No new per-cell state.
+
+### What the host must finish
+- **Build + test `bathymetry_layer`** (needs geodesy/nav2 underlay).
+- **Co-land cube_bathymetry#96** (synchronized merge — ADR-0002 A2.5): the
+  `SourceLayer` rename and the dropped per-cell time/source obligations are a
+  producer-side contract change; hold #96 until #248 is ready and merge together to
+  avoid a broken-build window.
+- Do NOT push / open PR (local-first; host publishes).

--- a/.agent/work-plans/issue-248/progress.md
+++ b/.agent/work-plans/issue-248/progress.md
@@ -77,3 +77,15 @@ Per the consequences map and ADR cross-references:
 - [ ] Widen ADR update scope in plan: add ADR-0007 amendment (D6 value bands, D7 layer collapse) and ADR-0005 amendment (per-cell source-index drop → coarse metadata) to the acceptance criteria or plan.
 - [ ] Clarify cube_bathymetry#96 sequencing and merge order relative to #248.
 - [ ] Resolve `registry.json` fate explicitly: removed, repurposed, or replaced by tile sidecar — record in the ADR addendum.
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-07-01 12:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Plan**: `.agent/work-plans/issue-248/plan.md` at `e4e9744`
+**Branch**: feature/issue-248 at `e4e9744`
+**Phases**: single
+
+### Open questions
+- [ ] No open questions — plan is review-plan-ready.

--- a/.agent/work-plans/issue-248/progress.md
+++ b/.agent/work-plans/issue-248/progress.md
@@ -190,3 +190,26 @@ Per the consequences map and ADR cross-references:
   producer-side contract change; hold #96 until #248 is ready and merge together to
   avoid a broken-build window.
 - Do NOT push / open PR (local-first; host publishes).
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-01 04:10 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-248 at `da258a1`
+**Mode**: pre-push
+**Depth**: Deep (reason: large cross-layer change — two C++ store libs + Nav2 costmap safety layer + 3 substantive ADR amendments)
+**Must-fix**: 1 | **Suggestions**: 5
+**Round**: 1 | **Ship**: continue — one safety-observability must-fix (silent-empty nav prior) worth closing before push; everything else clean
+
+### Findings
+- [ ] (must-fix) Bathy `load()`/`loadWindow()` silently return empty on an old-layout store dir (no `survey`/`reference` subdir) — no warning; with `unsurveyed_is_lethal_=false` default, unknown seabed reads as navigable. Add a warning matching the existing stale-subdir idiom. — `marine_bathymetry_store/src/tile_io.cpp:262,304`
+- [ ] (suggestion) Stale public accessor `preExistingWritable()` not renamed by the `da258a1` taxonomy rename → `referenceWritable()` + call sites. — `marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_store.hpp:114`
+- [ ] (suggestion) `registry.json` writes `"version": 2` but `load` never validates it; old-schema json loads all-empty silently — add version check or document advisory-only. — `marine_bathymetry_store/src/registry.cpp:57`
+- [ ] (suggestion) Stray `_time.tif`/`_source.tif` companion in a new-named dir aborts the entire bathy load (no per-file try/catch); skip known suffixes or warn-and-skip. — `marine_bathymetry_store/src/tile_io.cpp:269`
+- [ ] (suggestion) Stale class doc describes pre-#248 chart/draft/processed taxonomy. — `bathymetry_layer/src/bathymetry_layer.hpp:30`
+- [ ] (suggestion) progress.md Issue Review + Implementation narrative use old `cube`/`pre-existing` layer names (pre-`da258a1` rename); refresh to match shipped `survey`/`reference`. — `.agent/work-plans/issue-248/progress.md:30`
+- [ ] (host) Build+test `bathymetry_layer` (geodesy/nav2 underlay absent in-container) and sim-validate per ADR-0002 D7; co-land cube_bathymetry#96 (still on old API — build break if #248 lands alone).
+
+**Notes**: Static analysis clean on ament profile (cpplint/uncrustify/cppcheck); deeper cppcheck reports were serialization/separate-test-executable false positives, dropped. Two Deep Claude adversarial passes (Lens A logic + Lens B systemic/safety) both confirmed lossless store round-trips and a clean, complete staleness-gate retirement with LETHAL guards intact. Copilot Adversarial off (not opted in). Progress persisted to the project-repo timeline (`unh_marine_autonomy`), consistent with all prior #248 phase entries.

--- a/.agent/work-plans/issue-248/progress.md
+++ b/.agent/work-plans/issue-248/progress.md
@@ -89,3 +89,18 @@ Per the consequences map and ADR cross-references:
 
 ### Open questions
 - [ ] No open questions — plan is review-plan-ready.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-07-01 01:45 +00:00
+**By**: Claude Code Agent (Claude Opus)  <!-- independent: fresh-context Opus review of a Sonnet-authored plan; shared workspace agent-name is not a self-review signal -->
+
+**Plan**: `.agent/work-plans/issue-248/plan.md` at `e4e9744`
+**PR**: PR-less (--issue mode; layer worktree feature/issue-248)
+**Verdict**: changes-requested
+
+### Findings
+- [ ] (must-fix) `bathymetry_layer` costmap staleness gate reads `DepthSample::timestamp`, dropped by the plan — not in Files to Change; build break at `bathymetry_layer.cpp:842,885` + silently removes a Nav2 navigation-safety feature (ADR-0002 D3/D5). Keep per-cell bathy time or explicitly retire the gate (update layer+tests+README+ADR-0002 addendum). — `plan.md:108`
+- [ ] (must-fix) `marine_bathymetry_store/src/import_geotiff_main.cpp` (built `import_geotiff` CLI) uses `SourceRecord`/`SourceRegistry` and passes `registry` to load/save/import — not in Files to Change; build break. Redesign/remove its `--source-id`/`--datum` provenance path + help text. — `plan.md:110`
+- [ ] (suggestion) Consequences table claims no registry.json readers outside the store lib; `import_geotiff_main.cpp` is a counterexample. — `plan.md:157`
+- [ ] (suggestion) `marine_tiled_raster_store/README.md` cross-references the bathy tile format ("3 bands"); refresh or note out-of-scope. — `plan.md:116`

--- a/.agent/work-plans/issue-248/progress.md
+++ b/.agent/work-plans/issue-248/progress.md
@@ -1,0 +1,79 @@
+---
+issue: 248
+---
+
+# Issue #248 — Greenfield store-format simplification (bathy + MBES backscatter)
+
+## Issue Review
+**Status**: complete
+**When**: 2026-07-01 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Issue**: #248
+**Comment**: (best-effort post follows this entry; not recorded inline)
+**Scope verdict**: well-scoped
+
+### Summary
+
+Issue #248 proposes a greenfield simplification of the on-disk format for
+`marine_bathymetry_store` and `marine_mbes_backscatter_store`. The stores are
+treated as a regenerable derived cache (re-derivable from raw bags), so no
+migration is needed — a clean break is safe and the issue justifies it clearly.
+
+Key changes:
+- **Bathy store**: collapse three source layers (`chart`/`draft`/`processed`) to
+  two (`pre-existing` + `cube`); drop per-cell `_time` and `_source` rasters;
+  retain `depth`+`uncertainty` value tile (unchanged).
+- **Backscatter store**: collapse `draft`/`processed` to a single `cube` layer;
+  change value tile from `{intensity, intensity_variance}` to
+  `{mean, standard_error, sample_sd}` (Float32, 3-band); drop `_time`/`_source`
+  rasters; encode Welford sufficient stats for lossless reload.
+
+Pairs with cube_bathymetry#96 (consumption side: seed precedence, batch regen,
+import_bag). References #247 (sidescan/source-tag callback, deferred).
+
+### Principle Alignment
+
+| Principle | Status | Notes |
+|---|---|---|
+| Capture decisions, not just implementations | Action needed | Acceptance criteria mention "ADR-0002 addendum" only. ADR-0007 (MBES backscatter store) also requires an amendment: D6 value-band schema (`{intensity,intensity_variance}` → `{mean,SE,SD}`) and D7 draft/processed layer collapse are core decisions being reversed. ADR-0005 (per-cell source index, D2/D8) is also materially superseded by the drop of `_source` rasters in favour of coarse metadata — neither is mentioned in the issue's ADR update scope. |
+| A change includes its consequences | Watch | Store READMEs and ADR-0002 addendum are in scope; ADR-0005 and ADR-0007 are not. The issue should enumerate them or note them explicitly as follow-on so they don't slip. registry.json (ADR-0005's store-root sidecar) fate with the per-cell source-index drop should be clarified. |
+| Only what's needed | OK | Simplification rationale is solid: single-platform (M3), stores are regenerable caches, per-cell time/source were redundant with bags. |
+| Improve incrementally | OK | Two stores in one issue is appropriate — they share the same simplification logic and must be kept consistent. The "no migration" decision is explicit and well-motivated. |
+| Test what breaks | OK | Round-trip tests are specified: backscatter `(mean,SE,SD)↔(n,mean,M2)` lossless for n≥2 AND n=1 sentinel; bathy `uncertainty↔variance` unchanged; confidence scale divides out on read. |
+| Safety First (project) | OK | Backscatter is a cartographic product — not a navigation input. Bathy uncertainty convention is preserved (confidence-scaled sigma; inverts to estimator variance on reload). |
+| Modularity and Decoupling | OK | Layer naming/precedence constants scoped for cube_bathymetry#96 consumption — correct separation. |
+
+### ADR Applicability
+
+| ADR | Triggered | Notes |
+|---|---|---|
+| Project ADR-0001 (Adopt ADRs) | Yes | Design decisions being made (layer taxonomy reversal, value-band change, source-index drop). Issue proposes ADR-0002 addendum — scope should be widened. |
+| Project ADR-0002 (Bathy store) | Yes — amended | D3 layer taxonomy (`chart`/`draft`/`processed` → `pre-existing`/`cube`) and D5 per-tile file layout (drop `_time`/`_source`, single value tile) are directly revised. Issue correctly calls for an addendum. |
+| Project ADR-0005 (Provenance registry) | Yes — not listed | D2/D8 define the per-cell source index (`_source.tif`) + `registry.json` as the platform/sensor provenance mechanism. Dropping per-cell source rasters supersedes those decisions. "Coarse metadata at tile/store level" is the replacement; that decision should be recorded in ADR-0005 as an amendment or a superseding ADR. |
+| Project ADR-0007 (MBES backscatter store) | Yes — not listed | D6 (value tile schema: Float32 `{intensity, intensity_variance}`) and D7 (`draft`/`processed` layer semantics with live-vs-offline distinction) are both overridden by this issue. An ADR-0007 amendment (or addendum to ADR-0002's bathy-addendum) is needed. |
+| Workspace ADR-0008 (ROS 2 conventions) | Watch | No new `.msg`/`.srv` expected here (pure store-format change), so not directly triggered. If any ROS interface changes are added in implementation, conventions apply. |
+
+### Consequences
+
+Per the consequences map and ADR cross-references:
+
+- **`registry.json` fate**: ADR-0005's store-root registry sidecar maps local source
+  index → platform/sensor metadata. If per-cell source rasters are dropped, the
+  in-tile source index is gone too — confirm whether `registry.json` itself is
+  removed, repurposed as the "coarse metadata" store, or superseded by a new
+  per-tile sidecar. This should be explicit in the plan.
+- **cube_bathymetry#96 sequencing**: issue says "pairs with" but doesn't specify
+  which lands first. If the store format lands before the CUBE-side consumer is
+  updated, any intermediate state will be broken. Coordinate merge order or develop
+  atomically.
+- **Layer naming constants**: `SourceLayer` enum and `layerDirName` are consumable
+  by cube_bathymetry#96 — plan should confirm the constants are stable before
+  cube_bathymetry#96 merges.
+- **README / format doc**: listed in acceptance criteria — OK.
+- **ADR-0002 addendum**: listed — OK, but scope needs widening (see above).
+
+### Actions
+- [ ] Widen ADR update scope in plan: add ADR-0007 amendment (D6 value bands, D7 layer collapse) and ADR-0005 amendment (per-cell source-index drop → coarse metadata) to the acceptance criteria or plan.
+- [ ] Clarify cube_bathymetry#96 sequencing and merge order relative to #248.
+- [ ] Resolve `registry.json` fate explicitly: removed, repurposed, or replaced by tile sidecar — record in the ADR addendum.

--- a/.agent/work-plans/issue-248/progress.md
+++ b/.agent/work-plans/issue-248/progress.md
@@ -22,9 +22,9 @@ migration is needed — a clean break is safe and the issue justifies it clearly
 
 Key changes:
 - **Bathy store**: collapse three source layers (`chart`/`draft`/`processed`) to
-  two (`pre-existing` + `cube`); drop per-cell `_time` and `_source` rasters;
+  two (`reference` + `survey`); drop per-cell `_time` and `_source` rasters;
   retain `depth`+`uncertainty` value tile (unchanged).
-- **Backscatter store**: collapse `draft`/`processed` to a single `cube` layer;
+- **Backscatter store**: collapse `draft`/`processed` to a single `survey` layer;
   change value tile from `{intensity, intensity_variance}` to
   `{mean, standard_error, sample_sd}` (Float32, 3-band); drop `_time`/`_source`
   rasters; encode Welford sufficient stats for lossless reload.
@@ -49,7 +49,7 @@ import_bag). References #247 (sidescan/source-tag callback, deferred).
 | ADR | Triggered | Notes |
 |---|---|---|
 | Project ADR-0001 (Adopt ADRs) | Yes | Design decisions being made (layer taxonomy reversal, value-band change, source-index drop). Issue proposes ADR-0002 addendum — scope should be widened. |
-| Project ADR-0002 (Bathy store) | Yes — amended | D3 layer taxonomy (`chart`/`draft`/`processed` → `pre-existing`/`cube`) and D5 per-tile file layout (drop `_time`/`_source`, single value tile) are directly revised. Issue correctly calls for an addendum. |
+| Project ADR-0002 (Bathy store) | Yes — amended | D3 layer taxonomy (`chart`/`draft`/`processed` → `reference`/`survey`) and D5 per-tile file layout (drop `_time`/`_source`, single value tile) are directly revised. Issue correctly calls for an addendum. |
 | Project ADR-0005 (Provenance registry) | Yes — not listed | D2/D8 define the per-cell source index (`_source.tif`) + `registry.json` as the platform/sensor provenance mechanism. Dropping per-cell source rasters supersedes those decisions. "Coarse metadata at tile/store level" is the replacement; that decision should be recorded in ADR-0005 as an amendment or a superseding ADR. |
 | Project ADR-0007 (MBES backscatter store) | Yes — not listed | D6 (value tile schema: Float32 `{intensity, intensity_variance}`) and D7 (`draft`/`processed` layer semantics with live-vs-offline distinction) are both overridden by this issue. An ADR-0007 amendment (or addendum to ADR-0002's bathy-addendum) is needed. |
 | Workspace ADR-0008 (ROS 2 conventions) | Watch | No new `.msg`/`.srv` expected here (pure store-format change), so not directly triggered. If any ROS interface changes are added in implementation, conventions apply. |
@@ -114,29 +114,29 @@ Per the consequences map and ADR cross-references:
 **Commits** (atomic, agent identity, hooks passing, no `--no-verify`):
 - `af5189c` docs(adr): amend ADR-0002/0005/0007
 - `8c23003` feat(marine_bathymetry_store): greenfield store-format simplification
-- `09aed92` feat(bathymetry_layer): retire per-cell staleness gate + cube/pre-existing
-- `844ef82` feat(marine_mbes_backscatter_store): 3-band Welford value tile + single cube layer
+- `09aed92` feat(bathymetry_layer): retire per-cell staleness gate + survey/reference
+- `844ef82` feat(marine_mbes_backscatter_store): 3-band Welford value tile + single survey layer
 - `d68bc44` docs(marine_tiled_raster_store): refresh bathy/mbes tile-format cross-references
 
 ### What was implemented (all plan steps)
 
 1. **ADR addenda** (step 1, before code): ADR-0002 Amendment A2 (layer taxonomy
-   chart/draft/processed → cube/pre-existing; drop `_time`/`_source` tiles →
+   chart/draft/processed → survey/reference; drop `_time`/`_source` tiles →
    single 2-band value tile; registry.json → coarse StoreMetadata; **staleness-gate
    retirement rationale** — surveyed static bottom, not a live feed); ADR-0005
    amendment (per-cell source index dropped for single-platform stores; registry
    repurposed; multi-platform contract retained); ADR-0007 amendment A.1–A.4
    (value bands `{intensity,intensity_variance}` → `{mean,standard_error,sample_sd}`
-   Welford stats + confidence-scaled SE; draft/processed → single cube; `_time`/
+   Welford stats + confidence-scaled SE; draft/processed → single survey; `_time`/
    `_source` dropped; safety non-goal unchanged).
 
-2. **marine_bathymetry_store**: `SourceLayer{Cube,PreExisting}`; `BathyCell` /
+2. **marine_bathymetry_store**: `SourceLayer{Survey,Reference}`; `BathyCell` /
    `BathymetryTile` value-only 2-band tile (dropped timestamp/source_index and
    companion tiles); `registry.hpp/.cpp` `SourceRegistry` → flat `StoreMetadata`;
    persistence free fns take `StoreMetadata*`; `DepthSample` slimmed; `geotiff_import`
    drops registry/timestamp/source stamping; `import_geotiff` CLI drops
    `--source-id`/`--datum`/`--timestamp` + SourceRegistry, layer names
-   `cube|pre-existing`, added optional coarse `--platform/--sensor/--survey/--date`.
+   `survey|reference`, added optional coarse `--platform/--sensor/--survey/--date`.
    Tests + README updated; bathy uncertainty round-trip + StoreMetadata round-trip
    added.
 
@@ -145,10 +145,10 @@ Per the consequences map and ADR cross-references:
    re-render interval + `last_full_render_ns_`; `evaluateCell` LETHALs an
    over-uncertain/unreliable cell purely on the uncertainty gate. Removed the
    `StaleCellIsLethal` test and the staleness arm of test 7; dropped the `max_age`
-   README row/param/yaml. Adopted `cube/pre-existing` naming in the store
+   README row/param/yaml. Adopted `survey/reference` naming in the store
    construction + tests.
 
-4. **marine_mbes_backscatter_store**: single `cube` layer; 3-band `Float32`
+4. **marine_mbes_backscatter_store**: single `survey` layer; 3-band `Float32`
    `{mean,standard_error,sample_sd}` value tile; dropped companions; registry →
    `StoreMetadata{...,calibration_ref}`; `IntensitySample` → `BackscatterSample`.
    Tests + README updated.
@@ -204,12 +204,53 @@ Per the consequences map and ADR cross-references:
 **Round**: 1 | **Ship**: continue — one safety-observability must-fix (silent-empty nav prior) worth closing before push; everything else clean
 
 ### Findings
-- [ ] (must-fix) Bathy `load()`/`loadWindow()` silently return empty on an old-layout store dir (no `survey`/`reference` subdir) — no warning; with `unsurveyed_is_lethal_=false` default, unknown seabed reads as navigable. Add a warning matching the existing stale-subdir idiom. — `marine_bathymetry_store/src/tile_io.cpp:262,304`
-- [ ] (suggestion) Stale public accessor `preExistingWritable()` not renamed by the `da258a1` taxonomy rename → `referenceWritable()` + call sites. — `marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_store.hpp:114`
-- [ ] (suggestion) `registry.json` writes `"version": 2` but `load` never validates it; old-schema json loads all-empty silently — add version check or document advisory-only. — `marine_bathymetry_store/src/registry.cpp:57`
-- [ ] (suggestion) Stray `_time.tif`/`_source.tif` companion in a new-named dir aborts the entire bathy load (no per-file try/catch); skip known suffixes or warn-and-skip. — `marine_bathymetry_store/src/tile_io.cpp:269`
-- [ ] (suggestion) Stale class doc describes pre-#248 chart/draft/processed taxonomy. — `bathymetry_layer/src/bathymetry_layer.hpp:30`
-- [ ] (suggestion) progress.md Issue Review + Implementation narrative use old `cube`/`pre-existing` layer names (pre-`da258a1` rename); refresh to match shipped `survey`/`reference`. — `.agent/work-plans/issue-248/progress.md:30`
-- [ ] (host) Build+test `bathymetry_layer` (geodesy/nav2 underlay absent in-container) and sim-validate per ADR-0002 D7; co-land cube_bathymetry#96 (still on old API — build break if #248 lands alone).
+- [x] (must-fix) Bathy `load()`/`loadWindow()` silently return empty on an old-layout store dir (no `survey`/`reference` subdir) — no warning; with `unsurveyed_is_lethal_=false` default, unknown seabed reads as navigable. Add a warning matching the existing stale-subdir idiom. — `marine_bathymetry_store/src/tile_io.cpp:262,304`
+- [x] (suggestion) Stale public accessor `preExistingWritable()` not renamed by the `da258a1` taxonomy rename → `referenceWritable()` + call sites. — `marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_store.hpp:114`
+- [x] (suggestion) `registry.json` writes `"version": 2` but `load` never validates it; old-schema json loads all-empty silently — add version check or document advisory-only. — `marine_bathymetry_store/src/registry.cpp:57`
+- [x] (suggestion) Stray `_time.tif`/`_source.tif` companion in a new-named dir aborts the entire bathy load (no per-file try/catch); skip known suffixes or warn-and-skip. — `marine_bathymetry_store/src/tile_io.cpp:269`
+- [x] (suggestion) Stale class doc describes pre-#248 chart/draft/processed taxonomy. — `bathymetry_layer/src/bathymetry_layer.hpp:30`
+- [x] (suggestion) progress.md Issue Review + Implementation narrative use old `cube`/`pre-existing` layer names (pre-`da258a1` rename); refresh to match shipped `survey`/`reference`. — `.agent/work-plans/issue-248/progress.md:30`
+- [x] (host) Build+test `bathymetry_layer` (geodesy/nav2 underlay absent in-container) and sim-validate per ADR-0002 D7; co-land cube_bathymetry#96 (still on old API — build break if #248 lands alone). (deferred: host action — the geodesy/nav2 underlay is not built in this container, and sim-validation + cross-repo cube_bathymetry#96 co-land are host/operator responsibilities; carried forward to the host.)
 
 **Notes**: Static analysis clean on ament profile (cpplint/uncrustify/cppcheck); deeper cppcheck reports were serialization/separate-test-executable false positives, dropped. Two Deep Claude adversarial passes (Lens A logic + Lens B systemic/safety) both confirmed lossless store round-trips and a clean, complete staleness-gate retirement with LETHAL guards intact. Copilot Adversarial off (not opted in). Progress persisted to the project-repo timeline (`unh_marine_autonomy`), consistent with all prior #248 phase entries.
+
+## Implementation
+**Status**: complete
+**When**: 2026-07-01 04:38 +00:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Branch**: feature/issue-248 at `aefefa6`
+**Addressed**: `## Local Review (Pre-Push)` (When 2026-07-01 04:10 +00:00, branch feature/issue-248 at `da258a1`)
+**Commits**: `82ba65a`, `604512a`, `89e1952`, `b640f5b`, `aefefa6` (+ this progress commit)
+
+Worked the 7 open findings of the latest source review (the pre-push
+`## Local Review (Pre-Push)`). Six fixed with atomic commits (hooks passing, no
+`--no-verify`); the one `(host)` finding deferred with a reason. `marine_bathymetry_store`
+rebuilt and tested green after every change (**269 tests, 0 failures**); the
+doc-only `bathymetry_layer` change is not buildable in-container (geodesy underlay
+absent). No re-classification, no self-review — that is the next `review-code` pass.
+
+### Actions
+- [x] (must-fix) Warn on old-layout store load — `load()`/`loadWindow()` now emit a WARNING (matching the stale-subdir idiom) when a store dir holds content but exposes no recognized `survey/`/`reference/` layer subdir, so a silently-empty nav prior is observable; silent for a fresh/empty or metadata-only store. — `marine_bathymetry_store/src/tile_io.cpp` (`82ba65a`)
+- [x] (suggestion) Renamed stale accessor `preExistingWritable()` → `referenceWritable()` + call sites. — `marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_store.hpp` (`89e1952`)
+- [x] (suggestion) Validate `registry.json` schema version on load — added `kRegistryVersion` and a warn-on-mismatch so a pre-#248/foreign registry is not silently read all-empty. — `marine_bathymetry_store/src/registry.cpp` (`b640f5b`)
+- [x] (suggestion) Skip stray `_time`/`_source` companions on load — known-dropped suffixes are warned-and-skipped in both `load()`/`loadWindow()` so a lingering companion no longer aborts the whole load. — `marine_bathymetry_store/src/tile_io.cpp` (`604512a`)
+- [x] (suggestion) Refreshed stale pre-#248 class doc (and the identical README prose) to the shipped `survey`/`reference` taxonomy. — `bathymetry_layer/src/bathymetry_layer.hpp`, `bathymetry_layer/README.md` (`aefefa6`)
+- [x] (suggestion) Refreshed `cube`/`pre-existing` layer names in the Issue Review + Implementation narrative to `survey`/`reference` (the `cube_bathymetry#96` project name and the review-finding text left verbatim). — `.agent/work-plans/issue-248/progress.md` (this commit)
+- [x] (host) Build+test `bathymetry_layer` + sim-validate + co-land `cube_bathymetry#96` — checked, so it reads as consciously handled. (deferred: host action — the geodesy/nav2 underlay is not built in this container; sim-validation and the cross-repo #96 co-land are host/operator responsibilities. Carried forward to the host.)
+
+### Tests added
+- `LoadWarnsOnUnrecognizedStoreLayout` / `LoadDoesNotWarnOnFreshOrMetadataOnlyStore` (F1)
+- `LoadSkipsStrayCompanionRasters` (F4)
+- `MetadataLoadWarnsOnUnrecognizedSchemaVersion` / `MetadataLoadIsSilentOnCurrentSchemaVersion` (F3)
+
+### For the host
+- **Build + test `bathymetry_layer`** (needs the geodesy/nav2 underlay built) and sim-validate per ADR-0002 D7.
+- **Co-land `cube_bathymetry#96`** (synchronized merge — ADR-0002 A2.5) to avoid a broken-build window.
+- Do NOT push / open PR (local-first; host publishes).
+
+### Next step
+Lifecycle: **Implementation → review-code** (re-review the fixes). Hand off to a
+fresh-context sub-agent:
+
+    .agent/scripts/dispatch_subagent.sh --mode in-process --issue 248 --skill review-code

--- a/.agent/work-plans/issue-248/progress.md
+++ b/.agent/work-plans/issue-248/progress.md
@@ -254,3 +254,24 @@ Lifecycle: **Implementation → review-code** (re-review the fixes). Hand off to
 fresh-context sub-agent:
 
     .agent/scripts/dispatch_subagent.sh --mode in-process --issue 248 --skill review-code
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-01 04:50 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-248 at `7095cb3`
+**Mode**: pre-push
+**Depth**: Deep (reason: large cross-layer change — two C++ store libs + Nav2 costmap safety layer + 3 substantive ADR amendments; on-disk format break, no migration)
+**Must-fix**: 0 | **Suggestions**: 3
+**Round**: 2 | **Ship**: recommended — 0 must-fix; the primary change (lossless store round-trips + staleness-gate retirement) re-confirmed clean by both Deep adversarial lenses; the 3 surviving suggestions are mechanical twin-store parity guards, non-blocking
+
+### Findings
+- [ ] (suggestion) MBES `load()` lacks the dropped-companion skip the bathy store got in round 1 — a stray `*_time.tif`/`*_source.tif` in `survey/` throws in `loadTile` and aborts the whole load; mirror `isDroppedCompanionTile`. — `marine_mbes_backscatter_store/src/tile_io.cpp:132`
+- [ ] (suggestion) MBES `load()` lacks a `warnIfUnrecognizedStoreLayout` equivalent — a pre-#248 (`draft`/`processed`) store loads silently empty; diagnostic-only (MBES is not a costmap input) but an unjustified asymmetry with bathy. — `marine_mbes_backscatter_store/src/tile_io.cpp:122`
+- [ ] (suggestion) MBES `StoreMetadata::load()` never validates the `version` it writes (magic `2` at :57); a pre-#248/foreign registry loads all-empty untraced. Mirror bathy's `kRegistryVersion` + warn-on-mismatch. — `marine_mbes_backscatter_store/src/registry.cpp:57`
+- [ ] (host) Build + test `bathymetry_layer` (geodesy/nav2 underlay absent in-container) and sim-validate per ADR-0002 D7. (deferred: host action — carried forward from round 1.)
+- [ ] (host) Co-land `cube_bathymetry#96` (synchronized merge — ADR-0002 A2.5) to avoid a broken-build window. (deferred: host action — carried forward from round 1.)
+
+**Notes**: All 3 code suggestions are the same three round-1 bathy store-robustness fixes (`82ba65a`, `604512a`, `b640f5b`) never mirrored to the twin MBES store; round 1 reviewed only `marine_bathymetry_store`, so this round caught the parity gap. Both were cross-pass confirmed by Deep Lens A (logic) + Lens B (systemic/safety), which otherwise verified: lossless Welford `(mean,SE,SD)↔(n,M2)` round-trips with correct n=1 sentinel vs NaN no-data handling; complete, clean staleness-gate retirement with the uncertainty→LETHAL and no-data-conservative gates preserved (`bathymetry_layer.cpp:848–853`); no off-by-one in the collapsed layer arrays. Governance: all principles Pass/Watch, all 3 ADR amendments (0002/0005/0007) accurately mirror the code, all 4 READMEs updated. Plan drift: zero. Static analysis: ament cpplint clean; cppcheck effectively clean (one optional `useStlAlgorithm` nit dropped; ODR error is a separate-test-executable false positive). Copilot Adversarial off (not opted in). Persisted to the project-repo (`unh_marine_autonomy`) timeline, consistent with all prior #248 phase entries.

--- a/bathymetry_layer/README.md
+++ b/bathymetry_layer/README.md
@@ -6,9 +6,10 @@ the planner routes around shoals.
 
 This is the **D1** (prior-only, static) deliverable of issue
 [#164](https://github.com/rolker/unh_marine_autonomy/issues/164): the layer reads
-the store's read-only prior layers (`chart/`, and any `processed/` present) from
-disk and converts depth to cost. It does **not** yet reload live `draft/` tiles
-as the boat surveys — that is the D2 follow-on (see [Follow-on work](#follow-on-work)).
+the store's persisted layers (`survey/` and the read-only `reference/` prior — the
+post-#248 taxonomy) from disk and converts depth to cost. It does **not** yet
+re-read the store live as the boat surveys — that is the D2 follow-on (see
+[Follow-on work](#follow-on-work)).
 
 ## How it works
 
@@ -131,8 +132,8 @@ windowed tile residency keeps memory bounded even on a large global costmap).
 
 ## Follow-on work
 
-- **D2 — live Draft tile reload.** After [#189](https://github.com/rolker/unh_marine_autonomy/issues/189)
-  (atomic tile writes) merges, add tile-change detection on the `draft/` layer so
+- **D2 — live survey tile reload.** After [#189](https://github.com/rolker/unh_marine_autonomy/issues/189)
+  (atomic tile writes) merges, add tile-change detection on the `survey/` layer so
   the costmap refines where the boat has surveyed. File as a new issue:
   "Depends on #164 (D1) and #189 (atomic writes)".
 - **nav2_params registration.** Add the snippet above to the bizzy / echoboat

--- a/bathymetry_layer/README.md
+++ b/bathymetry_layer/README.md
@@ -49,9 +49,11 @@ Per cell the layer uses a **two-query** pattern (ADR-0002 §D7; review finding M
    behind the tide gate (below): no lethal-land is written before a valid tide.
 3. If `bestSource` is non-null → the cell **has data** → `shallowestReliable`
    applies the navigation-safety (uncertainty) gate. A cell that has data but
-   fails the gate (over-uncertain), or whose freshest sample is **stale**
-   (timestamp older than `max_age`), is written **`LETHAL_OBSTACLE`**
-   (conservative). Only a cell that passes both checks gets the clearance ramp.
+   fails the gate (over-uncertain) is written **`LETHAL_OBSTACLE`**
+   (conservative). Only a cell that passes the gate gets the clearance ramp.
+   (The pre-#248 per-cell staleness gate was **retired** — ADR-0002 Amendment
+   A2.4: the bathy store holds a surveyed *static* bottom, not a live sensor
+   feed, so per-cell age is not a meaningful costmap hazard.)
 
 The critical distinction: a surveyed-but-noisy cell is an **obstacle**, not an
 unsurveyed cell. Treating it as unsurveyed would be a safety regression.
@@ -65,7 +67,6 @@ unsurveyed cell. Treating it as unsurveyed would be a safety regression.
 | `minimum_depth` | double | `1.0` | Clearance (m) below which a cell is `LETHAL_OBSTACLE`. |
 | `maximum_caution_depth` | double | `2.5` | Clearance (m) at/above which a cell is `FREE_SPACE`; between `minimum_depth` and this the cost ramps. |
 | `max_uncertainty` | double | `0.5` | Max 1-sigma vertical uncertainty (m) for `shallowestReliable`. A surveyed cell exceeding this is LETHAL. |
-| `max_age` | double | `0.0` | Staleness window (s). `0` disables the gate (D1 chart priors have timestamp 0). A cell whose freshest sample is older than `now − max_age` is LETHAL. |
 | `unsurveyed_is_lethal` | bool | `false` | When `true`, a truly-unsurveyed (no-data) cell is `LETHAL_OBSTACLE` instead of left untouched. Blanket rule — suits a closed basin whose prior fills the whole interior (no-data = land). Still gated by the tide (no cost before a valid `map_tide`). |
 | `map_tide_frame` | string | `map_tide` | Frame whose z-origin is the current water-surface ellipsoidal height. Prefix per platform (`<tf_prefix>/map_tide`). |
 | `map_frame` | string | `map` | Ellipsoid-referenced world frame (REP-105 `map`, z=0 at the WGS84 ellipsoid). The water-surface height is read as `map_tide_frame`'s z in this frame. **Must** be set and distinct from both `map_tide_frame` and the costmap's own global frame — otherwise the tide lookup self-references and reads 0, flooding the survey LETHAL (#220). Prefix per platform (`<tf_prefix>/map`). |
@@ -120,7 +121,6 @@ local_costmap:
         minimum_depth: 1.0
         maximum_caution_depth: 2.5
         max_uncertainty: 0.5
-        max_age: 0.0
         unsurveyed_is_lethal: False   # True for a closed basin (no-data = land)
         map_tide_frame: <tf_prefix>/map_tide
         buffer_fraction: 0.05

--- a/bathymetry_layer/src/bathymetry_layer.cpp
+++ b/bathymetry_layer/src/bathymetry_layer.cpp
@@ -86,9 +86,6 @@ void BathymetryLayer::onInitialize()
   declareParameter("max_uncertainty", rclcpp::ParameterValue(max_uncertainty_));
   node->get_parameter(name_ + ".max_uncertainty", max_uncertainty_);
 
-  declareParameter("max_age", rclcpp::ParameterValue(max_age_));
-  node->get_parameter(name_ + ".max_age", max_age_);
-
   declareParameter("unsurveyed_is_lethal", rclcpp::ParameterValue(unsurveyed_is_lethal_));
   node->get_parameter(name_ + ".unsurveyed_is_lethal", unsurveyed_is_lethal_);
 
@@ -187,8 +184,8 @@ void BathymetryLayer::onInitialize()
     logger_,
     "bathymetry_layer '" << name_ << "': store_path='" << store_path_ << "', minimum_depth="
                          << minimum_depth_ << " m, maximum_caution_depth=" << maximum_caution_depth_
-                         << " m, max_uncertainty=" << max_uncertainty_ << " m, max_age=" << max_age_
-                         << " s, unsurveyed_is_lethal=" << unsurveyed_lethal_str
+                         << " m, max_uncertainty=" << max_uncertainty_
+                         << " m, unsurveyed_is_lethal=" << unsurveyed_lethal_str
                          << ", map_frame='" << map_frame_ << "', map_tide_frame='"
                          << map_tide_frame_ << "'");
 
@@ -217,8 +214,8 @@ void BathymetryLayer::openStore()
   }
   try {
     // The default level only governs cellIndex(lat,lon); the store is otherwise
-    // multi-level. chart_writable=false: a navigation consumer never mutates the
-    // read-only prior.
+    // multi-level. pre_existing_writable=false: a navigation consumer never
+    // mutates the read-only prior.
     store_ = std::make_unique<BathymetryStore>(
       BathymetryStore::fromCellSize(static_cast<float>(resolution_), false));
   } catch (const std::exception & e) {
@@ -427,7 +424,6 @@ void BathymetryLayer::generateTile(
     auto tile = std::make_shared<nav2_costmap_2d::Costmap2D>(
       tile_size_, tile_size_, resolution_, world_min_x, world_min_y,
       nav2_costmap_2d::NO_INFORMATION);
-    const int64_t now_ns = clock_->now().nanoseconds();
     const double inv = 1.0 / static_cast<double>(tile_size_);
     for (int ty = 0; ty < tile_size_; ++ty) {
       const double fy = (static_cast<double>(ty) + 0.5) * inv;
@@ -440,7 +436,7 @@ void BathymetryLayer::generateTile(
         const double lat = w00 * clat[0] + w10 * clat[1] + w01 * clat[2] + w11 * clat[3];
         const double lon = w00 * clon[0] + w10 * clon[1] + w01 * clon[2] + w11 * clon[3];
         const gggs::CellIndex cell = store_->cellIndex(lat, lon);
-        const std::optional<unsigned char> evaluated = evaluateCell(cell, now_ns);
+        const std::optional<unsigned char> evaluated = evaluateCell(cell);
         if (evaluated) {
           tile->setCost(
             static_cast<unsigned int>(tx), static_cast<unsigned int>(ty), *evaluated);
@@ -460,7 +456,6 @@ void BathymetryLayer::generateTile(
   auto tile = std::make_shared<nav2_costmap_2d::Costmap2D>(
     tile_size_, tile_size_, resolution_, world_min_x, world_min_y,
     nav2_costmap_2d::NO_INFORMATION);
-  const int64_t now_ns = clock_->now().nanoseconds();
   for (int ty = 0; ty < tile_size_; ++ty) {
     for (int tx = 0; tx < tile_size_; ++tx) {
       double wx;
@@ -478,7 +473,7 @@ void BathymetryLayer::generateTile(
           name_.c_str(), e.what());
         continue;
       }
-      const std::optional<unsigned char> evaluated = evaluateCell(cell, now_ns);
+      const std::optional<unsigned char> evaluated = evaluateCell(cell);
       if (evaluated) {
         tile->setCost(
           static_cast<unsigned int>(tx), static_cast<unsigned int>(ty), *evaluated);
@@ -647,8 +642,6 @@ void BathymetryLayer::updateBounds(
     const double buffer =
       std::max(world_max_x - world_min_x, world_max_y - world_min_y) * buffer_fraction_;
 
-    const int64_t now_ns = clock_->now().nanoseconds();
-
     // Tide-CHANGE invalidation: re-render when the surface MOVED materially.
     // Cached costs keep being served until each tile regenerates (no flicker).
     // NOTE: this handles a tide that *moves*, not a tide that *freezes/stops*
@@ -663,22 +656,6 @@ void BathymetryLayer::updateBounds(
       }
       last_tide_z_ = map_tide_z_;
       tide_rendered_ = true;
-    }
-
-    // Staleness vs caching: a tile is rendered once, so without this a cell that
-    // ages past max_age_ would keep its cached (possibly non-lethal) cost instead
-    // of flipping to stale-LETHAL like the old per-cycle evaluation did. When the
-    // staleness gate is on (max_age_ > 0), force a full re-render every
-    // ~max_age_/2 so a cell goes stale-LETHAL within ~max_age_ of when it should.
-    // max_age_ == 0 (default) disables the gate, keeping the full caching benefit.
-    if (max_age_ > 0.0) {
-      const int64_t interval_ns = static_cast<int64_t>(max_age_ * 5e8);
-      if (now_ns - last_full_render_ns_ >= interval_ns) {
-        for (auto & entry : tiles_) {
-          entry.second.needs_update = true;
-        }
-        last_full_render_ns_ = now_ns;
-      }
     }
 
     // Tiles overlapping the buffered window.
@@ -833,17 +810,8 @@ unsigned char BathymetryLayer::computeCost(double clearance) const
   return static_cast<unsigned char>(scaled);
 }
 
-bool BathymetryLayer::isStale(int64_t timestamp_ns, int64_t now_ns) const
-{
-  if (max_age_ <= 0.0 || timestamp_ns == 0) {
-    return false;
-  }
-  const int64_t max_age_ns = static_cast<int64_t>(max_age_ * 1e9);
-  return (now_ns - timestamp_ns) > max_age_ns;
-}
-
 std::optional<unsigned char> BathymetryLayer::evaluateCell(
-  const gggs::CellIndex & cell, int64_t now_ns) const
+  const gggs::CellIndex & cell) const
 {
   if (!store_) {
     return std::nullopt;
@@ -877,15 +845,10 @@ std::optional<unsigned char> BathymetryLayer::evaluateCell(
   //   2. shallowestReliable — the navigation-safety gate (uncertainty).
   const std::optional<DepthSample> sample = shallowestReliable(*store_, cell, max_uncertainty_);
 
-  // MF3: use sample->timestamp (the reliable record's age) for the staleness
-  // check, not any->timestamp (the quality-blind record). bestSource may return
-  // an over-uncertain record at this cell while shallowestReliable returns a
-  // different, confident one; we age-check the record we actually use for
-  // clearance (the reliable one), not the quality-blind bestSource record.
-  if (!sample || isStale(sample->timestamp, now_ns)) {
-    // Data exists but every sample is over-uncertain (sample==nullopt), or the
-    // reliable sample is stale → conservative LETHAL. A surveyed-but-unusable
-    // cell must NOT be treated as unsurveyed (review M1).
+  if (!sample) {
+    // Data exists but every sample is over-uncertain → conservative LETHAL. A
+    // surveyed-but-unusable cell must NOT be treated as unsurveyed (review M1).
+    // (The pre-#248 per-cell staleness gate was retired — ADR-0002 A2.4.)
     return nav2_costmap_2d::LETHAL_OBSTACLE;
   }
 

--- a/bathymetry_layer/src/bathymetry_layer.cpp
+++ b/bathymetry_layer/src/bathymetry_layer.cpp
@@ -214,7 +214,7 @@ void BathymetryLayer::openStore()
   }
   try {
     // The default level only governs cellIndex(lat,lon); the store is otherwise
-    // multi-level. pre_existing_writable=false: a navigation consumer never
+    // multi-level. reference_writable=false: a navigation consumer never
     // mutates the read-only prior.
     store_ = std::make_unique<BathymetryStore>(
       BathymetryStore::fromCellSize(static_cast<float>(resolution_), false));

--- a/bathymetry_layer/src/bathymetry_layer.hpp
+++ b/bathymetry_layer/src/bathymetry_layer.hpp
@@ -27,12 +27,12 @@ namespace bathymetry_layer
 
 /// @brief Nav2 costmap layer fed by the bathymetric store (marine_bathymetry_store).
 ///
-/// Reads the store's read-only prior layers (`chart/`, and any `processed/`
-/// present) from disk and turns *clearance* — the water-surface ellipsoidal
-/// height minus the seafloor ellipsoidal height — into occupancy cost so the
-/// planner routes around shoals. This is the D1 (prior-only, static) deliverable
-/// of issue #164: no live `draft/` reload (deferred to D2, which depends on the
-/// atomic-tile-write work in #189).
+/// Reads the store's persisted layers (`survey/` and the read-only `reference/`
+/// prior — the post-#248 taxonomy, ADR-0002 A2.1) from disk and turns *clearance*
+/// — the water-surface ellipsoidal height minus the seafloor ellipsoidal height —
+/// into occupancy cost so the planner routes around shoals. This is the D1
+/// (prior-only, static) deliverable of issue #164: no live re-read of the store
+/// (deferred to D2, which depends on the atomic-tile-write work in #189).
 ///
 /// **No-data policy (ADR-0002 §D7, two-query safety pattern):** per cell,
 /// `bestSource` first answers "is there ANY data here?" (quality-blind). If not,

--- a/bathymetry_layer/src/bathymetry_layer.hpp
+++ b/bathymetry_layer/src/bathymetry_layer.hpp
@@ -47,9 +47,11 @@ namespace bathymetry_layer
 /// choose it per deployment. It is still held behind the tide gate: no cost,
 /// lethal-land included, is emitted before a valid `map_tide` arrives.
 /// If there *is* data, `shallowestReliable` applies the navigation-safety gate; a
-/// cell that has data but fails the uncertainty gate, or whose freshest sample is
-/// stale, is written `LETHAL_OBSTACLE` (conservative). Only the clearance ramp
-/// produces non-lethal cost.
+/// cell that has data but fails the uncertainty gate is written `LETHAL_OBSTACLE`
+/// (conservative). Only the clearance ramp produces non-lethal cost. (The
+/// pre-#248 per-cell staleness gate was retired — ADR-0002 Amendment A2.4: the
+/// bathy store is a surveyed static bottom, not a live feed, so per-cell age is
+/// not a meaningful costmap hazard.)
 ///
 /// **Layer coexistence:** writes use max-cost semantics (a cell is only raised,
 /// never lowered, and an unsurveyed cell is skipped), so this layer composes with
@@ -88,14 +90,7 @@ protected:
   // decoupled from the costmap/TF pipeline. Reads store_ and map_tide_z_.
   // Returns std::nullopt when the cell is truly unsurveyed (the layer leaves the
   // master cost untouched); otherwise the cost to combine into the master grid.
-  // @p now_ns is "now" in nanoseconds since the Unix epoch (for the staleness gate).
-  std::optional<unsigned char> evaluateCell(
-    const gggs::CellIndex & cell, int64_t now_ns) const;
-
-  // Whether @p timestamp_ns (nanoseconds since the Unix epoch) is older than
-  // max_age_ relative to @p now_ns. Returns false when the gate is disabled
-  // (max_age_ <= 0) or the timestamp is unset (0).
-  bool isStale(int64_t timestamp_ns, int64_t now_ns) const;
+  std::optional<unsigned char> evaluateCell(const gggs::CellIndex & cell) const;
 
   // Expand a leading "~"/"~/" in @p path to $HOME (so one portable store_path
   // resolves on both the boat and dev/sim). Absolute, empty, and "~user" paths
@@ -170,7 +165,6 @@ protected:
   double minimum_depth_ = 1.0;
   double maximum_caution_depth_ = 2.5;
   double max_uncertainty_ = 0.5;
-  double max_age_ = 0.0;
   // When true, a truly-unsurveyed (no-data) cell is written LETHAL_OBSTACLE
   // instead of being left untouched (NO_INFORMATION). Opt-in (default false):
   // a blanket rule suited to a closed basin whose prior covers the whole
@@ -285,14 +279,6 @@ private:
   double last_tide_z_ = 0.0;
   bool tide_rendered_ = false;
   double tide_invalidate_threshold_ = 0.1;
-
-  // Staleness vs caching: a tile is rendered once, so a cell that ages past
-  // max_age_ would keep its cached (possibly non-lethal) cost rather than
-  // flipping to stale-LETHAL the way the old per-cycle evaluation did. When the
-  // staleness gate is enabled (max_age_ > 0) the cache is fully re-rendered on
-  // this interval so a cell goes stale-LETHAL within ~max_age_ of when it should.
-  // last_full_render_ns_ is the time of the last such forced re-render.
-  int64_t last_full_render_ns_ = 0;
 
   // Last buffered geographic window passed to loadWindow/evictOutside. Used to
   // skip redundant reloads when the costmap has not scrolled past the buffer.

--- a/bathymetry_layer/test/test_bathymetry_layer.cpp
+++ b/bathymetry_layer/test/test_bathymetry_layer.cpp
@@ -199,7 +199,7 @@ TEST(BathymetryLayer, SurveyedCellMapsClearanceToCost)
   const auto cell = store->cellIndex(kLat, kLon);
 
   // Shoal: seafloor 0.5 m below the water surface → clearance 0.5 m < 1.0 → LETHAL.
-  store->set(SourceLayer::Cube, cell, BathyCell{-0.5, 0.1});
+  store->set(SourceLayer::Survey, cell, BathyCell{-0.5, 0.1});
   layer.setStore(std::move(store));
   layer.setMapTideValid(true);
   auto shoal = layer.evaluateCell(cell);
@@ -209,7 +209,7 @@ TEST(BathymetryLayer, SurveyedCellMapsClearanceToCost)
   // Deep: seafloor 5 m down → clearance 5 m >= 3.0 → FREE_SPACE.
   auto deep_store = std::make_unique<BathymetryStore>(5);
   const auto deep_cell = deep_store->cellIndex(kLat, kLon);
-  deep_store->set(SourceLayer::Cube, deep_cell, BathyCell{-5.0, 0.1});
+  deep_store->set(SourceLayer::Survey, deep_cell, BathyCell{-5.0, 0.1});
   layer.setStore(std::move(deep_store));
   layer.setMapTideValid(true);
   auto deep = layer.evaluateCell(deep_cell);
@@ -232,7 +232,7 @@ TEST(BathymetryLayer, OverUncertainSurveyedCellIsLethal)
   // Data present, but uncertainty 5.0 m exceeds max_uncertainty 0.5 m: the cell
   // HAS data (bestSource non-null) but fails the reliability gate
   // (shallowestReliable nullopt).
-  store->set(SourceLayer::Cube, cell, BathyCell{-10.0, 5.0});
+  store->set(SourceLayer::Survey, cell, BathyCell{-10.0, 5.0});
   layer.setStore(std::move(store));
   layer.setMapTideValid(true);
 
@@ -259,7 +259,7 @@ TEST(BathymetryLayer, InvalidTideYieldsNoInformation)
   auto store = std::make_unique<BathymetryStore>(5);
   const auto cell = store->cellIndex(kLat, kLon);
   // A perfectly good surveyed cell (deep, reliable, fresh) must still be skipped.
-  store->set(SourceLayer::Cube, cell, BathyCell{47.0, 0.1});
+  store->set(SourceLayer::Survey, cell, BathyCell{47.0, 0.1});
   layer.setStore(std::move(store));
 
   const auto result = layer.evaluateCell(cell);
@@ -292,7 +292,7 @@ TEST(BathymetryLayer, OverUncertainCellIsLethalWithNoPriorFallback)
   {
     auto store = std::make_unique<BathymetryStore>(5);
     const auto cell = store->cellIndex(kLat, kLon);
-    store->set(SourceLayer::Cube, cell, BathyCell{-5.0, 5.0});
+    store->set(SourceLayer::Survey, cell, BathyCell{-5.0, 5.0});
     layer.setStore(std::move(store));
 
     const auto result = layer.evaluateCell(cell);
@@ -307,7 +307,7 @@ TEST(BathymetryLayer, OverUncertainCellIsLethalWithNoPriorFallback)
   {
     auto store = std::make_unique<BathymetryStore>(5);
     const auto cell = store->cellIndex(kLat, kLon);
-    store->set(SourceLayer::Cube, cell, BathyCell{-5.0, 0.1});
+    store->set(SourceLayer::Survey, cell, BathyCell{-5.0, 0.1});
     layer.setStore(std::move(store));
 
     const auto result = layer.evaluateCell(cell);
@@ -377,21 +377,21 @@ TEST(BathymetryLayer, WindowedResidencyStaysBounded)
   fs::create_directories(dir);
 
   // Build a store spanning a wide geographic strip so its tiles land in
-  // distinct GGGS grids, then persist it to disk. pre_existing_writable=true so
-  // the synthetic prior can be written on the read-only PreExisting layer.
+  // distinct GGGS grids, then persist it to disk. reference_writable=true so
+  // the synthetic prior can be written on the read-only Reference layer.
   {
-    BathymetryStore store(12, /*pre_existing_writable=*/true);
+    BathymetryStore store(12, /*reference_writable=*/true);
     for (int k = 0; k < 8; ++k) {
       const double lon = -70.5 + 0.05 * static_cast<double>(k);
       const auto cell = store.cellIndex(43.0, lon);
-      store.set(SourceLayer::PreExisting, cell, BathyCell{-10.0, 0.2});
+      store.set(SourceLayer::Reference, cell, BathyCell{-10.0, 0.2});
     }
     const std::size_t written = marine_bathymetry_store::save(store, dir.string(), nullptr);
     ASSERT_GT(written, 0u);
   }
 
   // A fresh consumer store loads only a small window, leaving most tiles on disk.
-  BathymetryStore consumer(12, /*pre_existing_writable=*/false);
+  BathymetryStore consumer(12, /*reference_writable=*/false);
   const auto small_min = gggs::geoPoint(42.999, -70.51);
   const auto small_max = gggs::geoPoint(43.001, -70.49);
   marine_bathymetry_store::loadWindow(consumer, dir.string(), small_min, small_max);

--- a/bathymetry_layer/test/test_bathymetry_layer.cpp
+++ b/bathymetry_layer/test/test_bathymetry_layer.cpp
@@ -40,9 +40,6 @@ namespace
 // Survey position used across the per-cell tests.
 constexpr double kLat = 43.0;
 constexpr double kLon = -70.5;
-
-// Nanoseconds in one second (timestamp arithmetic is ns since the Unix epoch).
-constexpr int64_t kNsPerSec = 1000000000LL;
 }  // namespace
 
 // Test subclass exposing the protected store / water-surface seam and the
@@ -61,7 +58,6 @@ public:
   void setMinimumDepth(double v) {minimum_depth_ = v;}
   void setMaximumCautionDepth(double v) {maximum_caution_depth_ = v;}
   void setMaxUncertainty(double v) {max_uncertainty_ = v;}
-  void setMaxAge(double v) {max_age_ = v;}
   void setUnsurveyedIsLethal(bool v) {unsurveyed_is_lethal_ = v;}
   void setWindowValid(bool v) {setWindowValidForTest(v);}
   void setCoverageEmptyLethal(bool v) {coverage_empty_lethal_ = v;}
@@ -71,7 +67,6 @@ public:
 
   using BathymetryLayer::computeCost;
   using BathymetryLayer::evaluateCell;
-  using BathymetryLayer::isStale;
   using BathymetryLayer::expandUserPath;
   using BathymetryLayer::injectTile;
   using BathymetryLayer::tileSize;
@@ -147,7 +142,7 @@ TEST(BathymetryLayer, UnsurveyedCellLeavesMasterUntouched)
 
   // A cell with no data anywhere in the store.
   const auto cell = layer.store().cellIndex(kLat, kLon);
-  const auto result = layer.evaluateCell(cell, /*now_ns=*/0);
+  const auto result = layer.evaluateCell(cell);
   EXPECT_FALSE(result.has_value()) << "Unsurveyed cells must not be written.";
 }
 
@@ -164,7 +159,7 @@ TEST(BathymetryLayer, UnsurveyedCellLethalWhenParamEnabled)
   layer.setUnsurveyedIsLethal(true);
 
   const auto cell = layer.store().cellIndex(kLat, kLon);
-  const auto result = layer.evaluateCell(cell, /*now_ns=*/0);
+  const auto result = layer.evaluateCell(cell);
   ASSERT_TRUE(result.has_value())
     << "With unsurveyed_is_lethal, a no-data cell must be written.";
   EXPECT_EQ(*result, nav2_costmap_2d::LETHAL_OBSTACLE);
@@ -184,7 +179,7 @@ TEST(BathymetryLayer, UnsurveyedLethalStillGatedByTide)
   // Deliberately do NOT mark the tide valid (map_tide_valid_ defaults false).
 
   const auto cell = layer.store().cellIndex(kLat, kLon);
-  const auto result = layer.evaluateCell(cell, /*now_ns=*/0);
+  const auto result = layer.evaluateCell(cell);
   EXPECT_FALSE(result.has_value())
     << "No tide yet: unsurveyed-lethal must still be gated (MF1).";
 }
@@ -204,20 +199,20 @@ TEST(BathymetryLayer, SurveyedCellMapsClearanceToCost)
   const auto cell = store->cellIndex(kLat, kLon);
 
   // Shoal: seafloor 0.5 m below the water surface → clearance 0.5 m < 1.0 → LETHAL.
-  store->set(SourceLayer::Processed, cell, BathyCell{-0.5, 0.1, 1LL});
+  store->set(SourceLayer::Cube, cell, BathyCell{-0.5, 0.1});
   layer.setStore(std::move(store));
   layer.setMapTideValid(true);
-  auto shoal = layer.evaluateCell(cell, /*now_ns=*/0);
+  auto shoal = layer.evaluateCell(cell);
   ASSERT_TRUE(shoal.has_value());
   EXPECT_EQ(*shoal, nav2_costmap_2d::LETHAL_OBSTACLE);
 
   // Deep: seafloor 5 m down → clearance 5 m >= 3.0 → FREE_SPACE.
   auto deep_store = std::make_unique<BathymetryStore>(5);
   const auto deep_cell = deep_store->cellIndex(kLat, kLon);
-  deep_store->set(SourceLayer::Processed, deep_cell, BathyCell{-5.0, 0.1, 1LL});
+  deep_store->set(SourceLayer::Cube, deep_cell, BathyCell{-5.0, 0.1});
   layer.setStore(std::move(deep_store));
   layer.setMapTideValid(true);
-  auto deep = layer.evaluateCell(deep_cell, /*now_ns=*/0);
+  auto deep = layer.evaluateCell(deep_cell);
   ASSERT_TRUE(deep.has_value());
   EXPECT_EQ(*deep, nav2_costmap_2d::FREE_SPACE);
 }
@@ -237,47 +232,14 @@ TEST(BathymetryLayer, OverUncertainSurveyedCellIsLethal)
   // Data present, but uncertainty 5.0 m exceeds max_uncertainty 0.5 m: the cell
   // HAS data (bestSource non-null) but fails the reliability gate
   // (shallowestReliable nullopt).
-  store->set(SourceLayer::Processed, cell, BathyCell{-10.0, 5.0, 1LL});
+  store->set(SourceLayer::Cube, cell, BathyCell{-10.0, 5.0});
   layer.setStore(std::move(store));
   layer.setMapTideValid(true);
 
-  const auto result = layer.evaluateCell(cell, /*now_ns=*/0);
+  const auto result = layer.evaluateCell(cell);
   ASSERT_TRUE(result.has_value())
     << "Over-uncertain surveyed cell must be written (not skipped as unsurveyed).";
   EXPECT_EQ(*result, nav2_costmap_2d::LETHAL_OBSTACLE);
-}
-
-// ---------------------------------------------------------------------------
-// Test case 5 (extra coverage of test case 4's sibling): a reliable but STALE
-// cell → LETHAL regardless of clearance.
-// ---------------------------------------------------------------------------
-TEST(BathymetryLayer, StaleCellIsLethal)
-{
-  BathymetryLayerForTest layer;
-  layer.setMinimumDepth(1.0);
-  layer.setMaximumCautionDepth(3.0);
-  layer.setMaxUncertainty(0.5);
-  layer.setMaxAge(1.0);          // 1-second staleness window.
-  layer.setMapTideZ(0.0);
-
-  auto store = std::make_unique<BathymetryStore>(5);
-  const auto cell = store->cellIndex(kLat, kLon);
-  // Deep + reliable (clearance would be FREE), but timestamp is 1 ns — ancient.
-  store->set(SourceLayer::Processed, cell, BathyCell{-5.0, 0.1, 1LL});
-  layer.setStore(std::move(store));
-  layer.setMapTideValid(true);
-
-  const int64_t now_ns = 10 * kNsPerSec;  // 10 s now, max_age 1 s → stale.
-  const auto stale = layer.evaluateCell(cell, now_ns);
-  ASSERT_TRUE(stale.has_value());
-  EXPECT_EQ(*stale, nav2_costmap_2d::LETHAL_OBSTACLE);
-
-  // With the staleness gate disabled (max_age 0), the same deep reliable cell
-  // is FREE_SPACE — confirming the stale verdict came from the age gate.
-  layer.setMaxAge(0.0);
-  const auto fresh = layer.evaluateCell(cell, now_ns);
-  ASSERT_TRUE(fresh.has_value());
-  EXPECT_EQ(*fresh, nav2_costmap_2d::FREE_SPACE);
 }
 
 // ---------------------------------------------------------------------------
@@ -297,23 +259,23 @@ TEST(BathymetryLayer, InvalidTideYieldsNoInformation)
   auto store = std::make_unique<BathymetryStore>(5);
   const auto cell = store->cellIndex(kLat, kLon);
   // A perfectly good surveyed cell (deep, reliable, fresh) must still be skipped.
-  store->set(SourceLayer::Processed, cell, BathyCell{47.0, 0.1, 1LL});
+  store->set(SourceLayer::Cube, cell, BathyCell{47.0, 0.1});
   layer.setStore(std::move(store));
 
-  const auto result = layer.evaluateCell(cell, /*now_ns=*/0);
+  const auto result = layer.evaluateCell(cell);
   EXPECT_FALSE(result.has_value())
     << "No tide yet: layer must not write any cost (MF1 safety gate).";
 }
 
 // ---------------------------------------------------------------------------
-// Test case 7 (S1/MF3, rewritten for #221): single fused surface — no prior
-// epoch to fall back to. With the per-day epoch dimension dropped, a cell whose
-// (only) record is over-uncertain has no older confident epoch to fall through
-// to: shallowestReliable returns nullopt and the cell is LETHAL (the deliberate
-// fallback-loss tradeoff recorded in ADR-0002 A1's supersession). This pins
-// that an over-uncertain cell is LETHAL even when bestSource finds fresh data,
-// that a confident-but-ancient record is stale (MF3 age-checks the reliable
-// record), and that the same confident record when fresh is FREE.
+// Test case 7 (S1, rewritten for #221 and #248): single fused surface — no prior
+// epoch to fall back to. A cell whose (only) record is over-uncertain has no
+// older confident epoch to fall through to: shallowestReliable returns nullopt
+// and the cell is LETHAL (the deliberate fallback-loss tradeoff recorded in
+// ADR-0002 A1's supersession). This pins that an over-uncertain cell is LETHAL
+// even when bestSource finds data, and that the same confident record is FREE.
+// (The per-cell staleness gate was retired in #248 — ADR-0002 A2.4 — so age no
+// longer factors into the verdict.)
 // ---------------------------------------------------------------------------
 TEST(BathymetryLayer, OverUncertainCellIsLethalWithNoPriorFallback)
 {
@@ -321,57 +283,37 @@ TEST(BathymetryLayer, OverUncertainCellIsLethalWithNoPriorFallback)
   layer.setMinimumDepth(1.0);
   layer.setMaximumCautionDepth(3.0);
   layer.setMaxUncertainty(0.5);
-  layer.setMaxAge(1.0);   // 1-second window.
   layer.setMapTideZ(0.0);
   layer.setMapTideValid(true);
 
-  const int64_t now_ns = 10 * kNsPerSec;  // "now" = 10 s.
-
-  // Single fused surface: one record per cell. A deep but OVER-UNCERTAIN + FRESH
-  // record. bestSource finds it (it has data) but shallowestReliable returns
-  // nullopt — and there is no prior epoch to fall through to, so the cell is
-  // LETHAL despite the fresh timestamp.
+  // Single fused surface: one record per cell. A deep but OVER-UNCERTAIN record.
+  // bestSource finds it (it has data) but shallowestReliable returns nullopt —
+  // and there is no prior epoch to fall through to, so the cell is LETHAL.
   {
     auto store = std::make_unique<BathymetryStore>(5);
     const auto cell = store->cellIndex(kLat, kLon);
-    const int64_t fresh_ns = 9 * kNsPerSec;  // 1 s ago — within max_age.
-    store->set(SourceLayer::Processed, cell, BathyCell{-5.0, 5.0, fresh_ns});
+    store->set(SourceLayer::Cube, cell, BathyCell{-5.0, 5.0});
     layer.setStore(std::move(store));
 
-    const auto result = layer.evaluateCell(cell, now_ns);
+    const auto result = layer.evaluateCell(cell);
     ASSERT_TRUE(result.has_value())
       << "Cell has data → must write something (not skip as unsurveyed).";
     EXPECT_EQ(*result, nav2_costmap_2d::LETHAL_OBSTACLE)
       << "Over-uncertain with no prior fallback → LETHAL (#221 tradeoff).";
   }
 
-  // A confident but ANCIENT record is also LETHAL — MF3 age-checks the reliable
-  // record shallowestReliable returns.
+  // The same confident record is FREE — confirming the LETHAL verdict above came
+  // from the reliability gate, not from the data being absent.
   {
     auto store = std::make_unique<BathymetryStore>(5);
     const auto cell = store->cellIndex(kLat, kLon);
-    const int64_t ancient_ns = 1LL;  // nanosecond 1 — very old.
-    store->set(SourceLayer::Processed, cell, BathyCell{-5.0, 0.1, ancient_ns});
+    store->set(SourceLayer::Cube, cell, BathyCell{-5.0, 0.1});
     layer.setStore(std::move(store));
 
-    const auto result = layer.evaluateCell(cell, now_ns);
-    ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(*result, nav2_costmap_2d::LETHAL_OBSTACLE)
-      << "Reliable but ancient record is stale → LETHAL (MF3).";
-  }
-
-  // The same confident record, fresh, is FREE — confirming the LETHAL verdicts
-  // above came from the reliability/age gates, not from the data being absent.
-  {
-    auto store = std::make_unique<BathymetryStore>(5);
-    const auto cell = store->cellIndex(kLat, kLon);
-    store->set(SourceLayer::Processed, cell, BathyCell{-5.0, 0.1, now_ns});
-    layer.setStore(std::move(store));
-
-    const auto result = layer.evaluateCell(cell, now_ns);
+    const auto result = layer.evaluateCell(cell);
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(*result, nav2_costmap_2d::FREE_SPACE)
-      << "Deep, reliable, fresh record → FREE.";
+      << "Deep, reliable record → FREE.";
   }
 }
 
@@ -435,21 +377,21 @@ TEST(BathymetryLayer, WindowedResidencyStaysBounded)
   fs::create_directories(dir);
 
   // Build a store spanning a wide geographic strip so its tiles land in
-  // distinct GGGS grids, then persist it to disk. chart_writable=true so the
-  // synthetic prior can be written on the read-only Chart layer.
+  // distinct GGGS grids, then persist it to disk. pre_existing_writable=true so
+  // the synthetic prior can be written on the read-only PreExisting layer.
   {
-    BathymetryStore store(12, /*chart_writable=*/true);
+    BathymetryStore store(12, /*pre_existing_writable=*/true);
     for (int k = 0; k < 8; ++k) {
       const double lon = -70.5 + 0.05 * static_cast<double>(k);
       const auto cell = store.cellIndex(43.0, lon);
-      store.set(SourceLayer::Chart, cell, BathyCell{-10.0, 0.2, 1LL});
+      store.set(SourceLayer::PreExisting, cell, BathyCell{-10.0, 0.2});
     }
     const std::size_t written = marine_bathymetry_store::save(store, dir.string(), nullptr);
     ASSERT_GT(written, 0u);
   }
 
   // A fresh consumer store loads only a small window, leaving most tiles on disk.
-  BathymetryStore consumer(12, /*chart_writable=*/false);
+  BathymetryStore consumer(12, /*pre_existing_writable=*/false);
   const auto small_min = gggs::geoPoint(42.999, -70.51);
   const auto small_max = gggs::geoPoint(43.001, -70.49);
   marine_bathymetry_store::loadWindow(consumer, dir.string(), small_min, small_max);

--- a/docs/decisions/0002-bathymetric-data-store.md
+++ b/docs/decisions/0002-bathymetric-data-store.md
@@ -41,6 +41,17 @@ compose with mixed-level `<level>_<row>_<col>` tile filenames. See **A1** below.
 > the end of the A1 section). A1 stood for three days. The detail is recorded so
 > readers understand both the original reasoning and why it was reversed.
 
+**Amended 2026-07-01 ([#248](https://github.com/rolker/unh_marine_autonomy/issues/248)):**
+greenfield store-format simplification — the store is a **regenerable cache** over
+raw bags, so the format is simplified with **no migration shim**. The three source
+layers collapse to **two** (`chart`/`draft`/`processed` → `pre-existing`/`cube`),
+the per-cell `_time.tif` and `_source.tif` rasters are **dropped** (a single 2-band
+`Float64` value tile per grid remains), `registry.json` is **repurposed** from a
+per-cell source-index intern table to a coarse store-level `StoreMetadata` sidecar
+(cross-ref [ADR-0005](0005-multi-platform-provenance-registry.md) #248 amendment),
+and the `bathymetry_layer` **per-cell staleness gate is retired** (it read the now-
+dropped per-cell time). See **Amendment A2** below.
+
 The full design is in the issue body; this ADR records the load-bearing
 architecture decisions and their rationale so they survive the issue. It is a
 **cross-cutting** decision in the sense ADR-0001 establishes for this repo's
@@ -471,6 +482,80 @@ The companion `cube_bathymetry` change (dropping `currentUtcDateString()` from
 `cube_bathymetry_node.cpp`, which fed the epoch label) is tracked separately as
 [rolker/cube_bathymetry#69](https://github.com/rolker/cube_bathymetry/issues/69)
 and lands as a coordinated follow-on against the new epoch-free store API.
+
+## Amendment A2 — Greenfield store-format simplification ([#248](https://github.com/rolker/unh_marine_autonomy/issues/248), 2026-07-01)
+
+The store is a **derived cache**: every tile is re-derivable from the raw soundings
+bags (D5/D9, ADR-0007 D1). That framing makes several D3/D5 structures redundant
+now that the deployment is **single-platform** (BizzyBoat M3) and single-coverage.
+This amendment removes them. Because there is no production store to migrate (the
+cache regenerates from bags), the change is a **clean break — no migration shim**.
+
+### A2.1 — Layer taxonomy: three layers collapse to two
+
+The D3 quality/maturity layers `chart` / `draft` / `processed` are replaced by
+**`cube`** (highest priority) and **`pre-existing`** (the read-only prior):
+
+- **`cube`** — the CUBE product, live or off-boat re-run. Subsumes the old
+  `draft` + `processed` distinction: with one fused surface per layer (#221,
+  last-write-wins) and a single platform, separating live from re-run added no
+  query value. Highest priority.
+- **`pre-existing`** — any prior surface imported before the survey (a chart-derived
+  contour prior, an external processed grid). This is the old `chart` layer
+  generalized and **remains the read-only prior**: live `cube` ingest can never
+  clobber it (the D3 read-only gate moves from `chart` to `pre-existing`, opted into
+  at construction by the importer only).
+
+The on-disk subdirectories become `cube/` and `pre-existing/` accordingly. The D3
+priority-overlay semantics (non-destructive, `cube > pre-existing`) are unchanged.
+
+### A2.2 — Tile layout: value tile only; `_time` / `_source` dropped
+
+D5 (as amended by #178) persisted **three** files per grid: a 2-band `Float64`
+value tile, a 1-band `Int64` `_time.tif`, and a 1-band `UInt16` `_source.tif`.
+This amendment keeps **only the 2-band `Float64` value tile** (depth +
+uncertainty; NaN no-data on both). The `_time.tif` and `_source.tif` companions
+are **dropped**:
+
+- **Per-cell time** is redundant with the bag record and its only in-tree consumer
+  was the `bathymetry_layer` staleness gate, retired in A2.4.
+- **Per-cell source index** was the ADR-0005 D2/D8 multi-platform provenance axis;
+  with a single platform it is a constant, so per-cell storage is unwarranted.
+  Coarse provenance moves to the store-level `StoreMetadata` sidecar (A2.3).
+
+`BathyCell` therefore carries only `{depth, uncertainty}`; `DepthSample` drops
+`timestamp` and `source_index`.
+
+### A2.3 — `registry.json` repurposed as coarse `StoreMetadata`
+
+The `registry.json` sidecar (D5/#178, ADR-0005 D2) is **repurposed**, not removed:
+from a per-cell source-index intern table (`SourceRegistry` / `SourceRecord`) to a
+flat store-level **`StoreMetadata{platform, sensor, survey, date}`**. It records who
+made the store once, at the root, instead of interning per-cell handles. The
+per-cell provenance drop and this repurpose are recorded on the owning ADR in the
+[ADR-0005](0005-multi-platform-provenance-registry.md) #248 amendment.
+
+### A2.4 — Retire the `bathymetry_layer` per-cell staleness gate
+
+The Nav2 costmap layer's per-cell staleness gate (`max_age` param + `isStale()`,
+which read `DepthSample::timestamp`) is **retired** — code, parameters, tests, and
+README mention removed, not stubbed. Rationale: the bathy store holds a **surveyed
+static bottom**, not a live sensor feed. A surveyed depth does not "expire": the
+seafloor a survey measured is still there. Per-cell staleness was a costmap hazard
+concept borrowed from live-perception layers that does not apply to a static prior,
+and it was the sole remaining reader of the per-cell time band (A2.2). The
+uncertainty gate (`max_uncertainty`, `shallowestReliable`) and the conservative
+no-data policy (D7) are unchanged and remain the safety mechanism: an over-uncertain
+or unsurveyed cell is still LETHAL / obstacle. This is a deliberate,
+operator-approved removal (issue #248 plan-review resolution, 2026-07-01), not a
+silent drop.
+
+### A2.5 — Synchronized landing with cube_bathymetry#96
+
+The `SourceLayer` rename and the dropped bathy-store obligations (no per-cell time /
+source to feed) are a producer-side contract change. cube_bathymetry#96 (the
+consumption side) must co-land so there is no broken-build window; the merge is
+coordinated (issue #248 resolution 2, 2026-06-30).
 
 ## Consequences
 

--- a/docs/decisions/0002-bathymetric-data-store.md
+++ b/docs/decisions/0002-bathymetric-data-store.md
@@ -44,7 +44,7 @@ compose with mixed-level `<level>_<row>_<col>` tile filenames. See **A1** below.
 **Amended 2026-07-01 ([#248](https://github.com/rolker/unh_marine_autonomy/issues/248)):**
 greenfield store-format simplification — the store is a **regenerable cache** over
 raw bags, so the format is simplified with **no migration shim**. The three source
-layers collapse to **two** (`chart`/`draft`/`processed` → `pre-existing`/`cube`),
+layers collapse to **two** (`chart`/`draft`/`processed` → `reference`/`survey`),
 the per-cell `_time.tif` and `_source.tif` rasters are **dropped** (a single 2-band
 `Float64` value tile per grid remains), `registry.json` is **repurposed** from a
 per-cell source-index intern table to a coarse store-level `StoreMetadata` sidecar
@@ -494,20 +494,20 @@ cache regenerates from bags), the change is a **clean break — no migration shi
 ### A2.1 — Layer taxonomy: three layers collapse to two
 
 The D3 quality/maturity layers `chart` / `draft` / `processed` are replaced by
-**`cube`** (highest priority) and **`pre-existing`** (the read-only prior):
+**`survey`** (highest priority) and **`reference`** (the read-only prior):
 
-- **`cube`** — the CUBE product, live or off-boat re-run. Subsumes the old
+- **`survey`** — the CUBE product, live or off-boat re-run. Subsumes the old
   `draft` + `processed` distinction: with one fused surface per layer (#221,
   last-write-wins) and a single platform, separating live from re-run added no
   query value. Highest priority.
-- **`pre-existing`** — any prior surface imported before the survey (a chart-derived
+- **`reference`** — any prior surface imported before the survey (a chart-derived
   contour prior, an external processed grid). This is the old `chart` layer
-  generalized and **remains the read-only prior**: live `cube` ingest can never
-  clobber it (the D3 read-only gate moves from `chart` to `pre-existing`, opted into
+  generalized and **remains the read-only prior**: live `survey` ingest can never
+  clobber it (the D3 read-only gate moves from `chart` to `reference`, opted into
   at construction by the importer only).
 
-The on-disk subdirectories become `cube/` and `pre-existing/` accordingly. The D3
-priority-overlay semantics (non-destructive, `cube > pre-existing`) are unchanged.
+The on-disk subdirectories become `survey/` and `reference/` accordingly. The D3
+priority-overlay semantics (non-destructive, `survey > reference`) are unchanged.
 
 ### A2.2 — Tile layout: value tile only; `_time` / `_source` dropped
 

--- a/docs/decisions/0005-multi-platform-provenance-registry.md
+++ b/docs/decisions/0005-multi-platform-provenance-registry.md
@@ -11,6 +11,15 @@ backscatter stores — **sidescan** (ADR-0006) and **MBES** (ADR-0007), both und
 #180 — and defines the provenance contract all three share. It is foundational to
 those store ADRs rather than owned by any one of them.
 
+**Amended 2026-07-01 ([#248](https://github.com/rolker/unh_marine_autonomy/issues/248)):**
+for the current **single-platform** deployment the per-cell source-index axis (D2)
+is **dropped** from the bathy and MBES stores, and their `registry.json` sidecar is
+**repurposed** from a per-cell interning table to a coarse store-level
+`StoreMetadata{platform, sensor, survey, date}`. The per-cell provenance mechanism
+(D2/D4) is **retained in this ADR as the multi-platform contract**; it is simply not
+instantiated per-cell while there is one platform. See the **#248 amendment** at the
+end of the Decision section.
+
 ## Context
 
 Depth and backscatter data will increasingly come from **more than one platform
@@ -275,6 +284,37 @@ navigation query.
   **local indices** stay consistent across synced stores, is deferred); and the
   reconciliation policy for divergent registry records. Staged with multi-platform
   ingest, after single-platform (Garmin) ingest is real.
+
+## Amendment — Per-cell source index dropped for single-platform stores ([#248](https://github.com/rolker/unh_marine_autonomy/issues/248), 2026-07-01)
+
+D2 persists a compact **per-cell source index** in each tile and a `registry.json`
+sidecar interning `index → { source-id, record }`. That is the right contract **once
+more than one platform contributes cells to the same tile** (D2's premise). The
+current deployment is **single-platform** (BizzyBoat M3), so within any tile the
+winning source is a **constant** — the exact condition ADR-0002's original D5 cited
+before multi-platform fusion reintroduced the band (D2, "Persistence — this amends
+ADR-0002 D5").
+
+Decision for the bathy store (ADR-0002) and the MBES backscatter store (ADR-0007):
+
+- **Drop the per-cell source-index band** (`_source.tif`). With one platform it
+  carries no information; storing it per-cell is unwarranted state. This reverts the
+  D2 per-cell obligation **for these two single-platform stores only**.
+- **Repurpose `registry.json`** from the D2/D3 interning table (`SourceRegistry` +
+  per-index `SourceRecord`) to a flat, store-level
+  **`StoreMetadata{platform, sensor, survey, date}`**. Coarse provenance — who made
+  this store — is recorded **once at the store root**, not per-cell. This keeps the
+  D3 core fields that matter at store granularity (`platform`, `sensor`, plus a
+  `survey`/`date`) without the interning machinery.
+- **The multi-platform contract (D1–D8) is unchanged and retained.** When a second
+  platform/sensor contributes, the per-cell index + interning registry is the
+  mechanism to reintroduce — this amendment does not delete the design, it declines
+  to instantiate it per-cell while there is nothing to disambiguate. The **D5 safety
+  carve-out** never depended on the source index (it selects by depth + uncertainty
+  only), so retiring the per-cell axis does not touch navigation safety.
+
+The sidescan store (ADR-0006) is **not** affected: its `uint16` value tile already
+co-locates the source index in a shared dtype, and it is the multi-sensor path.
 
 ## References
 

--- a/docs/decisions/0007-mbes-backscatter-store.md
+++ b/docs/decisions/0007-mbes-backscatter-store.md
@@ -18,6 +18,17 @@ reflectivity (dB) is now carried into the soundings point cloud by
 [cube_bathymetry#52](https://github.com/rolker/cube_bathymetry/issues/52) (merged).
 Kongsberg EM2040 is a later adopter of the *same* store.
 
+**Amended 2026-07-01 ([#248](https://github.com/rolker/unh_marine_autonomy/issues/248)):**
+greenfield format simplification (the store is a regenerable cache; no migration).
+The **value-band schema** changes from D6's 2-band `{intensity, intensity_variance}`
+to a **3-band `Float32` `{mean, standard_error, sample_sd}`** tile encoding the
+Welford sufficient statistics for lossless reload; the D7 `draft`/`processed` layers
+**collapse to a single `cube` layer**; and, matching the bathy store, the per-cell
+`_time.tif` / `_source.tif` companions are **dropped** with `registry.json`
+repurposed to a coarse store-level `StoreMetadata` (cross-ref
+[ADR-0005](0005-multi-platform-provenance-registry.md) #248 amendment). See the
+**#248 amendment** at the end of the Decision section.
+
 ## Context
 
 The M3 multibeam reports **per-beam acoustic backscatter** (reflectivity, dB)
@@ -224,6 +235,11 @@ Same two-layer priority overlay as the sidescan store:
 
 `draft → processed` is an overlay/promotion, mirroring ADR-0002 and ADR-0006.
 
+> **D7 layers collapsed 2026-07-01 ([#248](https://github.com/rolker/unh_marine_autonomy/issues/248)).**
+> The `draft` / `processed` two-layer overlay is superseded by a **single `cube`
+> layer** — see the #248 amendment (A.2). The overlay/promotion semantics above are
+> no longer instantiated for the single-platform, single-coverage deployment.
+
 ### D8 — Cross-sensor-class fusion with sidescan is at the query / central-server layer
 
 This store holds only `sensor_class: mbes-backscatter`. A unified "best backscatter
@@ -259,6 +275,75 @@ Part of #180 / #190):
 3. The MBES backscatter store package + GGGS tile IO (core_ws), `draft` live write.
 4. The deferred-settled processed build (offline CUBE re-run + GeoCoder correction +
    quality arbitration) and CAMP consumption via the #175 GPU tile-warp.
+
+## Amendment (#248) — Value-band schema, layer collapse, coarse metadata (2026-07-01)
+
+The store is a **regenerable cache** over the soundings bags (D1). For the
+single-platform (BizzyBoat M3), single-coverage deployment, this amendment
+simplifies the on-disk format with **no migration shim**.
+
+### A.1 — Value tile: `{mean, standard_error, sample_sd}` (3-band `Float32`)
+
+D6's value tile carried `{intensity, intensity_variance}` (2 bands). It is replaced
+by a **3-band `Float32`** value tile encoding the **Welford sufficient statistics**,
+so the estimate is losslessly reconstructable on reload rather than collapsed to a
+mean+variance pair:
+
+| Band | Field | Meaning |
+|------|-------|---------|
+| 0 | `mean` | Welford running mean of corrected backscatter. NaN = no data. |
+| 1 | `standard_error` | **confidence-scaled** standard error of the mean (D4 estimate uncertainty), `scale · sample_sd / √n`. |
+| 2 | `sample_sd` | sample standard deviation of contributing beams, `√(M2 / (n−1))`. |
+
+**Confidence-scale convention (mirrors the bathy `uncertainty`).** The producer
+writes `standard_error` **scaled by a confidence factor** so it reads symmetrically
+with the bathy store's confidence-scaled 1-σ uncertainty (ADR-0002 D3); the consumer
+**divides the scale out** on reload before interpreting it as a true standard error.
+The store round-trips all three floats bit-exactly and does no scaling itself.
+
+**Lossless reload.** From the three bands (dividing the confidence scale out of
+`standard_error` to recover the true `SE = sample_sd / √n`):
+
+- `n = (sample_sd / SE)²` — the contributing-beam count.
+- `M2 = sample_sd² · (n − 1)` — the Welford sum of squared deviations.
+
+so `{n, mean, M2}` (the full Welford state) is recovered for a downstream re-run to
+**continue** the accumulation, not just read a settled value.
+
+**`n = 1` sentinel.** A node with a single contributing beam has no dispersion:
+`sample_sd = 0` with a **finite** `mean` encodes `n = 1, M2 = 0`. This is distinct
+from **no-data** (`mean = NaN`): `hasData()` keys on `mean` being finite, so a
+one-sample cell is real data, and the `sample_sd == 0 ∧ finite mean` reload path
+recovers `n = 1` without a divide-by-zero.
+
+This supersedes D4's "`intensity_uncertainty` = posterior estimate variance" single
+band: the estimate uncertainty is now `standard_error` (band 1), and the D4
+within-node dispersion (the candidate texture band) is now **carried explicitly** as
+`sample_sd` (band 2).
+
+### A.2 — Single `cube` layer (D7 collapse)
+
+The D7 `draft` / `processed` two-layer overlay collapses to a **single `cube`
+layer**. With one platform, one coverage, and one fused surface per layer (the same
+reasoning as ADR-0002 A2.1), the live-vs-durable layer split added no query value.
+`SourceLayer` becomes a one-element enum (`Cube`); the on-disk subdirectory is
+`cube/`; `bestSource` walks the single layer. When a durable re-run product needs to
+coexist with a live surface again, the overlay is the mechanism to reintroduce.
+
+### A.3 — `_time` / `_source` dropped; `registry.json` → `StoreMetadata`
+
+Matching ADR-0002 A2.2/A2.3: the per-cell `_time.tif` and `_source.tif` companions
+are dropped (single 3-band value tile per grid), and `registry.json` is repurposed
+from the ADR-0005 D2 per-cell interning table to a coarse store-level
+**`StoreMetadata{platform, sensor, survey, date}`**. The `calibration_ref` D6 note
+survives as store-level metadata (empty until a beam-pattern calibration exists).
+The per-cell provenance drop is recorded on its owning ADR
+([ADR-0005](0005-multi-platform-provenance-registry.md) #248 amendment).
+
+### A.4 — Safety non-goal unchanged
+
+Backscatter remains a perception / cartographic product, **not** a navigation input
+(Consequences, safety non-goal). None of the above touches a costmap path.
 
 ## Consequences
 

--- a/docs/decisions/0007-mbes-backscatter-store.md
+++ b/docs/decisions/0007-mbes-backscatter-store.md
@@ -23,7 +23,7 @@ greenfield format simplification (the store is a regenerable cache; no migration
 The **value-band schema** changes from D6's 2-band `{intensity, intensity_variance}`
 to a **3-band `Float32` `{mean, standard_error, sample_sd}`** tile encoding the
 Welford sufficient statistics for lossless reload; the D7 `draft`/`processed` layers
-**collapse to a single `cube` layer**; and, matching the bathy store, the per-cell
+**collapse to a single `survey` layer**; and, matching the bathy store, the per-cell
 `_time.tif` / `_source.tif` companions are **dropped** with `registry.json`
 repurposed to a coarse store-level `StoreMetadata` (cross-ref
 [ADR-0005](0005-multi-platform-provenance-registry.md) #248 amendment). See the
@@ -236,7 +236,7 @@ Same two-layer priority overlay as the sidescan store:
 `draft → processed` is an overlay/promotion, mirroring ADR-0002 and ADR-0006.
 
 > **D7 layers collapsed 2026-07-01 ([#248](https://github.com/rolker/unh_marine_autonomy/issues/248)).**
-> The `draft` / `processed` two-layer overlay is superseded by a **single `cube`
+> The `draft` / `processed` two-layer overlay is superseded by a **single `survey`
 > layer** — see the #248 amendment (A.2). The overlay/promotion semantics above are
 > no longer instantiated for the single-platform, single-coverage deployment.
 
@@ -321,13 +321,13 @@ band: the estimate uncertainty is now `standard_error` (band 1), and the D4
 within-node dispersion (the candidate texture band) is now **carried explicitly** as
 `sample_sd` (band 2).
 
-### A.2 — Single `cube` layer (D7 collapse)
+### A.2 — Single `survey` layer (D7 collapse)
 
-The D7 `draft` / `processed` two-layer overlay collapses to a **single `cube`
+The D7 `draft` / `processed` two-layer overlay collapses to a **single `survey`
 layer**. With one platform, one coverage, and one fused surface per layer (the same
 reasoning as ADR-0002 A2.1), the live-vs-durable layer split added no query value.
-`SourceLayer` becomes a one-element enum (`Cube`); the on-disk subdirectory is
-`cube/`; `bestSource` walks the single layer. When a durable re-run product needs to
+`SourceLayer` becomes a one-element enum (`Survey`); the on-disk subdirectory is
+`survey/`; `bestSource` walks the single layer. When a durable re-run product needs to
 coexist with a live surface again, the overlay is the mechanism to reintroduce.
 
 ### A.3 — `_time` / `_source` dropped; `registry.json` → `StoreMetadata`

--- a/marine_bathymetry_store/README.md
+++ b/marine_bathymetry_store/README.md
@@ -21,23 +21,27 @@ or consumer-specific logic.
 
 ### Source layers (`bathy_cell.hpp`)
 
-`SourceLayer` is an ordered enum — `Processed` (highest priority) then `Draft`.
-`Chart` is reserved for a later phase (it depends on the `mru_transform`
-vertical-datum work). A cell's source is **implied by which layer holds it**:
-the store keeps one tile map per layer, so source is the map, not a per-cell
-field. Priority is a **non-destructive query-time overlay** — a noisy draft
-write never clobbers a trusted processed value, and a later processed import
-never has to merge with draft (ADR-0002 §D3).
+`SourceLayer` is an ordered enum — `Cube` (highest priority) then `PreExisting`
+(the read-only prior). The pre-#248 `chart`/`draft`/`processed` taxonomy collapsed
+to these two (ADR-0002 Amendment A2.1): with one platform and one fused surface per
+layer, the live-vs-durable split added no query value, and `chart` generalized to
+`pre-existing` (any prior surface imported before the survey). A cell's source is
+**implied by which layer holds it**: the store keeps one tile map per layer, so
+source is the map, not a per-cell field. Priority is a **non-destructive query-time
+overlay** — live `cube` ingest never clobbers the read-only `pre-existing` prior
+(ADR-0002 §D3).
 
 ### Per-cell record (`BathyCell`)
 
 `depth` (ellipsoidal height, WGS84, metres — up-positive, so a *shallower*
-seafloor is a *greater* value), `uncertainty` (1-σ, metres), and `timestamp`
-(Unix seconds). All three are `double`: the timestamp band needs the range
-(absolute Unix seconds in `float` resolve to ~128-second granularity, which
-would silently coarsen the staleness information the costmap will rely on —
-ADR-0002 §D7). A fully-allocated 960×960 tile is therefore ≈22 MB; tiles are
-allocated lazily, only when first written.
+seafloor is a *greater* value) and `uncertainty` (1-σ, metres), both `double` — a
+single 2-band `Float64` value tile. The pre-#248 per-cell `timestamp` and
+`source_index` were dropped (ADR-0002 Amendment A2.2): the store is a regenerable
+cache over raw bags, the per-cell time band's only reader (the costmap staleness
+gate) was retired, and per-cell source provenance is a constant for a single
+platform (coarse provenance moved to the store-level `registry.json`). A
+fully-allocated 960×960 tile is ≈14 MB; tiles are allocated lazily, only when first
+written.
 
 ### Queries (`query.hpp`)
 
@@ -54,11 +58,14 @@ as not-safe, never as deep water (ADR-0002 §D7).
 
 ### Persistence (`tile_io.hpp`)
 
-Each dirty tile is written as a 3-band `Float64` GeoTIFF
-(`<dir>/<layer>/<level>_<row>_<col>.tif`), WGS84-georeferenced from its GGGS
-grid corners. `save()` writes only dirty tiles (incremental); `load()` rebuilds
-the store, recovering each tile's `GridIndex` from the file geotransform and
-rejecting tiles written at a different GGGS level.
+Each dirty tile is written as a single 2-band `Float64` GeoTIFF (depth,
+uncertainty) at `<dir>/<layer>/<level>_<row>_<col>.tif`, WGS84-georeferenced from
+its GGGS grid corners (the pre-#248 `_time.tif` / `_source.tif` companions were
+dropped — ADR-0002 Amendment A2.2). `save()` writes only dirty tiles
+(incremental); `load()` rebuilds the store, recovering each tile's `GridIndex` from
+the file geotransform and rejecting tiles written at a different GGGS level.
+Coarse store-level provenance (`StoreMetadata{platform, sensor, survey, date}`) is
+persisted once at the store root as `registry.json` (`registry.hpp`).
 
 ## Build & test
 
@@ -71,8 +78,8 @@ colcon test --packages-select marine_bathymetry_store
 
 Tests (`test_store`, `test_query`, `test_tile_io`) are headless GTest and cover
 priority precedence, no-data handling, the height-aware shallowest-reliable
-semantics, persistence round-trip (including timestamp precision), incremental
-(dirty-only) save, and level-mismatch rejection.
+semantics, persistence round-trip (depth + uncertainty), incremental (dirty-only)
+save, level-mismatch rejection, and the coarse `StoreMetadata` round-trip.
 
 ## Dependencies
 

--- a/marine_bathymetry_store/README.md
+++ b/marine_bathymetry_store/README.md
@@ -21,14 +21,14 @@ or consumer-specific logic.
 
 ### Source layers (`bathy_cell.hpp`)
 
-`SourceLayer` is an ordered enum — `Cube` (highest priority) then `PreExisting`
+`SourceLayer` is an ordered enum — `Survey` (highest priority) then `Reference`
 (the read-only prior). The pre-#248 `chart`/`draft`/`processed` taxonomy collapsed
 to these two (ADR-0002 Amendment A2.1): with one platform and one fused surface per
 layer, the live-vs-durable split added no query value, and `chart` generalized to
-`pre-existing` (any prior surface imported before the survey). A cell's source is
+`reference` (any prior surface imported before the survey). A cell's source is
 **implied by which layer holds it**: the store keeps one tile map per layer, so
 source is the map, not a per-cell field. Priority is a **non-destructive query-time
-overlay** — live `cube` ingest never clobbers the read-only `pre-existing` prior
+overlay** — live `survey` ingest never clobbers the read-only `reference` prior
 (ADR-0002 §D3).
 
 ### Per-cell record (`BathyCell`)

--- a/marine_bathymetry_store/include/marine_bathymetry_store/bathy_cell.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/bathy_cell.hpp
@@ -37,59 +37,51 @@ namespace marine_bathymetry_store
 /// deliberate, cleaner realization of ADR-0002 §D3's "each cell stores a
 /// source layer": the layer is the map it lives in.
 ///
-/// The numeric value is the priority rank (0 = highest). `Chart` (the broad,
-/// coarse contour / S57-derived prior) is lowest priority: best-source falls
-/// through to it where no Processed/Draft data exists. Chart cells are
-/// ellipsoidal heights converted from chart datum **at import** (ADR-0002 §D7);
-/// the store treats Chart as a **read-only prior** so live Draft/CUBE ingest can
-/// never clobber it — see `BathymetryStore::set` and the `chart_writable`
+/// The taxonomy was simplified to **two** layers in #248 (ADR-0002 Amendment
+/// A2.1): the old `chart`/`draft`/`processed` collapse to `cube` (highest
+/// priority) and `pre-existing` (the read-only prior). The numeric value is the
+/// priority rank (0 = highest). `PreExisting` (any prior surface imported before
+/// the survey — a chart-derived contour prior, an external processed grid) is
+/// lowest priority: best-source falls through to it where no CUBE data exists.
+/// The store treats `PreExisting` as a **read-only prior** so live CUBE ingest can
+/// never clobber it — see `BathymetryStore::set` and the `pre_existing_writable`
 /// construction flag the importer opts into.
 enum class SourceLayer : uint8_t
 {
-  Processed = 0,  ///< The authoritative product: externally-processed grids
-                  ///< (bathy-BAG / GeoTIFF) OR the off-boat CUBE re-run (the full-bag
-                  ///< replay via cube_bathymetry `import_bag`, cube_bathymetry#85).
-                  ///< Highest confidence. Mirrors the backscatter store's Processed
-                  ///< (ADR-0007). The *live* node writes Draft, not Processed.
-  Draft = 1,      ///< Real-time (on-boat, live) CUBE output. Valuable but potentially noisy.
-  Chart = 2,      ///< Contour / S57-derived prior. Broad, coarse, read-only.
+  Cube = 0,         ///< The CUBE product (live on-boat or off-boat re-run). Highest
+                    ///< priority. Subsumes the pre-#248 draft/processed distinction
+                    ///< (one fused surface per layer since #221).
+  PreExisting = 1,  ///< A prior surface imported before the survey (chart-derived
+                    ///< contour prior, external processed grid). Broad, coarse,
+                    ///< read-only. Ellipsoidal heights converted at import (§D4).
 };
 
 /// @brief Source layers in descending priority order — iterate for best-source.
-inline constexpr std::array<SourceLayer, 3> source_layers_by_priority{
-  SourceLayer::Processed, SourceLayer::Draft, SourceLayer::Chart};
+inline constexpr std::array<SourceLayer, 2> source_layers_by_priority{
+  SourceLayer::Cube, SourceLayer::PreExisting};
 
 /// @brief Number of source layers present in this phase.
 inline constexpr std::size_t source_layer_count = source_layers_by_priority.size();
 
 /// @brief Per-cell bathymetric record.
 ///
-/// `depth` and `uncertainty` are `double` (a 2-band `Float64` value tile); the
-/// **timestamp is `int64_t` nanoseconds since the Unix epoch** (ROS-native:
-/// `rclcpp::Time` is int64 ns), persisted as a separate 1-band `Int64` tile so
-/// it keeps nanosecond exactness (a `Float64` seconds band resolved absolute
-/// 2026 stamps to only ~0.4 µs). The `source_index` is a small interning handle
-/// into the store-wide `registry.json` (ADR-0005 D2/D8): which platform/sensor
-/// contributed this cell. 0 = no-data/unset (ADR-0005 D4 sentinel) and is the
-/// default for pre-existing single-platform data. The on-disk layout is three
-/// tiles per grid — value (`<grid>.tif`), time (`<grid>_time.tif`), and source
-/// (`<grid>_source.tif`); see `BathymetryTile` and `tile_io`.
+/// `depth` and `uncertainty` are `double` — a single 2-band `Float64` value tile
+/// per grid (ADR-0002 §D5 as simplified by #248 / Amendment A2.2). The per-cell
+/// `timestamp` and `source_index` of the pre-#248 format were dropped: the store
+/// is a regenerable cache over raw bags, the per-cell time band's only in-tree
+/// consumer (the `bathymetry_layer` staleness gate) was retired, and per-cell
+/// source provenance is a constant for the single-platform deployment (coarse
+/// provenance now lives in the store-level `registry.json` `StoreMetadata`,
+/// ADR-0005 #248 amendment). The on-disk layout is one tile per grid —
+/// `<grid>.tif`; see `BathymetryTile` and `tile_io`.
 struct BathyCell
 {
   /// Ellipsoidal height (WGS84), metres. NaN = no data.
   double depth = std::numeric_limits<double>::quiet_NaN();
   /// 1-sigma vertical uncertainty, metres. NaN = unknown.
   double uncertainty = std::numeric_limits<double>::quiet_NaN();
-  /// Acquisition / import time, nanoseconds since the Unix epoch. 0 = unset.
-  int64_t timestamp = 0;
-  /// Local source index into the store-wide registry. 0 = no-data/unset.
-  uint16_t source_index = 0;
 
   /// @brief True if this cell carries a usable depth (depth is not NaN).
-  ///
-  /// Data presence is **depth-only**: `source_index` is provenance, not a
-  /// data-presence signal, so a cell with a registered source but NaN depth is
-  /// still no-data.
   bool hasData() const noexcept
   {
     return !std::isnan(depth);

--- a/marine_bathymetry_store/include/marine_bathymetry_store/bathy_cell.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/bathy_cell.hpp
@@ -38,27 +38,27 @@ namespace marine_bathymetry_store
 /// source layer": the layer is the map it lives in.
 ///
 /// The taxonomy was simplified to **two** layers in #248 (ADR-0002 Amendment
-/// A2.1): the old `chart`/`draft`/`processed` collapse to `cube` (highest
-/// priority) and `pre-existing` (the read-only prior). The numeric value is the
-/// priority rank (0 = highest). `PreExisting` (any prior surface imported before
+/// A2.1): the old `chart`/`draft`/`processed` collapse to `survey` (highest
+/// priority) and `reference` (the read-only prior). The numeric value is the
+/// priority rank (0 = highest). `Reference` (any prior surface imported before
 /// the survey — a chart-derived contour prior, an external processed grid) is
 /// lowest priority: best-source falls through to it where no CUBE data exists.
-/// The store treats `PreExisting` as a **read-only prior** so live CUBE ingest can
-/// never clobber it — see `BathymetryStore::set` and the `pre_existing_writable`
+/// The store treats `Reference` as a **read-only prior** so live CUBE ingest can
+/// never clobber it — see `BathymetryStore::set` and the `reference_writable`
 /// construction flag the importer opts into.
 enum class SourceLayer : uint8_t
 {
-  Cube = 0,         ///< The CUBE product (live on-boat or off-boat re-run). Highest
-                    ///< priority. Subsumes the pre-#248 draft/processed distinction
-                    ///< (one fused surface per layer since #221).
-  PreExisting = 1,  ///< A prior surface imported before the survey (chart-derived
-                    ///< contour prior, external processed grid). Broad, coarse,
-                    ///< read-only. Ellipsoidal heights converted at import (§D4).
+  Survey = 0,         ///< The CUBE product (live on-boat or off-boat re-run). Highest
+                      ///< priority. Subsumes the pre-#248 draft/processed distinction
+                      ///< (one fused surface per layer since #221).
+  Reference = 1,  ///< A prior surface imported before the survey (chart-derived
+                  ///< contour prior, external processed grid). Broad, coarse,
+                  ///< read-only. Ellipsoidal heights converted at import (§D4).
 };
 
 /// @brief Source layers in descending priority order — iterate for best-source.
 inline constexpr std::array<SourceLayer, 2> source_layers_by_priority{
-  SourceLayer::Cube, SourceLayer::PreExisting};
+  SourceLayer::Survey, SourceLayer::Reference};
 
 /// @brief Number of source layers present in this phase.
 inline constexpr std::size_t source_layer_count = source_layers_by_priority.size();

--- a/marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_store.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_store.hpp
@@ -41,7 +41,7 @@ class BathymetryStore;
 struct StoreMetadata;
 // Persistence free functions (defined in tile_io.cpp). Forward-declared here so
 // the store can friend them: `load` / `loadWindow` must reach getOrCreateTile on
-// any layer — including the read-only `PreExisting` prior — which the public API
+// any layer — including the read-only `Reference` prior — which the public API
 // otherwise forbids.  `evictOutside` must reach the non-const layerMap() to erase
 // tiles without const_cast.
 std::size_t save(
@@ -74,8 +74,8 @@ std::size_t evictOutside(
 /// Source priority is a **non-destructive query-time overlay** (see
 /// `query.hpp`): the layers are independent, so a live CUBE write never clobbers
 /// the read-only prior. The single fused surface within a layer is
-/// last-write-wins per cell (there is no provenance ordering); `cube >
-/// pre-existing` layer priority is the only provenance axis (ADR-0002 A2.1).
+/// last-write-wins per cell (there is no provenance ordering); `survey >
+/// reference` layer priority is the only provenance axis (ADR-0002 A2.1).
 ///
 /// This phase has no ROS interface or distribution — just storage, in-process
 /// queries (`query.hpp`), per-tile GeoTIFF persistence (`tile_io.hpp`), and the
@@ -90,28 +90,28 @@ public:
   /// convenience); stored tiles may be at any level (this store is multi-level,
   /// ADR-0002 §D2).
   ///
-  /// @param pre_existing_writable Opt in to per-cell `set()` writes on the
-  ///   read-only `PreExisting` prior layer. Default `false` — only the prior
+  /// @param reference_writable Opt in to per-cell `set()` writes on the
+  ///   read-only `Reference` prior layer. Default `false` — only the prior
   ///   importer (which converts the contour prior to ellipsoidal at import)
   ///   should pass `true`. Runtime consumers leave it `false` so live CUBE ingest
   ///   can never mutate the prior. `load()` (a friend) may still populate
-  ///   PreExisting from disk regardless of this flag — the read-only gate is on
+  ///   Reference from disk regardless of this flag — the read-only gate is on
   ///   per-cell mutation (`set`), not on loading the prior. Direct tile mutation
   ///   is impossible from outside: `getOrCreateTile` is private (persistence-only).
   /// @throws std::out_of_range if the level is invalid (via gggs::Level).
-  explicit BathymetryStore(uint8_t gggs_level, bool pre_existing_writable = false)
-  : level_(gggs_level), pre_existing_writable_(pre_existing_writable) {}
+  explicit BathymetryStore(uint8_t gggs_level, bool reference_writable = false)
+  : level_(gggs_level), reference_writable_(reference_writable) {}
 
   /// @brief Construct a store whose **default** level is the coarsest GGGS level
   ///        whose cells are no larger than @p cell_size_m (clamped to level 20).
-  static BathymetryStore fromCellSize(float cell_size_m, bool pre_existing_writable = false)
+  static BathymetryStore fromCellSize(float cell_size_m, bool reference_writable = false)
   {
     return BathymetryStore(
-      gggs::Level::fromCellSize(cell_size_m).level(), pre_existing_writable);
+      gggs::Level::fromCellSize(cell_size_m).level(), reference_writable);
   }
 
-  /// @brief Whether per-cell `set()` may write the read-only `PreExisting` layer.
-  bool preExistingWritable() const noexcept {return pre_existing_writable_;}
+  /// @brief Whether per-cell `set()` may write the read-only `Reference` layer.
+  bool preExistingWritable() const noexcept {return reference_writable_;}
 
   /// @brief The store's **default** level (used by `cellIndex(lat,lon)` only).
   ///
@@ -139,8 +139,8 @@ public:
   ///         return is retained for source/API stability with the prior epoch
   ///         model and possible future write gates.
   /// @throws std::invalid_argument if @p cell is invalid.
-  /// @throws std::logic_error if @p layer is `PreExisting` and the store was not
-  ///   constructed `pre_existing_writable` — the prior is read-only (ADR-0002 §D3).
+  /// @throws std::logic_error if @p layer is `Reference` and the store was not
+  ///   constructed `reference_writable` — the prior is read-only (ADR-0002 §D3).
   bool set(SourceLayer layer, const gggs::CellIndex & cell, const BathyCell & value);
 
   /// @brief Read the raw cell of one @p layer (no priority overlay).
@@ -154,7 +154,7 @@ public:
   /// tile replaces any tile already resident at that grid, and grids not in
   /// @p tiles are left untouched (no wholesale clear — there is no epoch to
   /// supersede). Every inserted tile is marked dirty so it persists. The
-  /// PreExisting read-only gate applies, identical to `set()`. Tiles may be at
+  /// Reference read-only gate applies, identical to `set()`. Tiles may be at
   /// heterogeneous levels (multi-level, ADR-0002 §D2).
   ///
   /// @note Additive-merge footgun: because this never clears and `save()` never
@@ -167,8 +167,8 @@ public:
   /// @return The number of grids inserted/replaced.
   /// @throws std::invalid_argument if any grid key is invalid or a tile's own
   ///   GridIndex does not match its map key.
-  /// @throws std::logic_error if @p layer is `PreExisting` and the store was not
-  ///   constructed `pre_existing_writable`.
+  /// @throws std::logic_error if @p layer is `Reference` and the store was not
+  ///   constructed `reference_writable`.
   std::size_t importTiles(
     SourceLayer layer, std::map<gggs::GridIndex, BathymetryTile> tiles);
 
@@ -181,11 +181,11 @@ public:
 
 private:
   // Persistence must reach getOrCreateTile to populate any layer (including the
-  // read-only `PreExisting` prior) from disk and to clear dirty flags after a
+  // read-only `Reference` prior) from disk and to clear dirty flags after a
   // save, so the free functions in tile_io.cpp are friends. With getOrCreateTile
-  // private, this is what makes the PreExisting read-only guarantee hold by
+  // private, this is what makes the Reference read-only guarantee hold by
   // construction, not just by convention: the only public per-cell mutator is
-  // `set` (which gates `PreExisting`), and external code cannot obtain a mutable
+  // `set` (which gates `Reference`), and external code cannot obtain a mutable
   // tile. `loadWindow` needs the same private access as `load`; `evictOutside`
   // needs the non-const layerMap() to erase tiles without const_cast.
   friend std::size_t save(
@@ -205,7 +205,7 @@ private:
   /// @brief Find or create the tile for @p grid in @p layer.
   ///
   /// Private: the only mutable tile access. Public mutation goes through `set`
-  /// (which gates `PreExisting`) or `importTiles`; persistence reaches this via
+  /// (which gates `Reference`) or `importTiles`; persistence reaches this via
   /// friendship. @p grid may be at any valid level (multi-level store, ADR-0002
   /// §D2).
   /// @throws std::invalid_argument if @p grid is invalid.
@@ -221,7 +221,7 @@ private:
   }
 
   gggs::Level level_;
-  bool pre_existing_writable_ = false;
+  bool reference_writable_ = false;
   std::array<std::map<gggs::GridIndex, BathymetryTile>, source_layer_count> layers_;
 };
 

--- a/marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_store.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_store.hpp
@@ -38,21 +38,21 @@ namespace marine_bathymetry_store
 {
 
 class BathymetryStore;
-class SourceRegistry;
+struct StoreMetadata;
 // Persistence free functions (defined in tile_io.cpp). Forward-declared here so
 // the store can friend them: `load` / `loadWindow` must reach getOrCreateTile on
-// any layer — including the read-only `Chart` prior — which the public API
+// any layer — including the read-only `PreExisting` prior — which the public API
 // otherwise forbids.  `evictOutside` must reach the non-const layerMap() to erase
 // tiles without const_cast.
 std::size_t save(
-  BathymetryStore & store, const std::string & dir, const SourceRegistry * registry);
+  BathymetryStore & store, const std::string & dir, const StoreMetadata * metadata);
 std::size_t load(
-  BathymetryStore & store, const std::string & dir, SourceRegistry * registry);
+  BathymetryStore & store, const std::string & dir, StoreMetadata * metadata);
 std::size_t loadWindow(
   BathymetryStore & store, const std::string & dir,
   const geographic_msgs::msg::GeoPoint & min_pt,
   const geographic_msgs::msg::GeoPoint & max_pt,
-  SourceRegistry * registry);
+  StoreMetadata * metadata);
 std::size_t evictOutside(
   BathymetryStore & store,
   const geographic_msgs::msg::GeoPoint & min_pt,
@@ -72,10 +72,10 @@ std::size_t evictOutside(
 /// stored tiles.
 ///
 /// Source priority is a **non-destructive query-time overlay** (see
-/// `query.hpp`): the layers are independent, so a noisy draft write never
-/// clobbers a trusted processed cell. The single fused surface within a layer is
-/// last-write-wins per cell (there is no provenance ordering); `processed >
-/// draft > chart` layer priority is the only provenance axis.
+/// `query.hpp`): the layers are independent, so a live CUBE write never clobbers
+/// the read-only prior. The single fused surface within a layer is
+/// last-write-wins per cell (there is no provenance ordering); `cube >
+/// pre-existing` layer priority is the only provenance axis (ADR-0002 A2.1).
 ///
 /// This phase has no ROS interface or distribution — just storage, in-process
 /// queries (`query.hpp`), per-tile GeoTIFF persistence (`tile_io.hpp`), and the
@@ -90,28 +90,28 @@ public:
   /// convenience); stored tiles may be at any level (this store is multi-level,
   /// ADR-0002 §D2).
   ///
-  /// @param chart_writable Opt in to per-cell `set()` writes on the read-only
-  ///   `Chart` prior layer. Default `false` — only the chart importer (which
-  ///   converts the contour prior to ellipsoidal at import) should pass `true`.
-  ///   Runtime consumers leave it `false` so live Draft/CUBE ingest can never
-  ///   mutate the prior. `load()` (a friend) may still populate Chart from disk
-  ///   regardless of this flag — the read-only gate is on per-cell mutation
-  ///   (`set`), not on loading the prior. Direct tile mutation is impossible
-  ///   from outside: `getOrCreateTile` is private (persistence-only).
+  /// @param pre_existing_writable Opt in to per-cell `set()` writes on the
+  ///   read-only `PreExisting` prior layer. Default `false` — only the prior
+  ///   importer (which converts the contour prior to ellipsoidal at import)
+  ///   should pass `true`. Runtime consumers leave it `false` so live CUBE ingest
+  ///   can never mutate the prior. `load()` (a friend) may still populate
+  ///   PreExisting from disk regardless of this flag — the read-only gate is on
+  ///   per-cell mutation (`set`), not on loading the prior. Direct tile mutation
+  ///   is impossible from outside: `getOrCreateTile` is private (persistence-only).
   /// @throws std::out_of_range if the level is invalid (via gggs::Level).
-  explicit BathymetryStore(uint8_t gggs_level, bool chart_writable = false)
-  : level_(gggs_level), chart_writable_(chart_writable) {}
+  explicit BathymetryStore(uint8_t gggs_level, bool pre_existing_writable = false)
+  : level_(gggs_level), pre_existing_writable_(pre_existing_writable) {}
 
   /// @brief Construct a store whose **default** level is the coarsest GGGS level
   ///        whose cells are no larger than @p cell_size_m (clamped to level 20).
-  static BathymetryStore fromCellSize(float cell_size_m, bool chart_writable = false)
+  static BathymetryStore fromCellSize(float cell_size_m, bool pre_existing_writable = false)
   {
     return BathymetryStore(
-      gggs::Level::fromCellSize(cell_size_m).level(), chart_writable);
+      gggs::Level::fromCellSize(cell_size_m).level(), pre_existing_writable);
   }
 
-  /// @brief Whether per-cell `set()` may write the read-only `Chart` layer.
-  bool chartWritable() const noexcept {return chart_writable_;}
+  /// @brief Whether per-cell `set()` may write the read-only `PreExisting` layer.
+  bool preExistingWritable() const noexcept {return pre_existing_writable_;}
 
   /// @brief The store's **default** level (used by `cellIndex(lat,lon)` only).
   ///
@@ -139,8 +139,8 @@ public:
   ///         return is retained for source/API stability with the prior epoch
   ///         model and possible future write gates.
   /// @throws std::invalid_argument if @p cell is invalid.
-  /// @throws std::logic_error if @p layer is `Chart` and the store was not
-  ///   constructed `chart_writable` — the prior is read-only (ADR-0002 §D3).
+  /// @throws std::logic_error if @p layer is `PreExisting` and the store was not
+  ///   constructed `pre_existing_writable` — the prior is read-only (ADR-0002 §D3).
   bool set(SourceLayer layer, const gggs::CellIndex & cell, const BathyCell & value);
 
   /// @brief Read the raw cell of one @p layer (no priority overlay).
@@ -153,9 +153,9 @@ public:
   /// Merges the supplied tile map into the layer's single tile map: each grid's
   /// tile replaces any tile already resident at that grid, and grids not in
   /// @p tiles are left untouched (no wholesale clear — there is no epoch to
-  /// supersede). Every inserted tile is marked dirty so it persists. The Chart
-  /// read-only gate applies, identical to `set()`. Tiles may be at heterogeneous
-  /// levels (multi-level, ADR-0002 §D2).
+  /// supersede). Every inserted tile is marked dirty so it persists. The
+  /// PreExisting read-only gate applies, identical to `set()`. Tiles may be at
+  /// heterogeneous levels (multi-level, ADR-0002 §D2).
   ///
   /// @note Additive-merge footgun: because this never clears and `save()` never
   ///   deletes on-disk tiles, a *shrinking* re-import (a corrected coverage with
@@ -167,8 +167,8 @@ public:
   /// @return The number of grids inserted/replaced.
   /// @throws std::invalid_argument if any grid key is invalid or a tile's own
   ///   GridIndex does not match its map key.
-  /// @throws std::logic_error if @p layer is `Chart` and the store was not
-  ///   constructed `chart_writable`.
+  /// @throws std::logic_error if @p layer is `PreExisting` and the store was not
+  ///   constructed `pre_existing_writable`.
   std::size_t importTiles(
     SourceLayer layer, std::map<gggs::GridIndex, BathymetryTile> tiles);
 
@@ -181,22 +181,22 @@ public:
 
 private:
   // Persistence must reach getOrCreateTile to populate any layer (including the
-  // read-only `Chart` prior) from disk and to clear dirty flags after a save, so
-  // the free functions in tile_io.cpp are friends. With getOrCreateTile private,
-  // this is what makes the Chart read-only guarantee hold by construction, not
-  // just by convention: the only public per-cell mutator is `set` (which gates
-  // `Chart`), and external code cannot obtain a mutable tile. `loadWindow` needs
-  // the same private access as `load`; `evictOutside` needs the non-const
-  // layerMap() to erase tiles without const_cast.
+  // read-only `PreExisting` prior) from disk and to clear dirty flags after a
+  // save, so the free functions in tile_io.cpp are friends. With getOrCreateTile
+  // private, this is what makes the PreExisting read-only guarantee hold by
+  // construction, not just by convention: the only public per-cell mutator is
+  // `set` (which gates `PreExisting`), and external code cannot obtain a mutable
+  // tile. `loadWindow` needs the same private access as `load`; `evictOutside`
+  // needs the non-const layerMap() to erase tiles without const_cast.
   friend std::size_t save(
-    BathymetryStore & store, const std::string & dir, const SourceRegistry * registry);
+    BathymetryStore & store, const std::string & dir, const StoreMetadata * metadata);
   friend std::size_t load(
-    BathymetryStore & store, const std::string & dir, SourceRegistry * registry);
+    BathymetryStore & store, const std::string & dir, StoreMetadata * metadata);
   friend std::size_t loadWindow(
     BathymetryStore & store, const std::string & dir,
     const geographic_msgs::msg::GeoPoint & min_pt,
     const geographic_msgs::msg::GeoPoint & max_pt,
-    SourceRegistry * registry);
+    StoreMetadata * metadata);
   friend std::size_t evictOutside(
     BathymetryStore & store,
     const geographic_msgs::msg::GeoPoint & min_pt,
@@ -205,7 +205,7 @@ private:
   /// @brief Find or create the tile for @p grid in @p layer.
   ///
   /// Private: the only mutable tile access. Public mutation goes through `set`
-  /// (which gates `Chart`) or `importTiles`; persistence reaches this via
+  /// (which gates `PreExisting`) or `importTiles`; persistence reaches this via
   /// friendship. @p grid may be at any valid level (multi-level store, ADR-0002
   /// §D2).
   /// @throws std::invalid_argument if @p grid is invalid.
@@ -221,7 +221,7 @@ private:
   }
 
   gggs::Level level_;
-  bool chart_writable_ = false;
+  bool pre_existing_writable_ = false;
   std::array<std::map<gggs::GridIndex, BathymetryTile>, source_layer_count> layers_;
 };
 

--- a/marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_store.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_store.hpp
@@ -111,7 +111,7 @@ public:
   }
 
   /// @brief Whether per-cell `set()` may write the read-only `Reference` layer.
-  bool preExistingWritable() const noexcept {return reference_writable_;}
+  bool referenceWritable() const noexcept {return reference_writable_;}
 
   /// @brief The store's **default** level (used by `cellIndex(lat,lon)` only).
   ///

--- a/marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_tile.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/bathymetry_tile.hpp
@@ -37,61 +37,45 @@ namespace marine_bathymetry_store
 
 /// @brief One GGGS grid (960×960 cells) of bathymetric data for a single layer.
 ///
-/// A bathy-semantic wrapper over **three** `marine_tiled_raster_store::
-/// TiledRasterTile<>` rasters (#172), one per on-disk tile file (#178):
+/// A bathy-semantic wrapper over a single `marine_tiled_raster_store::
+/// TiledRasterTile<double>` value raster (#172) — a **2-band `Float64`** tile
+/// (depth + uncertainty; both float, read together on the costmap hot path).
+/// The pre-#248 `_time` (int64 ns) and `_source` (uint16) companion rasters were
+/// dropped (ADR-0002 Amendment A2.2): a regenerable cache does not need per-cell
+/// time, and per-cell source is a constant for a single platform.
 ///
-/// - **value** (`TiledRasterTile<double>`, 2 bands): depth + uncertainty — both
-///   float, read together on the costmap hot path, so co-located.
-/// - **time** (`TiledRasterTile<int64_t>`, 1 band): timestamp ns — different
-///   dtype, cold access, so its own tile (ROS-native, exact).
-/// - **source** (`TiledRasterTile<uint16_t>`, 1 band): registry source index —
-///   different dtype, multi-platform provenance (ADR-0005 D2/D8).
-///
-/// Each generic tile owns its storage and GGGS-cell-order layout (row 0 = south);
+/// The generic tile owns its storage and GGGS-cell-order layout (row 0 = south);
 /// this wrapper adds the per-cell `BathyCell` record and the named band accessors
-/// the store and persistence rely on. The **value raster's dirty flag is
-/// authoritative** for the whole tile: `set()` marks it; `clearDirty()` /
-/// `markDirty()` operate through it; persistence writes/clears all three rasters
-/// together. Tiles are allocated lazily by the owning `BathymetryStore`.
+/// the store and persistence rely on. The value raster's dirty flag is
+/// authoritative for the whole tile. Tiles are allocated lazily by the owning
+/// `BathymetryStore`.
 class BathymetryTile
 {
 public:
   /// @brief The underlying generic raster tile type for depth + uncertainty.
   using Raster = marine_tiled_raster_store::TiledRasterTile<double>;
-  /// @brief The underlying raster type for the timestamp tile (int64 ns).
-  using TimeRaster = marine_tiled_raster_store::TiledRasterTile<int64_t>;
-  /// @brief The underlying raster type for the source-index tile (uint16).
-  using SourceRaster = marine_tiled_raster_store::TiledRasterTile<uint16_t>;
 
   /// @brief Number of cells along each grid edge (GGGS constant).
   static constexpr uint16_t edge = Raster::edge;
   /// @brief Total cells in a tile (edge × edge).
   static constexpr uint32_t cell_count = Raster::cell_count;
 
-  /// @brief Number of bands in each on-disk tile file.
-  /// @{
-  static constexpr std::size_t value_band_count = 2;   ///< depth + uncertainty
-  static constexpr std::size_t time_band_count = 1;    ///< timestamp ns
-  static constexpr std::size_t source_band_count = 1;  ///< source index
-  /// @}
+  /// @brief Number of bands in the on-disk value tile file (depth + uncertainty).
+  static constexpr std::size_t value_band_count = 2;
 
-  /// @brief Construct an empty tile for @p index (depth/uncertainty no-data, ts
-  ///        and source 0 = unset).
+  /// @brief Construct an empty tile for @p index (depth/uncertainty no-data).
   explicit BathymetryTile(gggs::GridIndex index)
   : value_(index, std::vector<double>{
-      std::numeric_limits<double>::quiet_NaN(),    // depth
-      std::numeric_limits<double>::quiet_NaN()}),  // uncertainty
-    time_(index, time_band_count, int64_t{0}),     // timestamp (0 = unset)
-    source_(index, source_band_count, uint16_t{0})  // source index (0 = unset)
+      std::numeric_limits<double>::quiet_NaN(),      // depth
+      std::numeric_limits<double>::quiet_NaN()})     // uncertainty
   {
   }
 
-  /// @brief Wrap rasters loaded from disk (persistence path).
+  /// @brief Wrap a value raster loaded from disk (persistence path).
   ///
-  /// The three rasters must cover the same grid; the value raster's grid is
-  /// authoritative for `index()`. The constructed tile is clean.
-  BathymetryTile(Raster value, TimeRaster time, SourceRaster source)
-  : value_(std::move(value)), time_(std::move(time)), source_(std::move(source)) {}
+  /// The constructed tile is clean.
+  explicit BathymetryTile(Raster value)
+  : value_(std::move(value)) {}
 
   /// @brief The grid this tile covers.
   const gggs::GridIndex & index() const noexcept {return value_.index();}
@@ -102,21 +86,17 @@ public:
     const uint32_t i = offset(row, col);
     value_.band(kDepth)[i] = cell.depth;
     value_.band(kUncertainty)[i] = cell.uncertainty;
-    time_.band(0)[i] = cell.timestamp;
-    source_.band(0)[i] = cell.source_index;
-    value_.markDirty();   // value raster's dirty flag is authoritative
+    value_.markDirty();
   }
 
   /// @brief Read the cell at (@p row, @p col) within the grid.
   BathyCell get(uint16_t row, uint16_t col) const
   {
     const uint32_t i = offset(row, col);
-    return BathyCell{
-      value_.band(kDepth)[i], value_.band(kUncertainty)[i],
-      time_.band(0)[i], source_.band(0)[i]};
+    return BathyCell{value_.band(kDepth)[i], value_.band(kUncertainty)[i]};
   }
 
-  /// @brief Whether this tile has unsaved changes (value raster is authoritative).
+  /// @brief Whether this tile has unsaved changes.
   bool dirty() const noexcept {return value_.dirty();}
   /// @brief Mark all changes saved (called by persistence after a successful write).
   void clearDirty() noexcept {value_.clearDirty();}
@@ -128,22 +108,14 @@ public:
   const std::vector<double> & depthBand() const noexcept {return value_.band(kDepth);}
   const std::vector<double> & uncertaintyBand() const noexcept
   {return value_.band(kUncertainty);}
-  const std::vector<int64_t> & timestampBand() const noexcept {return time_.band(0);}
-  const std::vector<uint16_t> & sourceBand() const noexcept {return source_.band(0);}
   std::vector<double> & depthBand() noexcept {return value_.band(kDepth);}
   std::vector<double> & uncertaintyBand() noexcept {return value_.band(kUncertainty);}
-  std::vector<int64_t> & timestampBand() noexcept {return time_.band(0);}
-  std::vector<uint16_t> & sourceBand() noexcept {return source_.band(0);}
   /// @}
 
-  /// @brief The underlying generic raster tiles (for persistence delegation).
+  /// @brief The underlying generic raster tile (for persistence delegation).
   /// @{
   Raster & valueRaster() noexcept {return value_;}
   const Raster & valueRaster() const noexcept {return value_;}
-  TimeRaster & timeRaster() noexcept {return time_;}
-  const TimeRaster & timeRaster() const noexcept {return time_;}
-  SourceRaster & sourceRaster() noexcept {return source_;}
-  const SourceRaster & sourceRaster() const noexcept {return source_;}
   /// @}
 
   /// @brief Row-major offset of cell (@p row, @p col). Asserts in debug builds.
@@ -154,8 +126,6 @@ private:
   static constexpr std::size_t kUncertainty = 1;
 
   Raster value_;
-  TimeRaster time_;
-  SourceRaster source_;
 };
 
 }  // namespace marine_bathymetry_store

--- a/marine_bathymetry_store/include/marine_bathymetry_store/geotiff_import.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/geotiff_import.hpp
@@ -29,14 +29,13 @@
 #include <string>
 
 #include "marine_bathymetry_store/bathymetry_store.hpp"
-#include "marine_bathymetry_store/registry.hpp"
 
 /// @file
 /// @brief Import a depth/uncertainty GeoTIFF into a store layer's single fused
 /// surface (ADR-0002 Phase 2, §D4). Footprint fill, datum conversion at import,
-/// lowest-uncertainty contention resolution, and per-cell SourceRegistry
-/// provenance stamping (ADR-0005 D2/D8). The per-day epoch dimension was dropped
-/// in #221; the importer bulk-inserts its tiles via `BathymetryStore::importTiles`.
+/// and lowest-uncertainty contention resolution. Per-cell provenance stamping was
+/// dropped in #248 (coarse provenance is store-level now, ADR-0005 #248 amendment);
+/// the importer bulk-inserts its tiles via `BathymetryStore::importTiles`.
 
 namespace marine_bathymetry_store
 {
@@ -57,9 +56,6 @@ struct GeoTiffImportOptions
   /// weight in 1/sigma^2 fusion). NaN (the default) makes such cells
   /// never-reliable in the safety query — the conservative choice.
   double default_uncertainty = std::numeric_limits<double>::quiet_NaN();
-  /// Acquisition time (Unix seconds) recorded on every imported cell — a
-  /// whole-file product carries no per-cell time. 0 = unset.
-  double timestamp = 0.0;
   /// Vertical conversion applied at import (ADR-0002 §D4):
   /// `height = depth_scale * pixel + depth_offset`. The defaults pass
   /// store-convention inputs (ellipsoidal height, up-positive) through
@@ -74,11 +70,6 @@ struct GeoTiffImportOptions
   /// store's default level (`store.level()`), preserving the single-level
   /// caller's behaviour; pass a level to match the source resolution.
   std::optional<uint8_t> level = std::nullopt;
-  /// Provenance record to register in the store's `SourceRegistry` (ADR-0005
-  /// D2/D8). Every imported cell is stamped with the returned source index. If
-  /// `source.source_id` is empty the importer skips registration and stamps the
-  /// unset index (0) — for callers that don't track provenance.
-  SourceRecord source;
 };
 
 /// @brief Import @p path into @p layer's single fused surface.
@@ -88,18 +79,16 @@ struct GeoTiffImportOptions
 /// still produces coverage), converts the vertical datum at import (§D4), keeps
 /// the lowest-uncertainty value on contention, and bulk-inserts the resulting
 /// tiles into @p layer via `BathymetryStore::importTiles` (merging into any
-/// existing surface; last-write-wins per cell). If `options.source.source_id` is
-/// non-empty, registers the `SourceRecord` in @p registry and stamps its index
-/// on every imported cell.
+/// existing surface; last-write-wins per cell).
 ///
 /// @return The number of distinct cells imported.
 /// @throws std::invalid_argument on a bad band index;
-///         std::logic_error if @p layer is `Chart` and the store is not
-///         `chart_writable` (the read-only-prior gate);
+///         std::logic_error if @p layer is `PreExisting` and the store is not
+///         `pre_existing_writable` (the read-only-prior gate);
 ///         std::runtime_error on GDAL failure, a non-WGS84 / rotated raster, or
 ///         a missing geotransform.
 std::size_t importGeoTiff(
-  BathymetryStore & store, SourceRegistry & registry, SourceLayer layer,
+  BathymetryStore & store, SourceLayer layer,
   const std::string & path,
   const GeoTiffImportOptions & options = GeoTiffImportOptions{});
 

--- a/marine_bathymetry_store/include/marine_bathymetry_store/geotiff_import.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/geotiff_import.hpp
@@ -83,8 +83,8 @@ struct GeoTiffImportOptions
 ///
 /// @return The number of distinct cells imported.
 /// @throws std::invalid_argument on a bad band index;
-///         std::logic_error if @p layer is `PreExisting` and the store is not
-///         `pre_existing_writable` (the read-only-prior gate);
+///         std::logic_error if @p layer is `Reference` and the store is not
+///         `reference_writable` (the read-only-prior gate);
 ///         std::runtime_error on GDAL failure, a non-WGS84 / rotated raster, or
 ///         a missing geotransform.
 std::size_t importGeoTiff(

--- a/marine_bathymetry_store/include/marine_bathymetry_store/query.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/query.hpp
@@ -43,14 +43,7 @@ struct DepthSample
 {
   double depth;            ///< Ellipsoidal height (WGS84, m, up-positive).
   double uncertainty;      ///< 1-sigma vertical uncertainty (m).
-  int64_t timestamp;       ///< Acquisition / import time (ns since the Unix epoch).
   SourceLayer source;      ///< Which layer this value came from.
-  /// Per-cell registry source index (ADR-0005 D2/D8): which platform/sensor
-  /// contributed this value. 0 = unset (pre-migration / single-platform data).
-  /// The navigation-safety query (`shallowestReliable`) ignores this axis
-  /// (ADR-0005 D5 carve-out); it is exposed so provenance-aware consumers can
-  /// resolve the record off a query result.
-  uint16_t source_index = 0;
   /// GGGS level of the cell this value was resolved at. The store is
   /// multi-level (ADR-0002 §D2); the query resolves the best-available level
   /// per cell, so a single region scan can return samples at mixed levels.

--- a/marine_bathymetry_store/include/marine_bathymetry_store/registry.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/registry.hpp
@@ -22,73 +22,40 @@
 #ifndef MARINE_BATHYMETRY_STORE__REGISTRY_HPP_
 #define MARINE_BATHYMETRY_STORE__REGISTRY_HPP_
 
-#include <cstdint>
-#include <map>
-#include <optional>
 #include <string>
-#include <vector>
 
 /// @file
-/// @brief Store-wide source registry: maps each per-cell `source_index` to a
-/// provenance record (ADR-0005 D2/D8). Persisted as `registry.json` at the store
-/// root with an atomic write-then-rename.
+/// @brief Store-level coarse provenance metadata, persisted as `registry.json` at
+/// the store root (ADR-0005 #248 amendment).
+///
+/// This replaces the pre-#248 per-cell `SourceRegistry`/`SourceRecord` interning
+/// table. For the single-platform deployment the winning source is constant across
+/// a store, so per-cell provenance carried no information; instead a single
+/// `StoreMetadata` record — who made this store — is written once at the root. The
+/// multi-platform per-cell interning contract (ADR-0005 D2/D8) is retained in the
+/// ADR and reintroduced when a second platform contributes.
 
 namespace marine_bathymetry_store
 {
 
-/// @brief One source's provenance record.
+/// @brief Coarse, store-level provenance recorded once at the store root.
 ///
-/// `source_id` is the origin-namespaced, never-reused wide id (ADR-0005 D4); the
-/// remaining fields are the ADR-0005 D3 core schema plus the bathy-specific
-/// `datum` extension (the converted-from vertical reference, ADR-0002 §D4). The
-/// `source_id` is the **identity** of a record — `registerSource` is idempotent
-/// on it (re-registering the same `source_id` returns the existing index).
-struct SourceRecord
+/// The ADR-0005 D3 core fields that matter at store granularity, plus a
+/// `survey`/`date` pair. Persisted as a flat `registry.json` sidecar (kept for
+/// filename stability; its schema is now `StoreMetadata`, not the interning table).
+/// All fields are optional (default empty).
+struct StoreMetadata
 {
-  std::string source_id;     ///< Origin-namespaced wide id (ADR-0005 D4).
-  std::string platform;      ///< Contributing platform (e.g. "bizzy").
-  std::string sensor;        ///< Contributing sensor (e.g. "m3").
-  std::string sensor_class;  ///< Sensor class (e.g. "multibeam").
-  std::string campaign;      ///< Acquisition campaign / deployment.
-  std::string datum;         ///< Bathy extension: converted-from vertical datum.
-};
+  std::string platform;  ///< Contributing platform (e.g. "bizzy").
+  std::string sensor;    ///< Contributing sensor (e.g. "m3").
+  std::string survey;    ///< Survey / campaign id (e.g. "massabesic-2026").
+  std::string date;      ///< Acquisition date (ISO-8601, e.g. "2026-06-30").
 
-/// @brief Interns `SourceRecord`s to small local indices and persists them.
-///
-/// Index 0 is reserved as the **no-data/unset sentinel** (ADR-0005 D4) and is
-/// never assigned to a real record; the first registered source gets index 1.
-/// Indices are assigned densely in registration order and are stable for the
-/// life of the store directory (they are the values written into the per-cell
-/// source-index tiles, so reassigning them would corrupt existing tiles).
-class SourceRegistry
-{
-public:
-  /// @brief The reserved no-data/unset source index.
-  static constexpr uint16_t kUnset = 0;
-
-  /// @brief Intern @p record, returning its local index; idempotent on `source_id`.
-  ///
-  /// If a record with the same `source_id` is already registered, its existing
-  /// index is returned (the rest of @p record is ignored). Otherwise a new index
-  /// (the next unused value, starting at 1) is assigned and returned.
-  ///
-  /// @note A registered source is held only in memory until persisted: call
-  ///   `BathymetryStore` `save()` (which invokes `saveRegistry()`), or
-  ///   `saveRegistry()` directly, to write it. A registration with no subsequent
-  ///   save is lost. Registry persistence is intentionally tied to the store's
-  ///   save lifecycle.
-  /// @throws std::overflow_error if all 65535 real indices are exhausted.
-  uint16_t registerSource(const SourceRecord & record);
-
-  /// @brief Look up the record for @p index, or `std::nullopt` if unregistered
-  ///        (including `index == kUnset`).
-  std::optional<SourceRecord> lookup(uint16_t index) const;
-
-  /// @brief Number of registered sources (excludes the reserved index 0).
-  std::size_t size() const noexcept {return by_index_.size();}
-
-  /// @brief Whether any source is registered.
-  bool empty() const noexcept {return by_index_.empty();}
+  /// @brief True if every field is empty (nothing worth persisting).
+  bool empty() const noexcept
+  {
+    return platform.empty() && sensor.empty() && survey.empty() && date.empty();
+  }
 
   /// @brief Write `registry.json` under @p store_root_dir atomically.
   ///
@@ -96,18 +63,12 @@ public:
   /// `registry.json`, so a crash mid-write never leaves a partial file. Creates
   /// @p store_root_dir if needed.
   /// @throws std::runtime_error / std::filesystem::filesystem_error on failure.
-  void saveRegistry(const std::string & store_root_dir) const;
+  void save(const std::string & store_root_dir) const;
 
   /// @brief Load `registry.json` from @p store_root_dir, replacing current
-  ///        contents. No-op (leaves the registry empty) if the file is absent.
+  ///        contents. No-op (leaves the metadata empty) if the file is absent.
   /// @throws std::runtime_error on a malformed registry file.
-  void loadRegistry(const std::string & store_root_dir);
-
-private:
-  /// index (1-based) -> record. by_index_[i] is the record for index i+1.
-  std::vector<SourceRecord> by_index_;
-  /// source_id -> local index, for idempotent registration / lookup.
-  std::map<std::string, uint16_t> by_source_id_;
+  void load(const std::string & store_root_dir);
 };
 
 }  // namespace marine_bathymetry_store

--- a/marine_bathymetry_store/include/marine_bathymetry_store/tile_io.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/tile_io.hpp
@@ -47,8 +47,8 @@
 /// cache, the per-cell time band's only reader (the costmap staleness gate) was
 /// retired, and per-cell source provenance is a constant for a single platform.
 ///
-/// The quality/maturity axis (Cube / PreExisting) is encoded as the on-disk
-/// subdirectory (`cube/`, `pre-existing/`); each holds **one fused** set of value
+/// The quality/maturity axis (Survey / Reference) is encoded as the on-disk
+/// subdirectory (`survey/`, `reference/`); each holds **one fused** set of value
 /// tiles directly (no per-day epoch subdirectory since #221). Coarse provenance
 /// moves to the store-wide `registry.json` `StoreMetadata` (ADR-0005 #248).
 ///
@@ -67,7 +67,7 @@ namespace marine_bathymetry_store
 ///        `<level>_<row>_<col>.tif`.
 std::string tileFilename(const gggs::GridIndex & grid);
 
-/// @brief Subdirectory name for a source layer (`"cube"` / `"pre-existing"`).
+/// @brief Subdirectory name for a source layer (`"survey"` / `"reference"`).
 ///        Each holds one fused set of value tiles directly (#221).
 std::string layerDirName(SourceLayer layer);
 
@@ -169,9 +169,9 @@ std::size_t loadWindow(
 /// `loadWindow`).
 ///
 /// **Dirty-tile guard (safety invariant)**: a tile flagged `dirty()` is **never**
-/// evicted, regardless of its position. A dirty Cube tile is live sensor data that
+/// evicted, regardless of its position. A dirty Survey tile is live sensor data that
 /// has not yet reached disk; evicting it would lose that data with no reload path.
-/// PreExisting tiles are always clean (never mutated at runtime) and are always
+/// Reference tiles are always clean (never mutated at runtime) and are always
 /// safely evictable. Save the store before calling `evictOutside` if you want all
 /// outside tiles to be eligible for eviction.
 ///

--- a/marine_bathymetry_store/include/marine_bathymetry_store/tile_io.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/tile_io.hpp
@@ -33,26 +33,24 @@
 #include "marine_bathymetry_store/registry.hpp"
 
 /// @file
-/// @brief Per-tile GeoTIFF persistence (ADR-0002 §D5, amended by #178).
+/// @brief Per-tile GeoTIFF persistence (ADR-0002 §D5, simplified by #248).
 ///
-/// Each GGGS tile is persisted as **three** GeoTIFFs, all WGS84-georeferenced
-/// from the same grid corners and written north-up (raster row 0 = north), so
-/// persistence flips rows relative to the in-memory GGGS cell order
-/// (row 0 = south):
+/// Each GGGS tile is persisted as **one** GeoTIFF, WGS84-georeferenced from its
+/// grid corners and written north-up (raster row 0 = north), so persistence flips
+/// rows relative to the in-memory GGGS cell order (row 0 = south):
 ///
 /// - `<level>_<row>_<col>.tif` — 2-band `Float64` value tile (depth,
 ///   uncertainty), NaN no-data on both.
-/// - `<level>_<row>_<col>_time.tif` — 1-band `Int64` timestamp tile
-///   (nanoseconds since epoch, ROS-native and exact; 0 = unset, no no-data tag).
-/// - `<level>_<row>_<col>_source.tif` — 1-band `UInt16` source-index tile
-///   (registry index, ADR-0005 D2/D8; 0 = no-data/unset).
 ///
-/// The quality/maturity axis (Processed / Draft / Chart) is encoded as the
-/// on-disk subdirectory (`processed/`, `draft/`, `chart/`); each holds **one
-/// fused** set of value tiles directly (no per-day epoch subdirectory since
-/// #221). The platform/sensor provenance axis moves to the per-cell source index
-/// + the store-wide `registry.json` (ADR-0005 D8). On load, a missing
-/// `_time.tif` / `_source.tif` fills timestamp / source_index with 0.
+/// The pre-#248 `_time.tif` (Int64 ns) and `_source.tif` (UInt16 source index)
+/// companions were dropped (ADR-0002 Amendment A2.2): the store is a regenerable
+/// cache, the per-cell time band's only reader (the costmap staleness gate) was
+/// retired, and per-cell source provenance is a constant for a single platform.
+///
+/// The quality/maturity axis (Cube / PreExisting) is encoded as the on-disk
+/// subdirectory (`cube/`, `pre-existing/`); each holds **one fused** set of value
+/// tiles directly (no per-day epoch subdirectory since #221). Coarse provenance
+/// moves to the store-wide `registry.json` `StoreMetadata` (ADR-0005 #248).
 ///
 /// @note Round-trip persistence is validated for **non-polar** latitudes
 /// (|lat| < 72°), the intended lake/coastal survey envelope. Near GGGS's polar
@@ -69,29 +67,23 @@ namespace marine_bathymetry_store
 ///        `<level>_<row>_<col>.tif`.
 std::string tileFilename(const gggs::GridIndex & grid);
 
-/// @brief Subdirectory name for a source layer (`"processed"` / `"draft"` /
-///        `"chart"`). Each holds one fused set of value tiles directly (#221).
+/// @brief Subdirectory name for a source layer (`"cube"` / `"pre-existing"`).
+///        Each holds one fused set of value tiles directly (#221).
 std::string layerDirName(SourceLayer layer);
 
-/// @brief Write one tile as three GeoTIFFs derived from the value-tile @p path.
-///
-/// @p path is the value tile (`<grid>.tif`); the `_time.tif` and `_source.tif`
-/// companions are written alongside it (same directory, suffixed stem).
+/// @brief Write one tile as a single value GeoTIFF at @p path (`<grid>.tif`).
 /// @throws std::runtime_error on any GDAL failure.
 void saveTile(const BathymetryTile & tile, const std::string & path);
 
-/// @brief Load a tile from its three GeoTIFFs, reconstructing its GridIndex at
+/// @brief Load a tile from its value GeoTIFF, reconstructing its GridIndex at
 ///        @p level.
 ///
-/// @p path is the value tile (`<grid>.tif`); the `_time.tif` and `_source.tif`
-/// companions are read from the derived paths. A **missing** companion fills the
-/// corresponding band with 0 (pre-migration backward compatibility). The grid is
-/// recovered from the value file's geotransform (the cell center maps back
-/// through @p level), so a file written at a different level is rejected. @p
-/// level must therefore be the level the file was written at — callers loading a
-/// multi-level store recover it from the `<level>_<row>_<col>` filename prefix
-/// (see `levelFromTileFilename`) and pass it per-file.
-/// The returned tile is clean (not dirty).
+/// @p path is the value tile (`<grid>.tif`). The grid is recovered from the
+/// value file's geotransform (the cell center maps back through @p level), so a
+/// file written at a different level is rejected. @p level must therefore be the
+/// level the file was written at — callers loading a multi-level store recover it
+/// from the `<level>_<row>_<col>` filename prefix (see `levelFromTileFilename`)
+/// and pass it per-file. The returned tile is clean (not dirty).
 /// @throws std::runtime_error on GDAL failure, wrong dimensions, or a
 ///         geotransform that doesn't match any grid at @p level.
 BathymetryTile loadTile(const std::string & path, const gggs::Level & level);
@@ -109,42 +101,39 @@ uint8_t levelFromTileFilename(const std::string & filename);
 /// @brief Persist every **dirty** tile of @p store under @p dir, then clear
 ///        their dirty flags. Also writes the store-wide `registry.json`.
 ///
-/// Layout: `<dir>/<layer>/<level>_<row>_<col>{,_time,_source}.tif` plus a
-/// store-wide `<dir>/registry.json` (flat, no per-day epoch subdirectory since
-/// #221). Creates directories as needed. Clean tiles are skipped (incremental
-/// save). The registry (a store-wide sidecar, not per-layer) is written once at
-/// the end via @p registry; pass `nullptr` to skip it (e.g. a caller with no
-/// registry to persist).
+/// Layout: `<dir>/<layer>/<level>_<row>_<col>.tif` plus a store-wide
+/// `<dir>/registry.json` (flat, no per-day epoch subdirectory since #221).
+/// Creates directories as needed. Clean tiles are skipped (incremental save). The
+/// coarse `StoreMetadata` (a store-wide sidecar, not per-layer) is written once at
+/// the end via @p metadata; pass `nullptr` to skip it (e.g. a caller with no
+/// metadata to persist).
 /// @return The number of tiles written.
 /// @throws std::runtime_error on any GDAL failure; std::filesystem::filesystem_error
 ///         (a std::runtime_error subclass) on a directory-creation failure.
 std::size_t save(
   BathymetryStore & store, const std::string & dir,
-  const SourceRegistry * registry = nullptr);
+  const StoreMetadata * metadata = nullptr);
 
-/// @brief Load every tile found under @p dir into @p store, plus the registry.
+/// @brief Load every tile found under @p dir into @p store, plus the metadata.
 ///
-/// Scans `<dir>/<layer>/` for value tiles (`<level>_<row>_<col>.tif`),
-/// **skipping** the `_time.tif` / `_source.tif` companions (loaded with their
-/// value tile). Each tile's level is recovered from its filename
-/// (`levelFromTileFilename`), so a **mixed-level** store loads correctly — the
-/// store's default level is irrelevant to loading (ADR-0002 §D2). Subdirectory
-/// entries (stale old-style epoch dirs, if any) are ignored — there is no
-/// production data to migrate (#221). If @p registry is non-null, `registry.json`
-/// is loaded into it. Loaded tiles are clean.
+/// Scans `<dir>/<layer>/` for value tiles (`<level>_<row>_<col>.tif`). Each
+/// tile's level is recovered from its filename (`levelFromTileFilename`), so a
+/// **mixed-level** store loads correctly — the store's default level is irrelevant
+/// to loading (ADR-0002 §D2). Subdirectory entries (stale old-style epoch dirs, if
+/// any) are ignored — there is no production data to migrate (#221). If @p
+/// metadata is non-null, `registry.json` is loaded into it. Loaded tiles are clean.
 /// @return The number of tiles loaded.
 /// @throws std::runtime_error on any GDAL failure or a per-file level mismatch;
 ///         std::filesystem::filesystem_error (a std::runtime_error subclass) on a
 ///         directory-iteration failure.
 std::size_t load(
   BathymetryStore & store, const std::string & dir,
-  SourceRegistry * registry = nullptr);
+  StoreMetadata * metadata = nullptr);
 
 /// @brief Load only tiles whose geographic AABB intersects [@p min_pt, @p max_pt].
 ///
-/// Mirrors `load()` in structure (flat layer-dir scan, companion-skip,
-/// level-recovery, backward-compat 0-fill for missing companions) but gates each
-/// tile on two conditions before paying the GDAL I/O cost:
+/// Mirrors `load()` in structure (flat layer-dir scan, level-recovery) but gates
+/// each tile on two conditions before paying the GDAL I/O cost:
 /// 1. The tile's geographic bounding box (derived from its `<level>_<row>_<col>`
 ///    filename, not from a file open) intersects the box [min_pt, max_pt]
 ///    (inclusive on all boundaries — a tile whose edge exactly touches the box
@@ -156,7 +145,7 @@ std::size_t load(
 /// overlap is tested using its own `GridIndex` geographic accessors rather than
 /// a single-level `GridAreaIterator`.
 ///
-/// If @p registry is non-null, `registry.json` is loaded into it (same as
+/// If @p metadata is non-null, `registry.json` is loaded into it (same as
 /// `load()`). Loaded tiles are clean.
 ///
 /// @note Concurrency: safe only if no concurrent writer is active in the same
@@ -171,7 +160,7 @@ std::size_t loadWindow(
   BathymetryStore & store, const std::string & dir,
   const geographic_msgs::msg::GeoPoint & min_pt,
   const geographic_msgs::msg::GeoPoint & max_pt,
-  SourceRegistry * registry = nullptr);
+  StoreMetadata * metadata = nullptr);
 
 /// @brief Remove all **clean** tiles outside [@p min_pt, @p max_pt] from @p store.
 ///
@@ -180,11 +169,11 @@ std::size_t loadWindow(
 /// `loadWindow`).
 ///
 /// **Dirty-tile guard (safety invariant)**: a tile flagged `dirty()` is **never**
-/// evicted, regardless of its position. A dirty Draft or Processed tile is live
-/// sensor data that has not yet reached disk; evicting it would lose that data
-/// with no reload path. Chart tiles are always clean (never mutated at runtime)
-/// and are always safely evictable. Save the store before calling `evictOutside`
-/// if you want all outside tiles to be eligible for eviction.
+/// evicted, regardless of its position. A dirty Cube tile is live sensor data that
+/// has not yet reached disk; evicting it would lose that data with no reload path.
+/// PreExisting tiles are always clean (never mutated at runtime) and are always
+/// safely evictable. Save the store before calling `evictOutside` if you want all
+/// outside tiles to be eligible for eviction.
 ///
 /// @note Concurrency: safe only if no concurrent writer is active in the same
 ///   process. A writer racing to dirty a tile between the dirty check and the

--- a/marine_bathymetry_store/src/bathymetry_store.cpp
+++ b/marine_bathymetry_store/src/bathymetry_store.cpp
@@ -34,15 +34,15 @@ bool BathymetryStore::set(
 {
   // Validate the input first, then the layer permission — so a malformed cell
   // always reports invalid_argument (the more actionable error), and the
-  // read-only logic_error fires only for an otherwise-valid Chart write. The
-  // cell may be at any valid level — the store is multi-level (ADR-0002 §D2).
+  // read-only logic_error fires only for an otherwise-valid PreExisting write.
+  // The cell may be at any valid level — the store is multi-level (ADR-0002 §D2).
   if (!cell.valid()) {
     throw std::invalid_argument("BathymetryStore::set: invalid CellIndex");
   }
-  if (layer == SourceLayer::Chart && !chart_writable_) {
+  if (layer == SourceLayer::PreExisting && !pre_existing_writable_) {
     throw std::logic_error(
-            "BathymetryStore::set: Chart is a read-only prior layer; construct "
-            "the store with chart_writable=true (importer only) to write it");
+            "BathymetryStore::set: PreExisting is a read-only prior layer; construct "
+            "the store with pre_existing_writable=true (importer only) to write it");
   }
   // Last-write-wins per cell: there is no per-day epoch ordering since #221.
   BathymetryTile & tile = getOrCreateTile(layer, cell.grid());
@@ -67,15 +67,15 @@ std::optional<BathyCell> BathymetryStore::get(
 std::size_t BathymetryStore::importTiles(
   SourceLayer layer, std::map<gggs::GridIndex, BathymetryTile> tiles)
 {
-  // Chart is a read-only prior (ADR-0002 §D3). importTiles is a public mutator
-  // just like set(), so it must honor the same gate -- otherwise the CLI or any
-  // library consumer could overwrite the Chart prior on a default store,
+  // PreExisting is a read-only prior (ADR-0002 §D3). importTiles is a public
+  // mutator just like set(), so it must honor the same gate -- otherwise the CLI
+  // or any library consumer could overwrite the prior on a default store,
   // defeating the read-only guarantee. Only an importer that explicitly opted in
-  // (chart_writable=true) may write Chart.
-  if (layer == SourceLayer::Chart && !chart_writable_) {
+  // (pre_existing_writable=true) may write PreExisting.
+  if (layer == SourceLayer::PreExisting && !pre_existing_writable_) {
     throw std::logic_error(
-            "BathymetryStore::importTiles: Chart is a read-only prior layer; "
-            "construct the store with chart_writable=true (importer only) to write it");
+            "BathymetryStore::importTiles: PreExisting is a read-only prior layer; "
+            "construct the store with pre_existing_writable=true (importer only) to write it");
   }
   for (const auto & [grid, tile] : tiles) {
     if (!grid.valid()) {

--- a/marine_bathymetry_store/src/bathymetry_store.cpp
+++ b/marine_bathymetry_store/src/bathymetry_store.cpp
@@ -34,15 +34,15 @@ bool BathymetryStore::set(
 {
   // Validate the input first, then the layer permission — so a malformed cell
   // always reports invalid_argument (the more actionable error), and the
-  // read-only logic_error fires only for an otherwise-valid PreExisting write.
+  // read-only logic_error fires only for an otherwise-valid Reference write.
   // The cell may be at any valid level — the store is multi-level (ADR-0002 §D2).
   if (!cell.valid()) {
     throw std::invalid_argument("BathymetryStore::set: invalid CellIndex");
   }
-  if (layer == SourceLayer::PreExisting && !pre_existing_writable_) {
+  if (layer == SourceLayer::Reference && !reference_writable_) {
     throw std::logic_error(
-            "BathymetryStore::set: PreExisting is a read-only prior layer; construct "
-            "the store with pre_existing_writable=true (importer only) to write it");
+            "BathymetryStore::set: Reference is a read-only prior layer; construct "
+            "the store with reference_writable=true (importer only) to write it");
   }
   // Last-write-wins per cell: there is no per-day epoch ordering since #221.
   BathymetryTile & tile = getOrCreateTile(layer, cell.grid());
@@ -67,15 +67,15 @@ std::optional<BathyCell> BathymetryStore::get(
 std::size_t BathymetryStore::importTiles(
   SourceLayer layer, std::map<gggs::GridIndex, BathymetryTile> tiles)
 {
-  // PreExisting is a read-only prior (ADR-0002 §D3). importTiles is a public
+  // Reference is a read-only prior (ADR-0002 §D3). importTiles is a public
   // mutator just like set(), so it must honor the same gate -- otherwise the CLI
   // or any library consumer could overwrite the prior on a default store,
   // defeating the read-only guarantee. Only an importer that explicitly opted in
-  // (pre_existing_writable=true) may write PreExisting.
-  if (layer == SourceLayer::PreExisting && !pre_existing_writable_) {
+  // (reference_writable=true) may write Reference.
+  if (layer == SourceLayer::Reference && !reference_writable_) {
     throw std::logic_error(
-            "BathymetryStore::importTiles: PreExisting is a read-only prior layer; "
-            "construct the store with pre_existing_writable=true (importer only) to write it");
+            "BathymetryStore::importTiles: Reference is a read-only prior layer; "
+            "construct the store with reference_writable=true (importer only) to write it");
   }
   for (const auto & [grid, tile] : tiles) {
     if (!grid.valid()) {

--- a/marine_bathymetry_store/src/geotiff_import.cpp
+++ b/marine_bathymetry_store/src/geotiff_import.cpp
@@ -48,7 +48,7 @@ struct DatasetCloser
 }  // namespace
 
 std::size_t importGeoTiff(
-  BathymetryStore & store, SourceRegistry & registry, SourceLayer layer,
+  BathymetryStore & store, SourceLayer layer,
   const std::string & path, const GeoTiffImportOptions & options)
 {
   if (options.depth_band < 1) {
@@ -56,14 +56,6 @@ std::size_t importGeoTiff(
   }
   if (options.uncertainty_band < 0) {
     throw std::invalid_argument("importGeoTiff: uncertainty_band must be >= 0 (0 = none)");
-  }
-
-  // Register the provenance source (if any) and resolve the per-cell index to
-  // stamp (ADR-0005 D2/D8). An empty source_id means the caller does not track
-  // provenance: stamp the unset index (0).
-  uint16_t source_index = SourceRegistry::kUnset;
-  if (!options.source.source_id.empty()) {
-    source_index = registry.registerSource(options.source);
   }
 
   // Target import level: a caller-specified level (multi-level, ADR-0002 §D2) or
@@ -202,16 +194,15 @@ std::size_t importGeoTiff(
           } else {
             ++imported;   // a new cell (replacements don't recount)
           }
-          tile_it->second.set(cell.row(), cell.column(), BathyCell{depth, uncertainty,
-              static_cast<int64_t>(options.timestamp * 1e9), source_index});
+          tile_it->second.set(cell.row(), cell.column(), BathyCell{depth, uncertainty});
         }
       }
     }
   }
 
-  // Bulk-insert into the layer's single fused surface (#221). The Chart
+  // Bulk-insert into the layer's single fused surface (#221). The PreExisting
   // read-only gate is enforced by importTiles (throws logic_error if the store
-  // is not chart_writable).
+  // is not pre_existing_writable).
   store.importTiles(layer, std::move(tiles));
   return imported;
 }

--- a/marine_bathymetry_store/src/geotiff_import.cpp
+++ b/marine_bathymetry_store/src/geotiff_import.cpp
@@ -200,9 +200,9 @@ std::size_t importGeoTiff(
     }
   }
 
-  // Bulk-insert into the layer's single fused surface (#221). The PreExisting
+  // Bulk-insert into the layer's single fused surface (#221). The Reference
   // read-only gate is enforced by importTiles (throws logic_error if the store
-  // is not pre_existing_writable).
+  // is not reference_writable).
   store.importTiles(layer, std::move(tiles));
   return imported;
 }

--- a/marine_bathymetry_store/src/import_geotiff_main.cpp
+++ b/marine_bathymetry_store/src/import_geotiff_main.cpp
@@ -23,16 +23,15 @@
 /// @brief CLI: import a depth/uncertainty GeoTIFF into a store layer.
 ///
 /// usage: import_geotiff <store_dir> <layer> <geotiff>
-///                       [--cell-size m] [--level N] [--timestamp unix_seconds]
+///                       [--cell-size m] [--level N]
 ///                       [--uncertainty m] [--depth-scale s] [--depth-offset m]
-///                       [--source-id ID --platform P --sensor S
-///                        --sensor-class C --campaign K --datum D]
+///                       [--platform P] [--sensor S] [--survey K] [--date D]
 ///
 /// Loads any existing tiles under <store_dir>, imports the GeoTIFF into <layer>'s
-/// single fused surface (#221 — no per-day epoch), registers the provenance
-/// source (if --source-id given) and stamps every cell with its registry index
-/// (ADR-0005 D2/D8), then saves. If --timestamp is omitted cells are stamped 0
-/// (unset) — a whole-file product carries no native per-cell time.
+/// single fused surface (#221 — no per-day epoch), then saves. Per-cell time /
+/// source provenance was dropped in #248; coarse store-level provenance
+/// (StoreMetadata) may be set with the --platform/--sensor/--survey/--date flags
+/// and is written to <store_dir>/registry.json.
 
 #include <cstring>
 #include <iostream>
@@ -51,39 +50,33 @@ void usage()
 {
   std::cout <<
     "usage: import_geotiff <store_dir> <layer> <geotiff>\n"
-    "                      [--cell-size m] [--level N] [--timestamp unix_seconds]\n"
+    "                      [--cell-size m] [--level N]\n"
     "                      [--uncertainty m] [--depth-scale s] [--depth-offset m]\n"
-    "                      [--source-id ID --platform P --sensor S\n"
-    "                       --sensor-class C --campaign K --datum D]\n"
-    "  layer:      processed | draft | chart\n"
+    "                      [--platform P] [--sensor S] [--survey K] [--date D]\n"
+    "  layer:      cube | pre-existing\n"
     "  --cell-size: store default cell size in metres (default 0.5)\n"
     "  --level:     GGGS level to import at (default: derived from --cell-size).\n"
     "               The store is multi-level; pass a level to match the source.\n"
-    "  --timestamp: per-cell acquisition time (Unix seconds); defaults to 0\n"
-    "               (unset) — a whole-file product carries no native per-cell time\n"
     "  --uncertainty: ignore the file's uncertainty band and assign this\n"
     "               constant 1-sigma value (for sources without one)\n"
     "  --depth-scale / --depth-offset: vertical conversion at import,\n"
     "               height = scale*pixel + offset (defaults 1, 0). A\n"
     "               positive-down depths-below-lake-surface product imports\n"
     "               with scale -1 and offset = lake surface ellipsoidal height\n"
-    "  --source-id ... --datum: register a provenance SourceRecord (ADR-0005);\n"
-    "               every imported cell is stamped with its registry index\n";
+    "  --platform/--sensor/--survey/--date: coarse store-level provenance\n"
+    "               (StoreMetadata) written to registry.json (ADR-0005 #248)\n";
   exit(1);
 }
 
 marine_bathymetry_store::SourceLayer layerFromName(const std::string & name)
 {
-  if (name == "processed") {
-    return marine_bathymetry_store::SourceLayer::Processed;
+  if (name == "cube") {
+    return marine_bathymetry_store::SourceLayer::Cube;
   }
-  if (name == "draft") {
-    return marine_bathymetry_store::SourceLayer::Draft;
+  if (name == "pre-existing") {
+    return marine_bathymetry_store::SourceLayer::PreExisting;
   }
-  if (name == "chart") {
-    return marine_bathymetry_store::SourceLayer::Chart;
-  }
-  std::cerr << "unknown layer '" << name << "' (expected processed|draft|chart)\n";
+  std::cerr << "unknown layer '" << name << "' (expected cube|pre-existing)\n";
   exit(1);
 }
 
@@ -95,11 +88,10 @@ int main(int argc, char * argv[])
   int n_positional = 0;
   double cell_size = 0.5;
   int level = -1;                       // sentinel: derive from --cell-size
-  double timestamp = 0.0;               // default: unset (no native per-cell time)
   double constant_uncertainty = -1.0;   // sentinel: use the file's band
   double depth_scale = 1.0;
   double depth_offset = 0.0;
-  marine_bathymetry_store::SourceRecord source;
+  marine_bathymetry_store::StoreMetadata metadata;
 
   const auto need_arg = [&](int & i) -> const char * {
       if (i + 1 >= argc) {
@@ -113,26 +105,20 @@ int main(int argc, char * argv[])
       cell_size = std::stod(need_arg(i));
     } else if (std::strcmp(argv[i], "--level") == 0) {
       level = std::stoi(need_arg(i));
-    } else if (std::strcmp(argv[i], "--timestamp") == 0) {
-      timestamp = std::stod(need_arg(i));
     } else if (std::strcmp(argv[i], "--uncertainty") == 0) {
       constant_uncertainty = std::stod(need_arg(i));
     } else if (std::strcmp(argv[i], "--depth-scale") == 0) {
       depth_scale = std::stod(need_arg(i));
     } else if (std::strcmp(argv[i], "--depth-offset") == 0) {
       depth_offset = std::stod(need_arg(i));
-    } else if (std::strcmp(argv[i], "--source-id") == 0) {
-      source.source_id = need_arg(i);
     } else if (std::strcmp(argv[i], "--platform") == 0) {
-      source.platform = need_arg(i);
+      metadata.platform = need_arg(i);
     } else if (std::strcmp(argv[i], "--sensor") == 0) {
-      source.sensor = need_arg(i);
-    } else if (std::strcmp(argv[i], "--sensor-class") == 0) {
-      source.sensor_class = need_arg(i);
-    } else if (std::strcmp(argv[i], "--campaign") == 0) {
-      source.campaign = need_arg(i);
-    } else if (std::strcmp(argv[i], "--datum") == 0) {
-      source.datum = need_arg(i);
+      metadata.sensor = need_arg(i);
+    } else if (std::strcmp(argv[i], "--survey") == 0) {
+      metadata.survey = need_arg(i);
+    } else if (std::strcmp(argv[i], "--date") == 0) {
+      metadata.date = need_arg(i);
     } else if (n_positional < 3) {
       positional[n_positional++] = argv[i];
     } else {
@@ -146,24 +132,24 @@ int main(int argc, char * argv[])
   const auto layer = layerFromName(positional[1]);
   const std::string & geotiff = positional[2];
 
-  // The importer is the one sanctioned writer of the read-only Chart prior, so
-  // it opts into chart_writable only when the target layer is Chart (ADR-0002
-  // §D3). For Processed/Draft this stays false, so a typo'd layer can't touch
-  // Chart.
-  const bool chart_writable = (layer == marine_bathymetry_store::SourceLayer::Chart);
+  // The importer is the one sanctioned writer of the read-only PreExisting prior,
+  // so it opts into pre_existing_writable only when the target layer is
+  // PreExisting (ADR-0002 §D3). For Cube this stays false, so a typo'd layer
+  // can't touch the prior.
+  const bool pre_existing_writable =
+    (layer == marine_bathymetry_store::SourceLayer::PreExisting);
   auto store = marine_bathymetry_store::BathymetryStore::fromCellSize(
-    static_cast<float>(cell_size), chart_writable);
+    static_cast<float>(cell_size), pre_existing_writable);
   std::cout << "store default level: " << static_cast<int>(store.level().level()) << "\n";
 
-  marine_bathymetry_store::SourceRegistry registry;
-  const std::size_t loaded = marine_bathymetry_store::load(store, store_dir, &registry);
+  marine_bathymetry_store::StoreMetadata existing_metadata;
+  const std::size_t loaded =
+    marine_bathymetry_store::load(store, store_dir, &existing_metadata);
   std::cout << "loaded " << loaded << " existing tile(s) from " << store_dir << "\n";
 
   marine_bathymetry_store::GeoTiffImportOptions options;
-  options.timestamp = timestamp;
   options.depth_scale = depth_scale;
   options.depth_offset = depth_offset;
-  options.source = source;
   if (level >= 0) {
     if (level > 20) {
       std::cerr << "invalid --level " << level << " (GGGS levels are 0..20)\n";
@@ -176,10 +162,15 @@ int main(int argc, char * argv[])
     options.default_uncertainty = constant_uncertainty;
   }
   const std::size_t imported = marine_bathymetry_store::importGeoTiff(
-    store, registry, layer, geotiff, options);
+    store, layer, geotiff, options);
   std::cout << "imported " << imported << " cell(s) into " << positional[1] << "\n";
 
-  const std::size_t saved = marine_bathymetry_store::save(store, store_dir, &registry);
+  // Write the coarse StoreMetadata only if any field was supplied; otherwise
+  // preserve whatever registry.json already held (loaded above).
+  const marine_bathymetry_store::StoreMetadata * to_write =
+    metadata.empty() ? (existing_metadata.empty() ? nullptr : &existing_metadata) :
+    &metadata;
+  const std::size_t saved = marine_bathymetry_store::save(store, store_dir, to_write);
   std::cout << "saved " << saved << " tile(s) under " << store_dir << "\n";
   return 0;
 }

--- a/marine_bathymetry_store/src/import_geotiff_main.cpp
+++ b/marine_bathymetry_store/src/import_geotiff_main.cpp
@@ -53,7 +53,7 @@ void usage()
     "                      [--cell-size m] [--level N]\n"
     "                      [--uncertainty m] [--depth-scale s] [--depth-offset m]\n"
     "                      [--platform P] [--sensor S] [--survey K] [--date D]\n"
-    "  layer:      cube | pre-existing\n"
+    "  layer:      survey | reference\n"
     "  --cell-size: store default cell size in metres (default 0.5)\n"
     "  --level:     GGGS level to import at (default: derived from --cell-size).\n"
     "               The store is multi-level; pass a level to match the source.\n"
@@ -70,13 +70,13 @@ void usage()
 
 marine_bathymetry_store::SourceLayer layerFromName(const std::string & name)
 {
-  if (name == "cube") {
-    return marine_bathymetry_store::SourceLayer::Cube;
+  if (name == "survey") {
+    return marine_bathymetry_store::SourceLayer::Survey;
   }
-  if (name == "pre-existing") {
-    return marine_bathymetry_store::SourceLayer::PreExisting;
+  if (name == "reference") {
+    return marine_bathymetry_store::SourceLayer::Reference;
   }
-  std::cerr << "unknown layer '" << name << "' (expected cube|pre-existing)\n";
+  std::cerr << "unknown layer '" << name << "' (expected survey|reference)\n";
   exit(1);
 }
 
@@ -132,14 +132,14 @@ int main(int argc, char * argv[])
   const auto layer = layerFromName(positional[1]);
   const std::string & geotiff = positional[2];
 
-  // The importer is the one sanctioned writer of the read-only PreExisting prior,
-  // so it opts into pre_existing_writable only when the target layer is
-  // PreExisting (ADR-0002 §D3). For Cube this stays false, so a typo'd layer
+  // The importer is the one sanctioned writer of the read-only Reference prior,
+  // so it opts into reference_writable only when the target layer is
+  // Reference (ADR-0002 §D3). For Survey this stays false, so a typo'd layer
   // can't touch the prior.
-  const bool pre_existing_writable =
-    (layer == marine_bathymetry_store::SourceLayer::PreExisting);
+  const bool reference_writable =
+    (layer == marine_bathymetry_store::SourceLayer::Reference);
   auto store = marine_bathymetry_store::BathymetryStore::fromCellSize(
-    static_cast<float>(cell_size), pre_existing_writable);
+    static_cast<float>(cell_size), reference_writable);
   std::cout << "store default level: " << static_cast<int>(store.level().level()) << "\n";
 
   marine_bathymetry_store::StoreMetadata existing_metadata;

--- a/marine_bathymetry_store/src/query.cpp
+++ b/marine_bathymetry_store/src/query.cpp
@@ -78,7 +78,7 @@ std::optional<DepthSample> sampleFor(
       (lvl == cell.level()) ? cell : gggs::Level(lvl).cellIndex(center);
     const auto c = cellIn(tiles, lvl_cell);
     if (c && c->hasData()) {
-      return DepthSample{c->depth, c->uncertainty, c->timestamp, layer, c->source_index, lvl};
+      return DepthSample{c->depth, c->uncertainty, layer, lvl};
     }
   }
   return std::nullopt;
@@ -124,8 +124,7 @@ std::optional<DepthSample> shallowestReliable(
         continue;
       }
       if (!shallowest || c->depth > shallowest->depth) {
-        shallowest = DepthSample{c->depth, c->uncertainty, c->timestamp, layer,
-          c->source_index, lvl};
+        shallowest = DepthSample{c->depth, c->uncertainty, layer, lvl};
       }
     }
   }

--- a/marine_bathymetry_store/src/registry.cpp
+++ b/marine_bathymetry_store/src/registry.cpp
@@ -23,6 +23,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <stdexcept>
 #include <string>
 
@@ -40,6 +41,11 @@ namespace
 constexpr const char * kRegistryFile = "registry.json";
 constexpr const char * kRegistryTmpFile = "registry.json.tmp";
 
+/// Schema version of the coarse `StoreMetadata` sidecar (ADR-0005 #248
+/// amendment). Bump when the field set or semantics change; `load` warns on a
+/// mismatch so an older/foreign schema is not silently read as all-empty.
+constexpr int kRegistryVersion = 2;
+
 /// Read a string field, defaulting to empty if absent (forward-compatible load).
 std::string jsonStr(const nlohmann::json & j, const char * key)
 {
@@ -54,7 +60,7 @@ void StoreMetadata::save(const std::string & store_root_dir) const
   fs::create_directories(store_root_dir);
 
   const nlohmann::json doc{
-    {"version", 2},
+    {"version", kRegistryVersion},
     {"platform", platform},
     {"sensor", sensor},
     {"survey", survey},
@@ -104,6 +110,20 @@ void StoreMetadata::load(const std::string & store_root_dir)
   } catch (const nlohmann::json::parse_error & e) {
     throw std::runtime_error(
             "StoreMetadata::load: malformed " + path.string() + ": " + e.what());
+  }
+
+  // Validate the schema version so a pre-#248 (or foreign) registry is not read
+  // as all-empty without a trace. Fields are still read forward-compatibly
+  // (jsonStr defaults absent keys to empty); the warning is the observability.
+  const auto vit = doc.find("version");
+  const int version = (vit != doc.end() && vit->is_number_integer()) ?
+    vit->get<int>() :
+    0;
+  if (version != kRegistryVersion) {
+    std::cerr << "[marine_bathymetry_store] WARNING: registry.json at '"
+              << path.string() << "' has unrecognized schema version " << version
+              << " (expected " << kRegistryVersion << "); coarse store provenance "
+              << "may load empty or incomplete.\n";
   }
 
   platform = jsonStr(doc, "platform");

--- a/marine_bathymetry_store/src/registry.cpp
+++ b/marine_bathymetry_store/src/registry.cpp
@@ -21,18 +21,16 @@
 
 #include "marine_bathymetry_store/registry.hpp"
 
-#include <cstdint>
 #include <filesystem>
 #include <fstream>
-#include <limits>
 #include <stdexcept>
 #include <string>
 
 #include <nlohmann/json.hpp>
 
 /// @file
-/// @brief `SourceRegistry` implementation: in-memory interning plus atomic
-/// `registry.json` persistence (ADR-0005 D2/D8).
+/// @brief `StoreMetadata` persistence: a flat, atomic `registry.json` sidecar
+/// recording coarse store-level provenance (ADR-0005 #248 amendment).
 
 namespace marine_bathymetry_store
 {
@@ -42,19 +40,6 @@ namespace
 constexpr const char * kRegistryFile = "registry.json";
 constexpr const char * kRegistryTmpFile = "registry.json.tmp";
 
-nlohmann::json recordToJson(uint16_t index, const SourceRecord & r)
-{
-  return nlohmann::json{
-    {"index", index},
-    {"source_id", r.source_id},
-    {"platform", r.platform},
-    {"sensor", r.sensor},
-    {"sensor_class", r.sensor_class},
-    {"campaign", r.campaign},
-    {"datum", r.datum},
-  };
-}
-
 /// Read a string field, defaulting to empty if absent (forward-compatible load).
 std::string jsonStr(const nlohmann::json & j, const char * key)
 {
@@ -63,42 +48,17 @@ std::string jsonStr(const nlohmann::json & j, const char * key)
 }
 }  // namespace
 
-uint16_t SourceRegistry::registerSource(const SourceRecord & record)
-{
-  const auto existing = by_source_id_.find(record.source_id);
-  if (existing != by_source_id_.end()) {
-    return existing->second;
-  }
-  // Indices are 1-based (0 reserved); the next index is size() + 1.
-  if (by_index_.size() >= std::numeric_limits<uint16_t>::max()) {
-    throw std::overflow_error("SourceRegistry: exhausted all 65535 source indices");
-  }
-  const uint16_t index = static_cast<uint16_t>(by_index_.size() + 1);
-  by_index_.push_back(record);
-  by_source_id_.emplace(record.source_id, index);
-  return index;
-}
-
-std::optional<SourceRecord> SourceRegistry::lookup(uint16_t index) const
-{
-  if (index == kUnset || index > by_index_.size()) {
-    return std::nullopt;
-  }
-  return by_index_[static_cast<std::size_t>(index) - 1];
-}
-
-void SourceRegistry::saveRegistry(const std::string & store_root_dir) const
+void StoreMetadata::save(const std::string & store_root_dir) const
 {
   namespace fs = std::filesystem;
   fs::create_directories(store_root_dir);
 
-  nlohmann::json sources = nlohmann::json::array();
-  for (std::size_t i = 0; i < by_index_.size(); ++i) {
-    sources.push_back(recordToJson(static_cast<uint16_t>(i + 1), by_index_[i]));
-  }
   const nlohmann::json doc{
-    {"version", 1},
-    {"sources", std::move(sources)},
+    {"version", 2},
+    {"platform", platform},
+    {"sensor", sensor},
+    {"survey", survey},
+    {"date", date},
   };
 
   const fs::path tmp = fs::path(store_root_dir) / kRegistryTmpFile;
@@ -106,15 +66,15 @@ void SourceRegistry::saveRegistry(const std::string & store_root_dir) const
   {
     std::ofstream out(tmp, std::ios::binary | std::ios::trunc);
     if (!out) {
-      throw std::runtime_error("SourceRegistry::saveRegistry: could not open " + tmp.string());
+      throw std::runtime_error("StoreMetadata::save: could not open " + tmp.string());
     }
     out << doc.dump(2) << '\n';
     out.flush();
     if (!out) {
-      throw std::runtime_error("SourceRegistry::saveRegistry: write failed for " + tmp.string());
+      throw std::runtime_error("StoreMetadata::save: write failed for " + tmp.string());
     }
   }
-  // Atomic publish: rename over the existing registry. rename() on the same
+  // Atomic publish: rename over the existing file. rename() on the same
   // filesystem is atomic, so a reader sees either the old or the new file whole.
   // On rename failure, remove the tmp file to avoid leaving an orphan.
   try {
@@ -126,71 +86,30 @@ void SourceRegistry::saveRegistry(const std::string & store_root_dir) const
   }
 }
 
-void SourceRegistry::loadRegistry(const std::string & store_root_dir)
+void StoreMetadata::load(const std::string & store_root_dir)
 {
   namespace fs = std::filesystem;
   const fs::path path = fs::path(store_root_dir) / kRegistryFile;
   if (!fs::is_regular_file(path)) {
-    return;   // fresh store: no registry yet
+    return;   // fresh store: no metadata yet
   }
 
   std::ifstream in(path, std::ios::binary);
   if (!in) {
-    throw std::runtime_error("SourceRegistry::loadRegistry: could not open " + path.string());
+    throw std::runtime_error("StoreMetadata::load: could not open " + path.string());
   }
   nlohmann::json doc;
   try {
     in >> doc;
   } catch (const nlohmann::json::parse_error & e) {
     throw std::runtime_error(
-            "SourceRegistry::loadRegistry: malformed " + path.string() + ": " + e.what());
+            "StoreMetadata::load: malformed " + path.string() + ": " + e.what());
   }
 
-  by_index_.clear();
-  by_source_id_.clear();
-  const auto sources = doc.find("sources");
-  if (sources == doc.end() || !sources->is_array()) {
-    return;   // empty / sourceless registry
-  }
-  // Records carry an explicit "index"; validate them against the expected
-  // position (1-based, contiguous, monotonically increasing by +1).  A
-  // reordered, sparse, or duplicate hand-edited registry.json would produce
-  // mismatches between the stored index and the reconstructed by_index_ /
-  // by_source_id_ maps — silently delivering wrong provenance.  Reject early
-  // with a clear error rather than silently diverge.
-  for (const auto & entry : *sources) {
-    SourceRecord r{
-      jsonStr(entry, "source_id"), jsonStr(entry, "platform"),
-      jsonStr(entry, "sensor"), jsonStr(entry, "sensor_class"),
-      jsonStr(entry, "campaign"), jsonStr(entry, "datum")};
-    // Expected index for this entry (1-based: position 0 → index 1, etc.).
-    const uint16_t expected = static_cast<uint16_t>(by_index_.size() + 1);
-    // Stored index field — must match.
-    const auto idx_it = entry.find("index");
-    if (idx_it == entry.end() || !idx_it->is_number_unsigned()) {
-      throw std::runtime_error(
-              "SourceRegistry::loadRegistry: entry for source_id=\"" + r.source_id +
-              "\" is missing a valid \"index\" field (expected " +
-              std::to_string(expected) + ")");
-    }
-    const uint16_t stored = idx_it->get<uint16_t>();
-    if (stored != expected) {
-      throw std::runtime_error(
-              "SourceRegistry::loadRegistry: entry for source_id=\"" + r.source_id +
-              "\" has stored index " + std::to_string(stored) +
-              " but expected " + std::to_string(expected) +
-              " (indices must be contiguous from 1; the registry may have been"
-              " reordered, has gaps, or contains duplicate entries)");
-    }
-    if (by_source_id_.count(r.source_id)) {
-      throw std::runtime_error(
-              "SourceRegistry::loadRegistry: duplicate source_id=\"" + r.source_id +
-              "\" at index " + std::to_string(expected) +
-              " (each source_id must appear at most once in registry.json)");
-    }
-    by_index_.push_back(r);
-    by_source_id_.emplace(r.source_id, expected);
-  }
+  platform = jsonStr(doc, "platform");
+  sensor = jsonStr(doc, "sensor");
+  survey = jsonStr(doc, "survey");
+  date = jsonStr(doc, "date");
 }
 
 }  // namespace marine_bathymetry_store

--- a/marine_bathymetry_store/src/tile_io.cpp
+++ b/marine_bathymetry_store/src/tile_io.cpp
@@ -153,6 +153,51 @@ bool tileOverlapsBox(
   return true;
 }
 
+/// @brief Warn when a store directory holds content but exposes no recognized
+/// `survey/`/`reference/` layer subdirectory — an old-layout (or foreign) store
+/// from which NOTHING loads.
+///
+/// This is a navigation-safety *observability* guard: `load()`/`loadWindow()`
+/// skip a layer whose subdir is absent, so a store written in the pre-#248
+/// taxonomy (`chart/`, `draft/`, `processed/`) loads as **empty** without error.
+/// With `BathymetryLayer`'s `unsurveyed_is_lethal_ == false` default, an empty
+/// bathy prior reads as *navigable*, so a silently-empty load must not pass
+/// unnoticed. Matches the store's existing stale-subdir WARNING idiom.
+///
+/// Stays silent for a genuinely fresh/absent store (a missing dir, or one
+/// holding only the `registry.json` metadata sidecar and no tiles yet):
+/// "content" here means a subdirectory or a top-level `.tif`, i.e. tile data
+/// that the recognized-layer walk could not reach.
+void warnIfUnrecognizedStoreLayout(const std::string & dir, bool any_layer_dir_present)
+{
+  namespace fs = std::filesystem;
+  if (any_layer_dir_present) {
+    return;
+  }
+  std::error_code ec;
+  if (!fs::is_directory(dir, ec)) {
+    return;   // fresh/absent store — nothing to warn about
+  }
+  bool has_store_content = false;
+  for (const auto & entry : fs::directory_iterator(dir, ec)) {
+    if (entry.is_directory() ||
+      (entry.is_regular_file() && entry.path().extension() == ".tif"))
+    {
+      has_store_content = true;
+      break;
+    }
+  }
+  if (!has_store_content) {
+    return;   // empty store, or metadata-only sidecar — legitimately nothing loaded
+  }
+  std::cerr << "[marine_bathymetry_store] WARNING: store directory '" << dir
+            << "' has content but no recognized 'survey/' or 'reference/' layer "
+            << "subdirectory — NOTHING was loaded. A pre-#248 old-layout store "
+            << "(chart/draft/processed) is not migrated (#221/#248); regenerate "
+            << "it. An empty bathy prior reads as unsurveyed (navigable unless "
+            << "unsurveyed_is_lethal is set).\n";
+}
+
 }  // namespace
 
 uint8_t levelFromTileFilename(const std::string & filename)
@@ -257,11 +302,13 @@ std::size_t load(
 {
   namespace fs = std::filesystem;
   std::size_t loaded = 0;
+  bool any_layer_dir_present = false;
   for (const SourceLayer layer : source_layers_by_priority) {
     const fs::path layer_dir = fs::path(dir) / layerDirName(layer);
     if (!fs::is_directory(layer_dir)) {
       continue;
     }
+    any_layer_dir_present = true;
     // Flat layout (#221): value tiles live directly under <dir>/<layer>/. A
     // subdirectory entry (e.g. a stale old-style epoch dir) is ignored — there
     // is no production data to migrate, so old epoch-subdir stores are simply
@@ -285,6 +332,7 @@ std::size_t load(
       ++loaded;
     }
   }
+  warnIfUnrecognizedStoreLayout(dir, any_layer_dir_present);
   if (metadata != nullptr) {
     metadata->load(dir);
   }
@@ -299,11 +347,13 @@ std::size_t loadWindow(
 {
   namespace fs = std::filesystem;
   std::size_t loaded = 0;
+  bool any_layer_dir_present = false;
   for (const SourceLayer layer : source_layers_by_priority) {
     const fs::path layer_dir = fs::path(dir) / layerDirName(layer);
     if (!fs::is_directory(layer_dir)) {
       continue;
     }
+    any_layer_dir_present = true;
     // Flat layout (#221): value tiles live directly under <dir>/<layer>/.
     for (const auto & entry : fs::directory_iterator(layer_dir)) {
       if (entry.is_directory()) {
@@ -336,6 +386,7 @@ std::size_t loadWindow(
       ++loaded;
     }
   }
+  warnIfUnrecognizedStoreLayout(dir, any_layer_dir_present);
   if (metadata != nullptr) {
     metadata->load(dir);
   }

--- a/marine_bathymetry_store/src/tile_io.cpp
+++ b/marine_bathymetry_store/src/tile_io.cpp
@@ -190,8 +190,8 @@ std::string tileFilename(const gggs::GridIndex & grid)
 std::string layerDirName(SourceLayer layer)
 {
   switch (layer) {
-    case SourceLayer::Cube: return "cube";
-    case SourceLayer::PreExisting: return "pre-existing";
+    case SourceLayer::Survey: return "survey";
+    case SourceLayer::Reference: return "reference";
   }
   throw std::runtime_error("layerDirName: unknown SourceLayer");
 }
@@ -357,9 +357,9 @@ std::size_t evictOutside(
       const gggs::GridIndex & grid = it->first;
       const BathymetryTile & tile = it->second;
       if (!tileOverlapsBox(grid, min_pt, max_pt)) {
-        // Dirty-tile guard: a dirty (unsaved) Cube tile is live sensor data that
+        // Dirty-tile guard: a dirty (unsaved) Survey tile is live sensor data that
         // has not yet reached disk; evicting it would lose that data with no
-        // reload path.  PreExisting tiles are always clean (never mutated at
+        // reload path.  Reference tiles are always clean (never mutated at
         // runtime) and are always safely evictable.  Skip dirty tiles here and
         // let them survive until they are either saved (clearing the flag) or
         // explicitly discarded by the caller.

--- a/marine_bathymetry_store/src/tile_io.cpp
+++ b/marine_bathymetry_store/src/tile_io.cpp
@@ -35,23 +35,19 @@
 #include "marine_tiled_raster_store/tile_io.hpp"
 
 /// @file
-/// @brief Bathymetry persistence (ADR-0002 §D5, amended by #178): the
+/// @brief Bathymetry persistence (ADR-0002 §D5, simplified by #248): the
 /// multi-layer, SourceLayer subdirectory save/load, delegating each tile's
 /// GeoTIFF read/write to the generic `marine_tiled_raster_store::saveTile` /
-/// `loadTile` (#172). Each GGGS tile persists as three files: a 2-band `Float64`
-/// value tile (depth, uncertainty; NaN no-data on both), a 1-band `Int64` time
-/// tile (`_time.tif`, timestamp ns; no no-data tag), and a 1-band `UInt16`
-/// source tile (`_source.tif`, registry index; 0 no-data). A store-wide
-/// `registry.json` sidecar maps source indices to provenance (ADR-0005 D2/D8).
+/// `loadTile` (#172). Each GGGS tile persists as a single 2-band `Float64` value
+/// tile (depth, uncertainty; NaN no-data on both) — the pre-#248 `_time` /
+/// `_source` companions were dropped (Amendment A2.2). A store-wide
+/// `registry.json` sidecar holds coarse `StoreMetadata` (ADR-0005 #248).
 
 namespace marine_bathymetry_store
 {
 
 namespace
 {
-constexpr const char * kTimeSuffix = "_time";
-constexpr const char * kSourceSuffix = "_source";
-
 /// Per-band no-data for the 2-band Float64 value tile: NaN on both depth and
 /// uncertainty. One entry per band, in band order.
 const std::vector<std::optional<double>> & valueBandNoData()
@@ -59,29 +55,6 @@ const std::vector<std::optional<double>> & valueBandNoData()
   static const double nan = std::numeric_limits<double>::quiet_NaN();
   static const std::vector<std::optional<double>> nodata{nan, nan};
   return nodata;
-}
-
-/// No-data for the 1-band Int64 time tile: none (0 = unset, never tagged).
-const std::vector<std::optional<int64_t>> & timeBandNoData()
-{
-  static const std::vector<std::optional<int64_t>> nodata{std::nullopt};
-  return nodata;
-}
-
-/// No-data for the 1-band UInt16 source tile: 0 = no-data/unset.
-const std::vector<std::optional<uint16_t>> & sourceBandNoData()
-{
-  static const std::vector<std::optional<uint16_t>> nodata{std::optional<uint16_t>(0)};
-  return nodata;
-}
-
-/// Derive a companion path (`_time` / `_source`) from a value-tile path: insert
-/// @p suffix before the `.tif` extension. e.g. `5_1_2.tif` -> `5_1_2_time.tif`.
-std::string companionPath(const std::string & value_path, const char * suffix)
-{
-  namespace fs = std::filesystem;
-  const fs::path p(value_path);
-  return (p.parent_path() / (p.stem().string() + suffix + p.extension().string())).string();
 }
 
 /// Reconstruct a `GridIndex` from a tile filename stem `<level>_<row>_<col>`
@@ -217,9 +190,8 @@ std::string tileFilename(const gggs::GridIndex & grid)
 std::string layerDirName(SourceLayer layer)
 {
   switch (layer) {
-    case SourceLayer::Processed: return "processed";
-    case SourceLayer::Draft: return "draft";
-    case SourceLayer::Chart: return "chart";
+    case SourceLayer::Cube: return "cube";
+    case SourceLayer::PreExisting: return "pre-existing";
   }
   throw std::runtime_error("layerDirName: unknown SourceLayer");
 }
@@ -227,94 +199,21 @@ std::string layerDirName(SourceLayer layer)
 void saveTile(const BathymetryTile & tile, const std::string & path)
 {
   namespace mtrs = marine_tiled_raster_store;
-  // Write ordering: value tile first, then time, then source.  The three files
-  // are not written atomically — a crash mid-sequence leaves a partial set on
-  // disk.  Writing the value tile first is intentional: the safety query
-  // (shallowestReliable) reads only the value tile, so a crashed write that
-  // leaves an absent or stale _time / _source companion does not affect the
-  // depth/uncertainty result used by the collision monitor.  A full reload
-  // after a crash will 0-fill missing companion tiles (backward-compat path
-  // in loadTile), which is the correct degraded-mode behaviour.
+  // A single 2-band Float64 value tile per grid (#248): the pre-#178 _time /
+  // _source companions were dropped (ADR-0002 Amendment A2.2).
   mtrs::saveTile<double>(tile.valueRaster(), path, valueBandNoData());
-  mtrs::saveTile<int64_t>(
-    tile.timeRaster(), companionPath(path, kTimeSuffix), timeBandNoData());
-  mtrs::saveTile<uint16_t>(
-    tile.sourceRaster(), companionPath(path, kSourceSuffix), sourceBandNoData());
 }
 
 BathymetryTile loadTile(const std::string & path, const gggs::Level & level)
 {
   namespace mtrs = marine_tiled_raster_store;
-  namespace fs = std::filesystem;
-
-  // Guard: reject legacy single-file 3-band Float64 tiles written before #178.
-  // The pre-migration layout (depth / uncertainty / Float64-seconds-timestamp)
-  // has exactly 3 bands in one file with no companion _time / _source tiles.
-  // Loading it with value_band_count=2 would silently discard band 3 (the old
-  // seconds timestamp) and 0-fill the new nadir Int64 time tile — losing
-  // acquisition times without warning.  There are no on-disk tiles at the time
-  // of this migration (pre-production), so this guard is a forward-safety check:
-  // if such a tile appears (e.g., from a backup or a partial manual migration),
-  // fail loudly rather than silently corrupt the provenance record.
-  // Decision: explicit rejection is preferred over silent data-drop per the
-  // workspace Quality Standard (never "good enough" when the proper fix exists).
-  {
-    const int band_count = mtrs::tileRasterCount(path);
-    if (band_count == 3) {
-      throw std::runtime_error(
-              "loadTile: rejected pre-#178 legacy 3-band Float64 tile at \"" + path +
-              "\".  This tile was written by a pre-migration store (depth/"
-              "uncertainty/Float64-seconds in one file).  Regenerate or migrate"
-              " the tile before loading it with the current store.");
-    }
-  }
-
   BathymetryTile::Raster value =
     mtrs::loadTile<double>(path, level, BathymetryTile::value_band_count);
-  const gggs::GridIndex grid = value.index();
-
-  // Companion tiles: load if present, else fill with 0 (pre-migration
-  // single-platform data has no _time / _source tile — backward compatibility).
-  const std::string time_path = companionPath(path, kTimeSuffix);
-  BathymetryTile::TimeRaster time =
-    fs::is_regular_file(time_path)
-    ? mtrs::loadTile<int64_t>(time_path, level, BathymetryTile::time_band_count)
-    : BathymetryTile::TimeRaster(grid, BathymetryTile::time_band_count, int64_t{0});
-
-  // Enforce GridIndex consistency: the time companion must map to the same
-  // tile as the value raster.  A mis-renamed companion (e.g., from a manual
-  // store reorganisation or file tampering) would combine cell-for-cell data
-  // from different geographic tiles, silently associating wrong timestamps with
-  // depths.  The check is cheap (one comparison) and closes the tampering hole.
-  if (fs::is_regular_file(time_path) && !(time.index() == grid)) {
-    throw std::runtime_error(
-            "loadTile: companion \"" + time_path +
-            "\" has a GridIndex that does not match the value tile at \"" + path +
-            "\".  The companion file may have been mis-renamed or the store is"
-            " inconsistent.");
-  }
-
-  const std::string source_path = companionPath(path, kSourceSuffix);
-  BathymetryTile::SourceRaster source =
-    fs::is_regular_file(source_path)
-    ? mtrs::loadTile<uint16_t>(source_path, level, BathymetryTile::source_band_count)
-    : BathymetryTile::SourceRaster(grid, BathymetryTile::source_band_count, uint16_t{0});
-
-  // Enforce GridIndex consistency for the source companion (same rationale as
-  // the time-companion check above).
-  if (fs::is_regular_file(source_path) && !(source.index() == grid)) {
-    throw std::runtime_error(
-            "loadTile: companion \"" + source_path +
-            "\" has a GridIndex that does not match the value tile at \"" + path +
-            "\".  The companion file may have been mis-renamed or the store is"
-            " inconsistent.");
-  }
-
-  return BathymetryTile(std::move(value), std::move(time), std::move(source));
+  return BathymetryTile(std::move(value));
 }
 
 std::size_t save(
-  BathymetryStore & store, const std::string & dir, const SourceRegistry * registry)
+  BathymetryStore & store, const std::string & dir, const StoreMetadata * metadata)
 {
   namespace fs = std::filesystem;
   std::size_t written = 0;
@@ -344,17 +243,17 @@ std::size_t save(
       ++written;
     }
   }
-  // The registry is a store-wide sidecar (not per-layer): persist it once at the
-  // end. Written unconditionally when present so a freshly-registered source is
-  // saved even when no tile is dirty.
-  if (registry != nullptr) {
-    registry->saveRegistry(dir);
+  // The metadata is a store-wide sidecar (not per-layer): persist it once at the
+  // end. Written unconditionally when present so coarse provenance is saved even
+  // when no tile is dirty.
+  if (metadata != nullptr) {
+    metadata->save(dir);
   }
   return written;
 }
 
 std::size_t load(
-  BathymetryStore & store, const std::string & dir, SourceRegistry * registry)
+  BathymetryStore & store, const std::string & dir, StoreMetadata * metadata)
 {
   namespace fs = std::filesystem;
   std::size_t loaded = 0;
@@ -378,18 +277,6 @@ std::size_t load(
       if (!entry.is_regular_file() || entry.path().extension() != ".tif") {
         continue;
       }
-      // Skip the companion tiles — they are loaded alongside their value tile,
-      // not as standalone value tiles (a bare *.tif glob would otherwise
-      // mis-load _time / _source as value tiles).
-      const std::string stem = entry.path().stem().string();
-      const auto ends_with = [&stem](const char * suffix) {
-          const std::string s(suffix);
-          return stem.size() >= s.size() &&
-                 stem.compare(stem.size() - s.size(), s.size(), s) == 0;
-        };
-      if (ends_with(kTimeSuffix) || ends_with(kSourceSuffix)) {
-        continue;
-      }
       // Multi-level: recover each tile's level from its filename and load at
       // that level (the store is not pinned to one level, ADR-0002 §D2).
       const uint8_t lvl = levelFromTileFilename(entry.path().filename().string());
@@ -398,8 +285,8 @@ std::size_t load(
       ++loaded;
     }
   }
-  if (registry != nullptr) {
-    registry->loadRegistry(dir);
+  if (metadata != nullptr) {
+    metadata->load(dir);
   }
   return loaded;
 }
@@ -408,7 +295,7 @@ std::size_t loadWindow(
   BathymetryStore & store, const std::string & dir,
   const geographic_msgs::msg::GeoPoint & min_pt,
   const geographic_msgs::msg::GeoPoint & max_pt,
-  SourceRegistry * registry)
+  StoreMetadata * metadata)
 {
   namespace fs = std::filesystem;
   std::size_t loaded = 0;
@@ -427,16 +314,6 @@ std::size_t loadWindow(
         continue;
       }
       if (!entry.is_regular_file() || entry.path().extension() != ".tif") {
-        continue;
-      }
-      // Skip companion tiles (_time / _source) — loaded alongside value tile.
-      const std::string stem = entry.path().stem().string();
-      const auto ends_with = [&stem](const char * suffix) {
-          const std::string s(suffix);
-          return stem.size() >= s.size() &&
-                 stem.compare(stem.size() - s.size(), s.size(), s) == 0;
-        };
-      if (ends_with(kTimeSuffix) || ends_with(kSourceSuffix)) {
         continue;
       }
 
@@ -459,8 +336,8 @@ std::size_t loadWindow(
       ++loaded;
     }
   }
-  if (registry != nullptr) {
-    registry->loadRegistry(dir);
+  if (metadata != nullptr) {
+    metadata->load(dir);
   }
   return loaded;
 }
@@ -480,12 +357,12 @@ std::size_t evictOutside(
       const gggs::GridIndex & grid = it->first;
       const BathymetryTile & tile = it->second;
       if (!tileOverlapsBox(grid, min_pt, max_pt)) {
-        // Dirty-tile guard: a dirty (unsaved) Draft or Processed tile is live
-        // sensor data that has not yet reached disk; evicting it would lose that
-        // data with no reload path.  Chart tiles are always clean (never mutated
-        // at runtime) and are always safely evictable.  Skip dirty tiles here
-        // and let them survive until they are either saved (clearing the flag)
-        // or explicitly discarded by the caller.
+        // Dirty-tile guard: a dirty (unsaved) Cube tile is live sensor data that
+        // has not yet reached disk; evicting it would lose that data with no
+        // reload path.  PreExisting tiles are always clean (never mutated at
+        // runtime) and are always safely evictable.  Skip dirty tiles here and
+        // let them survive until they are either saved (clearing the flag) or
+        // explicitly discarded by the caller.
         if (tile.dirty()) {
           ++it;
           continue;

--- a/marine_bathymetry_store/src/tile_io.cpp
+++ b/marine_bathymetry_store/src/tile_io.cpp
@@ -198,6 +198,24 @@ void warnIfUnrecognizedStoreLayout(const std::string & dir, bool any_layer_dir_p
             << "unsurveyed_is_lethal is set).\n";
 }
 
+/// @brief True if @p filename is a dropped pre-#248 companion raster
+/// (`*_time.tif` / `*_source.tif`).
+///
+/// The per-cell `_time`/`_source` companions were dropped by #248
+/// (Amendment A2.2). One may still linger inside a new-layout layer dir on a
+/// store written by old code; it is not a 2-band value tile and must be skipped
+/// rather than fed to `loadTile()`, which would throw and abort the whole load.
+/// (Value tiles are `<level>_<row>_<col>.tif` — all-numeric stems — so there is
+/// no collision with these non-numeric suffixes.)
+bool isDroppedCompanionTile(const std::string & filename)
+{
+  const auto hasSuffix = [&filename](const std::string & suffix) {
+      return filename.size() >= suffix.size() &&
+             filename.compare(filename.size() - suffix.size(), suffix.size(), suffix) == 0;
+    };
+  return hasSuffix("_time.tif") || hasSuffix("_source.tif");
+}
+
 }  // namespace
 
 uint8_t levelFromTileFilename(const std::string & filename)
@@ -324,6 +342,15 @@ std::size_t load(
       if (!entry.is_regular_file() || entry.path().extension() != ".tif") {
         continue;
       }
+      // Skip dropped pre-#248 companions (`*_time.tif`/`*_source.tif`) that may
+      // linger in a new-layout dir: they are not value tiles and would throw in
+      // loadTile(), aborting the load of every other (valid) tile.
+      if (isDroppedCompanionTile(entry.path().filename().string())) {
+        std::cerr << "[marine_bathymetry_store] WARNING: skipping dropped "
+                  << "companion raster (not a value tile; #248): " << entry.path()
+                  << "\n";
+        continue;
+      }
       // Multi-level: recover each tile's level from its filename and load at
       // that level (the store is not pinned to one level, ADR-0002 §D2).
       const uint8_t lvl = levelFromTileFilename(entry.path().filename().string());
@@ -364,6 +391,14 @@ std::size_t loadWindow(
         continue;
       }
       if (!entry.is_regular_file() || entry.path().extension() != ".tif") {
+        continue;
+      }
+      // Skip dropped pre-#248 companions (`*_time.tif`/`*_source.tif`): not value
+      // tiles; parsing their filename / feeding them to loadTile() would throw.
+      if (isDroppedCompanionTile(entry.path().filename().string())) {
+        std::cerr << "[marine_bathymetry_store] WARNING: skipping dropped "
+                  << "companion raster (not a value tile; #248): " << entry.path()
+                  << "\n";
         continue;
       }
 

--- a/marine_bathymetry_store/test/test_geotiff_import.cpp
+++ b/marine_bathymetry_store/test/test_geotiff_import.cpp
@@ -35,14 +35,11 @@
 #include "marine_autonomy/gggs.h"
 #include "marine_bathymetry_store/bathymetry_store.hpp"
 #include "marine_bathymetry_store/geotiff_import.hpp"
-#include "marine_bathymetry_store/registry.hpp"
 
 using marine_bathymetry_store::BathymetryStore;
 using marine_bathymetry_store::GeoTiffImportOptions;
 using marine_bathymetry_store::importGeoTiff;
 using marine_bathymetry_store::SourceLayer;
-using marine_bathymetry_store::SourceRecord;
-using marine_bathymetry_store::SourceRegistry;
 
 namespace fs = std::filesystem;
 
@@ -113,7 +110,6 @@ class GeoTiffImportTest : public ::testing::Test
 {
 protected:
   fs::path dir_;
-  SourceRegistry registry_;
 
   void SetUp() override
   {
@@ -145,66 +141,23 @@ TEST_F(GeoTiffImportTest, AlignedImportIsCellExact)
   const auto tif = writeTestTiff(dir_ / "aligned.tif", store.level(), 3, 3, depth, unc);
 
   GeoTiffImportOptions options;
-  options.timestamp = 1.78e9;   // Unix seconds; the store stamps int64 ns.
-  const auto imported = importGeoTiff(
-    store, registry_, SourceLayer::Draft, tif, options);
+  const auto imported = importGeoTiff(store, SourceLayer::Cube, tif, options);
   EXPECT_EQ(imported, 8u);   // 9 pixels minus the no-data centre
 
-  const auto nw = store.get(SourceLayer::Draft, nwCell(store, store.level()));
+  const auto nw = store.get(SourceLayer::Cube, nwCell(store, store.level()));
   ASSERT_TRUE(nw.has_value());
   EXPECT_FLOAT_EQ(static_cast<float>(nw->depth), -30.0f);
   EXPECT_FLOAT_EQ(static_cast<float>(nw->uncertainty), 0.1f);
-  EXPECT_EQ(nw->timestamp, static_cast<int64_t>(1.78e9 * 1e9));   // seconds -> ns
 
   // The import landed in the layer's single fused surface (#221).
-  EXPECT_FALSE(store.tiles(SourceLayer::Draft).empty());
-}
-
-TEST_F(GeoTiffImportTest, RegistersSourceAndStampsIndex)
-{
-  // The importer registers the SourceRecord and stamps every cell with its
-  // registry index (ADR-0005 D2/D8) — the #178 provenance axis #148 predated.
-  BathymetryStore store(11);
-  const std::vector<float> depth{-30.0f};
-  const std::vector<float> unc{0.1f};
-  const auto tif = writeTestTiff(dir_ / "prov.tif", store.level(), 1, 1, depth, unc);
-
-  GeoTiffImportOptions options;
-  options.source = SourceRecord{"bizzy:m3:0", "bizzy", "m3", "multibeam",
-    "massabesic-2026", "ellipsoid"};
-  EXPECT_EQ(importGeoTiff(store, registry_, SourceLayer::Draft, tif, options), 1u);
-
-  // The source was registered (index 1) and stamped on the cell.
-  EXPECT_EQ(registry_.size(), 1u);
-  const auto rec = registry_.lookup(1);
-  ASSERT_TRUE(rec.has_value());
-  EXPECT_EQ(rec->platform, "bizzy");
-  const auto got = store.get(SourceLayer::Draft, nwCell(store, store.level()));
-  ASSERT_TRUE(got.has_value());
-  EXPECT_EQ(got->source_index, 1u);
-}
-
-TEST_F(GeoTiffImportTest, NoSourceIdStampsUnsetIndex)
-{
-  // An empty source_id means the caller doesn't track provenance: no record is
-  // registered and the cell carries the unset index (0).
-  BathymetryStore store(11);
-  const std::vector<float> depth{-30.0f};
-  const std::vector<float> unc{0.1f};
-  const auto tif = writeTestTiff(dir_ / "nosrc.tif", store.level(), 1, 1, depth, unc);
-
-  EXPECT_EQ(importGeoTiff(store, registry_, SourceLayer::Draft, tif), 1u);
-  EXPECT_EQ(registry_.size(), 0u);
-  const auto got = store.get(SourceLayer::Draft, nwCell(store, store.level()));
-  ASSERT_TRUE(got.has_value());
-  EXPECT_EQ(got->source_index, SourceRegistry::kUnset);
+  EXPECT_FALSE(store.tiles(SourceLayer::Cube).empty());
 }
 
 TEST_F(GeoTiffImportTest, ImportsAtCallerSpecifiedLevel)
 {
   // Multi-level (ADR-0002 §D2): import at a level other than the store default.
-  // Importing to the read-only Chart prior requires the importer opt-in.
-  BathymetryStore store(11, /*chart_writable=*/true);   // default level 11
+  // Importing to the read-only PreExisting prior requires the importer opt-in.
+  BathymetryStore store(11, /*pre_existing_writable=*/true);   // default level 11
   const std::vector<float> depth{-30.0f};
   const std::vector<float> unc{0.1f};
   gggs::Level coarse(8);
@@ -212,7 +165,7 @@ TEST_F(GeoTiffImportTest, ImportsAtCallerSpecifiedLevel)
 
   GeoTiffImportOptions options;
   options.level = 8;   // import at level 8, not the store's default 11
-  EXPECT_EQ(importGeoTiff(store, registry_, SourceLayer::Chart, tif, options), 1u);
+  EXPECT_EQ(importGeoTiff(store, SourceLayer::PreExisting, tif, options), 1u);
 
   // The imported tile is at level 8, queryable at that level. The fixture's
   // single pixel sits at the level-8 grid's NW corner, so query that cell.
@@ -221,11 +174,11 @@ TEST_F(GeoTiffImportTest, ImportsAtCallerSpecifiedLevel)
   const double cell_y = grid8.latitudinalSpan() / gggs::cell_rows_per_grid;
   const auto cell = coarse.cellIndex(gggs::geoPoint(
       grid8.northLatitude() - 0.5 * cell_y, grid8.westLongitude() + 0.5 * cell_x));
-  const auto got = store.get(SourceLayer::Chart, cell);
+  const auto got = store.get(SourceLayer::PreExisting, cell);
   ASSERT_TRUE(got.has_value());
   EXPECT_FLOAT_EQ(static_cast<float>(got->depth), -30.0f);
   // And the stored grid carries the level-8 prefix.
-  const auto & tiles = store.tiles(SourceLayer::Chart);
+  const auto & tiles = store.tiles(SourceLayer::PreExisting);
   ASSERT_FALSE(tiles.empty());
   EXPECT_EQ(tiles.begin()->first.level(), 8u);
 }
@@ -239,11 +192,10 @@ TEST_F(GeoTiffImportTest, FinerInputKeepsLowestUncertainty)
   const std::vector<float> unc{0.5f, 0.2f, 0.9f, 0.7f};
   const auto tif = writeTestTiff(dir_ / "fine.tif", store.level(), 2, 2, depth, unc, 2);
 
-  const auto imported = importGeoTiff(
-    store, registry_, SourceLayer::Draft, tif);
+  const auto imported = importGeoTiff(store, SourceLayer::Cube, tif);
   EXPECT_EQ(imported, 1u);   // four pixels, one cell
 
-  const auto got = store.get(SourceLayer::Draft, nwCell(store, store.level()));
+  const auto got = store.get(SourceLayer::Cube, nwCell(store, store.level()));
   ASSERT_TRUE(got.has_value());
   EXPECT_FLOAT_EQ(static_cast<float>(got->depth), -31.0f);       // unc 0.2 wins
   EXPECT_FLOAT_EQ(static_cast<float>(got->uncertainty), 0.2f);
@@ -260,14 +212,14 @@ TEST_F(GeoTiffImportTest, ReimportMergesLastWriteWins)
   const auto second =
     writeTestTiff(dir_ / "second.tif", store.level(), 1, 1, {-28.0f}, unc);
 
-  EXPECT_EQ(importGeoTiff(store, registry_, SourceLayer::Draft, first), 1u);
+  EXPECT_EQ(importGeoTiff(store, SourceLayer::Cube, first), 1u);
   EXPECT_DOUBLE_EQ(
-    store.get(SourceLayer::Draft, nwCell(store, store.level()))->depth, -30.0);
+    store.get(SourceLayer::Cube, nwCell(store, store.level()))->depth, -30.0);
 
   // A second import of the same cell overwrites the first.
-  EXPECT_EQ(importGeoTiff(store, registry_, SourceLayer::Draft, second), 1u);
+  EXPECT_EQ(importGeoTiff(store, SourceLayer::Cube, second), 1u);
   EXPECT_DOUBLE_EQ(
-    store.get(SourceLayer::Draft, nwCell(store, store.level()))->depth, -28.0);
+    store.get(SourceLayer::Cube, nwCell(store, store.level()))->depth, -28.0);
 }
 
 TEST_F(GeoTiffImportTest, MissingUncertaintyBandUsesDefault)
@@ -280,9 +232,9 @@ TEST_F(GeoTiffImportTest, MissingUncertaintyBandUsesDefault)
   GeoTiffImportOptions options;
   options.uncertainty_band = 0;
   options.default_uncertainty = 3.5;
-  EXPECT_EQ(importGeoTiff(store, registry_, SourceLayer::Processed, tif, options), 1u);
+  EXPECT_EQ(importGeoTiff(store, SourceLayer::Cube, tif, options), 1u);
 
-  const auto got = store.get(SourceLayer::Processed, nwCell(store, store.level()));
+  const auto got = store.get(SourceLayer::Cube, nwCell(store, store.level()));
   ASSERT_TRUE(got.has_value());
   EXPECT_DOUBLE_EQ(got->uncertainty, 3.5);
 }
@@ -291,7 +243,7 @@ TEST_F(GeoTiffImportTest, DepthScaleOffsetAndFiniteNoData)
 {
   // A lake-prior product: depths positive-down below the surface, with a FINITE
   // no-data value (-9999) that must not import as a 9 km depth.
-  BathymetryStore store(11, /*chart_writable=*/true);  // imports to Chart
+  BathymetryStore store(11, /*pre_existing_writable=*/true);  // imports to prior
   const std::vector<float> depth{4.0f, -9999.0f};   // 4 m of water; one no-data
   const std::vector<float> unc{0.0f, 0.0f};         // source has no real band
   const auto tif = writeTestTiff(dir_ / "lake.tif", store.level(), 2, 1, depth, unc);
@@ -308,11 +260,10 @@ TEST_F(GeoTiffImportTest, DepthScaleOffsetAndFiniteNoData)
   options.default_uncertainty = 3.0;
   options.depth_scale = -1.0;       // positive-down -> up-positive
   options.depth_offset = -20.0;     // lake surface ellipsoidal height
-  const auto imported = importGeoTiff(
-    store, registry_, SourceLayer::Chart, tif, options);
+  const auto imported = importGeoTiff(store, SourceLayer::PreExisting, tif, options);
   EXPECT_EQ(imported, 1u);         // the -9999 pixel was skipped
 
-  const auto got = store.get(SourceLayer::Chart, nwCell(store, store.level()));
+  const auto got = store.get(SourceLayer::PreExisting, nwCell(store, store.level()));
   ASSERT_TRUE(got.has_value());
   EXPECT_DOUBLE_EQ(got->depth, -24.0);          // -1 * 4 + (-20)
   EXPECT_DOUBLE_EQ(got->uncertainty, 3.0);
@@ -323,7 +274,7 @@ TEST_F(GeoTiffImportTest, CoarserInputFillsPixelFootprint)
   // A 5x-coarser pixel must fill its whole footprint of store cells — coverage,
   // not isolated dots (the contour-prior case). The helper only does integer
   // pixels-per-cell, so build the 1x1 raster with a 5-cell pixel directly.
-  BathymetryStore store(11, /*chart_writable=*/true);  // imports to Chart
+  BathymetryStore store(11, /*pre_existing_writable=*/true);  // imports to prior
   const std::vector<float> depth{-30.0f};
   const std::vector<float> unc{3.0f};
   const gggs::GridIndex grid = store.level().gridIndex(43.0, -70.5);
@@ -356,14 +307,13 @@ TEST_F(GeoTiffImportTest, CoarserInputFillsPixelFootprint)
     GDALClose(ds);
   }
 
-  const auto imported = importGeoTiff(
-    store, registry_, SourceLayer::Chart, path);
+  const auto imported = importGeoTiff(store, SourceLayer::PreExisting, path);
   EXPECT_EQ(imported, 25u);   // 5x5 store cells under the one pixel
 
   // Every cell of the footprint carries the value — spot-check a middle one.
   const auto mid = store.cellIndex(
     grid.northLatitude() - 2.5 * cell_y, grid.westLongitude() + 2.5 * cell_x);
-  const auto got = store.get(SourceLayer::Chart, mid);
+  const auto got = store.get(SourceLayer::PreExisting, mid);
   ASSERT_TRUE(got.has_value());
   EXPECT_FLOAT_EQ(static_cast<float>(got->depth), -30.0f);
 }
@@ -377,8 +327,7 @@ TEST_F(GeoTiffImportTest, ZeroUncertaintyIsMissingNotPerfect)
   const std::vector<float> unc{0.0f, 0.4f};
   const auto tif = writeTestTiff(dir_ / "zerounc.tif", store.level(), 2, 1, depth, unc);
 
-  const auto imported = importGeoTiff(
-    store, registry_, SourceLayer::Draft, tif);
+  const auto imported = importGeoTiff(store, SourceLayer::Cube, tif);
   EXPECT_EQ(imported, 2u);   // both cells import (depth is real)
 
   const gggs::GridIndex grid = store.level().gridIndex(43.0, -70.5);
@@ -389,11 +338,11 @@ TEST_F(GeoTiffImportTest, ZeroUncertaintyIsMissingNotPerfect)
   const auto good_cell = store.cellIndex(
     grid.northLatitude() - 0.5 * cell_y, grid.westLongitude() + 1.5 * cell_x);
 
-  const auto zero = store.get(SourceLayer::Draft, zero_cell);
+  const auto zero = store.get(SourceLayer::Cube, zero_cell);
   ASSERT_TRUE(zero.has_value());
   EXPECT_TRUE(std::isnan(zero->uncertainty));   // missing, not 0
 
-  const auto good = store.get(SourceLayer::Draft, good_cell);
+  const auto good = store.get(SourceLayer::Cube, good_cell);
   ASSERT_TRUE(good.has_value());
   EXPECT_FLOAT_EQ(static_cast<float>(good->uncertainty), 0.4f);
 }
@@ -402,7 +351,6 @@ TEST_F(GeoTiffImportTest, MissingFileThrows)
 {
   BathymetryStore store(11);
   EXPECT_THROW(
-    importGeoTiff(
-      store, registry_, SourceLayer::Draft, (dir_ / "absent.tif").string()),
+    importGeoTiff(store, SourceLayer::Cube, (dir_ / "absent.tif").string()),
     std::runtime_error);
 }

--- a/marine_bathymetry_store/test/test_geotiff_import.cpp
+++ b/marine_bathymetry_store/test/test_geotiff_import.cpp
@@ -141,23 +141,23 @@ TEST_F(GeoTiffImportTest, AlignedImportIsCellExact)
   const auto tif = writeTestTiff(dir_ / "aligned.tif", store.level(), 3, 3, depth, unc);
 
   GeoTiffImportOptions options;
-  const auto imported = importGeoTiff(store, SourceLayer::Cube, tif, options);
+  const auto imported = importGeoTiff(store, SourceLayer::Survey, tif, options);
   EXPECT_EQ(imported, 8u);   // 9 pixels minus the no-data centre
 
-  const auto nw = store.get(SourceLayer::Cube, nwCell(store, store.level()));
+  const auto nw = store.get(SourceLayer::Survey, nwCell(store, store.level()));
   ASSERT_TRUE(nw.has_value());
   EXPECT_FLOAT_EQ(static_cast<float>(nw->depth), -30.0f);
   EXPECT_FLOAT_EQ(static_cast<float>(nw->uncertainty), 0.1f);
 
   // The import landed in the layer's single fused surface (#221).
-  EXPECT_FALSE(store.tiles(SourceLayer::Cube).empty());
+  EXPECT_FALSE(store.tiles(SourceLayer::Survey).empty());
 }
 
 TEST_F(GeoTiffImportTest, ImportsAtCallerSpecifiedLevel)
 {
   // Multi-level (ADR-0002 §D2): import at a level other than the store default.
-  // Importing to the read-only PreExisting prior requires the importer opt-in.
-  BathymetryStore store(11, /*pre_existing_writable=*/true);   // default level 11
+  // Importing to the read-only Reference prior requires the importer opt-in.
+  BathymetryStore store(11, /*reference_writable=*/true);   // default level 11
   const std::vector<float> depth{-30.0f};
   const std::vector<float> unc{0.1f};
   gggs::Level coarse(8);
@@ -165,7 +165,7 @@ TEST_F(GeoTiffImportTest, ImportsAtCallerSpecifiedLevel)
 
   GeoTiffImportOptions options;
   options.level = 8;   // import at level 8, not the store's default 11
-  EXPECT_EQ(importGeoTiff(store, SourceLayer::PreExisting, tif, options), 1u);
+  EXPECT_EQ(importGeoTiff(store, SourceLayer::Reference, tif, options), 1u);
 
   // The imported tile is at level 8, queryable at that level. The fixture's
   // single pixel sits at the level-8 grid's NW corner, so query that cell.
@@ -174,11 +174,11 @@ TEST_F(GeoTiffImportTest, ImportsAtCallerSpecifiedLevel)
   const double cell_y = grid8.latitudinalSpan() / gggs::cell_rows_per_grid;
   const auto cell = coarse.cellIndex(gggs::geoPoint(
       grid8.northLatitude() - 0.5 * cell_y, grid8.westLongitude() + 0.5 * cell_x));
-  const auto got = store.get(SourceLayer::PreExisting, cell);
+  const auto got = store.get(SourceLayer::Reference, cell);
   ASSERT_TRUE(got.has_value());
   EXPECT_FLOAT_EQ(static_cast<float>(got->depth), -30.0f);
   // And the stored grid carries the level-8 prefix.
-  const auto & tiles = store.tiles(SourceLayer::PreExisting);
+  const auto & tiles = store.tiles(SourceLayer::Reference);
   ASSERT_FALSE(tiles.empty());
   EXPECT_EQ(tiles.begin()->first.level(), 8u);
 }
@@ -192,10 +192,10 @@ TEST_F(GeoTiffImportTest, FinerInputKeepsLowestUncertainty)
   const std::vector<float> unc{0.5f, 0.2f, 0.9f, 0.7f};
   const auto tif = writeTestTiff(dir_ / "fine.tif", store.level(), 2, 2, depth, unc, 2);
 
-  const auto imported = importGeoTiff(store, SourceLayer::Cube, tif);
+  const auto imported = importGeoTiff(store, SourceLayer::Survey, tif);
   EXPECT_EQ(imported, 1u);   // four pixels, one cell
 
-  const auto got = store.get(SourceLayer::Cube, nwCell(store, store.level()));
+  const auto got = store.get(SourceLayer::Survey, nwCell(store, store.level()));
   ASSERT_TRUE(got.has_value());
   EXPECT_FLOAT_EQ(static_cast<float>(got->depth), -31.0f);       // unc 0.2 wins
   EXPECT_FLOAT_EQ(static_cast<float>(got->uncertainty), 0.2f);
@@ -212,14 +212,14 @@ TEST_F(GeoTiffImportTest, ReimportMergesLastWriteWins)
   const auto second =
     writeTestTiff(dir_ / "second.tif", store.level(), 1, 1, {-28.0f}, unc);
 
-  EXPECT_EQ(importGeoTiff(store, SourceLayer::Cube, first), 1u);
+  EXPECT_EQ(importGeoTiff(store, SourceLayer::Survey, first), 1u);
   EXPECT_DOUBLE_EQ(
-    store.get(SourceLayer::Cube, nwCell(store, store.level()))->depth, -30.0);
+    store.get(SourceLayer::Survey, nwCell(store, store.level()))->depth, -30.0);
 
   // A second import of the same cell overwrites the first.
-  EXPECT_EQ(importGeoTiff(store, SourceLayer::Cube, second), 1u);
+  EXPECT_EQ(importGeoTiff(store, SourceLayer::Survey, second), 1u);
   EXPECT_DOUBLE_EQ(
-    store.get(SourceLayer::Cube, nwCell(store, store.level()))->depth, -28.0);
+    store.get(SourceLayer::Survey, nwCell(store, store.level()))->depth, -28.0);
 }
 
 TEST_F(GeoTiffImportTest, MissingUncertaintyBandUsesDefault)
@@ -232,9 +232,9 @@ TEST_F(GeoTiffImportTest, MissingUncertaintyBandUsesDefault)
   GeoTiffImportOptions options;
   options.uncertainty_band = 0;
   options.default_uncertainty = 3.5;
-  EXPECT_EQ(importGeoTiff(store, SourceLayer::Cube, tif, options), 1u);
+  EXPECT_EQ(importGeoTiff(store, SourceLayer::Survey, tif, options), 1u);
 
-  const auto got = store.get(SourceLayer::Cube, nwCell(store, store.level()));
+  const auto got = store.get(SourceLayer::Survey, nwCell(store, store.level()));
   ASSERT_TRUE(got.has_value());
   EXPECT_DOUBLE_EQ(got->uncertainty, 3.5);
 }
@@ -243,7 +243,7 @@ TEST_F(GeoTiffImportTest, DepthScaleOffsetAndFiniteNoData)
 {
   // A lake-prior product: depths positive-down below the surface, with a FINITE
   // no-data value (-9999) that must not import as a 9 km depth.
-  BathymetryStore store(11, /*pre_existing_writable=*/true);  // imports to prior
+  BathymetryStore store(11, /*reference_writable=*/true);  // imports to prior
   const std::vector<float> depth{4.0f, -9999.0f};   // 4 m of water; one no-data
   const std::vector<float> unc{0.0f, 0.0f};         // source has no real band
   const auto tif = writeTestTiff(dir_ / "lake.tif", store.level(), 2, 1, depth, unc);
@@ -260,10 +260,10 @@ TEST_F(GeoTiffImportTest, DepthScaleOffsetAndFiniteNoData)
   options.default_uncertainty = 3.0;
   options.depth_scale = -1.0;       // positive-down -> up-positive
   options.depth_offset = -20.0;     // lake surface ellipsoidal height
-  const auto imported = importGeoTiff(store, SourceLayer::PreExisting, tif, options);
+  const auto imported = importGeoTiff(store, SourceLayer::Reference, tif, options);
   EXPECT_EQ(imported, 1u);         // the -9999 pixel was skipped
 
-  const auto got = store.get(SourceLayer::PreExisting, nwCell(store, store.level()));
+  const auto got = store.get(SourceLayer::Reference, nwCell(store, store.level()));
   ASSERT_TRUE(got.has_value());
   EXPECT_DOUBLE_EQ(got->depth, -24.0);          // -1 * 4 + (-20)
   EXPECT_DOUBLE_EQ(got->uncertainty, 3.0);
@@ -274,7 +274,7 @@ TEST_F(GeoTiffImportTest, CoarserInputFillsPixelFootprint)
   // A 5x-coarser pixel must fill its whole footprint of store cells — coverage,
   // not isolated dots (the contour-prior case). The helper only does integer
   // pixels-per-cell, so build the 1x1 raster with a 5-cell pixel directly.
-  BathymetryStore store(11, /*pre_existing_writable=*/true);  // imports to prior
+  BathymetryStore store(11, /*reference_writable=*/true);  // imports to prior
   const std::vector<float> depth{-30.0f};
   const std::vector<float> unc{3.0f};
   const gggs::GridIndex grid = store.level().gridIndex(43.0, -70.5);
@@ -307,13 +307,13 @@ TEST_F(GeoTiffImportTest, CoarserInputFillsPixelFootprint)
     GDALClose(ds);
   }
 
-  const auto imported = importGeoTiff(store, SourceLayer::PreExisting, path);
+  const auto imported = importGeoTiff(store, SourceLayer::Reference, path);
   EXPECT_EQ(imported, 25u);   // 5x5 store cells under the one pixel
 
   // Every cell of the footprint carries the value — spot-check a middle one.
   const auto mid = store.cellIndex(
     grid.northLatitude() - 2.5 * cell_y, grid.westLongitude() + 2.5 * cell_x);
-  const auto got = store.get(SourceLayer::PreExisting, mid);
+  const auto got = store.get(SourceLayer::Reference, mid);
   ASSERT_TRUE(got.has_value());
   EXPECT_FLOAT_EQ(static_cast<float>(got->depth), -30.0f);
 }
@@ -327,7 +327,7 @@ TEST_F(GeoTiffImportTest, ZeroUncertaintyIsMissingNotPerfect)
   const std::vector<float> unc{0.0f, 0.4f};
   const auto tif = writeTestTiff(dir_ / "zerounc.tif", store.level(), 2, 1, depth, unc);
 
-  const auto imported = importGeoTiff(store, SourceLayer::Cube, tif);
+  const auto imported = importGeoTiff(store, SourceLayer::Survey, tif);
   EXPECT_EQ(imported, 2u);   // both cells import (depth is real)
 
   const gggs::GridIndex grid = store.level().gridIndex(43.0, -70.5);
@@ -338,11 +338,11 @@ TEST_F(GeoTiffImportTest, ZeroUncertaintyIsMissingNotPerfect)
   const auto good_cell = store.cellIndex(
     grid.northLatitude() - 0.5 * cell_y, grid.westLongitude() + 1.5 * cell_x);
 
-  const auto zero = store.get(SourceLayer::Cube, zero_cell);
+  const auto zero = store.get(SourceLayer::Survey, zero_cell);
   ASSERT_TRUE(zero.has_value());
   EXPECT_TRUE(std::isnan(zero->uncertainty));   // missing, not 0
 
-  const auto good = store.get(SourceLayer::Cube, good_cell);
+  const auto good = store.get(SourceLayer::Survey, good_cell);
   ASSERT_TRUE(good.has_value());
   EXPECT_FLOAT_EQ(static_cast<float>(good->uncertainty), 0.4f);
 }
@@ -351,6 +351,6 @@ TEST_F(GeoTiffImportTest, MissingFileThrows)
 {
   BathymetryStore store(11);
   EXPECT_THROW(
-    importGeoTiff(store, SourceLayer::Cube, (dir_ / "absent.tif").string()),
+    importGeoTiff(store, SourceLayer::Survey, (dir_ / "absent.tif").string()),
     std::runtime_error);
 }

--- a/marine_bathymetry_store/test/test_query.cpp
+++ b/marine_bathymetry_store/test/test_query.cpp
@@ -39,26 +39,26 @@ using marine_bathymetry_store::SourceLayer;
 
 TEST(Query, BestSourcePrefersHigherPriorityLayer)
 {
-  BathymetryStore store(5, /*pre_existing_writable=*/true);
+  BathymetryStore store(5, /*reference_writable=*/true);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::PreExisting, cell, BathyCell{-12.0, 2.0});
-  store.set(SourceLayer::Cube, cell, BathyCell{-10.0, 0.1});
+  store.set(SourceLayer::Reference, cell, BathyCell{-12.0, 2.0});
+  store.set(SourceLayer::Survey, cell, BathyCell{-10.0, 0.1});
 
   const auto best = bestSource(store, cell);
   ASSERT_TRUE(best.has_value());
-  EXPECT_EQ(best->source, SourceLayer::Cube);
+  EXPECT_EQ(best->source, SourceLayer::Survey);
   EXPECT_DOUBLE_EQ(best->depth, -10.0);
 }
 
 TEST(Query, BestSourceFallsBackToLowerPriority)
 {
-  BathymetryStore store(5, /*pre_existing_writable=*/true);
+  BathymetryStore store(5, /*reference_writable=*/true);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::PreExisting, cell, BathyCell{-12.0, 2.0});
+  store.set(SourceLayer::Reference, cell, BathyCell{-12.0, 2.0});
 
   const auto best = bestSource(store, cell);
   ASSERT_TRUE(best.has_value());
-  EXPECT_EQ(best->source, SourceLayer::PreExisting);
+  EXPECT_EQ(best->source, SourceLayer::Reference);
 }
 
 TEST(Query, UnknownCellIsNullopt)
@@ -68,43 +68,43 @@ TEST(Query, UnknownCellIsNullopt)
   EXPECT_FALSE(bestSource(store, cell).has_value());
 
   // A written-but-no-data cell is still unknown (not "deep water").
-  store.set(SourceLayer::Cube, cell, BathyCell{});
+  store.set(SourceLayer::Survey, cell, BathyCell{});
   EXPECT_FALSE(bestSource(store, cell).has_value());
 }
 
 TEST(Query, ShallowestReliablePicksGreatestHeight)
 {
   // depth is ellipsoidal height (up-positive): shallower == greater value.
-  BathymetryStore store(5, /*pre_existing_writable=*/true);
+  BathymetryStore store(5, /*reference_writable=*/true);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::PreExisting, cell, BathyCell{-30.0, 0.1});  // deeper
-  store.set(SourceLayer::Cube, cell, BathyCell{-25.0, 0.2});         // shallower
+  store.set(SourceLayer::Reference, cell, BathyCell{-30.0, 0.1});  // deeper
+  store.set(SourceLayer::Survey, cell, BathyCell{-25.0, 0.2});         // shallower
 
   const auto result = shallowestReliable(store, cell, 1.0);
   ASSERT_TRUE(result.has_value());
   EXPECT_DOUBLE_EQ(result->depth, -25.0);
-  EXPECT_EQ(result->source, SourceLayer::Cube);
+  EXPECT_EQ(result->source, SourceLayer::Survey);
 }
 
 TEST(Query, ShallowestReliableExcludesOverUncertain)
 {
-  BathymetryStore store(5, /*pre_existing_writable=*/true);
+  BathymetryStore store(5, /*reference_writable=*/true);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::PreExisting, cell, BathyCell{-30.0, 0.1});  // reliable, deeper
+  store.set(SourceLayer::Reference, cell, BathyCell{-30.0, 0.1});  // reliable, deeper
   // shallower, but too uncertain to be reliable:
-  store.set(SourceLayer::Cube, cell, BathyCell{-25.0, 5.0});
+  store.set(SourceLayer::Survey, cell, BathyCell{-25.0, 5.0});
 
   const auto result = shallowestReliable(store, cell, 1.0);
   ASSERT_TRUE(result.has_value());
-  EXPECT_DOUBLE_EQ(result->depth, -30.0);   // cube excluded
-  EXPECT_EQ(result->source, SourceLayer::PreExisting);
+  EXPECT_DOUBLE_EQ(result->depth, -30.0);   // survey excluded
+  EXPECT_EQ(result->source, SourceLayer::Reference);
 }
 
 TEST(Query, ShallowestReliableTreatsNaNUncertaintyAsUnreliable)
 {
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Cube, cell, BathyCell{-25.0, std::nan("")});
+  store.set(SourceLayer::Survey, cell, BathyCell{-25.0, std::nan("")});
   EXPECT_FALSE(shallowestReliable(store, cell, 1.0).has_value());
 }
 
@@ -112,7 +112,7 @@ TEST(Query, ForEachRegionVisitsCoveredCells)
 {
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Cube, cell, BathyCell{-20.0, 0.5});
+  store.set(SourceLayer::Survey, cell, BathyCell{-20.0, 0.5});
 
   std::size_t visited = 0;
   std::size_t with_data = 0;
@@ -129,28 +129,28 @@ TEST(Query, ForEachRegionVisitsCoveredCells)
   EXPECT_GE(with_data, 1u);   // the written cell falls inside the box
 }
 
-TEST(Query, BestSourceFallsThroughToPreExistingPrior)
+TEST(Query, BestSourceFallsThroughToReferencePrior)
 {
-  // PreExisting is the lowest-priority prior: used only where nothing newer
-  // exists, and overridden by Cube where it does (ADR-0002 §D3).
-  BathymetryStore store(5, /*pre_existing_writable=*/true);
+  // Reference is the lowest-priority prior: used only where nothing newer
+  // exists, and overridden by Survey where it does (ADR-0002 §D3).
+  BathymetryStore store(5, /*reference_writable=*/true);
   const auto unsurveyed = store.cellIndex(43.0, -70.5);
   const auto surveyed = store.cellIndex(43.0, -70.4);
 
-  store.set(SourceLayer::PreExisting, unsurveyed, BathyCell{38.0, 3.0});
-  store.set(SourceLayer::PreExisting, surveyed, BathyCell{38.0, 3.0});
-  store.set(SourceLayer::Cube, surveyed, BathyCell{40.0, 0.5});
+  store.set(SourceLayer::Reference, unsurveyed, BathyCell{38.0, 3.0});
+  store.set(SourceLayer::Reference, surveyed, BathyCell{38.0, 3.0});
+  store.set(SourceLayer::Survey, surveyed, BathyCell{40.0, 0.5});
 
   // Unsurveyed cell falls through to the prior.
   const auto a = bestSource(store, unsurveyed);
   ASSERT_TRUE(a.has_value());
-  EXPECT_EQ(a->source, SourceLayer::PreExisting);
+  EXPECT_EQ(a->source, SourceLayer::Reference);
   EXPECT_DOUBLE_EQ(a->depth, 38.0);
 
-  // Surveyed cell prefers the live cube over the prior.
+  // Surveyed cell prefers the live survey over the prior.
   const auto b = bestSource(store, surveyed);
   ASSERT_TRUE(b.has_value());
-  EXPECT_EQ(b->source, SourceLayer::Cube);
+  EXPECT_EQ(b->source, SourceLayer::Survey);
   EXPECT_DOUBLE_EQ(b->depth, 40.0);
 }
 
@@ -159,20 +159,20 @@ TEST(Query, BestSourcePrefersFinerLevelAcrossLevels)
   // Multi-level store (ADR-0002 §D2): a coarse prior and a fine survey grid in
   // the SAME layer at DIFFERENT levels. best-available resolves the finest level
   // present that has data at the query position.
-  BathymetryStore store(5, /*pre_existing_writable=*/true);
+  BathymetryStore store(5, /*reference_writable=*/true);
   gggs::Level coarse(4);
   gggs::Level fine(7);
   const auto pt = gggs::geoPoint(43.0, -70.5);
 
-  store.set(SourceLayer::PreExisting, coarse.cellIndex(pt), BathyCell{38.0, 3.0});
-  store.set(SourceLayer::PreExisting, fine.cellIndex(pt), BathyCell{40.0, 0.5});
+  store.set(SourceLayer::Reference, coarse.cellIndex(pt), BathyCell{38.0, 3.0});
+  store.set(SourceLayer::Reference, fine.cellIndex(pt), BathyCell{40.0, 0.5});
 
   // Query at the finest present level (its center is closest to the survey
   // point, so the coarse cell also covers it): best-available resolves the
   // finer (level 7) value, not the coarse prior, where both cover the cell.
   const auto best = bestSource(store, fine.cellIndex(pt));
   ASSERT_TRUE(best.has_value());
-  EXPECT_EQ(best->source, SourceLayer::PreExisting);
+  EXPECT_EQ(best->source, SourceLayer::Reference);
   EXPECT_DOUBLE_EQ(best->depth, 40.0);   // finer level wins
   EXPECT_EQ(best->level, 7u);
 }
@@ -180,15 +180,15 @@ TEST(Query, BestSourcePrefersFinerLevelAcrossLevels)
 TEST(Query, BestSourceFallsToCoarseLevelWhereFineAbsent)
 {
   // Where only the coarse level covers a cell, the query falls through to it.
-  BathymetryStore store(5, /*pre_existing_writable=*/true);
+  BathymetryStore store(5, /*reference_writable=*/true);
   gggs::Level coarse(4);
   gggs::Level fine(7);
   const auto surveyed = gggs::geoPoint(43.0, -70.5);
   const auto unsurveyed = gggs::geoPoint(43.0, -70.4);
 
-  store.set(SourceLayer::PreExisting, coarse.cellIndex(surveyed), BathyCell{38.0, 3.0});
-  store.set(SourceLayer::PreExisting, coarse.cellIndex(unsurveyed), BathyCell{37.0, 3.0});
-  store.set(SourceLayer::PreExisting, fine.cellIndex(surveyed), BathyCell{40.0, 0.5});
+  store.set(SourceLayer::Reference, coarse.cellIndex(surveyed), BathyCell{38.0, 3.0});
+  store.set(SourceLayer::Reference, coarse.cellIndex(unsurveyed), BathyCell{37.0, 3.0});
+  store.set(SourceLayer::Reference, fine.cellIndex(surveyed), BathyCell{40.0, 0.5});
 
   // Cell with no fine-level data: only the coarse level covers it -> resolves
   // to the coarse value.
@@ -208,8 +208,8 @@ TEST(Query, ShallowestReliableConsidersAllLevels)
   const auto pt = gggs::geoPoint(43.0, -70.5);
 
   // Fine level: shallower but too uncertain. Coarse: deeper but reliable.
-  store.set(SourceLayer::Cube, fine.cellIndex(pt), BathyCell{-20.0, 5.0});
-  store.set(SourceLayer::Cube, coarse.cellIndex(pt), BathyCell{-30.0, 0.2});
+  store.set(SourceLayer::Survey, fine.cellIndex(pt), BathyCell{-20.0, 5.0});
+  store.set(SourceLayer::Survey, coarse.cellIndex(pt), BathyCell{-30.0, 0.2});
 
   const auto result = shallowestReliable(store, store.cellIndex(43.0, -70.5), 1.0);
   ASSERT_TRUE(result.has_value());
@@ -217,14 +217,14 @@ TEST(Query, ShallowestReliableConsidersAllLevels)
   EXPECT_EQ(result->level, 4u);
 }
 
-TEST(Query, ShallowestReliableGatesPreExistingByUncertainty)
+TEST(Query, ShallowestReliableGatesReferenceByUncertainty)
 {
   // The coarse prior carries a fixed import uncertainty (3.0 m). It feeds the
   // safety query shallowestReliable, so the uncertainty gate must admit it only
   // when the caller's tolerance allows — both sides of the threshold.
-  BathymetryStore store(5, /*pre_existing_writable=*/true);
+  BathymetryStore store(5, /*reference_writable=*/true);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::PreExisting, cell, BathyCell{38.0, 3.0});
+  store.set(SourceLayer::Reference, cell, BathyCell{38.0, 3.0});
 
   // Tolerance below the prior uncertainty excludes it -> cell reads as unknown.
   EXPECT_FALSE(shallowestReliable(store, cell, 2.9).has_value());
@@ -232,7 +232,7 @@ TEST(Query, ShallowestReliableGatesPreExistingByUncertainty)
   // Tolerance at the prior uncertainty (comparison is strictly >) admits it.
   const auto at = shallowestReliable(store, cell, 3.0);
   ASSERT_TRUE(at.has_value());
-  EXPECT_EQ(at->source, SourceLayer::PreExisting);
+  EXPECT_EQ(at->source, SourceLayer::Reference);
   EXPECT_DOUBLE_EQ(at->depth, 38.0);
 }
 
@@ -242,11 +242,11 @@ TEST(Query, ShallowestReliableWithNoReliableDataReturnsNullopt)
   // fall through to. If the only data over a cell is over-uncertain, the safety
   // query returns nullopt — the caller treats that as unknown → obstacle
   // (ADR-0002 §D7).
-  BathymetryStore store(5, /*pre_existing_writable=*/true);
+  BathymetryStore store(5, /*reference_writable=*/true);
   const auto cell = store.cellIndex(43.0, -70.5);
   // Over-uncertain across both layers that hold this cell.
-  store.set(SourceLayer::PreExisting, cell, BathyCell{-30.0, 5.0});
-  store.set(SourceLayer::Cube, cell, BathyCell{-25.0, 9.0});
+  store.set(SourceLayer::Reference, cell, BathyCell{-30.0, 5.0});
+  store.set(SourceLayer::Survey, cell, BathyCell{-25.0, 9.0});
 
   EXPECT_FALSE(shallowestReliable(store, cell, 1.0).has_value());
 

--- a/marine_bathymetry_store/test/test_query.cpp
+++ b/marine_bathymetry_store/test/test_query.cpp
@@ -39,26 +39,26 @@ using marine_bathymetry_store::SourceLayer;
 
 TEST(Query, BestSourcePrefersHigherPriorityLayer)
 {
-  BathymetryStore store(5);
+  BathymetryStore store(5, /*pre_existing_writable=*/true);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Draft, cell, BathyCell{-12.0, 2.0, 2LL});
-  store.set(SourceLayer::Processed, cell, BathyCell{-10.0, 0.1, 1LL});
+  store.set(SourceLayer::PreExisting, cell, BathyCell{-12.0, 2.0});
+  store.set(SourceLayer::Cube, cell, BathyCell{-10.0, 0.1});
 
   const auto best = bestSource(store, cell);
   ASSERT_TRUE(best.has_value());
-  EXPECT_EQ(best->source, SourceLayer::Processed);
+  EXPECT_EQ(best->source, SourceLayer::Cube);
   EXPECT_DOUBLE_EQ(best->depth, -10.0);
 }
 
 TEST(Query, BestSourceFallsBackToLowerPriority)
 {
-  BathymetryStore store(5);
+  BathymetryStore store(5, /*pre_existing_writable=*/true);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Draft, cell, BathyCell{-12.0, 2.0, 2LL});
+  store.set(SourceLayer::PreExisting, cell, BathyCell{-12.0, 2.0});
 
   const auto best = bestSource(store, cell);
   ASSERT_TRUE(best.has_value());
-  EXPECT_EQ(best->source, SourceLayer::Draft);
+  EXPECT_EQ(best->source, SourceLayer::PreExisting);
 }
 
 TEST(Query, UnknownCellIsNullopt)
@@ -68,43 +68,43 @@ TEST(Query, UnknownCellIsNullopt)
   EXPECT_FALSE(bestSource(store, cell).has_value());
 
   // A written-but-no-data cell is still unknown (not "deep water").
-  store.set(SourceLayer::Draft, cell, BathyCell{});
+  store.set(SourceLayer::Cube, cell, BathyCell{});
   EXPECT_FALSE(bestSource(store, cell).has_value());
 }
 
 TEST(Query, ShallowestReliablePicksGreatestHeight)
 {
   // depth is ellipsoidal height (up-positive): shallower == greater value.
-  BathymetryStore store(5);
+  BathymetryStore store(5, /*pre_existing_writable=*/true);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Processed, cell, BathyCell{-30.0, 0.1, 1LL});  // deeper
-  store.set(SourceLayer::Draft, cell, BathyCell{-25.0, 0.2, 2LL});      // shallower
+  store.set(SourceLayer::PreExisting, cell, BathyCell{-30.0, 0.1});  // deeper
+  store.set(SourceLayer::Cube, cell, BathyCell{-25.0, 0.2});         // shallower
 
   const auto result = shallowestReliable(store, cell, 1.0);
   ASSERT_TRUE(result.has_value());
   EXPECT_DOUBLE_EQ(result->depth, -25.0);
-  EXPECT_EQ(result->source, SourceLayer::Draft);
+  EXPECT_EQ(result->source, SourceLayer::Cube);
 }
 
 TEST(Query, ShallowestReliableExcludesOverUncertain)
 {
-  BathymetryStore store(5);
+  BathymetryStore store(5, /*pre_existing_writable=*/true);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Processed, cell, BathyCell{-30.0, 0.1, 1LL});  // reliable, deeper
+  store.set(SourceLayer::PreExisting, cell, BathyCell{-30.0, 0.1});  // reliable, deeper
   // shallower, but too uncertain to be reliable:
-  store.set(SourceLayer::Draft, cell, BathyCell{-25.0, 5.0, 2LL});
+  store.set(SourceLayer::Cube, cell, BathyCell{-25.0, 5.0});
 
   const auto result = shallowestReliable(store, cell, 1.0);
   ASSERT_TRUE(result.has_value());
-  EXPECT_DOUBLE_EQ(result->depth, -30.0);   // draft excluded
-  EXPECT_EQ(result->source, SourceLayer::Processed);
+  EXPECT_DOUBLE_EQ(result->depth, -30.0);   // cube excluded
+  EXPECT_EQ(result->source, SourceLayer::PreExisting);
 }
 
 TEST(Query, ShallowestReliableTreatsNaNUncertaintyAsUnreliable)
 {
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Draft, cell, BathyCell{-25.0, std::nan(""), 2LL});
+  store.set(SourceLayer::Cube, cell, BathyCell{-25.0, std::nan("")});
   EXPECT_FALSE(shallowestReliable(store, cell, 1.0).has_value());
 }
 
@@ -112,7 +112,7 @@ TEST(Query, ForEachRegionVisitsCoveredCells)
 {
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Draft, cell, BathyCell{-20.0, 0.5, 1LL});
+  store.set(SourceLayer::Cube, cell, BathyCell{-20.0, 0.5});
 
   std::size_t visited = 0;
   std::size_t with_data = 0;
@@ -129,80 +129,50 @@ TEST(Query, ForEachRegionVisitsCoveredCells)
   EXPECT_GE(with_data, 1u);   // the written cell falls inside the box
 }
 
-TEST(Query, BestSourceFallsThroughToChartPrior)
+TEST(Query, BestSourceFallsThroughToPreExistingPrior)
 {
-  // Chart is the lowest-priority prior: used only where nothing newer exists,
-  // and overridden by Draft/Processed where they do (ADR-0002 §D3).
-  BathymetryStore store(5, /*chart_writable=*/true);
+  // PreExisting is the lowest-priority prior: used only where nothing newer
+  // exists, and overridden by Cube where it does (ADR-0002 §D3).
+  BathymetryStore store(5, /*pre_existing_writable=*/true);
   const auto unsurveyed = store.cellIndex(43.0, -70.5);
   const auto surveyed = store.cellIndex(43.0, -70.4);
 
-  store.set(SourceLayer::Chart, unsurveyed, BathyCell{38.0, 3.0, 1LL});
-  store.set(SourceLayer::Chart, surveyed, BathyCell{38.0, 3.0, 1LL});
-  store.set(SourceLayer::Draft, surveyed, BathyCell{40.0, 0.5, 2LL});
+  store.set(SourceLayer::PreExisting, unsurveyed, BathyCell{38.0, 3.0});
+  store.set(SourceLayer::PreExisting, surveyed, BathyCell{38.0, 3.0});
+  store.set(SourceLayer::Cube, surveyed, BathyCell{40.0, 0.5});
 
-  // Unsurveyed cell falls through to the chart prior.
+  // Unsurveyed cell falls through to the prior.
   const auto a = bestSource(store, unsurveyed);
   ASSERT_TRUE(a.has_value());
-  EXPECT_EQ(a->source, SourceLayer::Chart);
+  EXPECT_EQ(a->source, SourceLayer::PreExisting);
   EXPECT_DOUBLE_EQ(a->depth, 38.0);
 
-  // Surveyed cell prefers the live draft over the chart prior.
+  // Surveyed cell prefers the live cube over the prior.
   const auto b = bestSource(store, surveyed);
   ASSERT_TRUE(b.has_value());
-  EXPECT_EQ(b->source, SourceLayer::Draft);
+  EXPECT_EQ(b->source, SourceLayer::Cube);
   EXPECT_DOUBLE_EQ(b->depth, 40.0);
-}
-
-TEST(Query, ShallowestReliableUnaffectedBySourceIndex)
-{
-  // ADR-0005 D5 safety carve-out: the navigation-safety query ignores the
-  // source-index / registry priority axis entirely. Two cells in the same layer
-  // with DIFFERENT source indices must produce exactly the same shallowest-
-  // reliable result as if source_index were unset — selection is by depth +
-  // uncertainty only, never by which platform/sensor contributed the cell.
-  BathymetryStore store(5);
-  const auto cell = store.cellIndex(43.0, -70.5);
-
-  // Deeper cell from a "high" source index; shallower from a "low" one. If the
-  // query ever consulted source_index, the answer could flip — it must not.
-  store.set(SourceLayer::Processed, cell, BathyCell{-30.0, 0.1, 1LL, 9000u});  // deeper
-  store.set(SourceLayer::Draft, cell, BathyCell{-25.0, 0.2, 2LL, 1u});         // shallower
-
-  const auto result = shallowestReliable(store, cell, 1.0);
-  ASSERT_TRUE(result.has_value());
-  EXPECT_DOUBLE_EQ(result->depth, -25.0);          // shallowest, regardless of source
-  EXPECT_EQ(result->source, SourceLayer::Draft);
-
-  // Same geometry with source indices swapped -> identical result.
-  BathymetryStore swapped(5);
-  swapped.set(SourceLayer::Processed, cell, BathyCell{-30.0, 0.1, 1LL, 1u});
-  swapped.set(SourceLayer::Draft, cell, BathyCell{-25.0, 0.2, 2LL, 9000u});
-  const auto result2 = shallowestReliable(swapped, cell, 1.0);
-  ASSERT_TRUE(result2.has_value());
-  EXPECT_DOUBLE_EQ(result2->depth, -25.0);
-  EXPECT_EQ(result2->source, SourceLayer::Draft);
 }
 
 TEST(Query, BestSourcePrefersFinerLevelAcrossLevels)
 {
-  // Multi-level store (ADR-0002 §D2): a coarse chart prior and a fine survey
-  // grid in the SAME layer at DIFFERENT levels. best-available resolves the
-  // finest level present that has data at the query position.
-  BathymetryStore store(5, /*chart_writable=*/true);
+  // Multi-level store (ADR-0002 §D2): a coarse prior and a fine survey grid in
+  // the SAME layer at DIFFERENT levels. best-available resolves the finest level
+  // present that has data at the query position.
+  BathymetryStore store(5, /*pre_existing_writable=*/true);
   gggs::Level coarse(4);
   gggs::Level fine(7);
   const auto pt = gggs::geoPoint(43.0, -70.5);
 
-  store.set(SourceLayer::Chart, coarse.cellIndex(pt), BathyCell{38.0, 3.0, 1LL});
-  store.set(SourceLayer::Chart, fine.cellIndex(pt), BathyCell{40.0, 0.5, 2LL});
+  store.set(SourceLayer::PreExisting, coarse.cellIndex(pt), BathyCell{38.0, 3.0});
+  store.set(SourceLayer::PreExisting, fine.cellIndex(pt), BathyCell{40.0, 0.5});
 
   // Query at the finest present level (its center is closest to the survey
   // point, so the coarse cell also covers it): best-available resolves the
   // finer (level 7) value, not the coarse prior, where both cover the cell.
   const auto best = bestSource(store, fine.cellIndex(pt));
   ASSERT_TRUE(best.has_value());
-  EXPECT_EQ(best->source, SourceLayer::Chart);
+  EXPECT_EQ(best->source, SourceLayer::PreExisting);
   EXPECT_DOUBLE_EQ(best->depth, 40.0);   // finer level wins
   EXPECT_EQ(best->level, 7u);
 }
@@ -210,15 +180,15 @@ TEST(Query, BestSourcePrefersFinerLevelAcrossLevels)
 TEST(Query, BestSourceFallsToCoarseLevelWhereFineAbsent)
 {
   // Where only the coarse level covers a cell, the query falls through to it.
-  BathymetryStore store(5, /*chart_writable=*/true);
+  BathymetryStore store(5, /*pre_existing_writable=*/true);
   gggs::Level coarse(4);
   gggs::Level fine(7);
   const auto surveyed = gggs::geoPoint(43.0, -70.5);
   const auto unsurveyed = gggs::geoPoint(43.0, -70.4);
 
-  store.set(SourceLayer::Chart, coarse.cellIndex(surveyed), BathyCell{38.0, 3.0, 1LL});
-  store.set(SourceLayer::Chart, coarse.cellIndex(unsurveyed), BathyCell{37.0, 3.0, 1LL});
-  store.set(SourceLayer::Chart, fine.cellIndex(surveyed), BathyCell{40.0, 0.5, 2LL});
+  store.set(SourceLayer::PreExisting, coarse.cellIndex(surveyed), BathyCell{38.0, 3.0});
+  store.set(SourceLayer::PreExisting, coarse.cellIndex(unsurveyed), BathyCell{37.0, 3.0});
+  store.set(SourceLayer::PreExisting, fine.cellIndex(surveyed), BathyCell{40.0, 0.5});
 
   // Cell with no fine-level data: only the coarse level covers it -> resolves
   // to the coarse value.
@@ -238,8 +208,8 @@ TEST(Query, ShallowestReliableConsidersAllLevels)
   const auto pt = gggs::geoPoint(43.0, -70.5);
 
   // Fine level: shallower but too uncertain. Coarse: deeper but reliable.
-  store.set(SourceLayer::Draft, fine.cellIndex(pt), BathyCell{-20.0, 5.0, 2LL});
-  store.set(SourceLayer::Draft, coarse.cellIndex(pt), BathyCell{-30.0, 0.2, 1LL});
+  store.set(SourceLayer::Cube, fine.cellIndex(pt), BathyCell{-20.0, 5.0});
+  store.set(SourceLayer::Cube, coarse.cellIndex(pt), BathyCell{-30.0, 0.2});
 
   const auto result = shallowestReliable(store, store.cellIndex(43.0, -70.5), 1.0);
   ASSERT_TRUE(result.has_value());
@@ -247,22 +217,22 @@ TEST(Query, ShallowestReliableConsidersAllLevels)
   EXPECT_EQ(result->level, 4u);
 }
 
-TEST(Query, ShallowestReliableGatesChartByUncertainty)
+TEST(Query, ShallowestReliableGatesPreExistingByUncertainty)
 {
-  // The coarse Chart prior carries a fixed import uncertainty (3.0 m). It feeds
-  // the safety query shallowestReliable, so the uncertainty gate must admit it
-  // only when the caller's tolerance allows — both sides of the threshold.
-  BathymetryStore store(5, /*chart_writable=*/true);
+  // The coarse prior carries a fixed import uncertainty (3.0 m). It feeds the
+  // safety query shallowestReliable, so the uncertainty gate must admit it only
+  // when the caller's tolerance allows — both sides of the threshold.
+  BathymetryStore store(5, /*pre_existing_writable=*/true);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Chart, cell, BathyCell{38.0, 3.0, 1LL});
+  store.set(SourceLayer::PreExisting, cell, BathyCell{38.0, 3.0});
 
-  // Tolerance below the chart uncertainty excludes it -> cell reads as unknown.
+  // Tolerance below the prior uncertainty excludes it -> cell reads as unknown.
   EXPECT_FALSE(shallowestReliable(store, cell, 2.9).has_value());
 
-  // Tolerance at the chart uncertainty (comparison is strictly >) admits it.
+  // Tolerance at the prior uncertainty (comparison is strictly >) admits it.
   const auto at = shallowestReliable(store, cell, 3.0);
   ASSERT_TRUE(at.has_value());
-  EXPECT_EQ(at->source, SourceLayer::Chart);
+  EXPECT_EQ(at->source, SourceLayer::PreExisting);
   EXPECT_DOUBLE_EQ(at->depth, 38.0);
 }
 
@@ -271,13 +241,12 @@ TEST(Query, ShallowestReliableWithNoReliableDataReturnsNullopt)
   // #221 deliberate tradeoff: with one fused surface there is no prior epoch to
   // fall through to. If the only data over a cell is over-uncertain, the safety
   // query returns nullopt — the caller treats that as unknown → obstacle
-  // (ADR-0002 §D7). (Before #221, a confident older epoch could have rescued it;
-  // that fallback is gone by design — recorded in ADR-0002 A1's supersession.)
-  BathymetryStore store(5);
+  // (ADR-0002 §D7).
+  BathymetryStore store(5, /*pre_existing_writable=*/true);
   const auto cell = store.cellIndex(43.0, -70.5);
   // Over-uncertain across both layers that hold this cell.
-  store.set(SourceLayer::Processed, cell, BathyCell{-30.0, 5.0, 1LL});
-  store.set(SourceLayer::Draft, cell, BathyCell{-25.0, 9.0, 2LL});
+  store.set(SourceLayer::PreExisting, cell, BathyCell{-30.0, 5.0});
+  store.set(SourceLayer::Cube, cell, BathyCell{-25.0, 9.0});
 
   EXPECT_FALSE(shallowestReliable(store, cell, 1.0).has_value());
 

--- a/marine_bathymetry_store/test/test_store.cpp
+++ b/marine_bathymetry_store/test/test_store.cpp
@@ -148,7 +148,7 @@ TEST(Store, ReferenceIsReadOnlyByDefault)
   // The prior must be unclobberable by live ingest: set(Reference) throws
   // unless the store was explicitly opened reference_writable (ADR-0002 §D3).
   BathymetryStore store(5);
-  EXPECT_FALSE(store.preExistingWritable());
+  EXPECT_FALSE(store.referenceWritable());
   EXPECT_THROW(
     store.set(SourceLayer::Reference, store.cellIndex(43.0, -70.5), BathyCell{-10.0, 3.0}),
     std::logic_error);
@@ -161,7 +161,7 @@ TEST(Store, ReferenceWritableStoreAllowsSet)
 {
   // The importer opts in; the converted prior then writes and reads back.
   BathymetryStore store(5, /*reference_writable=*/true);
-  EXPECT_TRUE(store.preExistingWritable());
+  EXPECT_TRUE(store.referenceWritable());
   const auto cell = store.cellIndex(43.0, -70.5);
   store.set(SourceLayer::Reference, cell, BathyCell{38.58, 3.0});
   const auto got = store.get(SourceLayer::Reference, cell);
@@ -172,7 +172,7 @@ TEST(Store, ReferenceWritableStoreAllowsSet)
 TEST(Store, FromCellSizePropagatesReferenceWritable)
 {
   auto store = BathymetryStore::fromCellSize(30.0f, /*reference_writable=*/true);
-  EXPECT_TRUE(store.preExistingWritable());
+  EXPECT_TRUE(store.referenceWritable());
   EXPECT_NO_THROW(
     store.set(SourceLayer::Reference, store.cellIndex(43.0, -70.5), BathyCell{40.0, 3.0}));
 }

--- a/marine_bathymetry_store/test/test_store.cpp
+++ b/marine_bathymetry_store/test/test_store.cpp
@@ -44,9 +44,9 @@ TEST(Store, SetGetRoundTrip)
 {
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Cube, cell, BathyCell{-30.0, 0.5});
+  store.set(SourceLayer::Survey, cell, BathyCell{-30.0, 0.5});
 
-  const auto got = store.get(SourceLayer::Cube, cell);
+  const auto got = store.get(SourceLayer::Survey, cell);
   ASSERT_TRUE(got.has_value());
   EXPECT_DOUBLE_EQ(got->depth, -30.0);
   EXPECT_DOUBLE_EQ(got->uncertainty, 0.5);
@@ -55,18 +55,18 @@ TEST(Store, SetGetRoundTrip)
 TEST(Store, GetEmptyLayerIsNullopt)
 {
   BathymetryStore store(5);
-  EXPECT_FALSE(store.get(SourceLayer::Cube, store.cellIndex(43.0, -70.5)).has_value());
+  EXPECT_FALSE(store.get(SourceLayer::Survey, store.cellIndex(43.0, -70.5)).has_value());
 }
 
 TEST(Store, LayersAreIndependent)
 {
-  // A cube write must not touch the pre-existing layer at the same cell.
-  BathymetryStore store(5, /*pre_existing_writable=*/true);
+  // A survey write must not touch the reference layer at the same cell.
+  BathymetryStore store(5, /*reference_writable=*/true);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::PreExisting, cell, BathyCell{-10.0, 0.1});
-  store.set(SourceLayer::Cube, cell, BathyCell{-12.0, 2.0});
-  EXPECT_DOUBLE_EQ(store.get(SourceLayer::PreExisting, cell)->depth, -10.0);
-  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Cube, cell)->depth, -12.0);
+  store.set(SourceLayer::Reference, cell, BathyCell{-10.0, 0.1});
+  store.set(SourceLayer::Survey, cell, BathyCell{-12.0, 2.0});
+  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Reference, cell)->depth, -10.0);
+  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Survey, cell)->depth, -12.0);
 }
 
 TEST(Store, DoubleWriteSameCellLastWriteWins)
@@ -75,33 +75,33 @@ TEST(Store, DoubleWriteSameCellLastWriteWins)
   // first — there is no per-day epoch ordering or provenance guard.
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  EXPECT_TRUE(store.set(SourceLayer::Cube, cell, BathyCell{-10.0, 0.1}));
-  EXPECT_TRUE(store.set(SourceLayer::Cube, cell, BathyCell{-12.0, 0.2}));
-  const auto got = store.get(SourceLayer::Cube, cell);
+  EXPECT_TRUE(store.set(SourceLayer::Survey, cell, BathyCell{-10.0, 0.1}));
+  EXPECT_TRUE(store.set(SourceLayer::Survey, cell, BathyCell{-12.0, 0.2}));
+  const auto got = store.get(SourceLayer::Survey, cell);
   ASSERT_TRUE(got.has_value());
   EXPECT_DOUBLE_EQ(got->depth, -12.0);
   EXPECT_DOUBLE_EQ(got->uncertainty, 0.2);
   // Still one tile (same grid).
-  EXPECT_EQ(tilesIn(store, SourceLayer::Cube), 1u);
+  EXPECT_EQ(tilesIn(store, SourceLayer::Survey), 1u);
 }
 
 TEST(Store, TilesAllocatedLazilyPerLayer)
 {
   BathymetryStore store(5);
-  EXPECT_TRUE(store.tiles(SourceLayer::Cube).empty());
-  EXPECT_TRUE(store.tiles(SourceLayer::PreExisting).empty());
+  EXPECT_TRUE(store.tiles(SourceLayer::Survey).empty());
+  EXPECT_TRUE(store.tiles(SourceLayer::Reference).empty());
 
-  store.set(SourceLayer::Cube, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5});
-  EXPECT_EQ(tilesIn(store, SourceLayer::Cube), 1u);
-  EXPECT_TRUE(store.tiles(SourceLayer::PreExisting).empty());
+  store.set(SourceLayer::Survey, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5});
+  EXPECT_EQ(tilesIn(store, SourceLayer::Survey), 1u);
+  EXPECT_TRUE(store.tiles(SourceLayer::Reference).empty());
 }
 
 TEST(Store, NoDataCellReadsBackAsNoData)
 {
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Cube, cell, BathyCell{});  // depth NaN
-  const auto got = store.get(SourceLayer::Cube, cell);
+  store.set(SourceLayer::Survey, cell, BathyCell{});  // depth NaN
+  const auto got = store.get(SourceLayer::Survey, cell);
   ASSERT_TRUE(got.has_value());      // tile exists
   EXPECT_FALSE(got->hasData());      // but the cell carries no usable depth
 }
@@ -116,15 +116,15 @@ TEST(Store, MultiLevelTilesCoexist)
   const auto default_cell = store.cellIndex(43.0, -70.5);
   ASSERT_NE(fine_cell.level(), default_cell.level());
 
-  EXPECT_NO_THROW(store.set(SourceLayer::Cube, fine_cell, BathyCell{-22.0, 0.3}));
-  store.set(SourceLayer::Cube, default_cell, BathyCell{-20.0, 0.5});
+  EXPECT_NO_THROW(store.set(SourceLayer::Survey, fine_cell, BathyCell{-22.0, 0.3}));
+  store.set(SourceLayer::Survey, default_cell, BathyCell{-20.0, 0.5});
 
   // Both tiles exist in the same layer at different levels.
-  EXPECT_EQ(tilesIn(store, SourceLayer::Cube), 2u);
-  const auto fine_got = store.get(SourceLayer::Cube, fine_cell);
+  EXPECT_EQ(tilesIn(store, SourceLayer::Survey), 2u);
+  const auto fine_got = store.get(SourceLayer::Survey, fine_cell);
   ASSERT_TRUE(fine_got.has_value());
   EXPECT_DOUBLE_EQ(fine_got->depth, -22.0);
-  const auto default_got = store.get(SourceLayer::Cube, default_cell);
+  const auto default_got = store.get(SourceLayer::Survey, default_cell);
   ASSERT_TRUE(default_got.has_value());
   EXPECT_DOUBLE_EQ(default_got->depth, -20.0);
 }
@@ -132,7 +132,7 @@ TEST(Store, MultiLevelTilesCoexist)
 TEST(Store, InvalidCellThrows)
 {
   BathymetryStore store(5);
-  EXPECT_THROW(store.set(SourceLayer::Cube, gggs::CellIndex{}, BathyCell{}),
+  EXPECT_THROW(store.set(SourceLayer::Survey, gggs::CellIndex{}, BathyCell{}),
     std::invalid_argument);
 }
 
@@ -143,38 +143,38 @@ TEST(Store, FromCellSizeChoosesAFiniteLevel)
   EXPECT_TRUE(store.cellIndex(43.0, -70.5).valid());
 }
 
-TEST(Store, PreExistingIsReadOnlyByDefault)
+TEST(Store, ReferenceIsReadOnlyByDefault)
 {
-  // The prior must be unclobberable by live ingest: set(PreExisting) throws
-  // unless the store was explicitly opened pre_existing_writable (ADR-0002 §D3).
+  // The prior must be unclobberable by live ingest: set(Reference) throws
+  // unless the store was explicitly opened reference_writable (ADR-0002 §D3).
   BathymetryStore store(5);
   EXPECT_FALSE(store.preExistingWritable());
   EXPECT_THROW(
-    store.set(SourceLayer::PreExisting, store.cellIndex(43.0, -70.5), BathyCell{-10.0, 3.0}),
+    store.set(SourceLayer::Reference, store.cellIndex(43.0, -70.5), BathyCell{-10.0, 3.0}),
     std::logic_error);
   // Other layers are unaffected by the guard.
   const auto cell = store.cellIndex(43.0, -70.5);
-  EXPECT_NO_THROW(store.set(SourceLayer::Cube, cell, BathyCell{-12.0, 2.0}));
+  EXPECT_NO_THROW(store.set(SourceLayer::Survey, cell, BathyCell{-12.0, 2.0}));
 }
 
-TEST(Store, PreExistingWritableStoreAllowsSet)
+TEST(Store, ReferenceWritableStoreAllowsSet)
 {
   // The importer opts in; the converted prior then writes and reads back.
-  BathymetryStore store(5, /*pre_existing_writable=*/true);
+  BathymetryStore store(5, /*reference_writable=*/true);
   EXPECT_TRUE(store.preExistingWritable());
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::PreExisting, cell, BathyCell{38.58, 3.0});
-  const auto got = store.get(SourceLayer::PreExisting, cell);
+  store.set(SourceLayer::Reference, cell, BathyCell{38.58, 3.0});
+  const auto got = store.get(SourceLayer::Reference, cell);
   ASSERT_TRUE(got.has_value());
   EXPECT_DOUBLE_EQ(got->depth, 38.58);
 }
 
-TEST(Store, FromCellSizePropagatesPreExistingWritable)
+TEST(Store, FromCellSizePropagatesReferenceWritable)
 {
-  auto store = BathymetryStore::fromCellSize(30.0f, /*pre_existing_writable=*/true);
+  auto store = BathymetryStore::fromCellSize(30.0f, /*reference_writable=*/true);
   EXPECT_TRUE(store.preExistingWritable());
   EXPECT_NO_THROW(
-    store.set(SourceLayer::PreExisting, store.cellIndex(43.0, -70.5), BathyCell{40.0, 3.0}));
+    store.set(SourceLayer::Reference, store.cellIndex(43.0, -70.5), BathyCell{40.0, 3.0}));
 }
 
 namespace
@@ -198,22 +198,22 @@ TEST(Store, ImportTilesBulkInsert)
   // (last-write-wins) while leaving other grids untouched.
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  EXPECT_EQ(store.importTiles(SourceLayer::Cube, oneTile(cell, BathyCell{-30.0, 0.5})), 1u);
-  const auto got = store.get(SourceLayer::Cube, cell);
+  EXPECT_EQ(store.importTiles(SourceLayer::Survey, oneTile(cell, BathyCell{-30.0, 0.5})), 1u);
+  const auto got = store.get(SourceLayer::Survey, cell);
   ASSERT_TRUE(got.has_value());
   EXPECT_DOUBLE_EQ(got->depth, -30.0);
 
   // Re-importing the same grid replaces it (no provenance ordering since #221).
-  EXPECT_EQ(store.importTiles(SourceLayer::Cube, oneTile(cell, BathyCell{-28.0, 0.4})), 1u);
-  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Cube, cell)->depth, -28.0);
-  EXPECT_EQ(tilesIn(store, SourceLayer::Cube), 1u);
+  EXPECT_EQ(store.importTiles(SourceLayer::Survey, oneTile(cell, BathyCell{-28.0, 0.4})), 1u);
+  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Survey, cell)->depth, -28.0);
+  EXPECT_EQ(tilesIn(store, SourceLayer::Survey), 1u);
 
   // A grid not in the import is left untouched: import a second, distinct grid.
   const auto other = store.cellIndex(44.0, -71.0);
   ASSERT_FALSE(cell.grid() == other.grid());
-  store.importTiles(SourceLayer::Cube, oneTile(other, BathyCell{-15.0, 0.6}));
-  EXPECT_EQ(tilesIn(store, SourceLayer::Cube), 2u);
-  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Cube, cell)->depth, -28.0);   // first grid intact
+  store.importTiles(SourceLayer::Survey, oneTile(other, BathyCell{-15.0, 0.6}));
+  EXPECT_EQ(tilesIn(store, SourceLayer::Survey), 2u);
+  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Survey, cell)->depth, -28.0);   // first grid intact
 }
 
 TEST(Store, ImportTilesRejectsTileKeyMismatch)
@@ -230,26 +230,26 @@ TEST(Store, ImportTilesRejectsTileKeyMismatch)
   marine_bathymetry_store::BathymetryTile mismatched(cell_b.grid());
   tiles.emplace(cell_a.grid(), std::move(mismatched));
   EXPECT_THROW(
-    store.importTiles(SourceLayer::Cube, std::move(tiles)),
+    store.importTiles(SourceLayer::Survey, std::move(tiles)),
     std::invalid_argument);
 }
 
-TEST(Store, ImportTilesHonorsPreExistingReadOnlyGate)
+TEST(Store, ImportTilesHonorsReferenceReadOnlyGate)
 {
-  // importTiles is a public mutator like set(), so it must honor the PreExisting
+  // importTiles is a public mutator like set(), so it must honor the Reference
   // read-only gate (ADR-0002 §D3) — otherwise a bulk import would overwrite the
-  // prior on a default store. Only a pre_existing_writable (importer) store may.
+  // prior on a default store. Only a reference_writable (importer) store may.
   const auto cell = BathymetryStore(5).cellIndex(43.0, -70.5);
 
   BathymetryStore read_only(5);
   EXPECT_THROW(
-    read_only.importTiles(SourceLayer::PreExisting, oneTile(cell, BathyCell{-10.0, 3.0})),
+    read_only.importTiles(SourceLayer::Reference, oneTile(cell, BathyCell{-10.0, 3.0})),
     std::logic_error);
 
-  BathymetryStore importer(5, /*pre_existing_writable=*/true);
+  BathymetryStore importer(5, /*reference_writable=*/true);
   EXPECT_EQ(
-    importer.importTiles(SourceLayer::PreExisting, oneTile(cell, BathyCell{-10.0, 3.0})), 1u);
-  EXPECT_DOUBLE_EQ(importer.get(SourceLayer::PreExisting, cell)->depth, -10.0);
+    importer.importTiles(SourceLayer::Reference, oneTile(cell, BathyCell{-10.0, 3.0})), 1u);
+  EXPECT_DOUBLE_EQ(importer.get(SourceLayer::Reference, cell)->depth, -10.0);
 }
 
 TEST(Store, ImportTilesEmptyIsNoOp)
@@ -257,6 +257,6 @@ TEST(Store, ImportTilesEmptyIsNoOp)
   // An empty import (e.g. an entirely no-data GeoTIFF) inserts nothing and adds
   // no tiles to the layer.
   BathymetryStore store(5);
-  EXPECT_EQ(store.importTiles(SourceLayer::Cube, {}), 0u);
-  EXPECT_TRUE(store.tiles(SourceLayer::Cube).empty());
+  EXPECT_EQ(store.importTiles(SourceLayer::Survey, {}), 0u);
+  EXPECT_TRUE(store.tiles(SourceLayer::Survey).empty());
 }

--- a/marine_bathymetry_store/test/test_store.cpp
+++ b/marine_bathymetry_store/test/test_store.cpp
@@ -44,45 +44,29 @@ TEST(Store, SetGetRoundTrip)
 {
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  // timestamp is int64 nanoseconds since the epoch (1 s = 1e9 ns).
-  store.set(SourceLayer::Draft, cell, BathyCell{-30.0, 0.5, 1'000'000'000'000LL});
+  store.set(SourceLayer::Cube, cell, BathyCell{-30.0, 0.5});
 
-  const auto got = store.get(SourceLayer::Draft, cell);
+  const auto got = store.get(SourceLayer::Cube, cell);
   ASSERT_TRUE(got.has_value());
   EXPECT_DOUBLE_EQ(got->depth, -30.0);
   EXPECT_DOUBLE_EQ(got->uncertainty, 0.5);
-  EXPECT_EQ(got->timestamp, 1'000'000'000'000LL);
-  EXPECT_EQ(got->source_index, 0u);   // default unset
-}
-
-TEST(Store, SetGetRoundTripWithSourceIndex)
-{
-  BathymetryStore store(5);
-  const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Draft, cell, BathyCell{-30.0, 0.5, 2'000'000'000LL, 3u});
-
-  const auto got = store.get(SourceLayer::Draft, cell);
-  ASSERT_TRUE(got.has_value());
-  EXPECT_DOUBLE_EQ(got->depth, -30.0);
-  EXPECT_EQ(got->timestamp, 2'000'000'000LL);
-  EXPECT_EQ(got->source_index, 3u);
 }
 
 TEST(Store, GetEmptyLayerIsNullopt)
 {
   BathymetryStore store(5);
-  EXPECT_FALSE(store.get(SourceLayer::Processed, store.cellIndex(43.0, -70.5)).has_value());
+  EXPECT_FALSE(store.get(SourceLayer::Cube, store.cellIndex(43.0, -70.5)).has_value());
 }
 
 TEST(Store, LayersAreIndependent)
 {
-  // A draft write must not touch the processed layer at the same cell.
-  BathymetryStore store(5);
+  // A cube write must not touch the pre-existing layer at the same cell.
+  BathymetryStore store(5, /*pre_existing_writable=*/true);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Processed, cell, BathyCell{-10.0, 0.1, 1LL});
-  store.set(SourceLayer::Draft, cell, BathyCell{-12.0, 2.0, 2LL});
-  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Processed, cell)->depth, -10.0);
-  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Draft, cell)->depth, -12.0);
+  store.set(SourceLayer::PreExisting, cell, BathyCell{-10.0, 0.1});
+  store.set(SourceLayer::Cube, cell, BathyCell{-12.0, 2.0});
+  EXPECT_DOUBLE_EQ(store.get(SourceLayer::PreExisting, cell)->depth, -10.0);
+  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Cube, cell)->depth, -12.0);
 }
 
 TEST(Store, DoubleWriteSameCellLastWriteWins)
@@ -91,35 +75,33 @@ TEST(Store, DoubleWriteSameCellLastWriteWins)
   // first — there is no per-day epoch ordering or provenance guard.
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  EXPECT_TRUE(store.set(SourceLayer::Draft, cell, BathyCell{-10.0, 0.1, 1LL, 1u}));
-  EXPECT_TRUE(store.set(SourceLayer::Draft, cell, BathyCell{-12.0, 0.2, 2LL, 7u}));
-  const auto got = store.get(SourceLayer::Draft, cell);
+  EXPECT_TRUE(store.set(SourceLayer::Cube, cell, BathyCell{-10.0, 0.1}));
+  EXPECT_TRUE(store.set(SourceLayer::Cube, cell, BathyCell{-12.0, 0.2}));
+  const auto got = store.get(SourceLayer::Cube, cell);
   ASSERT_TRUE(got.has_value());
   EXPECT_DOUBLE_EQ(got->depth, -12.0);
   EXPECT_DOUBLE_EQ(got->uncertainty, 0.2);
-  EXPECT_EQ(got->timestamp, 2LL);
-  EXPECT_EQ(got->source_index, 7u);
   // Still one tile (same grid).
-  EXPECT_EQ(tilesIn(store, SourceLayer::Draft), 1u);
+  EXPECT_EQ(tilesIn(store, SourceLayer::Cube), 1u);
 }
 
 TEST(Store, TilesAllocatedLazilyPerLayer)
 {
   BathymetryStore store(5);
-  EXPECT_TRUE(store.tiles(SourceLayer::Draft).empty());
-  EXPECT_TRUE(store.tiles(SourceLayer::Processed).empty());
+  EXPECT_TRUE(store.tiles(SourceLayer::Cube).empty());
+  EXPECT_TRUE(store.tiles(SourceLayer::PreExisting).empty());
 
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1LL});
-  EXPECT_EQ(tilesIn(store, SourceLayer::Draft), 1u);
-  EXPECT_TRUE(store.tiles(SourceLayer::Processed).empty());
+  store.set(SourceLayer::Cube, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5});
+  EXPECT_EQ(tilesIn(store, SourceLayer::Cube), 1u);
+  EXPECT_TRUE(store.tiles(SourceLayer::PreExisting).empty());
 }
 
 TEST(Store, NoDataCellReadsBackAsNoData)
 {
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Draft, cell, BathyCell{});  // depth NaN
-  const auto got = store.get(SourceLayer::Draft, cell);
+  store.set(SourceLayer::Cube, cell, BathyCell{});  // depth NaN
+  const auto got = store.get(SourceLayer::Cube, cell);
   ASSERT_TRUE(got.has_value());      // tile exists
   EXPECT_FALSE(got->hasData());      // but the cell carries no usable depth
 }
@@ -134,15 +116,15 @@ TEST(Store, MultiLevelTilesCoexist)
   const auto default_cell = store.cellIndex(43.0, -70.5);
   ASSERT_NE(fine_cell.level(), default_cell.level());
 
-  EXPECT_NO_THROW(store.set(SourceLayer::Draft, fine_cell, BathyCell{-22.0, 0.3, 1LL}));
-  store.set(SourceLayer::Draft, default_cell, BathyCell{-20.0, 0.5, 2LL});
+  EXPECT_NO_THROW(store.set(SourceLayer::Cube, fine_cell, BathyCell{-22.0, 0.3}));
+  store.set(SourceLayer::Cube, default_cell, BathyCell{-20.0, 0.5});
 
   // Both tiles exist in the same layer at different levels.
-  EXPECT_EQ(tilesIn(store, SourceLayer::Draft), 2u);
-  const auto fine_got = store.get(SourceLayer::Draft, fine_cell);
+  EXPECT_EQ(tilesIn(store, SourceLayer::Cube), 2u);
+  const auto fine_got = store.get(SourceLayer::Cube, fine_cell);
   ASSERT_TRUE(fine_got.has_value());
   EXPECT_DOUBLE_EQ(fine_got->depth, -22.0);
-  const auto default_got = store.get(SourceLayer::Draft, default_cell);
+  const auto default_got = store.get(SourceLayer::Cube, default_cell);
   ASSERT_TRUE(default_got.has_value());
   EXPECT_DOUBLE_EQ(default_got->depth, -20.0);
 }
@@ -150,7 +132,7 @@ TEST(Store, MultiLevelTilesCoexist)
 TEST(Store, InvalidCellThrows)
 {
   BathymetryStore store(5);
-  EXPECT_THROW(store.set(SourceLayer::Draft, gggs::CellIndex{}, BathyCell{}),
+  EXPECT_THROW(store.set(SourceLayer::Cube, gggs::CellIndex{}, BathyCell{}),
     std::invalid_argument);
 }
 
@@ -161,38 +143,38 @@ TEST(Store, FromCellSizeChoosesAFiniteLevel)
   EXPECT_TRUE(store.cellIndex(43.0, -70.5).valid());
 }
 
-TEST(Store, ChartIsReadOnlyByDefault)
+TEST(Store, PreExistingIsReadOnlyByDefault)
 {
-  // The contour prior must be unclobberable by live ingest: set(Chart) throws
-  // unless the store was explicitly opened chart_writable (ADR-0002 §D3).
+  // The prior must be unclobberable by live ingest: set(PreExisting) throws
+  // unless the store was explicitly opened pre_existing_writable (ADR-0002 §D3).
   BathymetryStore store(5);
-  EXPECT_FALSE(store.chartWritable());
+  EXPECT_FALSE(store.preExistingWritable());
   EXPECT_THROW(
-    store.set(SourceLayer::Chart, store.cellIndex(43.0, -70.5), BathyCell{-10.0, 3.0, 1LL}),
+    store.set(SourceLayer::PreExisting, store.cellIndex(43.0, -70.5), BathyCell{-10.0, 3.0}),
     std::logic_error);
   // Other layers are unaffected by the guard.
   const auto cell = store.cellIndex(43.0, -70.5);
-  EXPECT_NO_THROW(store.set(SourceLayer::Draft, cell, BathyCell{-12.0, 2.0, 2LL}));
+  EXPECT_NO_THROW(store.set(SourceLayer::Cube, cell, BathyCell{-12.0, 2.0}));
 }
 
-TEST(Store, ChartWritableStoreAllowsChartSet)
+TEST(Store, PreExistingWritableStoreAllowsSet)
 {
   // The importer opts in; the converted prior then writes and reads back.
-  BathymetryStore store(5, /*chart_writable=*/true);
-  EXPECT_TRUE(store.chartWritable());
+  BathymetryStore store(5, /*pre_existing_writable=*/true);
+  EXPECT_TRUE(store.preExistingWritable());
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Chart, cell, BathyCell{38.58, 3.0, 1000LL});
-  const auto got = store.get(SourceLayer::Chart, cell);
+  store.set(SourceLayer::PreExisting, cell, BathyCell{38.58, 3.0});
+  const auto got = store.get(SourceLayer::PreExisting, cell);
   ASSERT_TRUE(got.has_value());
   EXPECT_DOUBLE_EQ(got->depth, 38.58);
 }
 
-TEST(Store, FromCellSizePropagatesChartWritable)
+TEST(Store, FromCellSizePropagatesPreExistingWritable)
 {
-  auto store = BathymetryStore::fromCellSize(30.0f, /*chart_writable=*/true);
-  EXPECT_TRUE(store.chartWritable());
+  auto store = BathymetryStore::fromCellSize(30.0f, /*pre_existing_writable=*/true);
+  EXPECT_TRUE(store.preExistingWritable());
   EXPECT_NO_THROW(
-    store.set(SourceLayer::Chart, store.cellIndex(43.0, -70.5), BathyCell{40.0, 3.0, 1LL}));
+    store.set(SourceLayer::PreExisting, store.cellIndex(43.0, -70.5), BathyCell{40.0, 3.0}));
 }
 
 namespace
@@ -216,22 +198,22 @@ TEST(Store, ImportTilesBulkInsert)
   // (last-write-wins) while leaving other grids untouched.
   BathymetryStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  EXPECT_EQ(store.importTiles(SourceLayer::Draft, oneTile(cell, BathyCell{-30.0, 0.5, 1LL})), 1u);
-  const auto got = store.get(SourceLayer::Draft, cell);
+  EXPECT_EQ(store.importTiles(SourceLayer::Cube, oneTile(cell, BathyCell{-30.0, 0.5})), 1u);
+  const auto got = store.get(SourceLayer::Cube, cell);
   ASSERT_TRUE(got.has_value());
   EXPECT_DOUBLE_EQ(got->depth, -30.0);
 
   // Re-importing the same grid replaces it (no provenance ordering since #221).
-  EXPECT_EQ(store.importTiles(SourceLayer::Draft, oneTile(cell, BathyCell{-28.0, 0.4, 2LL})), 1u);
-  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Draft, cell)->depth, -28.0);
-  EXPECT_EQ(tilesIn(store, SourceLayer::Draft), 1u);
+  EXPECT_EQ(store.importTiles(SourceLayer::Cube, oneTile(cell, BathyCell{-28.0, 0.4})), 1u);
+  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Cube, cell)->depth, -28.0);
+  EXPECT_EQ(tilesIn(store, SourceLayer::Cube), 1u);
 
   // A grid not in the import is left untouched: import a second, distinct grid.
   const auto other = store.cellIndex(44.0, -71.0);
   ASSERT_FALSE(cell.grid() == other.grid());
-  store.importTiles(SourceLayer::Draft, oneTile(other, BathyCell{-15.0, 0.6, 3LL}));
-  EXPECT_EQ(tilesIn(store, SourceLayer::Draft), 2u);
-  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Draft, cell)->depth, -28.0);   // first grid intact
+  store.importTiles(SourceLayer::Cube, oneTile(other, BathyCell{-15.0, 0.6}));
+  EXPECT_EQ(tilesIn(store, SourceLayer::Cube), 2u);
+  EXPECT_DOUBLE_EQ(store.get(SourceLayer::Cube, cell)->depth, -28.0);   // first grid intact
 }
 
 TEST(Store, ImportTilesRejectsTileKeyMismatch)
@@ -248,26 +230,26 @@ TEST(Store, ImportTilesRejectsTileKeyMismatch)
   marine_bathymetry_store::BathymetryTile mismatched(cell_b.grid());
   tiles.emplace(cell_a.grid(), std::move(mismatched));
   EXPECT_THROW(
-    store.importTiles(SourceLayer::Draft, std::move(tiles)),
+    store.importTiles(SourceLayer::Cube, std::move(tiles)),
     std::invalid_argument);
 }
 
-TEST(Store, ImportTilesHonorsChartReadOnlyGate)
+TEST(Store, ImportTilesHonorsPreExistingReadOnlyGate)
 {
-  // importTiles is a public mutator like set(), so it must honor the Chart
+  // importTiles is a public mutator like set(), so it must honor the PreExisting
   // read-only gate (ADR-0002 §D3) — otherwise a bulk import would overwrite the
-  // prior on a default store. Only a chart_writable (importer) store may.
+  // prior on a default store. Only a pre_existing_writable (importer) store may.
   const auto cell = BathymetryStore(5).cellIndex(43.0, -70.5);
 
   BathymetryStore read_only(5);
   EXPECT_THROW(
-    read_only.importTiles(SourceLayer::Chart, oneTile(cell, BathyCell{-10.0, 3.0, 1LL})),
+    read_only.importTiles(SourceLayer::PreExisting, oneTile(cell, BathyCell{-10.0, 3.0})),
     std::logic_error);
 
-  BathymetryStore importer(5, /*chart_writable=*/true);
+  BathymetryStore importer(5, /*pre_existing_writable=*/true);
   EXPECT_EQ(
-    importer.importTiles(SourceLayer::Chart, oneTile(cell, BathyCell{-10.0, 3.0, 1LL})), 1u);
-  EXPECT_DOUBLE_EQ(importer.get(SourceLayer::Chart, cell)->depth, -10.0);
+    importer.importTiles(SourceLayer::PreExisting, oneTile(cell, BathyCell{-10.0, 3.0})), 1u);
+  EXPECT_DOUBLE_EQ(importer.get(SourceLayer::PreExisting, cell)->depth, -10.0);
 }
 
 TEST(Store, ImportTilesEmptyIsNoOp)
@@ -275,6 +257,6 @@ TEST(Store, ImportTilesEmptyIsNoOp)
   // An empty import (e.g. an entirely no-data GeoTIFF) inserts nothing and adds
   // no tiles to the layer.
   BathymetryStore store(5);
-  EXPECT_EQ(store.importTiles(SourceLayer::Draft, {}), 0u);
-  EXPECT_TRUE(store.tiles(SourceLayer::Draft).empty());
+  EXPECT_EQ(store.importTiles(SourceLayer::Cube, {}), 0u);
+  EXPECT_TRUE(store.tiles(SourceLayer::Cube).empty());
 }

--- a/marine_bathymetry_store/test/test_tile_io.cpp
+++ b/marine_bathymetry_store/test/test_tile_io.cpp
@@ -337,6 +337,33 @@ TEST_F(TileIoTest, LoadDoesNotWarnOnFreshOrMetadataOnlyStore)
     << "metadata-only store must not warn";
 }
 
+TEST_F(TileIoTest, LoadSkipsStrayCompanionRasters)
+{
+  // A dropped pre-#248 companion (`*_time.tif`/`*_source.tif`) may linger inside
+  // a new-layout survey/ dir on a store written by old code. It is not a value
+  // tile; feeding it to loadTile() would throw and abort the WHOLE load. It must
+  // be skipped so the valid value tiles still load.
+  BathymetryStore writer(5);
+  const auto cell = writer.cellIndex(43.0, -70.5);
+  writer.set(SourceLayer::Survey, cell, BathyCell{-30.0, 0.5});
+  marine_bathymetry_store::save(writer, dir_.string());
+
+  const std::string tile = marine_bathymetry_store::tileFilename(cell.grid());
+  const std::string stem = tile.substr(0, tile.size() - 4);   // drop ".tif"
+  {std::ofstream(dir_ / "survey" / (stem + "_source.tif")) << "stale companion";}
+  {std::ofstream(dir_ / "survey" / (stem + "_time.tif")) << "stale companion";}
+
+  BathymetryStore reloaded(5);
+  std::ostringstream captured;
+  std::streambuf * prev = std::cerr.rdbuf(captured.rdbuf());
+  const std::size_t n = marine_bathymetry_store::load(reloaded, dir_.string());
+  std::cerr.rdbuf(prev);
+
+  EXPECT_EQ(n, 1u) << "the valid value tile must still load past the companions";
+  EXPECT_DOUBLE_EQ(reloaded.get(SourceLayer::Survey, cell)->depth, -30.0);
+  EXPECT_NE(captured.str().find("companion raster"), std::string::npos);
+}
+
 TEST_F(TileIoTest, ImportTilesPersistAndReload)
 {
   // The bulk-insert path persists its tiles to the flat layout and reloads.

--- a/marine_bathymetry_store/test/test_tile_io.cpp
+++ b/marine_bathymetry_store/test/test_tile_io.cpp
@@ -62,23 +62,23 @@ protected:
 
 TEST_F(TileIoTest, RoundTripPreservesCells)
 {
-  BathymetryStore store(5, /*pre_existing_writable=*/true);
+  BathymetryStore store(5, /*reference_writable=*/true);
   // A non-trivial uncertainty checks lossless Float64 round-trip of the value tile.
-  store.set(SourceLayer::Cube, store.cellIndex(43.0, -70.5), BathyCell{-30.123, 0.456789});
+  store.set(SourceLayer::Survey, store.cellIndex(43.0, -70.5), BathyCell{-30.123, 0.456789});
   store.set(
-    SourceLayer::PreExisting, store.cellIndex(44.0, -71.0), BathyCell{-12.5, 0.2});
+    SourceLayer::Reference, store.cellIndex(44.0, -71.0), BathyCell{-12.5, 0.2});
 
   EXPECT_EQ(marine_bathymetry_store::save(store, dir_.string()), 2u);
 
   BathymetryStore reloaded(5);
   EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 2u);
 
-  const auto cube = reloaded.get(SourceLayer::Cube, reloaded.cellIndex(43.0, -70.5));
-  ASSERT_TRUE(cube.has_value());
-  EXPECT_DOUBLE_EQ(cube->depth, -30.123);
-  EXPECT_DOUBLE_EQ(cube->uncertainty, 0.456789);   // uncertainty round-trips exactly
+  const auto survey = reloaded.get(SourceLayer::Survey, reloaded.cellIndex(43.0, -70.5));
+  ASSERT_TRUE(survey.has_value());
+  EXPECT_DOUBLE_EQ(survey->depth, -30.123);
+  EXPECT_DOUBLE_EQ(survey->uncertainty, 0.456789);   // uncertainty round-trips exactly
 
-  const auto pre = reloaded.get(SourceLayer::PreExisting, reloaded.cellIndex(44.0, -71.0));
+  const auto pre = reloaded.get(SourceLayer::Reference, reloaded.cellIndex(44.0, -71.0));
   ASSERT_TRUE(pre.has_value());
   EXPECT_DOUBLE_EQ(pre->depth, -12.5);
   EXPECT_DOUBLE_EQ(pre->uncertainty, 0.2);
@@ -87,7 +87,7 @@ TEST_F(TileIoTest, RoundTripPreservesCells)
 TEST_F(TileIoTest, LoadedTilesAreCleanAndDontResave)
 {
   BathymetryStore store(5);
-  store.set(SourceLayer::Cube, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5});
+  store.set(SourceLayer::Survey, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5});
 
   EXPECT_EQ(marine_bathymetry_store::save(store, dir_.string()), 1u);
   // No changes since the last save -> nothing re-written (incremental save).
@@ -102,23 +102,23 @@ TEST_F(TileIoTest, LoadedTilesAreCleanAndDontResave)
 TEST_F(TileIoTest, WritingAfterSaveRedirties)
 {
   BathymetryStore store(5);
-  store.set(SourceLayer::Cube, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5});
+  store.set(SourceLayer::Survey, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5});
   EXPECT_EQ(marine_bathymetry_store::save(store, dir_.string()), 1u);
 
-  store.set(SourceLayer::Cube, store.cellIndex(43.0, -70.5), BathyCell{-31.0, 0.4});
+  store.set(SourceLayer::Survey, store.cellIndex(43.0, -70.5), BathyCell{-31.0, 0.4});
   EXPECT_EQ(marine_bathymetry_store::save(store, dir_.string()), 1u);
 }
 
 TEST_F(TileIoTest, LayersWriteToSeparateSubdirectories)
 {
-  BathymetryStore store(5, /*pre_existing_writable=*/true);
+  BathymetryStore store(5, /*reference_writable=*/true);
   const auto pcell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::PreExisting, pcell, BathyCell{-10.0, 0.1});
-  store.set(SourceLayer::Cube, pcell, BathyCell{-12.0, 0.5});
+  store.set(SourceLayer::Reference, pcell, BathyCell{-10.0, 0.1});
+  store.set(SourceLayer::Survey, pcell, BathyCell{-12.0, 0.5});
   marine_bathymetry_store::save(store, dir_.string());
 
-  EXPECT_TRUE(fs::is_directory(dir_ / "pre-existing"));
-  EXPECT_TRUE(fs::is_directory(dir_ / "cube"));
+  EXPECT_TRUE(fs::is_directory(dir_ / "reference"));
+  EXPECT_TRUE(fs::is_directory(dir_ / "survey"));
 }
 
 TEST_F(TileIoTest, LoadAcceptsMixedLevelTiles)
@@ -131,59 +131,59 @@ TEST_F(TileIoTest, LoadAcceptsMixedLevelTiles)
   gggs::Level fine(7);
   const auto coarse_cell = coarse.cellIndex(gggs::geoPoint(43.0, -70.5));
   const auto fine_cell = fine.cellIndex(gggs::geoPoint(43.0, -70.5));
-  writer.set(SourceLayer::Cube, coarse_cell, BathyCell{-30.0, 0.5});
-  writer.set(SourceLayer::Cube, fine_cell, BathyCell{-22.0, 0.3});
+  writer.set(SourceLayer::Survey, coarse_cell, BathyCell{-30.0, 0.5});
+  writer.set(SourceLayer::Survey, fine_cell, BathyCell{-22.0, 0.3});
   EXPECT_EQ(marine_bathymetry_store::save(writer, dir_.string()), 2u);
 
   // Reload into a store whose default level (6) matches NEITHER stored level.
   BathymetryStore reloaded(6);
   EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 2u);
-  const auto coarse_got = reloaded.get(SourceLayer::Cube, coarse_cell);
+  const auto coarse_got = reloaded.get(SourceLayer::Survey, coarse_cell);
   ASSERT_TRUE(coarse_got.has_value());
   EXPECT_DOUBLE_EQ(coarse_got->depth, -30.0);
-  const auto fine_got = reloaded.get(SourceLayer::Cube, fine_cell);
+  const auto fine_got = reloaded.get(SourceLayer::Survey, fine_cell);
   ASSERT_TRUE(fine_got.has_value());
   EXPECT_DOUBLE_EQ(fine_got->depth, -22.0);
 }
 
-TEST_F(TileIoTest, PreExistingRoundTripsAndLoadsIntoReadOnlyStore)
+TEST_F(TileIoTest, ReferenceRoundTripsAndLoadsIntoReadOnlyStore)
 {
-  // The importer writes PreExisting (pre_existing_writable); the runtime loads it
+  // The importer writes Reference (reference_writable); the runtime loads it
   // into a default (read-only-prior) store. load() populates via getOrCreateTile,
-  // not set(), so the prior loads even though live set(PreExisting) stays
+  // not set(), so the prior loads even though live set(Reference) stays
   // forbidden.
-  BathymetryStore writer(5, /*pre_existing_writable=*/true);
-  writer.set(SourceLayer::PreExisting, writer.cellIndex(43.0, -70.5), BathyCell{38.58, 3.0});
+  BathymetryStore writer(5, /*reference_writable=*/true);
+  writer.set(SourceLayer::Reference, writer.cellIndex(43.0, -70.5), BathyCell{38.58, 3.0});
   EXPECT_EQ(marine_bathymetry_store::save(writer, dir_.string()), 1u);
-  EXPECT_TRUE(fs::is_directory(dir_ / "pre-existing"));
+  EXPECT_TRUE(fs::is_directory(dir_ / "reference"));
 
-  BathymetryStore runtime(5);   // PreExisting NOT writable
+  BathymetryStore runtime(5);   // Reference NOT writable
   EXPECT_FALSE(runtime.preExistingWritable());
   EXPECT_EQ(marine_bathymetry_store::load(runtime, dir_.string()), 1u);
 
   const auto rcell = runtime.cellIndex(43.0, -70.5);
-  const auto got = runtime.get(SourceLayer::PreExisting, rcell);
+  const auto got = runtime.get(SourceLayer::Reference, rcell);
   ASSERT_TRUE(got.has_value());
   EXPECT_DOUBLE_EQ(got->depth, 38.58);
 
   // The read-only guard still holds after the prior is loaded.
   EXPECT_THROW(
-    runtime.set(SourceLayer::PreExisting, rcell, BathyCell{1.0, 1.0}),
+    runtime.set(SourceLayer::Reference, rcell, BathyCell{1.0, 1.0}),
     std::logic_error);
 }
 
-TEST_F(TileIoTest, CubeOnlyStoreLoadsWithoutPreExistingDir)
+TEST_F(TileIoTest, SurveyOnlyStoreLoadsWithoutReferenceDir)
 {
-  // A store with no pre-existing/ subdir still saves and loads; the absent prior
+  // A store with no reference/ subdir still saves and loads; the absent prior
   // layer is simply skipped, not an error.
   BathymetryStore store(5);
-  store.set(SourceLayer::Cube, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5});
+  store.set(SourceLayer::Survey, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5});
   marine_bathymetry_store::save(store, dir_.string());
-  EXPECT_FALSE(fs::exists(dir_ / "pre-existing"));   // no spurious empty dir
+  EXPECT_FALSE(fs::exists(dir_ / "reference"));   // no spurious empty dir
 
   BathymetryStore reloaded(5);
   EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 1u);
-  EXPECT_TRUE(reloaded.tiles(SourceLayer::PreExisting).empty());
+  EXPECT_TRUE(reloaded.tiles(SourceLayer::Reference).empty());
 }
 
 // --- Coarse StoreMetadata (registry.json) round-trip (#248) ---
@@ -209,7 +209,7 @@ TEST_F(TileIoTest, SaveWritesMetadataWhenProvided)
 {
   // The store save() persists the metadata sidecar once, at the store root.
   BathymetryStore store(5);
-  store.set(SourceLayer::Cube, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5});
+  store.set(SourceLayer::Survey, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5});
   StoreMetadata md{"bizzy", "m3", "massabesic-2026", "2026-06-30"};
 
   marine_bathymetry_store::save(store, dir_.string(), &md);
@@ -225,7 +225,7 @@ TEST_F(TileIoTest, LoadWithoutMetadataFileLeavesMetadataEmpty)
 {
   // A store with no registry.json loads cleanly; StoreMetadata stays empty.
   BathymetryStore store(5);
-  store.set(SourceLayer::Cube, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5});
+  store.set(SourceLayer::Survey, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5});
   marine_bathymetry_store::save(store, dir_.string());   // no metadata passed
   EXPECT_FALSE(fs::exists(dir_ / "registry.json"));
 
@@ -243,22 +243,22 @@ TEST_F(TileIoTest, SaveWritesFlatLayoutNoEpochSubdir)
   // subdirectory and no provenance marker file (#221).
   BathymetryStore writer(5);
   const auto cell = writer.cellIndex(43.0, -70.5);
-  writer.set(SourceLayer::Cube, cell, BathyCell{-30.0, 0.5});
+  writer.set(SourceLayer::Survey, cell, BathyCell{-30.0, 0.5});
   EXPECT_EQ(marine_bathymetry_store::save(writer, dir_.string()), 1u);
 
-  // The value tile sits directly in cube/, and no subdirectory or provenance
+  // The value tile sits directly in survey/, and no subdirectory or provenance
   // marker exists.
   const std::string filename =
     marine_bathymetry_store::tileFilename(cell.grid());
-  EXPECT_TRUE(fs::is_regular_file(dir_ / "cube" / filename));
-  EXPECT_FALSE(fs::exists(dir_ / "cube" / "provenance"));
-  for (const auto & e : fs::directory_iterator(dir_ / "cube")) {
+  EXPECT_TRUE(fs::is_regular_file(dir_ / "survey" / filename));
+  EXPECT_FALSE(fs::exists(dir_ / "survey" / "provenance"));
+  for (const auto & e : fs::directory_iterator(dir_ / "survey")) {
     EXPECT_FALSE(e.is_directory()) << "no epoch subdirectory expected: " << e.path();
   }
 
   BathymetryStore reloaded(5);
   EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 1u);
-  EXPECT_DOUBLE_EQ(reloaded.get(SourceLayer::Cube, cell)->depth, -30.0);
+  EXPECT_DOUBLE_EQ(reloaded.get(SourceLayer::Survey, cell)->depth, -30.0);
 }
 
 TEST_F(TileIoTest, LoadIgnoresEpochSubdirectories)
@@ -268,11 +268,11 @@ TEST_F(TileIoTest, LoadIgnoresEpochSubdirectories)
   // (#221). Only the flat value tiles load.
   BathymetryStore writer(5);
   const auto cell = writer.cellIndex(43.0, -70.5);
-  writer.set(SourceLayer::Cube, cell, BathyCell{-30.0, 0.5});
+  writer.set(SourceLayer::Survey, cell, BathyCell{-30.0, 0.5});
   marine_bathymetry_store::save(writer, dir_.string());
 
   // Drop an old-style epoch subdirectory containing a (would-be) tile file.
-  const fs::path epoch_dir = dir_ / "cube" / "2026-06-10";
+  const fs::path epoch_dir = dir_ / "survey" / "2026-06-10";
   fs::create_directories(epoch_dir);
   {
     std::ofstream(epoch_dir / "5_0_0.tif") << "stale";
@@ -282,7 +282,7 @@ TEST_F(TileIoTest, LoadIgnoresEpochSubdirectories)
   // Only the flat tile loads; the subdirectory's contents are ignored (not
   // mis-loaded as a tile, which would have thrown on the bogus file).
   EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 1u);
-  EXPECT_DOUBLE_EQ(reloaded.get(SourceLayer::Cube, cell)->depth, -30.0);
+  EXPECT_DOUBLE_EQ(reloaded.get(SourceLayer::Survey, cell)->depth, -30.0);
 }
 
 TEST_F(TileIoTest, ImportTilesPersistAndReload)
@@ -299,13 +299,13 @@ TEST_F(TileIoTest, ImportTilesPersistAndReload)
     t.set(c.row(), c.column(), BathyCell{-30.0, 0.5});
     tiles.emplace(c.grid(), std::move(t));
   }
-  EXPECT_EQ(writer.importTiles(SourceLayer::Cube, std::move(tiles)), 2u);
+  EXPECT_EQ(writer.importTiles(SourceLayer::Survey, std::move(tiles)), 2u);
   EXPECT_EQ(marine_bathymetry_store::save(writer, dir_.string()), 2u);
 
   BathymetryStore reloaded(5);
   EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 2u);
-  EXPECT_TRUE(reloaded.get(SourceLayer::Cube, cell_a).has_value());
-  EXPECT_TRUE(reloaded.get(SourceLayer::Cube, cell_b).has_value());
+  EXPECT_TRUE(reloaded.get(SourceLayer::Survey, cell_a).has_value());
+  EXPECT_TRUE(reloaded.get(SourceLayer::Survey, cell_b).has_value());
 }
 
 TEST_F(TileIoTest, LevelFromTileFilenameParsesPrefix)
@@ -355,14 +355,14 @@ TEST_F(TileIoTest, LoadWindowLoadsOnlyOverlappingTiles)
   {
     BathymetryStore writer(lvl);
     const auto c_in = lev.cellIndex(gggs::geoPoint(43.0, -70.5));
-    writer.set(SourceLayer::Cube, c_in, BathyCell{-10.0, 0.5});
+    writer.set(SourceLayer::Survey, c_in, BathyCell{-10.0, 0.5});
     const auto c_out = lev.cellIndex(gggs::geoPoint(50.0, -40.0));
-    writer.set(SourceLayer::Cube, c_out, BathyCell{-20.0, 0.5});
+    writer.set(SourceLayer::Survey, c_out, BathyCell{-20.0, 0.5});
     const auto c_str = lev.cellIndex(
       gggs::geoPoint(
         inside_grid.southLatitude() - 0.001,
         inside_grid.westLongitude() + 0.001));
-    writer.set(SourceLayer::Cube, c_str, BathyCell{-30.0, 0.5});
+    writer.set(SourceLayer::Survey, c_str, BathyCell{-30.0, 0.5});
     ASSERT_EQ(marine_bathymetry_store::save(writer, dir_.string()), 3u);
   }
 
@@ -377,7 +377,7 @@ TEST_F(TileIoTest, LoadWindowLoadsOnlyOverlappingTiles)
   // so exactly two tiles load (proves "only overlapping", not just "at least one").
   EXPECT_EQ(n, 2u);
   // outside_grid must not have been loaded.
-  EXPECT_FALSE(result.get(SourceLayer::Cube, lev.cellIndex(
+  EXPECT_FALSE(result.get(SourceLayer::Survey, lev.cellIndex(
     gggs::geoPoint(50.0, -40.0))).has_value());
 }
 
@@ -392,7 +392,7 @@ TEST_F(TileIoTest, LoadWindowBoundaryStraddle)
   {
     BathymetryStore writer(lvl);
     const auto cell = lev.cellIndex(gggs::geoPoint(43.0, -70.5));
-    writer.set(SourceLayer::Cube, cell, BathyCell{-15.0, 0.5});
+    writer.set(SourceLayer::Survey, cell, BathyCell{-15.0, 0.5});
     ASSERT_EQ(marine_bathymetry_store::save(writer, dir_.string()), 1u);
   }
 
@@ -404,7 +404,7 @@ TEST_F(TileIoTest, LoadWindowBoundaryStraddle)
   const std::size_t n = marine_bathymetry_store::loadWindow(
     result, dir_.string(), min_pt, max_pt);
   EXPECT_EQ(n, 1u);
-  EXPECT_TRUE(result.get(SourceLayer::Cube,
+  EXPECT_TRUE(result.get(SourceLayer::Survey,
     lev.cellIndex(gggs::geoPoint(43.0, -70.5))).has_value());
 }
 
@@ -417,7 +417,7 @@ TEST_F(TileIoTest, LoadWindowIdempotent)
   {
     BathymetryStore writer(lvl);
     const auto cell = lev.cellIndex(gggs::geoPoint(43.0, -70.5));
-    writer.set(SourceLayer::Cube, cell, BathyCell{-10.0, 0.5});
+    writer.set(SourceLayer::Survey, cell, BathyCell{-10.0, 0.5});
     ASSERT_EQ(marine_bathymetry_store::save(writer, dir_.string()), 1u);
   }
 
@@ -434,7 +434,7 @@ TEST_F(TileIoTest, LoadWindowIdempotent)
   // Second call should skip the already-resident tile.
   EXPECT_EQ(second, 0u);
   // Tile count in store is still 1 (not doubled).
-  EXPECT_EQ(result.tiles(SourceLayer::Cube).size(), 1u);
+  EXPECT_EQ(result.tiles(SourceLayer::Survey).size(), 1u);
 }
 
 TEST_F(TileIoTest, LoadWindowRejectsMalformedTileFilename)
@@ -447,12 +447,12 @@ TEST_F(TileIoTest, LoadWindowRejectsMalformedTileFilename)
   {
     BathymetryStore writer(lvl);
     writer.set(
-      SourceLayer::Cube, lev.cellIndex(gggs::geoPoint(43.0, -70.5)),
+      SourceLayer::Survey, lev.cellIndex(gggs::geoPoint(43.0, -70.5)),
       BathyCell{-10.0, 0.5});
     ASSERT_EQ(marine_bathymetry_store::save(writer, dir_.string()), 1u);
   }
   // Drop a bogus value-tile name (level 99) into the same layer dir.
-  const std::filesystem::path bogus = dir_ / "cube" / "99_0_0.tif";
+  const std::filesystem::path bogus = dir_ / "survey" / "99_0_0.tif";
   {
     std::ofstream(bogus) << "not a tile";
   }
@@ -488,12 +488,12 @@ TEST_F(TileIoTest, EvictOutsideDropsOutsideKeepsInside)
     tiles.emplace(cell_out.grid(), std::move(t_out));
 
     BathymetryStore store(lvl);
-    ASSERT_EQ(store.importTiles(SourceLayer::Cube, std::move(tiles)), 2u);
+    ASSERT_EQ(store.importTiles(SourceLayer::Survey, std::move(tiles)), 2u);
     // Save so tiles are clean (importTiles marks them dirty; we want to test
     // eviction of clean tiles here — the dirty-guard test is separate).
     marine_bathymetry_store::save(store, dir_.string());
-    ASSERT_TRUE(store.get(SourceLayer::Cube, cell_in).has_value());
-    ASSERT_TRUE(store.get(SourceLayer::Cube, cell_out).has_value());
+    ASSERT_TRUE(store.get(SourceLayer::Survey, cell_in).has_value());
+    ASSERT_TRUE(store.get(SourceLayer::Survey, cell_out).has_value());
 
     const gggs::GridIndex grid_in = cell_in.grid();
     const auto min_pt =
@@ -505,14 +505,14 @@ TEST_F(TileIoTest, EvictOutsideDropsOutsideKeepsInside)
       store, min_pt, max_pt);
 
     EXPECT_EQ(evicted, 1u);
-    EXPECT_TRUE(store.get(SourceLayer::Cube, cell_in).has_value());
-    EXPECT_FALSE(store.get(SourceLayer::Cube, cell_out).has_value());
+    EXPECT_TRUE(store.get(SourceLayer::Survey, cell_in).has_value());
+    EXPECT_FALSE(store.get(SourceLayer::Survey, cell_out).has_value());
   }
 }
 
 TEST_F(TileIoTest, EvictOutsideDirtyTileNotEvicted)
 {
-  // A dirty (unsaved) Cube tile outside the keep-box must NOT be evicted.
+  // A dirty (unsaved) Survey tile outside the keep-box must NOT be evicted.
   // importTiles marks tiles dirty, so we skip save() intentionally.
   const uint8_t lvl = 5;
   gggs::Level lev(lvl);
@@ -524,9 +524,9 @@ TEST_F(TileIoTest, EvictOutsideDirtyTileNotEvicted)
   tiles.emplace(cell_out.grid(), std::move(t));
 
   BathymetryStore store(lvl);
-  ASSERT_EQ(store.importTiles(SourceLayer::Cube, std::move(tiles)), 1u);
+  ASSERT_EQ(store.importTiles(SourceLayer::Survey, std::move(tiles)), 1u);
   // Tile is dirty (importTiles marks it dirty); do NOT save here.
-  ASSERT_TRUE(store.get(SourceLayer::Cube, cell_out)->depth == -20.0);
+  ASSERT_TRUE(store.get(SourceLayer::Survey, cell_out)->depth == -20.0);
 
   // Keep-box is far from the tile's position.
   const auto min_pt = makeGeoPoint(42.0, -71.0);
@@ -538,5 +538,5 @@ TEST_F(TileIoTest, EvictOutsideDirtyTileNotEvicted)
   // Dirty-tile guard: evicted count must be 0 (tile was outside but dirty).
   EXPECT_EQ(evicted, 0u);
   // Tile must still be present.
-  EXPECT_TRUE(store.get(SourceLayer::Cube, cell_out).has_value());
+  EXPECT_TRUE(store.get(SourceLayer::Survey, cell_out).has_value());
 }

--- a/marine_bathymetry_store/test/test_tile_io.cpp
+++ b/marine_bathymetry_store/test/test_tile_io.cpp
@@ -24,7 +24,9 @@
 #include <cstddef>
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <map>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -283,6 +285,56 @@ TEST_F(TileIoTest, LoadIgnoresEpochSubdirectories)
   // mis-loaded as a tile, which would have thrown on the bogus file).
   EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 1u);
   EXPECT_DOUBLE_EQ(reloaded.get(SourceLayer::Survey, cell)->depth, -30.0);
+}
+
+TEST_F(TileIoTest, LoadWarnsOnUnrecognizedStoreLayout)
+{
+  // A store dir written in the pre-#248 taxonomy (chart/draft/processed) has no
+  // survey/ or reference/ subdir, so load() reaches no tiles and returns empty.
+  // Because an empty bathy prior reads as navigable (unsurveyed_is_lethal default
+  // false), that silent-empty load must warn — matching the stale-subdir idiom.
+  fs::create_directories(dir_ / "chart");
+  {std::ofstream(dir_ / "chart" / "5_0_0.tif") << "old-layout tile";}
+
+  BathymetryStore reloaded(5);
+  std::ostringstream captured;
+  std::streambuf * prev = std::cerr.rdbuf(captured.rdbuf());
+  const std::size_t n = marine_bathymetry_store::load(reloaded, dir_.string());
+  std::cerr.rdbuf(prev);
+
+  EXPECT_EQ(n, 0u);
+  EXPECT_NE(captured.str().find("no recognized"), std::string::npos)
+    << "expected an old-layout warning, got: " << captured.str();
+}
+
+TEST_F(TileIoTest, LoadDoesNotWarnOnFreshOrMetadataOnlyStore)
+{
+  // A genuinely fresh store — absent, empty, or holding only the registry.json
+  // metadata sidecar with no tiles yet — is NOT an old-layout store, so load()
+  // stays silent (no spurious navigation-safety warning).
+  auto load_stderr = [this]() {
+      BathymetryStore reloaded(5);
+      std::ostringstream captured;
+      std::streambuf * prev = std::cerr.rdbuf(captured.rdbuf());
+      marine_bathymetry_store::load(reloaded, dir_.string());
+      std::cerr.rdbuf(prev);
+      return captured.str();
+    };
+
+  // Absent store dir.
+  EXPECT_TRUE(load_stderr().empty());
+
+  // Empty store dir.
+  fs::create_directories(dir_);
+  EXPECT_TRUE(load_stderr().empty());
+
+  // Metadata-only store (registry.json, no tiles).
+  StoreMetadata md;
+  md.survey = "massabesic-2026";
+  md.save(dir_.string());
+  ASSERT_TRUE(fs::is_regular_file(dir_ / "registry.json"));
+  EXPECT_TRUE(load_stderr().empty())
+    << "metadata-only store must not warn";
 }
 
 TEST_F(TileIoTest, ImportTilesPersistAndReload)

--- a/marine_bathymetry_store/test/test_tile_io.cpp
+++ b/marine_bathymetry_store/test/test_tile_io.cpp
@@ -160,7 +160,7 @@ TEST_F(TileIoTest, ReferenceRoundTripsAndLoadsIntoReadOnlyStore)
   EXPECT_TRUE(fs::is_directory(dir_ / "reference"));
 
   BathymetryStore runtime(5);   // Reference NOT writable
-  EXPECT_FALSE(runtime.preExistingWritable());
+  EXPECT_FALSE(runtime.referenceWritable());
   EXPECT_EQ(marine_bathymetry_store::load(runtime, dir_.string()), 1u);
 
   const auto rcell = runtime.cellIndex(43.0, -70.5);

--- a/marine_bathymetry_store/test/test_tile_io.cpp
+++ b/marine_bathymetry_store/test/test_tile_io.cpp
@@ -22,7 +22,6 @@
 #include <gtest/gtest.h>
 
 #include <cstddef>
-#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <map>
@@ -30,19 +29,15 @@
 #include <string>
 #include <utility>
 
-#include <nlohmann/json.hpp>
-
 #include "marine_bathymetry_store/bathymetry_store.hpp"
 #include "marine_bathymetry_store/bathymetry_tile.hpp"
 #include "marine_bathymetry_store/registry.hpp"
 #include "marine_bathymetry_store/tile_io.hpp"
-#include "marine_tiled_raster_store/tile_io.hpp"
 
 using marine_bathymetry_store::BathyCell;
 using marine_bathymetry_store::BathymetryStore;
 using marine_bathymetry_store::SourceLayer;
-using marine_bathymetry_store::SourceRecord;
-using marine_bathymetry_store::SourceRegistry;
+using marine_bathymetry_store::StoreMetadata;
 
 namespace fs = std::filesystem;
 
@@ -67,110 +62,32 @@ protected:
 
 TEST_F(TileIoTest, RoundTripPreservesCells)
 {
-  BathymetryStore store(5);
-  // int64 ns stamps with sub-second precision that a Float64 seconds band could
-  // not have represented exactly — the Int64 time tile preserves them bit-exact.
-  const int64_t ts_draft = 1'780'000'000'123'456'789LL;
-  const int64_t ts_proc = 1'790'000'000'987'654'321LL;
+  BathymetryStore store(5, /*pre_existing_writable=*/true);
+  // A non-trivial uncertainty checks lossless Float64 round-trip of the value tile.
+  store.set(SourceLayer::Cube, store.cellIndex(43.0, -70.5), BathyCell{-30.123, 0.456789});
   store.set(
-    SourceLayer::Draft, store.cellIndex(43.0, -70.5),
-    BathyCell{-30.123, 0.456, ts_draft, 7u});
-  store.set(
-    SourceLayer::Processed, store.cellIndex(44.0, -71.0),
-    BathyCell{-12.5, 0.2, ts_proc, 0u});
+    SourceLayer::PreExisting, store.cellIndex(44.0, -71.0), BathyCell{-12.5, 0.2});
 
   EXPECT_EQ(marine_bathymetry_store::save(store, dir_.string()), 2u);
 
   BathymetryStore reloaded(5);
   EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 2u);
 
-  const auto draft = reloaded.get(SourceLayer::Draft, reloaded.cellIndex(43.0, -70.5));
-  ASSERT_TRUE(draft.has_value());
-  EXPECT_DOUBLE_EQ(draft->depth, -30.123);
-  EXPECT_DOUBLE_EQ(draft->uncertainty, 0.456);
-  // Int64 ns timestamp band: nanosecond stamps survive exactly.
-  EXPECT_EQ(draft->timestamp, ts_draft);
-  EXPECT_EQ(draft->source_index, 7u);
+  const auto cube = reloaded.get(SourceLayer::Cube, reloaded.cellIndex(43.0, -70.5));
+  ASSERT_TRUE(cube.has_value());
+  EXPECT_DOUBLE_EQ(cube->depth, -30.123);
+  EXPECT_DOUBLE_EQ(cube->uncertainty, 0.456789);   // uncertainty round-trips exactly
 
-  const auto pcell = reloaded.cellIndex(44.0, -71.0);
-  const auto processed = reloaded.get(SourceLayer::Processed, pcell);
-  ASSERT_TRUE(processed.has_value());
-  EXPECT_DOUBLE_EQ(processed->depth, -12.5);
-  EXPECT_EQ(processed->timestamp, ts_proc);
-}
-
-TEST_F(TileIoTest, RoundTripPreservesSourceIndex)
-{
-  // The per-cell source index (registry handle, ADR-0005 D2/D8) round-trips
-  // through the separate UInt16 _source.tif independently of depth/time.
-  BathymetryStore store(5);
-  store.set(
-    SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 10LL, 1u});
-  store.set(
-    SourceLayer::Draft, store.cellIndex(43.0, -70.4), BathyCell{-31.0, 0.5, 11LL, 4242u});
-  EXPECT_EQ(marine_bathymetry_store::save(store, dir_.string()), 1u);
-
-  BathymetryStore reloaded(5);
-  EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 1u);
-  EXPECT_EQ(
-    reloaded.get(SourceLayer::Draft, reloaded.cellIndex(43.0, -70.5))->source_index, 1u);
-  EXPECT_EQ(
-    reloaded.get(SourceLayer::Draft, reloaded.cellIndex(43.0, -70.4))->source_index, 4242u);
-}
-
-TEST_F(TileIoTest, MissingTimeTileLoadsAsZero)
-{
-  // Pre-migration single-platform data has no _time.tif. Deleting it before load
-  // must not fail — the timestamp band fills with 0 (backward compatibility).
-  BathymetryStore store(5);
-  store.set(
-    SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 99LL, 2u});
-  marine_bathymetry_store::save(store, dir_.string());
-
-  // Remove every _time.tif under the draft layer.
-  for (const auto & e : fs::recursive_directory_iterator(dir_ / "draft")) {
-    if (e.is_regular_file() && e.path().filename().string().find("_time.tif") != std::string::npos)
-    {
-      fs::remove(e.path());
-    }
-  }
-
-  BathymetryStore reloaded(5);
-  EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 1u);
-  const auto got = reloaded.get(SourceLayer::Draft, reloaded.cellIndex(43.0, -70.5));
-  ASSERT_TRUE(got.has_value());
-  EXPECT_DOUBLE_EQ(got->depth, -30.0);   // value tile still loaded
-  EXPECT_EQ(got->timestamp, 0);          // missing time tile -> 0
-  EXPECT_EQ(got->source_index, 2u);      // source tile still loaded
-}
-
-TEST_F(TileIoTest, MissingSourceTileLoadsAsZero)
-{
-  BathymetryStore store(5);
-  store.set(
-    SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 99LL, 5u});
-  marine_bathymetry_store::save(store, dir_.string());
-
-  for (const auto & e : fs::recursive_directory_iterator(dir_ / "draft")) {
-    if (e.is_regular_file() &&
-      e.path().filename().string().find("_source.tif") != std::string::npos)
-    {
-      fs::remove(e.path());
-    }
-  }
-
-  BathymetryStore reloaded(5);
-  EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 1u);
-  const auto got = reloaded.get(SourceLayer::Draft, reloaded.cellIndex(43.0, -70.5));
-  ASSERT_TRUE(got.has_value());
-  EXPECT_EQ(got->timestamp, 99);         // time tile still loaded
-  EXPECT_EQ(got->source_index, 0u);      // missing source tile -> 0
+  const auto pre = reloaded.get(SourceLayer::PreExisting, reloaded.cellIndex(44.0, -71.0));
+  ASSERT_TRUE(pre.has_value());
+  EXPECT_DOUBLE_EQ(pre->depth, -12.5);
+  EXPECT_DOUBLE_EQ(pre->uncertainty, 0.2);
 }
 
 TEST_F(TileIoTest, LoadedTilesAreCleanAndDontResave)
 {
   BathymetryStore store(5);
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1LL});
+  store.set(SourceLayer::Cube, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5});
 
   EXPECT_EQ(marine_bathymetry_store::save(store, dir_.string()), 1u);
   // No changes since the last save -> nothing re-written (incremental save).
@@ -185,276 +102,137 @@ TEST_F(TileIoTest, LoadedTilesAreCleanAndDontResave)
 TEST_F(TileIoTest, WritingAfterSaveRedirties)
 {
   BathymetryStore store(5);
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1LL});
+  store.set(SourceLayer::Cube, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5});
   EXPECT_EQ(marine_bathymetry_store::save(store, dir_.string()), 1u);
 
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-31.0, 0.4, 2LL});
+  store.set(SourceLayer::Cube, store.cellIndex(43.0, -70.5), BathyCell{-31.0, 0.4});
   EXPECT_EQ(marine_bathymetry_store::save(store, dir_.string()), 1u);
 }
 
 TEST_F(TileIoTest, LayersWriteToSeparateSubdirectories)
 {
-  BathymetryStore store(5);
+  BathymetryStore store(5, /*pre_existing_writable=*/true);
   const auto pcell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Processed, pcell, BathyCell{-10.0, 0.1, 1LL});
-  store.set(SourceLayer::Draft, pcell, BathyCell{-12.0, 0.5, 2LL});
+  store.set(SourceLayer::PreExisting, pcell, BathyCell{-10.0, 0.1});
+  store.set(SourceLayer::Cube, pcell, BathyCell{-12.0, 0.5});
   marine_bathymetry_store::save(store, dir_.string());
 
-  EXPECT_TRUE(fs::is_directory(dir_ / "processed"));
-  EXPECT_TRUE(fs::is_directory(dir_ / "draft"));
+  EXPECT_TRUE(fs::is_directory(dir_ / "pre-existing"));
+  EXPECT_TRUE(fs::is_directory(dir_ / "cube"));
 }
 
 TEST_F(TileIoTest, LoadAcceptsMixedLevelTiles)
 {
-  // The store is multi-level (ADR-0002 §D2): tiles at different levels share an
-  // epoch directory, and load recovers each tile's level from its filename. A
+  // The store is multi-level (ADR-0002 §D2): tiles at different levels share a
+  // layer directory, and load recovers each tile's level from its filename. A
   // store loaded with a DIFFERENT default level still reads them all back.
   BathymetryStore writer(5);
   gggs::Level coarse(4);
   gggs::Level fine(7);
   const auto coarse_cell = coarse.cellIndex(gggs::geoPoint(43.0, -70.5));
   const auto fine_cell = fine.cellIndex(gggs::geoPoint(43.0, -70.5));
-  writer.set(SourceLayer::Draft, coarse_cell, BathyCell{-30.0, 0.5, 1LL});
-  writer.set(SourceLayer::Draft, fine_cell, BathyCell{-22.0, 0.3, 2LL});
+  writer.set(SourceLayer::Cube, coarse_cell, BathyCell{-30.0, 0.5});
+  writer.set(SourceLayer::Cube, fine_cell, BathyCell{-22.0, 0.3});
   EXPECT_EQ(marine_bathymetry_store::save(writer, dir_.string()), 2u);
 
   // Reload into a store whose default level (6) matches NEITHER stored level.
   BathymetryStore reloaded(6);
   EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 2u);
-  const auto coarse_got = reloaded.get(SourceLayer::Draft, coarse_cell);
+  const auto coarse_got = reloaded.get(SourceLayer::Cube, coarse_cell);
   ASSERT_TRUE(coarse_got.has_value());
   EXPECT_DOUBLE_EQ(coarse_got->depth, -30.0);
-  const auto fine_got = reloaded.get(SourceLayer::Draft, fine_cell);
+  const auto fine_got = reloaded.get(SourceLayer::Cube, fine_cell);
   ASSERT_TRUE(fine_got.has_value());
   EXPECT_DOUBLE_EQ(fine_got->depth, -22.0);
 }
 
-TEST_F(TileIoTest, ChartRoundTripsAndLoadsIntoReadOnlyStore)
+TEST_F(TileIoTest, PreExistingRoundTripsAndLoadsIntoReadOnlyStore)
 {
-  // The importer writes Chart (chart_writable); the runtime loads it into a
-  // default (read-only-Chart) store. load() populates via getOrCreateTile, not
-  // set(), so the prior loads even though live set(Chart) stays forbidden.
-  const int64_t ts = 1'780'000'000'000'000'000LL;
-  BathymetryStore writer(5, /*chart_writable=*/true);
-  writer.set(SourceLayer::Chart, writer.cellIndex(43.0, -70.5), BathyCell{38.58, 3.0, ts});
+  // The importer writes PreExisting (pre_existing_writable); the runtime loads it
+  // into a default (read-only-prior) store. load() populates via getOrCreateTile,
+  // not set(), so the prior loads even though live set(PreExisting) stays
+  // forbidden.
+  BathymetryStore writer(5, /*pre_existing_writable=*/true);
+  writer.set(SourceLayer::PreExisting, writer.cellIndex(43.0, -70.5), BathyCell{38.58, 3.0});
   EXPECT_EQ(marine_bathymetry_store::save(writer, dir_.string()), 1u);
-  EXPECT_TRUE(fs::is_directory(dir_ / "chart"));
+  EXPECT_TRUE(fs::is_directory(dir_ / "pre-existing"));
 
-  BathymetryStore runtime(5);   // Chart NOT writable
-  EXPECT_FALSE(runtime.chartWritable());
+  BathymetryStore runtime(5);   // PreExisting NOT writable
+  EXPECT_FALSE(runtime.preExistingWritable());
   EXPECT_EQ(marine_bathymetry_store::load(runtime, dir_.string()), 1u);
 
   const auto rcell = runtime.cellIndex(43.0, -70.5);
-  const auto got = runtime.get(SourceLayer::Chart, rcell);
+  const auto got = runtime.get(SourceLayer::PreExisting, rcell);
   ASSERT_TRUE(got.has_value());
   EXPECT_DOUBLE_EQ(got->depth, 38.58);
-  EXPECT_EQ(got->timestamp, ts);
 
   // The read-only guard still holds after the prior is loaded.
   EXPECT_THROW(
-    runtime.set(SourceLayer::Chart, rcell, BathyCell{1.0, 1.0, 1LL}),
+    runtime.set(SourceLayer::PreExisting, rcell, BathyCell{1.0, 1.0}),
     std::logic_error);
 }
 
-TEST_F(TileIoTest, ProcessedDraftOnlyStoreLoadsWithoutChartDir)
+TEST_F(TileIoTest, CubeOnlyStoreLoadsWithoutPreExistingDir)
 {
-  // Back-compat: a Phase-1 store with no chart/ subdir still saves and loads;
-  // the absent chart layer is simply skipped, not an error.
+  // A store with no pre-existing/ subdir still saves and loads; the absent prior
+  // layer is simply skipped, not an error.
   BathymetryStore store(5);
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5, 1LL});
+  store.set(SourceLayer::Cube, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5});
   marine_bathymetry_store::save(store, dir_.string());
-  EXPECT_FALSE(fs::exists(dir_ / "chart"));   // no spurious empty chart/ dir
+  EXPECT_FALSE(fs::exists(dir_ / "pre-existing"));   // no spurious empty dir
 
   BathymetryStore reloaded(5);
   EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 1u);
-  EXPECT_TRUE(reloaded.tiles(SourceLayer::Chart).empty());
+  EXPECT_TRUE(reloaded.tiles(SourceLayer::PreExisting).empty());
 }
 
-TEST_F(TileIoTest, RegistryAtomicWrite)
-{
-  // saveRegistry must publish registry.json atomically: the final file exists
-  // and no .tmp scratch file is left behind.
-  fs::create_directories(dir_);
-  SourceRegistry registry;
-  const uint16_t idx = registry.registerSource(
-    SourceRecord{"bizzy:m3:0", "bizzy", "m3", "multibeam", "massabesic-2026", "ellipsoid"});
-  EXPECT_EQ(idx, 1u);                           // first real index (0 reserved)
+// --- Coarse StoreMetadata (registry.json) round-trip (#248) ---
 
-  registry.saveRegistry(dir_.string());
+TEST_F(TileIoTest, StoreMetadataAtomicRoundTrip)
+{
+  // StoreMetadata is written atomically (no leftover .tmp) and reloads exactly.
+  fs::create_directories(dir_);
+  StoreMetadata md{"bizzy", "m3", "massabesic-2026", "2026-06-30"};
+  md.save(dir_.string());
   EXPECT_TRUE(fs::is_regular_file(dir_ / "registry.json"));
   EXPECT_FALSE(fs::exists(dir_ / "registry.json.tmp"));   // no leftover scratch
 
-  SourceRegistry loaded;
-  loaded.loadRegistry(dir_.string());
-  const auto rec = loaded.lookup(1);
-  ASSERT_TRUE(rec.has_value());
-  EXPECT_EQ(rec->platform, "bizzy");
-  EXPECT_EQ(rec->datum, "ellipsoid");
-  EXPECT_FALSE(loaded.lookup(SourceRegistry::kUnset).has_value());   // index 0 is unset
+  StoreMetadata loaded;
+  loaded.load(dir_.string());
+  EXPECT_EQ(loaded.platform, "bizzy");
+  EXPECT_EQ(loaded.sensor, "m3");
+  EXPECT_EQ(loaded.survey, "massabesic-2026");
+  EXPECT_EQ(loaded.date, "2026-06-30");
 }
 
-TEST_F(TileIoTest, RegistryRegisterSourceIsIdempotent)
+TEST_F(TileIoTest, SaveWritesMetadataWhenProvided)
 {
-  SourceRegistry registry;
-  const uint16_t a = registry.registerSource(SourceRecord{"bizzy:m3:0", "bizzy", "m3", "", "", ""});
-  const uint16_t b = registry.registerSource(SourceRecord{"izzy:m3:0", "izzy", "m3", "", "", ""});
-  const uint16_t a2 = registry.registerSource(SourceRecord{"bizzy:m3:0", "x", "y", "", "", ""});
-  EXPECT_EQ(a, 1u);
-  EXPECT_EQ(b, 2u);
-  EXPECT_EQ(a2, a);                 // same source_id -> same index, no new entry
-  EXPECT_EQ(registry.size(), 2u);
-}
-
-TEST_F(TileIoTest, SaveWritesRegistryWhenProvided)
-{
-  // The store save() persists the registry sidecar once, at the store root.
+  // The store save() persists the metadata sidecar once, at the store root.
   BathymetryStore store(5);
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5),
-    BathyCell{-30.0, 0.5, 1LL, 1u});
-  SourceRegistry registry;
-  registry.registerSource(SourceRecord{"bizzy:m3:0", "bizzy", "m3", "multibeam", "", "ellipsoid"});
+  store.set(SourceLayer::Cube, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5});
+  StoreMetadata md{"bizzy", "m3", "massabesic-2026", "2026-06-30"};
 
-  marine_bathymetry_store::save(store, dir_.string(), &registry);
+  marine_bathymetry_store::save(store, dir_.string(), &md);
   EXPECT_TRUE(fs::is_regular_file(dir_ / "registry.json"));
 
-  SourceRegistry reloaded;
+  StoreMetadata reloaded;
   marine_bathymetry_store::load(store, dir_.string(), &reloaded);
-  EXPECT_EQ(reloaded.size(), 1u);
-  ASSERT_TRUE(reloaded.lookup(1).has_value());
-  EXPECT_EQ(reloaded.lookup(1)->platform, "bizzy");
+  EXPECT_EQ(reloaded.platform, "bizzy");
+  EXPECT_EQ(reloaded.survey, "massabesic-2026");
 }
 
-// --- Item 1: registry.cpp loadRegistry index validation ---
-
-TEST_F(TileIoTest, LoadRegistryRejectsReorderedIndex)
+TEST_F(TileIoTest, LoadWithoutMetadataFileLeavesMetadataEmpty)
 {
-  // A hand-edited registry.json with a swapped/reordered "index" field must be
-  // rejected with a clear error (not silently accepted as a contiguous sequence).
-  fs::create_directories(dir_);
-  // Write a registry with two entries but with their index values swapped
-  // (entry 0 claims index=2, entry 1 claims index=1).
-  const nlohmann::json bad_registry = {
-    {"version", 1},
-    {"sources", nlohmann::json::array({
-      {{"index", 2}, {"source_id", "a"}, {"platform", "p1"}, {"sensor", "s"},
-       {"sensor_class", ""}, {"campaign", ""}, {"datum", ""}},
-      {{"index", 1}, {"source_id", "b"}, {"platform", "p2"}, {"sensor", "s"},
-       {"sensor_class", ""}, {"campaign", ""}, {"datum", ""}},
-    })}
-  };
-  {
-    std::ofstream out(dir_ / "registry.json");
-    out << bad_registry.dump(2);
-  }
-  SourceRegistry reg;
-  EXPECT_THROW(reg.loadRegistry(dir_.string()), std::runtime_error);
-}
-
-TEST_F(TileIoTest, LoadRegistryRejectsMissingIndexField)
-{
-  // An entry that lacks the "index" field entirely must also be rejected.
-  fs::create_directories(dir_);
-  const nlohmann::json bad_registry = {
-    {"version", 1},
-    {"sources", nlohmann::json::array({
-      // "index" field deliberately omitted
-      {{"source_id", "a"}, {"platform", "p1"}, {"sensor", "s"},
-       {"sensor_class", ""}, {"campaign", ""}, {"datum", ""}},
-    })}
-  };
-  {
-    std::ofstream out(dir_ / "registry.json");
-    out << bad_registry.dump(2);
-  }
-  SourceRegistry reg;
-  EXPECT_THROW(reg.loadRegistry(dir_.string()), std::runtime_error);
-}
-
-TEST_F(TileIoTest, LoadRegistryRejectsDuplicateSourceId)
-{
-  // Two entries with the same source_id at distinct contiguous indices must be
-  // rejected: duplicate source_id desynchronises by_index_ and by_source_id_.
-  fs::create_directories(dir_);
-  const nlohmann::json bad_registry = {
-    {"version", 1},
-    {"sources", nlohmann::json::array({
-      {{"index", 1}, {"source_id", "dup"}, {"platform", "p1"}, {"sensor", "s"},
-       {"sensor_class", ""}, {"campaign", ""}, {"datum", ""}},
-      {{"index", 2}, {"source_id", "dup"}, {"platform", "p2"}, {"sensor", "s"},
-       {"sensor_class", ""}, {"campaign", ""}, {"datum", ""}},
-    })}
-  };
-  {
-    std::ofstream out(dir_ / "registry.json");
-    out << bad_registry.dump(2);
-  }
-  SourceRegistry reg;
-  EXPECT_THROW(reg.loadRegistry(dir_.string()), std::runtime_error);
-}
-
-// --- Item 2: tile_io.cpp loadTile — legacy 3-band guard ---
-
-TEST_F(TileIoTest, LoadTileRejectsLegacyThreeBandValueTile)
-{
-  // A value tile with exactly 3 bands (the pre-#178 depth/uncertainty/Float64-
-  // seconds layout) must be rejected with a clear error on load rather than
-  // silently loading 2 bands and discarding the third.
-  namespace mtrs = marine_tiled_raster_store;
-  fs::create_directories(dir_ / "draft");
-
-  // Create a fake 3-band Float64 tile that mimics the old layout.
-  const gggs::Level level(5);
-  const gggs::GridIndex grid = level.gridIndex(43.0, -70.5);
-  const std::string filename = marine_bathymetry_store::tileFilename(grid);
-  const std::string path = (dir_ / "draft" / filename).string();
-
-  mtrs::TiledRasterTile<double> legacy_tile(grid, 3, 0.0);
-  legacy_tile.set(10, 20, 0, -12.5);    // depth
-  legacy_tile.set(10, 20, 1, 0.3);      // uncertainty
-  legacy_tile.set(10, 20, 2, 1.78e9);   // old Float64 seconds timestamp
-  mtrs::saveTile<double>(legacy_tile, path, {std::nullopt, std::nullopt, std::nullopt});
-
-  // loadTile must throw, not silently drop band 3.
+  // A store with no registry.json loads cleanly; StoreMetadata stays empty.
   BathymetryStore store(5);
-  EXPECT_THROW(marine_bathymetry_store::load(store, dir_.string()), std::runtime_error);
-}
-
-// --- Item 4: tile_io.cpp loadTile — GridIndex consistency ---
-
-TEST_F(TileIoTest, LoadTileRejectsCompanionWithWrongGrid)
-{
-  // If a _time.tif companion is manually replaced with a file from a different
-  // grid (simulating file tampering or mis-rename), loadTile must throw a clear
-  // error rather than silently combining cell-for-cell data from two different
-  // geographic locations.
-  namespace mtrs = marine_tiled_raster_store;
-  fs::create_directories(dir_ / "draft");
-
-  const gggs::Level level(5);
-  // Two grids in different locations.
-  const gggs::GridIndex grid_a = level.gridIndex(43.0, -70.5);
-  const gggs::GridIndex grid_b = level.gridIndex(44.0, -71.0);
-  ASSERT_FALSE(grid_a == grid_b);
-
-  // Save a normal tile for grid_a.
-  BathymetryStore store(5);
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5),
-    BathyCell{-30.0, 0.5, 42LL, 1u});
-  marine_bathymetry_store::save(store, dir_.string());
-
-  // Replace grid_a's _time companion with a time tile written for grid_b.
-  // The companion filename is derived from the value tile stem (grid_a filename
-  // + "_time.tif"), but we write a file whose geotransform encodes grid_b.
-  const std::string value_filename = marine_bathymetry_store::tileFilename(grid_a);
-  const fs::path time_path =
-    dir_ / "draft" / (fs::path(value_filename).stem().string() + "_time.tif");
-  // Write a time tile for grid_b at that path (overwrites any existing companion).
-  mtrs::TiledRasterTile<int64_t> wrong_time(grid_b, 1, int64_t{0});
-  wrong_time.set(0, 0, 0, 99LL);
-  mtrs::saveTile<int64_t>(wrong_time, time_path.string(), {std::nullopt});
+  store.set(SourceLayer::Cube, store.cellIndex(43.0, -70.5), BathyCell{-30.0, 0.5});
+  marine_bathymetry_store::save(store, dir_.string());   // no metadata passed
+  EXPECT_FALSE(fs::exists(dir_ / "registry.json"));
 
   BathymetryStore reloaded(5);
-  EXPECT_THROW(marine_bathymetry_store::load(reloaded, dir_.string()), std::runtime_error);
+  StoreMetadata md;
+  marine_bathymetry_store::load(reloaded, dir_.string(), &md);
+  EXPECT_TRUE(md.empty());
 }
 
 // --- Flat layout persistence (#221: per-day epoch subdirectory dropped) ---
@@ -465,22 +243,22 @@ TEST_F(TileIoTest, SaveWritesFlatLayoutNoEpochSubdir)
   // subdirectory and no provenance marker file (#221).
   BathymetryStore writer(5);
   const auto cell = writer.cellIndex(43.0, -70.5);
-  writer.set(SourceLayer::Draft, cell, BathyCell{-30.0, 0.5, 1LL});
+  writer.set(SourceLayer::Cube, cell, BathyCell{-30.0, 0.5});
   EXPECT_EQ(marine_bathymetry_store::save(writer, dir_.string()), 1u);
 
-  // The value tile sits directly in draft/, and no subdirectory or provenance
+  // The value tile sits directly in cube/, and no subdirectory or provenance
   // marker exists.
   const std::string filename =
     marine_bathymetry_store::tileFilename(cell.grid());
-  EXPECT_TRUE(fs::is_regular_file(dir_ / "draft" / filename));
-  EXPECT_FALSE(fs::exists(dir_ / "draft" / "provenance"));
-  for (const auto & e : fs::directory_iterator(dir_ / "draft")) {
+  EXPECT_TRUE(fs::is_regular_file(dir_ / "cube" / filename));
+  EXPECT_FALSE(fs::exists(dir_ / "cube" / "provenance"));
+  for (const auto & e : fs::directory_iterator(dir_ / "cube")) {
     EXPECT_FALSE(e.is_directory()) << "no epoch subdirectory expected: " << e.path();
   }
 
   BathymetryStore reloaded(5);
   EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 1u);
-  EXPECT_DOUBLE_EQ(reloaded.get(SourceLayer::Draft, cell)->depth, -30.0);
+  EXPECT_DOUBLE_EQ(reloaded.get(SourceLayer::Cube, cell)->depth, -30.0);
 }
 
 TEST_F(TileIoTest, LoadIgnoresEpochSubdirectories)
@@ -490,11 +268,11 @@ TEST_F(TileIoTest, LoadIgnoresEpochSubdirectories)
   // (#221). Only the flat value tiles load.
   BathymetryStore writer(5);
   const auto cell = writer.cellIndex(43.0, -70.5);
-  writer.set(SourceLayer::Draft, cell, BathyCell{-30.0, 0.5, 1LL});
+  writer.set(SourceLayer::Cube, cell, BathyCell{-30.0, 0.5});
   marine_bathymetry_store::save(writer, dir_.string());
 
   // Drop an old-style epoch subdirectory containing a (would-be) tile file.
-  const fs::path epoch_dir = dir_ / "draft" / "2026-06-10";
+  const fs::path epoch_dir = dir_ / "cube" / "2026-06-10";
   fs::create_directories(epoch_dir);
   {
     std::ofstream(epoch_dir / "5_0_0.tif") << "stale";
@@ -504,7 +282,7 @@ TEST_F(TileIoTest, LoadIgnoresEpochSubdirectories)
   // Only the flat tile loads; the subdirectory's contents are ignored (not
   // mis-loaded as a tile, which would have thrown on the bogus file).
   EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 1u);
-  EXPECT_DOUBLE_EQ(reloaded.get(SourceLayer::Draft, cell)->depth, -30.0);
+  EXPECT_DOUBLE_EQ(reloaded.get(SourceLayer::Cube, cell)->depth, -30.0);
 }
 
 TEST_F(TileIoTest, ImportTilesPersistAndReload)
@@ -518,16 +296,16 @@ TEST_F(TileIoTest, ImportTilesPersistAndReload)
   std::map<gggs::GridIndex, marine_bathymetry_store::BathymetryTile> tiles;
   for (const auto & c : {cell_a, cell_b}) {
     marine_bathymetry_store::BathymetryTile t(c.grid());
-    t.set(c.row(), c.column(), BathyCell{-30.0, 0.5, 1LL});
+    t.set(c.row(), c.column(), BathyCell{-30.0, 0.5});
     tiles.emplace(c.grid(), std::move(t));
   }
-  EXPECT_EQ(writer.importTiles(SourceLayer::Draft, std::move(tiles)), 2u);
+  EXPECT_EQ(writer.importTiles(SourceLayer::Cube, std::move(tiles)), 2u);
   EXPECT_EQ(marine_bathymetry_store::save(writer, dir_.string()), 2u);
 
   BathymetryStore reloaded(5);
   EXPECT_EQ(marine_bathymetry_store::load(reloaded, dir_.string()), 2u);
-  EXPECT_TRUE(reloaded.get(SourceLayer::Draft, cell_a).has_value());
-  EXPECT_TRUE(reloaded.get(SourceLayer::Draft, cell_b).has_value());
+  EXPECT_TRUE(reloaded.get(SourceLayer::Cube, cell_a).has_value());
+  EXPECT_TRUE(reloaded.get(SourceLayer::Cube, cell_b).has_value());
 }
 
 TEST_F(TileIoTest, LevelFromTileFilenameParsesPrefix)
@@ -562,44 +340,32 @@ geographic_msgs::msg::GeoPoint makeGeoPoint(double lat, double lon)
 TEST_F(TileIoTest, LoadWindowLoadsOnlyOverlappingTiles)
 {
   // Three tiles at level 5: one inside the box, one outside, one at the edge
-  // (boundary straddle).  Write them to separate directories (save merges tiles
-  // in the same layer/epoch), then check that loadWindow loads the two that
-  // overlap.
+  // (boundary straddle). loadWindow loads only the two that overlap.
   const uint8_t lvl = 5;
   gggs::Level lev(lvl);
 
   // inside box: 43.0°N, -70.5°W
   const gggs::GridIndex inside_grid = lev.gridIndex(43.0, -70.5);
-  // outside box: 50.0°N, -40.0°W (well outside any reasonable test box) —
-  // referenced by geoPoint only, GridIndex not needed at this scope.
-  // boundary straddle: a tile whose south or west edge touches the box min
-  // We will use the exact inside_grid's south edge as the box min, so the grid
-  // itself is the straddler — easiest way to guarantee edge-touch.
-  // Use a second nearby grid as the boundary case: choose a tile one row south
-  // of inside_grid, set the box min to exactly that tile's north edge.
+  // boundary straddle: a tile one row south of inside_grid.
   const gggs::GridIndex straddle_grid = lev.gridIndex(
-    inside_grid.southLatitude() - 0.001,  // one small step south into the next tile
+    inside_grid.southLatitude() - 0.001,
     inside_grid.westLongitude() + 0.001);
 
   // Write all three tiles to disk.
   {
     BathymetryStore writer(lvl);
     const auto c_in = lev.cellIndex(gggs::geoPoint(43.0, -70.5));
-    writer.set(SourceLayer::Draft, c_in, BathyCell{-10.0, 0.5, 1LL});
+    writer.set(SourceLayer::Cube, c_in, BathyCell{-10.0, 0.5});
     const auto c_out = lev.cellIndex(gggs::geoPoint(50.0, -40.0));
-    writer.set(SourceLayer::Draft, c_out, BathyCell{-20.0, 0.5, 2LL});
+    writer.set(SourceLayer::Cube, c_out, BathyCell{-20.0, 0.5});
     const auto c_str = lev.cellIndex(
       gggs::geoPoint(
         inside_grid.southLatitude() - 0.001,
         inside_grid.westLongitude() + 0.001));
-    writer.set(SourceLayer::Draft, c_str, BathyCell{-30.0, 0.5, 3LL});
+    writer.set(SourceLayer::Cube, c_str, BathyCell{-30.0, 0.5});
     ASSERT_EQ(marine_bathymetry_store::save(writer, dir_.string()), 3u);
   }
 
-  // Box: from straddle_grid's north latitude (so the straddle tile's north edge
-  // exactly touches min_pt.latitude) to well above inside_grid.
-  // Actually simpler: box just covers inside_grid and straddle_grid but not
-  // outside_grid.  The straddle_grid is south of inside_grid.
   const auto min_pt = makeGeoPoint(straddle_grid.southLatitude(), -72.0);
   const auto max_pt = makeGeoPoint(inside_grid.northLatitude(), -70.0);
 
@@ -611,7 +377,7 @@ TEST_F(TileIoTest, LoadWindowLoadsOnlyOverlappingTiles)
   // so exactly two tiles load (proves "only overlapping", not just "at least one").
   EXPECT_EQ(n, 2u);
   // outside_grid must not have been loaded.
-  EXPECT_FALSE(result.get(SourceLayer::Draft, lev.cellIndex(
+  EXPECT_FALSE(result.get(SourceLayer::Cube, lev.cellIndex(
     gggs::geoPoint(50.0, -40.0))).has_value());
 }
 
@@ -626,7 +392,7 @@ TEST_F(TileIoTest, LoadWindowBoundaryStraddle)
   {
     BathymetryStore writer(lvl);
     const auto cell = lev.cellIndex(gggs::geoPoint(43.0, -70.5));
-    writer.set(SourceLayer::Draft, cell, BathyCell{-15.0, 0.5, 1LL});
+    writer.set(SourceLayer::Cube, cell, BathyCell{-15.0, 0.5});
     ASSERT_EQ(marine_bathymetry_store::save(writer, dir_.string()), 1u);
   }
 
@@ -638,7 +404,7 @@ TEST_F(TileIoTest, LoadWindowBoundaryStraddle)
   const std::size_t n = marine_bathymetry_store::loadWindow(
     result, dir_.string(), min_pt, max_pt);
   EXPECT_EQ(n, 1u);
-  EXPECT_TRUE(result.get(SourceLayer::Draft,
+  EXPECT_TRUE(result.get(SourceLayer::Cube,
     lev.cellIndex(gggs::geoPoint(43.0, -70.5))).has_value());
 }
 
@@ -651,7 +417,7 @@ TEST_F(TileIoTest, LoadWindowIdempotent)
   {
     BathymetryStore writer(lvl);
     const auto cell = lev.cellIndex(gggs::geoPoint(43.0, -70.5));
-    writer.set(SourceLayer::Draft, cell, BathyCell{-10.0, 0.5, 1LL});
+    writer.set(SourceLayer::Cube, cell, BathyCell{-10.0, 0.5});
     ASSERT_EQ(marine_bathymetry_store::save(writer, dir_.string()), 1u);
   }
 
@@ -668,7 +434,7 @@ TEST_F(TileIoTest, LoadWindowIdempotent)
   // Second call should skip the already-resident tile.
   EXPECT_EQ(second, 0u);
   // Tile count in store is still 1 (not doubled).
-  EXPECT_EQ(result.tiles(SourceLayer::Draft).size(), 1u);
+  EXPECT_EQ(result.tiles(SourceLayer::Cube).size(), 1u);
 }
 
 TEST_F(TileIoTest, LoadWindowRejectsMalformedTileFilename)
@@ -681,12 +447,12 @@ TEST_F(TileIoTest, LoadWindowRejectsMalformedTileFilename)
   {
     BathymetryStore writer(lvl);
     writer.set(
-      SourceLayer::Draft, lev.cellIndex(gggs::geoPoint(43.0, -70.5)),
-      BathyCell{-10.0, 0.5, 1LL});
+      SourceLayer::Cube, lev.cellIndex(gggs::geoPoint(43.0, -70.5)),
+      BathyCell{-10.0, 0.5});
     ASSERT_EQ(marine_bathymetry_store::save(writer, dir_.string()), 1u);
   }
-  // Drop a bogus value-tile name (level 99) into the same layer/epoch dir.
-  const std::filesystem::path bogus = dir_ / "draft" / "99_0_0.tif";
+  // Drop a bogus value-tile name (level 99) into the same layer dir.
+  const std::filesystem::path bogus = dir_ / "cube" / "99_0_0.tif";
   {
     std::ofstream(bogus) << "not a tile";
   }
@@ -706,7 +472,6 @@ TEST_F(TileIoTest, LoadWindowRejectsMalformedTileFilename)
 TEST_F(TileIoTest, EvictOutsideDropsOutsideKeepsInside)
 {
   // Two tiles: one inside the keep-box, one outside.
-  // Populate in-memory via importTiles (no disk I/O needed for evictOutside).
   const uint8_t lvl = 5;
   gggs::Level lev(lvl);
   const auto cell_in = lev.cellIndex(gggs::geoPoint(43.0, -70.5));
@@ -716,19 +481,19 @@ TEST_F(TileIoTest, EvictOutsideDropsOutsideKeepsInside)
   {
     std::map<gggs::GridIndex, marine_bathymetry_store::BathymetryTile> tiles;
     marine_bathymetry_store::BathymetryTile t_in(cell_in.grid());
-    t_in.set(cell_in.row(), cell_in.column(), BathyCell{-10.0, 0.5, 1LL});
+    t_in.set(cell_in.row(), cell_in.column(), BathyCell{-10.0, 0.5});
     tiles.emplace(cell_in.grid(), std::move(t_in));
     marine_bathymetry_store::BathymetryTile t_out(cell_out.grid());
-    t_out.set(cell_out.row(), cell_out.column(), BathyCell{-20.0, 0.5, 2LL});
+    t_out.set(cell_out.row(), cell_out.column(), BathyCell{-20.0, 0.5});
     tiles.emplace(cell_out.grid(), std::move(t_out));
 
     BathymetryStore store(lvl);
-    ASSERT_EQ(store.importTiles(SourceLayer::Draft, std::move(tiles)), 2u);
+    ASSERT_EQ(store.importTiles(SourceLayer::Cube, std::move(tiles)), 2u);
     // Save so tiles are clean (importTiles marks them dirty; we want to test
     // eviction of clean tiles here — the dirty-guard test is separate).
     marine_bathymetry_store::save(store, dir_.string());
-    ASSERT_TRUE(store.get(SourceLayer::Draft, cell_in).has_value());
-    ASSERT_TRUE(store.get(SourceLayer::Draft, cell_out).has_value());
+    ASSERT_TRUE(store.get(SourceLayer::Cube, cell_in).has_value());
+    ASSERT_TRUE(store.get(SourceLayer::Cube, cell_out).has_value());
 
     const gggs::GridIndex grid_in = cell_in.grid();
     const auto min_pt =
@@ -740,14 +505,14 @@ TEST_F(TileIoTest, EvictOutsideDropsOutsideKeepsInside)
       store, min_pt, max_pt);
 
     EXPECT_EQ(evicted, 1u);
-    EXPECT_TRUE(store.get(SourceLayer::Draft, cell_in).has_value());
-    EXPECT_FALSE(store.get(SourceLayer::Draft, cell_out).has_value());
+    EXPECT_TRUE(store.get(SourceLayer::Cube, cell_in).has_value());
+    EXPECT_FALSE(store.get(SourceLayer::Cube, cell_out).has_value());
   }
 }
 
 TEST_F(TileIoTest, EvictOutsideDirtyTileNotEvicted)
 {
-  // A dirty (unsaved) Draft tile outside the keep-box must NOT be evicted.
+  // A dirty (unsaved) Cube tile outside the keep-box must NOT be evicted.
   // importTiles marks tiles dirty, so we skip save() intentionally.
   const uint8_t lvl = 5;
   gggs::Level lev(lvl);
@@ -755,13 +520,13 @@ TEST_F(TileIoTest, EvictOutsideDirtyTileNotEvicted)
 
   std::map<gggs::GridIndex, marine_bathymetry_store::BathymetryTile> tiles;
   marine_bathymetry_store::BathymetryTile t(cell_out.grid());
-  t.set(cell_out.row(), cell_out.column(), BathyCell{-20.0, 0.5, 1LL});
+  t.set(cell_out.row(), cell_out.column(), BathyCell{-20.0, 0.5});
   tiles.emplace(cell_out.grid(), std::move(t));
 
   BathymetryStore store(lvl);
-  ASSERT_EQ(store.importTiles(SourceLayer::Draft, std::move(tiles)), 1u);
+  ASSERT_EQ(store.importTiles(SourceLayer::Cube, std::move(tiles)), 1u);
   // Tile is dirty (importTiles marks it dirty); do NOT save here.
-  ASSERT_TRUE(store.get(SourceLayer::Draft, cell_out)->depth == -20.0);
+  ASSERT_TRUE(store.get(SourceLayer::Cube, cell_out)->depth == -20.0);
 
   // Keep-box is far from the tile's position.
   const auto min_pt = makeGeoPoint(42.0, -71.0);
@@ -773,5 +538,5 @@ TEST_F(TileIoTest, EvictOutsideDirtyTileNotEvicted)
   // Dirty-tile guard: evicted count must be 0 (tile was outside but dirty).
   EXPECT_EQ(evicted, 0u);
   // Tile must still be present.
-  EXPECT_TRUE(store.get(SourceLayer::Draft, cell_out).has_value());
+  EXPECT_TRUE(store.get(SourceLayer::Cube, cell_out).has_value());
 }

--- a/marine_bathymetry_store/test/test_tile_io.cpp
+++ b/marine_bathymetry_store/test/test_tile_io.cpp
@@ -207,6 +207,42 @@ TEST_F(TileIoTest, StoreMetadataAtomicRoundTrip)
   EXPECT_EQ(loaded.date, "2026-06-30");
 }
 
+TEST_F(TileIoTest, MetadataLoadWarnsOnUnrecognizedSchemaVersion)
+{
+  // A pre-#248 (or foreign) registry.json whose "version" != the current schema
+  // would otherwise load as all-empty without a trace. load() must warn.
+  fs::create_directories(dir_);
+  {std::ofstream(dir_ / "registry.json") << R"({"version": 1, "site": "old"})";}
+
+  StoreMetadata md;
+  std::ostringstream captured;
+  std::streambuf * prev = std::cerr.rdbuf(captured.rdbuf());
+  md.load(dir_.string());
+  std::cerr.rdbuf(prev);
+
+  EXPECT_NE(captured.str().find("unrecognized schema version"), std::string::npos)
+    << "expected a version-mismatch warning, got: " << captured.str();
+  EXPECT_TRUE(md.empty());   // unknown-schema fields do not map — loads empty
+}
+
+TEST_F(TileIoTest, MetadataLoadIsSilentOnCurrentSchemaVersion)
+{
+  // A registry.json written by the current code (version == schema) loads
+  // without any warning.
+  fs::create_directories(dir_);
+  StoreMetadata md{"bizzy", "m3", "massabesic-2026", "2026-06-30"};
+  md.save(dir_.string());
+
+  StoreMetadata loaded;
+  std::ostringstream captured;
+  std::streambuf * prev = std::cerr.rdbuf(captured.rdbuf());
+  loaded.load(dir_.string());
+  std::cerr.rdbuf(prev);
+
+  EXPECT_TRUE(captured.str().empty()) << "current-schema load must be silent";
+  EXPECT_EQ(loaded.survey, "massabesic-2026");
+}
+
 TEST_F(TileIoTest, SaveWritesMetadataWhenProvided)
 {
   // The store save() persists the metadata sidecar once, at the store root.

--- a/marine_mbes_backscatter_store/README.md
+++ b/marine_mbes_backscatter_store/README.md
@@ -12,14 +12,14 @@ provenance registry pattern.
 
 ## What this phase provides
 
-- An in-memory, GGGS-tiled store with **two priority source layers** — `Draft`
-  (live, newest-valid-wins) and `Processed` (durable overlay). **No Chart layer:**
-  a contour / S57 prior is a bathymetric concept; MBES backscatter has none
-  (ADR-0007 D7).
+- An in-memory, GGGS-tiled store with a **single `cube` source layer** (the CUBE
+  node-output product, live or off-boat re-run). The pre-#248 `draft`/`processed`
+  overlay collapsed to one layer (ADR-0007 #248 amendment A.2). **No Chart layer:**
+  a contour / S57 prior is a bathymetric concept; MBES backscatter has none.
 - A **best-source** query and its region (visitor) form.
-- A store-wide **`SourceRegistry`** (intern + atomic `registry.json`).
-- **Per-tile GeoTIFF persistence** — three files per grid (float value, int64
-  time, uint16 source), incremental save / reload.
+- A coarse store-level **`StoreMetadata`** sidecar (`registry.json`).
+- **Per-tile GeoTIFF persistence** — one 3-band `Float32` value tile per grid,
+  incremental save / reload.
 
 It deliberately does **not** include the producer (the CUBE node-output pass that
 computes corrected, angle-removed backscatter and calls `set(Draft, cell, …)` —
@@ -28,26 +28,31 @@ that is `cube_bathymetry#54`, out of scope here), the offline `Processed` build
 library; it **ingests already-corrected node output** and does no accumulation or
 radiometric correction itself.
 
-## The 3-tile schema (ADR-0007 D6)
+## The value-tile schema (ADR-0007 D6, #248 amendment A.1)
 
-A GeoTIFF is single-dtype-per-file, and the value band is `float`
-(`intensity_variance` rides alongside `intensity`, and the variance **is** the
-quality signal — there is no separate integer quality band as in the sidescan
-store). So each GGGS tile is persisted as three files:
+Each GGGS tile is persisted as a **single 3-band `Float32` value tile**
+`<grid>.tif` encoding the **Welford sufficient statistics** so the estimate
+reconstructs losslessly on reload:
 
-- `<grid>.tif` — 2-band `Float32` value tile (intensity, intensity_variance),
-  NaN no-data on both.
-- `<grid>_time.tif` — 1-band `Int64` timestamp tile (nanoseconds since the Unix
-  epoch, ROS-native and exact; 0 = unset).
-- `<grid>_source.tif` — 1-band `UInt16` source-index tile (registry index,
-  ADR-0005 D2/D8; 0 = no-data/unset).
+| Band | Field | Meaning |
+|------|-------|---------|
+| 0 | `mean` | Welford running mean of corrected backscatter. NaN = no data. |
+| 1 | `standard_error` | **confidence-scaled** standard error of the mean (`scale · sample_sd / √n`); the consumer divides the scale out on reload. |
+| 2 | `sample_sd` | sample standard deviation of contributing beams (`√(M2 / (n−1))`). |
 
-This is the one place the MBES schema departs from the sidescan store, where the
-value/quality/source share a `uint16` dtype and co-locate. The `float` value tile
-is backed by the `GDT_Float32` instantiation added to `marine_tiled_raster_store`
-([#194](https://github.com/rolker/unh_marine_autonomy/issues/194)), mirroring the
-`Int64` instantiation [#178](https://github.com/rolker/unh_marine_autonomy/issues/178)
-added for the bathy time band.
+From these (dividing the confidence scale out of `standard_error` to recover the
+true `SE = sample_sd / √n`), a downstream re-run recovers the full Welford state:
+`n = (sample_sd / SE)²` and `M2 = sample_sd² · (n − 1)`. A single-beam node has no
+dispersion — `sample_sd == 0` with a **finite** `mean` is the **n = 1 sentinel**
+(`n = 1, M2 = 0`), distinct from no-data (`mean = NaN`).
+
+The pre-#248 `_time.tif` (Int64 ns) and `_source.tif` (UInt16) companions were
+dropped (#248 amendment A.3): the store is a regenerable cache and the deployment
+is single-platform. Coarse provenance moves to the store-level `registry.json`
+`StoreMetadata{platform, sensor, survey, date, calibration_ref}`. The `float`
+value tile is backed by the `GDT_Float32` instantiation of
+`marine_tiled_raster_store`
+([#194](https://github.com/rolker/unh_marine_autonomy/issues/194)).
 
 ## Bag-retention dependency (ADR-0007 D1)
 
@@ -67,10 +72,10 @@ scope for this package), but the dependency is real and stated.
 - `marine_autonomy` — the GGGS spatial index (`gggs::Level`/`GridIndex`/`CellIndex`).
 - `marine_tiled_raster_store` — generic tiled-raster type + GeoTIFF persistence
   (the `float`/`int64`/`uint16` tile instantiations).
-- `marine_backscatter` — modality-agnostic backscatter core (provenance schema /
-  `writeRegistry`, future GeoCoder radiometry). This package keeps its **own**
-  multi-source `SourceRegistry` because `marine_backscatter::writeRegistry` is
-  write-only and single-source.
+- `marine_backscatter` — modality-agnostic backscatter core (provenance schema,
+  future GeoCoder radiometry). Since #248 this store keeps only a coarse
+  store-level `StoreMetadata` sidecar (the per-cell interning `SourceRegistry` was
+  dropped for the single-platform deployment — ADR-0005 #248 amendment).
 - `geographic_msgs` — `GeoPoint` for the region query API.
 - `nlohmann_json` — `registry.json` (implementation-only).
 
@@ -87,8 +92,8 @@ colcon test --packages-select marine_mbes_backscatter_store
 ```
 
 Tests (`test_store`, `test_query`, `test_tile_io`) are headless GTest and cover
-set/get round-trip, draft newest-valid-wins recency, best-source priority /
-fallback / nullopt, the region visitor, the 3-tile persistence round-trip
-(float value + int64 time + uint16 source), missing-companion 0-fill for both
-`_time` and `_source`, layer subdirectory layout, level-mismatch rejection,
-companion grid-mismatch rejection, and registry write / intern.
+set/get round-trip, newest-valid-wins recency, the n=1 sentinel, best-source /
+nullopt, the region visitor, the 3-band value-tile persistence round-trip, the
+**Welford sufficient-statistics round-trip** (n≥2 reconstruction of `{n, M2}`, the
+n=1 sentinel, and the confidence-scale divide-out), the `cube/` subdirectory
+layout, level-mismatch rejection, and the coarse `StoreMetadata` round-trip.

--- a/marine_mbes_backscatter_store/README.md
+++ b/marine_mbes_backscatter_store/README.md
@@ -12,7 +12,7 @@ provenance registry pattern.
 
 ## What this phase provides
 
-- An in-memory, GGGS-tiled store with a **single `cube` source layer** (the CUBE
+- An in-memory, GGGS-tiled store with a **single `survey` source layer** (the CUBE
   node-output product, live or off-boat re-run). The pre-#248 `draft`/`processed`
   overlay collapsed to one layer (ADR-0007 #248 amendment A.2). **No Chart layer:**
   a contour / S57 prior is a bathymetric concept; MBES backscatter has none.
@@ -95,5 +95,5 @@ Tests (`test_store`, `test_query`, `test_tile_io`) are headless GTest and cover
 set/get round-trip, newest-valid-wins recency, the n=1 sentinel, best-source /
 nullopt, the region visitor, the 3-band value-tile persistence round-trip, the
 **Welford sufficient-statistics round-trip** (n≥2 reconstruction of `{n, M2}`, the
-n=1 sentinel, and the confidence-scale divide-out), the `cube/` subdirectory
+n=1 sentinel, and the confidence-scale divide-out), the `survey/` subdirectory
 layout, level-mismatch rejection, and the coarse `StoreMetadata` round-trip.

--- a/marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/mbes_cell.hpp
+++ b/marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/mbes_cell.hpp
@@ -35,15 +35,15 @@ namespace marine_mbes_backscatter_store
 /// As in the bathy store, a cell's source layer is implied by which layer holds
 /// it (the store keeps one tile map per layer), so it is not stored in the
 /// per-cell record. The pre-#248 `draft`/`processed` two-layer overlay collapsed
-/// to a **single `cube` layer** (ADR-0007 #248 amendment A.2): with one platform
+/// to a **single `survey` layer** (ADR-0007 #248 amendment A.2): with one platform
 /// and one coverage, the live-vs-durable split added no query value.
 enum class SourceLayer : uint8_t
 {
-  Cube = 0,  ///< The CUBE node-output product (live or off-boat re-run). The only layer.
+  Survey = 0,  ///< The CUBE node-output product (live or off-boat re-run). The only layer.
 };
 
 /// @brief Source layers in descending priority order — iterate for best-source.
-inline constexpr std::array<SourceLayer, 1> source_layers_by_priority{SourceLayer::Cube};
+inline constexpr std::array<SourceLayer, 1> source_layers_by_priority{SourceLayer::Survey};
 
 /// @brief Number of source layers present in this phase.
 inline constexpr std::size_t source_layer_count = source_layers_by_priority.size();

--- a/marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/mbes_cell.hpp
+++ b/marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/mbes_cell.hpp
@@ -34,59 +34,59 @@ namespace marine_mbes_backscatter_store
 ///
 /// As in the bathy store, a cell's source layer is implied by which layer holds
 /// it (the store keeps one tile map per layer), so it is not stored in the
-/// per-cell record. There is **no Chart layer** here: a contour / S57 prior is a
-/// bathymetric concept; MBES backscatter has no chart prior (ADR-0007 D7). The
-/// two layers are `Processed` (the durable, quality-arbitrated re-run) and
-/// `Draft` (the live, newest-valid-wins survey view).
-///
-/// The numeric value is the priority rank (0 = highest): best-source prefers
-/// `Processed` and falls through to `Draft`.
+/// per-cell record. The pre-#248 `draft`/`processed` two-layer overlay collapsed
+/// to a **single `cube` layer** (ADR-0007 #248 amendment A.2): with one platform
+/// and one coverage, the live-vs-durable split added no query value.
 enum class SourceLayer : uint8_t
 {
-  Processed = 0,  ///< Durable deferred-settled re-run product (ADR-0007 D7). Highest.
-  Draft = 1,      ///< Live CUBE node-output, newest-valid-wins (ADR-0007 D7).
+  Cube = 0,  ///< The CUBE node-output product (live or off-boat re-run). The only layer.
 };
 
 /// @brief Source layers in descending priority order — iterate for best-source.
-inline constexpr std::array<SourceLayer, 2> source_layers_by_priority{
-  SourceLayer::Processed, SourceLayer::Draft};
+inline constexpr std::array<SourceLayer, 1> source_layers_by_priority{SourceLayer::Cube};
 
 /// @brief Number of source layers present in this phase.
 inline constexpr std::size_t source_layer_count = source_layers_by_priority.size();
 
-/// @brief Per-cell MBES backscatter record (ADR-0007 D4/D6).
+/// @brief Per-cell MBES backscatter record (ADR-0007 D6, #248 amendment A.1).
 ///
-/// `intensity` and `intensity_variance` are `float` (a 2-band `Float32` value
-/// tile): the M3 is AGC/relative, so single-precision is ample, and the variance
-/// **is** the quality/uncertainty signal (ADR-0007 D6 — there is no separate
-/// integer quality band as in the sidescan store). `intensity_variance` is the
-/// Welford estimate variance (D4), shrinking with sample count, mirroring the
-/// bathy store's depth uncertainty. The `timestamp` is `int64_t` nanoseconds
-/// since the Unix epoch (ROS-native, exact), persisted as a separate 1-band
-/// `Int64` tile. The `source_index` is a small interning handle into the
-/// store-wide `registry.json` (ADR-0005 D2/D8); 0 = no-data/unset. The on-disk
-/// layout is three tiles per grid — value (`<grid>.tif`), time
-/// (`<grid>_time.tif`), and source (`<grid>_source.tif`); see `MbesTile` and
-/// `tile_io`.
+/// A 3-band `Float32` value tile encoding the **Welford sufficient statistics**
+/// so the estimate reconstructs losslessly on reload (rather than collapsing to a
+/// mean+variance pair):
+///
+/// - `mean` — Welford running mean of corrected backscatter. NaN = no data.
+/// - `standard_error` — **confidence-scaled** standard error of the mean (D4
+///   estimate uncertainty), `scale · sample_sd / √n`. The scale mirrors the bathy
+///   store's confidence-scaled uncertainty convention; the consumer divides it
+///   out on reload before interpreting it as a true standard error.
+/// - `sample_sd` — sample standard deviation of the contributing beams,
+///   `√(M2 / (n−1))` — the D4 within-node dispersion / texture signal.
+///
+/// The store round-trips all three floats bit-exactly and does **no** scaling.
+/// From them (dividing the confidence scale out of `standard_error` to recover
+/// the true `SE = sample_sd / √n`), a downstream re-run recovers the full Welford
+/// state: `n = (sample_sd / SE)²` and `M2 = sample_sd² · (n − 1)`.
+///
+/// **`n = 1` sentinel:** a single-beam node has no dispersion — `sample_sd == 0`
+/// with a **finite** `mean` encodes `n = 1, M2 = 0`, distinct from **no-data**
+/// (`mean = NaN`). `hasData()` keys on `mean`, so a one-sample cell is real data.
+///
+/// The pre-#248 per-cell `timestamp` (`_time.tif`) and `source_index`
+/// (`_source.tif`) companions were dropped (#248 amendment A.3); each grid is a
+/// single 3-band value tile. See `MbesTile` and `tile_io`.
 struct MbesCell
 {
-  /// Corrected backscatter intensity (relative, dB-domain). NaN = no data.
-  float intensity = std::numeric_limits<float>::quiet_NaN();
-  /// Welford estimate variance of the intensity. NaN = unknown.
-  float intensity_variance = std::numeric_limits<float>::quiet_NaN();
-  /// Acquisition / import time, nanoseconds since the Unix epoch. 0 = unset.
-  int64_t timestamp = 0;
-  /// Local source index into the store-wide registry. 0 = no-data/unset.
-  uint16_t source_index = 0;
+  /// Welford running mean of corrected backscatter (relative). NaN = no data.
+  float mean = std::numeric_limits<float>::quiet_NaN();
+  /// Confidence-scaled standard error of the mean (D4 estimate uncertainty).
+  float standard_error = std::numeric_limits<float>::quiet_NaN();
+  /// Sample standard deviation of contributing beams (within-node dispersion).
+  float sample_sd = std::numeric_limits<float>::quiet_NaN();
 
-  /// @brief True if this cell carries a usable intensity (intensity is not NaN).
-  ///
-  /// Data presence is **intensity-only**: `source_index` is provenance, not a
-  /// data-presence signal, so a cell with a registered source but NaN intensity
-  /// is still no-data.
+  /// @brief True if this cell carries a usable mean (mean is not NaN).
   bool hasData() const noexcept
   {
-    return !std::isnan(intensity);
+    return !std::isnan(mean);
   }
 };
 

--- a/marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/mbes_store.hpp
+++ b/marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/mbes_store.hpp
@@ -47,12 +47,12 @@ std::size_t load(
 
 /// @brief In-memory, GGGS-tiled, single-layer MBES backscatter store (ADR-0007).
 ///
-/// Holds one tile map for the sole `SourceLayer::Cube`, keyed by
+/// Holds one tile map for the sole `SourceLayer::Survey`, keyed by
 /// `gggs::GridIndex`. All tiles live at a single GGGS level fixed at
 /// construction. The pre-#248 `draft`/`processed` two-layer overlay collapsed to
-/// this single `cube` layer (ADR-0007 #248 amendment A.2).
+/// this single `survey` layer (ADR-0007 #248 amendment A.2).
 ///
-/// **Recency policy (ADR-0007 D7):** `set(Cube, …)` is *newest-valid-wins* — it
+/// **Recency policy (ADR-0007 D7):** `set(Survey, …)` is *newest-valid-wins* — it
 /// overwrites the existing cell unconditionally. Callers supply angle-corrected
 /// node-output values (ADR-0007 D2/D3); the store does **no** accumulation. The
 /// Welford sufficient statistics `{mean, standard_error, sample_sd}` ride the

--- a/marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/mbes_store.hpp
+++ b/marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/mbes_store.hpp
@@ -36,33 +36,31 @@ namespace marine_mbes_backscatter_store
 {
 
 class MbesBackscatterStore;
-class SourceRegistry;
+struct StoreMetadata;
 // Persistence free functions (defined in tile_io.cpp). Forward-declared here so
-// the store can friend them: `load` must populate any layer from disk, which the
+// the store can friend them: `load` must populate the layer from disk, which the
 // public API otherwise routes only through set().
 std::size_t save(
-  MbesBackscatterStore & store, const std::string & dir, const SourceRegistry * registry);
+  MbesBackscatterStore & store, const std::string & dir, const StoreMetadata * metadata);
 std::size_t load(
-  MbesBackscatterStore & store, const std::string & dir, SourceRegistry * registry);
+  MbesBackscatterStore & store, const std::string & dir, StoreMetadata * metadata);
 
-/// @brief In-memory, GGGS-tiled, two-layer MBES backscatter store (ADR-0007 phase 3).
+/// @brief In-memory, GGGS-tiled, single-layer MBES backscatter store (ADR-0007).
 ///
-/// Holds one tile map per `SourceLayer` (`Draft`, `Processed`), keyed by
+/// Holds one tile map for the sole `SourceLayer::Cube`, keyed by
 /// `gggs::GridIndex`. All tiles live at a single GGGS level fixed at
-/// construction. Source priority is a **non-destructive query-time overlay**
-/// (see `query.hpp`): the layers are independent, so a live draft write never
-/// clobbers a durable processed cell and a later processed build never has to
-/// merge with draft (ADR-0007 D7, mirroring ADR-0002 §D3).
+/// construction. The pre-#248 `draft`/`processed` two-layer overlay collapsed to
+/// this single `cube` layer (ADR-0007 #248 amendment A.2).
 ///
-/// **Draft recency policy (ADR-0007 D7):** `set(Draft, …)` is *newest-valid-wins*
-/// — it overwrites the existing cell unconditionally. Callers supply
-/// angle-corrected node-output values (ADR-0007 D2/D3); the store does **no**
-/// accumulation. Welford accumulation lives upstream in the CUBE node-output
-/// pass (cube#54), not here.
+/// **Recency policy (ADR-0007 D7):** `set(Cube, …)` is *newest-valid-wins* — it
+/// overwrites the existing cell unconditionally. Callers supply angle-corrected
+/// node-output values (ADR-0007 D2/D3); the store does **no** accumulation. The
+/// Welford sufficient statistics `{mean, standard_error, sample_sd}` ride the
+/// per-cell record so a downstream re-run can continue the accumulation.
 ///
 /// This phase has no importers, ROS interface, or distribution — just storage,
 /// in-process queries (`query.hpp`), per-tile GeoTIFF persistence
-/// (`tile_io.hpp`), and the source registry (`registry.hpp`).
+/// (`tile_io.hpp`), and the coarse store metadata (`registry.hpp`).
 class MbesBackscatterStore
 {
 public:
@@ -93,8 +91,8 @@ public:
   /// @brief Write @p value into @p layer at @p cell (newest-valid-wins overwrite).
   ///
   /// Creates the backing tile on first write to its grid. The cell's grid must
-  /// be at this store's level. On `Draft`, an existing cell is overwritten
-  /// unconditionally (ADR-0007 D7 recency policy) — there is no accumulation.
+  /// be at this store's level. An existing cell is overwritten unconditionally
+  /// (ADR-0007 D7 recency policy) — there is no accumulation.
   /// @throws std::invalid_argument if @p cell is invalid or at the wrong level.
   void set(SourceLayer layer, const gggs::CellIndex & cell, const MbesCell & value);
 
@@ -110,12 +108,12 @@ public:
   }
 
 private:
-  // Persistence needs to populate any layer from disk, so the free functions in
+  // Persistence needs to populate the layer from disk, so the free functions in
   // tile_io.cpp are friends.
   friend std::size_t save(
-    MbesBackscatterStore & store, const std::string & dir, const SourceRegistry * registry);
+    MbesBackscatterStore & store, const std::string & dir, const StoreMetadata * metadata);
   friend std::size_t load(
-    MbesBackscatterStore & store, const std::string & dir, SourceRegistry * registry);
+    MbesBackscatterStore & store, const std::string & dir, StoreMetadata * metadata);
 
   /// @brief Find or create the tile for @p grid in @p layer.
   ///

--- a/marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/mbes_tile.hpp
+++ b/marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/mbes_tile.hpp
@@ -37,61 +37,45 @@ namespace marine_mbes_backscatter_store
 
 /// @brief One GGGS grid (960×960 cells) of MBES backscatter for a single layer.
 ///
-/// An MBES-semantic wrapper over **three** `marine_tiled_raster_store::
-/// TiledRasterTile<>` rasters, one per on-disk tile file (ADR-0007 D6):
+/// An MBES-semantic wrapper over a single `marine_tiled_raster_store::
+/// TiledRasterTile<float>` value raster — a **3-band `Float32`** tile
+/// `{mean, standard_error, sample_sd}` (ADR-0007 D6, #248 amendment A.1). The
+/// pre-#248 `_time` (int64 ns) and `_source` (uint16) companion rasters were
+/// dropped (#248 amendment A.3).
 ///
-/// - **value** (`TiledRasterTile<float>`, 2 bands): intensity +
-///   intensity_variance — both float, read together, so co-located in one tile.
-/// - **time** (`TiledRasterTile<int64_t>`, 1 band): timestamp ns — different
-///   dtype, ROS-native and exact, so its own tile.
-/// - **source** (`TiledRasterTile<uint16_t>`, 1 band): registry source index —
-///   different dtype, multi-platform provenance (ADR-0005 D2/D8).
-///
-/// Each generic tile owns its storage and GGGS-cell-order layout (row 0 = south);
+/// The generic tile owns its storage and GGGS-cell-order layout (row 0 = south);
 /// this wrapper adds the per-cell `MbesCell` record and the named raster
-/// accessors the store and persistence rely on. The **value raster's dirty flag
-/// is authoritative** for the whole tile: `set()` marks it; `clearDirty()` /
-/// `markDirty()` operate through it; persistence writes/clears all three rasters
-/// together. Tiles are allocated lazily by the owning `MbesBackscatterStore`.
+/// accessors the store and persistence rely on. The value raster's dirty flag is
+/// authoritative for the whole tile. Tiles are allocated lazily by the owning
+/// `MbesBackscatterStore`.
 class MbesTile
 {
 public:
-  /// @brief The underlying generic raster tile type for intensity + variance.
+  /// @brief The underlying generic raster tile type for the 3-band value tile.
   using Raster = marine_tiled_raster_store::TiledRasterTile<float>;
-  /// @brief The underlying raster type for the timestamp tile (int64 ns).
-  using TimeRaster = marine_tiled_raster_store::TiledRasterTile<int64_t>;
-  /// @brief The underlying raster type for the source-index tile (uint16).
-  using SourceRaster = marine_tiled_raster_store::TiledRasterTile<uint16_t>;
 
   /// @brief Number of cells along each grid edge (GGGS constant).
   static constexpr uint16_t edge = Raster::edge;
   /// @brief Total cells in a tile (edge × edge).
   static constexpr uint32_t cell_count = Raster::cell_count;
 
-  /// @brief Number of bands in each on-disk tile file.
-  /// @{
-  static constexpr std::size_t value_band_count = 2;   ///< intensity + variance
-  static constexpr std::size_t time_band_count = 1;    ///< timestamp ns
-  static constexpr std::size_t source_band_count = 1;  ///< source index
-  /// @}
+  /// @brief Number of bands in the on-disk value tile (mean, SE, sample_sd).
+  static constexpr std::size_t value_band_count = 3;
 
-  /// @brief Construct an empty tile for @p index (intensity/variance no-data, ts
-  ///        and source 0 = unset).
+  /// @brief Construct an empty tile for @p index (all three bands no-data).
   explicit MbesTile(gggs::GridIndex index)
   : value_(index, std::vector<float>{
-      std::numeric_limits<float>::quiet_NaN(),    // intensity
-      std::numeric_limits<float>::quiet_NaN()}),  // intensity_variance
-    time_(index, time_band_count, int64_t{0}),     // timestamp (0 = unset)
-    source_(index, source_band_count, uint16_t{0})  // source index (0 = unset)
+      std::numeric_limits<float>::quiet_NaN(),    // mean
+      std::numeric_limits<float>::quiet_NaN(),    // standard_error
+      std::numeric_limits<float>::quiet_NaN()})   // sample_sd
   {
   }
 
-  /// @brief Wrap rasters loaded from disk (persistence path).
+  /// @brief Wrap a value raster loaded from disk (persistence path).
   ///
-  /// The three rasters must cover the same grid; the value raster's grid is
-  /// authoritative for `index()`. The constructed tile is clean.
-  MbesTile(Raster value, TimeRaster time, SourceRaster source)
-  : value_(std::move(value)), time_(std::move(time)), source_(std::move(source)) {}
+  /// The constructed tile is clean.
+  explicit MbesTile(Raster value)
+  : value_(std::move(value)) {}
 
   /// @brief The grid this tile covers.
   const gggs::GridIndex & index() const noexcept {return value_.index();}
@@ -100,11 +84,10 @@ public:
   void set(uint16_t row, uint16_t col, const MbesCell & cell)
   {
     const uint32_t i = offset(row, col);
-    value_.band(kIntensity)[i] = cell.intensity;
-    value_.band(kVariance)[i] = cell.intensity_variance;
-    time_.band(0)[i] = cell.timestamp;
-    source_.band(0)[i] = cell.source_index;
-    value_.markDirty();   // value raster's dirty flag is authoritative
+    value_.band(kMean)[i] = cell.mean;
+    value_.band(kStandardError)[i] = cell.standard_error;
+    value_.band(kSampleSd)[i] = cell.sample_sd;
+    value_.markDirty();
   }
 
   /// @brief Read the cell at (@p row, @p col) within the grid.
@@ -112,37 +95,34 @@ public:
   {
     const uint32_t i = offset(row, col);
     return MbesCell{
-      value_.band(kIntensity)[i], value_.band(kVariance)[i],
-      time_.band(0)[i], source_.band(0)[i]};
+      value_.band(kMean)[i], value_.band(kStandardError)[i], value_.band(kSampleSd)[i]};
   }
 
-  /// @brief Whether this tile has unsaved changes (value raster is authoritative).
+  /// @brief Whether this tile has unsaved changes.
   bool dirty() const noexcept {return value_.dirty();}
   /// @brief Mark all changes saved (called by persistence after a successful write).
   void clearDirty() noexcept {value_.clearDirty();}
   /// @brief Force the dirty flag (used when reconstructing a tile in memory).
   void markDirty() noexcept {value_.markDirty();}
 
-  /// @brief The underlying generic raster tiles (for persistence delegation).
+  /// @brief The underlying generic raster tile (for persistence delegation).
   /// @{
   Raster & valueRaster() noexcept {return value_;}
   const Raster & valueRaster() const noexcept {return value_;}
-  TimeRaster & timeRaster() noexcept {return time_;}
-  const TimeRaster & timeRaster() const noexcept {return time_;}
-  SourceRaster & sourceRaster() noexcept {return source_;}
-  const SourceRaster & sourceRaster() const noexcept {return source_;}
   /// @}
 
   /// @brief Row-major offset of cell (@p row, @p col). Asserts in debug builds.
   static uint32_t offset(uint16_t row, uint16_t col) {return Raster::offset(row, col);}
 
-private:
-  static constexpr std::size_t kIntensity = 0;
-  static constexpr std::size_t kVariance = 1;
+  /// @brief Value-tile band indices.
+  /// @{
+  static constexpr std::size_t kMean = 0;
+  static constexpr std::size_t kStandardError = 1;
+  static constexpr std::size_t kSampleSd = 2;
+  /// @}
 
+private:
   Raster value_;
-  TimeRaster time_;
-  SourceRaster source_;
 };
 
 }  // namespace marine_mbes_backscatter_store

--- a/marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/query.hpp
+++ b/marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/query.hpp
@@ -36,25 +36,25 @@ namespace marine_mbes_backscatter_store
 
 /// @brief A backscatter value resolved from the store, tagged with its layer.
 ///
-/// `intensity` is corrected, relative MBES backscatter (ADR-0007 D2/D3);
-/// `intensity_variance` is the Welford estimate variance (D4) — the
-/// quality/uncertainty signal, shrinking with sample count. This is a
-/// perception / cartographic product, **not** a navigation or costmap input
-/// (ADR-0007 Consequences, safety non-goal).
-struct IntensitySample
+/// `mean` is corrected, relative MBES backscatter (ADR-0007 D2/D3);
+/// `standard_error` is the confidence-scaled Welford estimate uncertainty (D4),
+/// and `sample_sd` the within-node dispersion — the Welford sufficient statistics
+/// (#248 amendment A.1). This is a perception / cartographic product, **not** a
+/// navigation or costmap input (ADR-0007 Consequences, safety non-goal).
+struct BackscatterSample
 {
-  float intensity;            ///< Corrected relative backscatter.
-  float intensity_variance;   ///< Welford estimate variance (quality).
-  int64_t timestamp;          ///< Acquisition / import time (ns since the Unix epoch).
-  SourceLayer source;         ///< Which layer this value came from.
+  float mean;             ///< Corrected relative backscatter (Welford mean).
+  float standard_error;   ///< Confidence-scaled standard error of the mean.
+  float sample_sd;        ///< Sample standard deviation (within-node dispersion).
+  SourceLayer source;     ///< Which layer this value came from.
 };
 
-/// @brief Highest-priority layer that has data at @p cell.
+/// @brief The layer that has data at @p cell.
 ///
-/// Walks layers in `source_layers_by_priority` order (`Processed` then `Draft`)
-/// and returns the first with usable data (`hasData()`). `std::nullopt` means no
+/// Walks `source_layers_by_priority` (the sole `Cube` layer since #248) and
+/// returns the first with usable data (`hasData()`). `std::nullopt` means no
 /// layer has backscatter here.
-std::optional<IntensitySample> bestSource(
+std::optional<BackscatterSample> bestSource(
   const MbesBackscatterStore & store, const gggs::CellIndex & cell);
 
 /// @brief Visit every GGGS cell overlapping the geographic box, with its best source.
@@ -68,7 +68,7 @@ void forEachCellBestSource(
   const geographic_msgs::msg::GeoPoint & minimum,
   const geographic_msgs::msg::GeoPoint & maximum,
   const std::function<void(const gggs::CellIndex &,
-  const std::optional<IntensitySample> &)> & visitor);
+  const std::optional<BackscatterSample> &)> & visitor);
 
 }  // namespace marine_mbes_backscatter_store
 

--- a/marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/query.hpp
+++ b/marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/query.hpp
@@ -51,7 +51,7 @@ struct BackscatterSample
 
 /// @brief The layer that has data at @p cell.
 ///
-/// Walks `source_layers_by_priority` (the sole `Cube` layer since #248) and
+/// Walks `source_layers_by_priority` (the sole `Survey` layer since #248) and
 /// returns the first with usable data (`hasData()`). `std::nullopt` means no
 /// layer has backscatter here.
 std::optional<BackscatterSample> bestSource(

--- a/marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/registry.hpp
+++ b/marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/registry.hpp
@@ -22,79 +22,43 @@
 #ifndef MARINE_MBES_BACKSCATTER_STORE__REGISTRY_HPP_
 #define MARINE_MBES_BACKSCATTER_STORE__REGISTRY_HPP_
 
-#include <cstdint>
-#include <map>
-#include <optional>
 #include <string>
-#include <vector>
 
 /// @file
-/// @brief Store-wide source registry: maps each per-cell `source_index` to a
-/// provenance record (ADR-0005 D2/D8). Persisted as `registry.json` at the store
-/// root with an atomic write-then-rename.
+/// @brief Store-level coarse provenance metadata, persisted as `registry.json` at
+/// the store root (ADR-0005 #248 amendment).
 ///
-/// This is the MBES store's **own** registry, mirroring `marine_bathymetry_store`'s
-/// `SourceRegistry`: `marine_backscatter::writeRegistry` is write-only and
-/// single-source (`writeRegistry(path, source_id, platform, sensor, sensor_class,
-/// campaign)`), so it cannot back the multi-record load/intern path the store and
-/// its tests need. The schema matches ADR-0005 D3 with an MBES-specific
-/// `calibration_ref` extension (empty until a beam-pattern calibration exists —
-/// the M3 is AGC/relative, ADR-0007 D6).
+/// This replaces the pre-#248 per-cell `SourceRegistry`/`SourceRecord` interning
+/// table. For the single-platform deployment the winning source is constant across
+/// a store, so per-cell provenance carried no information; instead a single
+/// `StoreMetadata` record — who made this store — is written once at the root. The
+/// multi-platform per-cell interning contract (ADR-0005 D2/D8) is retained in the
+/// ADR and reintroduced when a second platform contributes.
 
 namespace marine_mbes_backscatter_store
 {
 
-/// @brief One source's provenance record.
+/// @brief Coarse, store-level provenance recorded once at the store root.
 ///
-/// `source_id` is the origin-namespaced, never-reused wide id (ADR-0005 D4); the
-/// remaining fields are the ADR-0005 D3 core schema plus the MBES-specific
-/// `calibration_ref` extension. The `source_id` is the **identity** of a record —
-/// `registerSource` is idempotent on it (re-registering the same `source_id`
-/// returns the existing index).
-struct SourceRecord
+/// The ADR-0005 D3 core fields that matter at store granularity, plus a
+/// `survey`/`date` pair and the MBES-specific `calibration_ref` (D6 — empty until
+/// a beam-pattern calibration exists; the M3 is AGC/relative). Persisted as a flat
+/// `registry.json` sidecar (kept for filename stability; its schema is now
+/// `StoreMetadata`, not the interning table). All fields are optional.
+struct StoreMetadata
 {
-  std::string source_id;        ///< Origin-namespaced wide id (ADR-0005 D4).
   std::string platform;         ///< Contributing platform (e.g. "bizzyboat").
   std::string sensor;           ///< Contributing sensor (e.g. "kongsberg-m3").
-  std::string sensor_class;     ///< Sensor class (e.g. "mbes-backscatter").
-  std::string campaign;         ///< Acquisition campaign / deployment.
+  std::string survey;           ///< Survey / campaign id (e.g. "massabesic-2026").
+  std::string date;             ///< Acquisition date (ISO-8601, e.g. "2026-06-30").
   std::string calibration_ref;  ///< MBES extension: beam-pattern calibration ref.
-};
 
-/// @brief Interns `SourceRecord`s to small local indices and persists them.
-///
-/// Index 0 is reserved as the **no-data/unset sentinel** (ADR-0005 D4) and is
-/// never assigned to a real record; the first registered source gets index 1.
-/// Indices are assigned densely in registration order and are stable for the
-/// life of the store directory (they are the values written into the per-cell
-/// source-index tiles, so reassigning them would corrupt existing tiles).
-class SourceRegistry
-{
-public:
-  /// @brief The reserved no-data/unset source index.
-  static constexpr uint16_t kUnset = 0;
-
-  /// @brief Intern @p record, returning its local index; idempotent on `source_id`.
-  ///
-  /// If a record with the same `source_id` is already registered, its existing
-  /// index is returned (the rest of @p record is ignored). Otherwise a new index
-  /// (the next unused value, starting at 1) is assigned and returned.
-  ///
-  /// @note A registered source is held only in memory until persisted: call the
-  ///   store `save()` (which invokes `saveRegistry()`), or `saveRegistry()`
-  ///   directly, to write it.
-  /// @throws std::overflow_error if all 65535 real indices are exhausted.
-  uint16_t registerSource(const SourceRecord & record);
-
-  /// @brief Look up the record for @p index, or `std::nullopt` if unregistered
-  ///        (including `index == kUnset`).
-  std::optional<SourceRecord> lookup(uint16_t index) const;
-
-  /// @brief Number of registered sources (excludes the reserved index 0).
-  std::size_t size() const noexcept {return by_index_.size();}
-
-  /// @brief Whether any source is registered.
-  bool empty() const noexcept {return by_index_.empty();}
+  /// @brief True if every field is empty (nothing worth persisting).
+  bool empty() const noexcept
+  {
+    return platform.empty() && sensor.empty() && survey.empty() && date.empty() &&
+           calibration_ref.empty();
+  }
 
   /// @brief Write `registry.json` under @p store_root_dir atomically.
   ///
@@ -102,18 +66,12 @@ public:
   /// `registry.json`, so a crash mid-write never leaves a partial file. Creates
   /// @p store_root_dir if needed.
   /// @throws std::runtime_error / std::filesystem::filesystem_error on failure.
-  void saveRegistry(const std::string & store_root_dir) const;
+  void save(const std::string & store_root_dir) const;
 
   /// @brief Load `registry.json` from @p store_root_dir, replacing current
-  ///        contents. No-op (leaves the registry empty) if the file is absent.
+  ///        contents. No-op (leaves the metadata empty) if the file is absent.
   /// @throws std::runtime_error on a malformed registry file.
-  void loadRegistry(const std::string & store_root_dir);
-
-private:
-  /// index (1-based) -> record. by_index_[i] is the record for index i+1.
-  std::vector<SourceRecord> by_index_;
-  /// source_id -> local index, for idempotent registration / lookup.
-  std::map<std::string, uint16_t> by_source_id_;
+  void load(const std::string & store_root_dir);
 };
 
 }  // namespace marine_mbes_backscatter_store

--- a/marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/tile_io.hpp
+++ b/marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/tile_io.hpp
@@ -32,25 +32,19 @@
 #include "marine_mbes_backscatter_store/registry.hpp"
 
 /// @file
-/// @brief Per-tile GeoTIFF persistence (ADR-0007 D6).
+/// @brief Per-tile GeoTIFF persistence (ADR-0007 D6, #248 amendment A.1/A.3).
 ///
-/// Each GGGS tile is persisted as **three** GeoTIFFs, all WGS84-georeferenced
-/// from the same grid corners and written north-up (raster row 0 = north), so
-/// persistence flips rows relative to the in-memory GGGS cell order
-/// (row 0 = south):
+/// Each GGGS tile is persisted as **one** GeoTIFF, WGS84-georeferenced from its
+/// grid corners and written north-up (raster row 0 = north), so persistence flips
+/// rows relative to the in-memory GGGS cell order (row 0 = south):
 ///
-/// - `<level>_<row>_<col>.tif` — 2-band `Float32` value tile (intensity,
-///   intensity_variance), NaN no-data on both.
-/// - `<level>_<row>_<col>_time.tif` — 1-band `Int64` timestamp tile
-///   (nanoseconds since epoch, ROS-native and exact; 0 = unset, no no-data tag).
-/// - `<level>_<row>_<col>_source.tif` — 1-band `UInt16` source-index tile
-///   (registry index, ADR-0005 D2/D8; 0 = no-data/unset).
+/// - `<level>_<row>_<col>.tif` — 3-band `Float32` value tile
+///   (mean, standard_error, sample_sd), NaN no-data on all three.
 ///
-/// The maturity axis (`Processed` / `Draft`) is encoded as the on-disk
-/// subdirectory (`processed/`, `draft/`); the platform/sensor provenance axis is
-/// the per-cell source index + the store-wide `registry.json` (ADR-0005 D8). On
-/// load, a missing `_time.tif` / `_source.tif` companion fills its band with 0
-/// (degraded-mode recovery after a partial write).
+/// The pre-#248 `_time.tif` (Int64 ns) and `_source.tif` (UInt16 source index)
+/// companions were dropped (#248 amendment A.3). The sole layer (`Cube`) is
+/// encoded as the on-disk subdirectory (`cube/`); coarse provenance lives in the
+/// store-wide `registry.json` `StoreMetadata` (ADR-0005 #248).
 ///
 /// @note Round-trip persistence is validated for **non-polar** latitudes
 /// (|lat| < 72°), the intended lake/coastal survey envelope; polar tiles are out
@@ -63,57 +57,47 @@ namespace marine_mbes_backscatter_store
 ///        `<level>_<row>_<col>.tif`.
 std::string tileFilename(const gggs::GridIndex & grid);
 
-/// @brief Subdirectory name for a source layer (`"processed"` / `"draft"`).
+/// @brief Subdirectory name for a source layer (`"cube"`).
 std::string layerDirName(SourceLayer layer);
 
-/// @brief Write one tile as three GeoTIFFs derived from the value-tile @p path.
-///
-/// @p path is the value tile (`<grid>.tif`); the `_time.tif` and `_source.tif`
-/// companions are written alongside it (same directory, suffixed stem). The
-/// value tile is written first (it is the load-bearing file).
+/// @brief Write one tile as a single 3-band value GeoTIFF at @p path (`<grid>.tif`).
 /// @throws std::runtime_error on any GDAL failure.
 void saveTile(const MbesTile & tile, const std::string & path);
 
-/// @brief Load a tile from its three GeoTIFFs, reconstructing its GridIndex at
+/// @brief Load a tile from its value GeoTIFF, reconstructing its GridIndex at
 ///        @p level.
 ///
-/// @p path is the value tile (`<grid>.tif`); the `_time.tif` and `_source.tif`
-/// companions are read from the derived paths. A **missing** companion fills the
-/// corresponding band with 0 (degraded-mode recovery). The grid is recovered
-/// from the value file's geotransform, so a file written at a different level is
-/// rejected, as is a companion whose GridIndex does not match the value tile. The
+/// @p path is the value tile (`<grid>.tif`). The grid is recovered from the value
+/// file's geotransform, so a file written at a different level is rejected. The
 /// returned tile is clean (not dirty).
-/// @throws std::runtime_error on GDAL failure, wrong dimensions/level, or a
-///         companion grid mismatch.
+/// @throws std::runtime_error on GDAL failure, or wrong dimensions/level.
 MbesTile loadTile(const std::string & path, const gggs::Level & level);
 
 /// @brief Persist every **dirty** tile of @p store under @p dir, then clear
 ///        their dirty flags. Also writes the store-wide `registry.json`.
 ///
-/// Layout: `<dir>/<layer>/<level>_<row>_<col>{,_time,_source}.tif`, plus
-/// `<dir>/registry.json`. Creates directories as needed. Clean tiles are skipped
-/// (incremental save). The registry (a store-wide sidecar, not per-layer) is
-/// written once at the end via @p registry; pass `nullptr` to skip it.
+/// Layout: `<dir>/<layer>/<level>_<row>_<col>.tif`, plus `<dir>/registry.json`.
+/// Creates directories as needed. Clean tiles are skipped (incremental save). The
+/// coarse `StoreMetadata` (a store-wide sidecar, not per-layer) is written once at
+/// the end via @p metadata; pass `nullptr` to skip it.
 /// @return The number of tiles written.
 /// @throws std::runtime_error on any GDAL failure; std::filesystem::filesystem_error
 ///         on a directory-creation failure.
 std::size_t save(
   MbesBackscatterStore & store, const std::string & dir,
-  const SourceRegistry * registry = nullptr);
+  const StoreMetadata * metadata = nullptr);
 
-/// @brief Load every tile found under @p dir into @p store, plus the registry.
+/// @brief Load every tile found under @p dir into @p store, plus the metadata.
 ///
-/// Scans `<dir>/<layer>/` for value tiles (`<grid>.tif`), **skipping** the
-/// `_time.tif` / `_source.tif` companions (they are loaded with their value
-/// tile). @p store must already be at the level the tiles were written at
-/// (loadTile enforces per-file). If @p registry is non-null, `registry.json` is
-/// loaded into it. Loaded tiles are clean.
+/// Scans `<dir>/<layer>/` for value tiles (`<grid>.tif`). @p store must already be
+/// at the level the tiles were written at (loadTile enforces per-file). If @p
+/// metadata is non-null, `registry.json` is loaded into it. Loaded tiles are clean.
 /// @return The number of tiles loaded.
 /// @throws std::runtime_error on any GDAL failure or level mismatch;
 ///         std::filesystem::filesystem_error on a directory-iteration failure.
 std::size_t load(
   MbesBackscatterStore & store, const std::string & dir,
-  SourceRegistry * registry = nullptr);
+  StoreMetadata * metadata = nullptr);
 
 }  // namespace marine_mbes_backscatter_store
 

--- a/marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/tile_io.hpp
+++ b/marine_mbes_backscatter_store/include/marine_mbes_backscatter_store/tile_io.hpp
@@ -42,8 +42,8 @@
 ///   (mean, standard_error, sample_sd), NaN no-data on all three.
 ///
 /// The pre-#248 `_time.tif` (Int64 ns) and `_source.tif` (UInt16 source index)
-/// companions were dropped (#248 amendment A.3). The sole layer (`Cube`) is
-/// encoded as the on-disk subdirectory (`cube/`); coarse provenance lives in the
+/// companions were dropped (#248 amendment A.3). The sole layer (`Survey`) is
+/// encoded as the on-disk subdirectory (`survey/`); coarse provenance lives in the
 /// store-wide `registry.json` `StoreMetadata` (ADR-0005 #248).
 ///
 /// @note Round-trip persistence is validated for **non-polar** latitudes
@@ -57,7 +57,7 @@ namespace marine_mbes_backscatter_store
 ///        `<level>_<row>_<col>.tif`.
 std::string tileFilename(const gggs::GridIndex & grid);
 
-/// @brief Subdirectory name for a source layer (`"cube"`).
+/// @brief Subdirectory name for a source layer (`"survey"`).
 std::string layerDirName(SourceLayer layer);
 
 /// @brief Write one tile as a single 3-band value GeoTIFF at @p path (`<grid>.tif`).

--- a/marine_mbes_backscatter_store/src/mbes_store.cpp
+++ b/marine_mbes_backscatter_store/src/mbes_store.cpp
@@ -39,9 +39,9 @@ void MbesBackscatterStore::set(
             std::to_string(cell.level()) + " but store is at level " +
             std::to_string(level_.level()));
   }
-  // Draft recency policy (ADR-0007 D7): newest-valid-wins. tile.set overwrites
-  // the cell unconditionally — there is no accumulation in the store; the
-  // caller supplies already-corrected node-output values.
+  // Recency policy (ADR-0007 D7): newest-valid-wins. tile.set overwrites the cell
+  // unconditionally — there is no accumulation in the store; the caller supplies
+  // already-corrected node-output values.
   MbesTile & tile = getOrCreateTile(layer, cell.grid());
   tile.set(cell.row(), cell.column(), value);
 }

--- a/marine_mbes_backscatter_store/src/query.cpp
+++ b/marine_mbes_backscatter_store/src/query.cpp
@@ -28,19 +28,19 @@ namespace
 {
 
 /// Resolve a single layer's sample at a cell, or nullopt if it has no usable data.
-std::optional<IntensitySample> sampleFor(
+std::optional<BackscatterSample> sampleFor(
   const MbesBackscatterStore & store, SourceLayer layer, const gggs::CellIndex & cell)
 {
   const auto c = store.get(layer, cell);
   if (!c || !c->hasData()) {
     return std::nullopt;
   }
-  return IntensitySample{c->intensity, c->intensity_variance, c->timestamp, layer};
+  return BackscatterSample{c->mean, c->standard_error, c->sample_sd, layer};
 }
 
 }  // namespace
 
-std::optional<IntensitySample> bestSource(
+std::optional<BackscatterSample> bestSource(
   const MbesBackscatterStore & store, const gggs::CellIndex & cell)
 {
   for (const SourceLayer layer : source_layers_by_priority) {
@@ -56,7 +56,7 @@ void forEachCellBestSource(
   const geographic_msgs::msg::GeoPoint & minimum,
   const geographic_msgs::msg::GeoPoint & maximum,
   const std::function<void(const gggs::CellIndex &,
-  const std::optional<IntensitySample> &)> & visitor)
+  const std::optional<BackscatterSample> &)> & visitor)
 {
   const gggs::Level & level = store.level();
   gggs::GridAreaIterator grid_it(

--- a/marine_mbes_backscatter_store/src/registry.cpp
+++ b/marine_mbes_backscatter_store/src/registry.cpp
@@ -23,6 +23,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <stdexcept>
 #include <string>
 
@@ -40,6 +41,11 @@ namespace
 constexpr const char * kRegistryFile = "registry.json";
 constexpr const char * kRegistryTmpFile = "registry.json.tmp";
 
+/// Schema version of the coarse `StoreMetadata` sidecar (ADR-0005 / ADR-0007
+/// #248 amendment). Bump when the field set or semantics change; `load` warns on
+/// a mismatch so an older/foreign schema is not silently read as all-empty.
+constexpr int kRegistryVersion = 2;
+
 /// Read a string field, defaulting to empty if absent (forward-compatible load).
 std::string jsonStr(const nlohmann::json & j, const char * key)
 {
@@ -54,7 +60,7 @@ void StoreMetadata::save(const std::string & store_root_dir) const
   fs::create_directories(store_root_dir);
 
   const nlohmann::json doc{
-    {"version", 2},
+    {"version", kRegistryVersion},
     {"platform", platform},
     {"sensor", sensor},
     {"survey", survey},
@@ -105,6 +111,20 @@ void StoreMetadata::load(const std::string & store_root_dir)
   } catch (const nlohmann::json::parse_error & e) {
     throw std::runtime_error(
             "StoreMetadata::load: malformed " + path.string() + ": " + e.what());
+  }
+
+  // Validate the schema version so a pre-#248 (or foreign) registry is not read
+  // as all-empty without a trace. Fields are still read forward-compatibly
+  // (jsonStr defaults absent keys to empty); the warning is the observability.
+  const auto vit = doc.find("version");
+  const int version = (vit != doc.end() && vit->is_number_integer()) ?
+    vit->get<int>() :
+    0;
+  if (version != kRegistryVersion) {
+    std::cerr << "[marine_mbes_backscatter_store] WARNING: registry.json at '"
+              << path.string() << "' has unrecognized schema version " << version
+              << " (expected " << kRegistryVersion << "); coarse store provenance "
+              << "may load empty or incomplete.\n";
   }
 
   platform = jsonStr(doc, "platform");

--- a/marine_mbes_backscatter_store/src/registry.cpp
+++ b/marine_mbes_backscatter_store/src/registry.cpp
@@ -21,20 +21,16 @@
 
 #include "marine_mbes_backscatter_store/registry.hpp"
 
-#include <cstdint>
 #include <filesystem>
 #include <fstream>
-#include <limits>
 #include <stdexcept>
 #include <string>
 
 #include <nlohmann/json.hpp>
 
 /// @file
-/// @brief `SourceRegistry` implementation: in-memory interning plus atomic
-/// `registry.json` persistence (ADR-0005 D2/D8). Mirrors
-/// `marine_bathymetry_store::SourceRegistry`; `marine_backscatter::writeRegistry`
-/// is write-only / single-source and does not cover the load/intern path here.
+/// @brief `StoreMetadata` persistence: a flat, atomic `registry.json` sidecar
+/// recording coarse store-level provenance (ADR-0005 #248 amendment).
 
 namespace marine_mbes_backscatter_store
 {
@@ -44,19 +40,6 @@ namespace
 constexpr const char * kRegistryFile = "registry.json";
 constexpr const char * kRegistryTmpFile = "registry.json.tmp";
 
-nlohmann::json recordToJson(uint16_t index, const SourceRecord & r)
-{
-  return nlohmann::json{
-    {"index", index},
-    {"source_id", r.source_id},
-    {"platform", r.platform},
-    {"sensor", r.sensor},
-    {"sensor_class", r.sensor_class},
-    {"campaign", r.campaign},
-    {"calibration_ref", r.calibration_ref},
-  };
-}
-
 /// Read a string field, defaulting to empty if absent (forward-compatible load).
 std::string jsonStr(const nlohmann::json & j, const char * key)
 {
@@ -65,42 +48,18 @@ std::string jsonStr(const nlohmann::json & j, const char * key)
 }
 }  // namespace
 
-uint16_t SourceRegistry::registerSource(const SourceRecord & record)
-{
-  const auto existing = by_source_id_.find(record.source_id);
-  if (existing != by_source_id_.end()) {
-    return existing->second;
-  }
-  // Indices are 1-based (0 reserved); the next index is size() + 1.
-  if (by_index_.size() >= std::numeric_limits<uint16_t>::max()) {
-    throw std::overflow_error("SourceRegistry: exhausted all 65535 source indices");
-  }
-  const uint16_t index = static_cast<uint16_t>(by_index_.size() + 1);
-  by_index_.push_back(record);
-  by_source_id_.emplace(record.source_id, index);
-  return index;
-}
-
-std::optional<SourceRecord> SourceRegistry::lookup(uint16_t index) const
-{
-  if (index == kUnset || index > by_index_.size()) {
-    return std::nullopt;
-  }
-  return by_index_[static_cast<std::size_t>(index) - 1];
-}
-
-void SourceRegistry::saveRegistry(const std::string & store_root_dir) const
+void StoreMetadata::save(const std::string & store_root_dir) const
 {
   namespace fs = std::filesystem;
   fs::create_directories(store_root_dir);
 
-  nlohmann::json sources = nlohmann::json::array();
-  for (std::size_t i = 0; i < by_index_.size(); ++i) {
-    sources.push_back(recordToJson(static_cast<uint16_t>(i + 1), by_index_[i]));
-  }
   const nlohmann::json doc{
-    {"version", 1},
-    {"sources", std::move(sources)},
+    {"version", 2},
+    {"platform", platform},
+    {"sensor", sensor},
+    {"survey", survey},
+    {"date", date},
+    {"calibration_ref", calibration_ref},
   };
 
   const fs::path tmp = fs::path(store_root_dir) / kRegistryTmpFile;
@@ -108,15 +67,15 @@ void SourceRegistry::saveRegistry(const std::string & store_root_dir) const
   {
     std::ofstream out(tmp, std::ios::binary | std::ios::trunc);
     if (!out) {
-      throw std::runtime_error("SourceRegistry::saveRegistry: could not open " + tmp.string());
+      throw std::runtime_error("StoreMetadata::save: could not open " + tmp.string());
     }
     out << doc.dump(2) << '\n';
     out.flush();
     if (!out) {
-      throw std::runtime_error("SourceRegistry::saveRegistry: write failed for " + tmp.string());
+      throw std::runtime_error("StoreMetadata::save: write failed for " + tmp.string());
     }
   }
-  // Atomic publish: rename over the existing registry. rename() on the same
+  // Atomic publish: rename over the existing file. rename() on the same
   // filesystem is atomic, so a reader sees either the old or the new file whole.
   // On rename failure, remove the tmp file to avoid leaving an orphan.
   try {
@@ -128,68 +87,31 @@ void SourceRegistry::saveRegistry(const std::string & store_root_dir) const
   }
 }
 
-void SourceRegistry::loadRegistry(const std::string & store_root_dir)
+void StoreMetadata::load(const std::string & store_root_dir)
 {
   namespace fs = std::filesystem;
   const fs::path path = fs::path(store_root_dir) / kRegistryFile;
   if (!fs::is_regular_file(path)) {
-    return;   // fresh store: no registry yet
+    return;   // fresh store: no metadata yet
   }
 
   std::ifstream in(path, std::ios::binary);
   if (!in) {
-    throw std::runtime_error("SourceRegistry::loadRegistry: could not open " + path.string());
+    throw std::runtime_error("StoreMetadata::load: could not open " + path.string());
   }
   nlohmann::json doc;
   try {
     in >> doc;
   } catch (const nlohmann::json::parse_error & e) {
     throw std::runtime_error(
-            "SourceRegistry::loadRegistry: malformed " + path.string() + ": " + e.what());
+            "StoreMetadata::load: malformed " + path.string() + ": " + e.what());
   }
 
-  by_index_.clear();
-  by_source_id_.clear();
-  const auto sources = doc.find("sources");
-  if (sources == doc.end() || !sources->is_array()) {
-    return;   // empty / sourceless registry
-  }
-  // Records carry an explicit "index"; validate them against the expected
-  // position (1-based, contiguous, monotonically increasing by +1).  A
-  // reordered, sparse, or duplicate hand-edited registry.json would produce
-  // mismatches between the stored index and the reconstructed maps — silently
-  // delivering wrong provenance.  Reject early with a clear error.
-  for (const auto & entry : *sources) {
-    SourceRecord r{
-      jsonStr(entry, "source_id"), jsonStr(entry, "platform"),
-      jsonStr(entry, "sensor"), jsonStr(entry, "sensor_class"),
-      jsonStr(entry, "campaign"), jsonStr(entry, "calibration_ref")};
-    const uint16_t expected = static_cast<uint16_t>(by_index_.size() + 1);
-    const auto idx_it = entry.find("index");
-    if (idx_it == entry.end() || !idx_it->is_number_unsigned()) {
-      throw std::runtime_error(
-              "SourceRegistry::loadRegistry: entry for source_id=\"" + r.source_id +
-              "\" is missing a valid \"index\" field (expected " +
-              std::to_string(expected) + ")");
-    }
-    const uint16_t stored = idx_it->get<uint16_t>();
-    if (stored != expected) {
-      throw std::runtime_error(
-              "SourceRegistry::loadRegistry: entry for source_id=\"" + r.source_id +
-              "\" has stored index " + std::to_string(stored) +
-              " but expected " + std::to_string(expected) +
-              " (indices must be contiguous from 1; the registry may have been"
-              " reordered, has gaps, or contains duplicate entries)");
-    }
-    if (by_source_id_.count(r.source_id)) {
-      throw std::runtime_error(
-              "SourceRegistry::loadRegistry: duplicate source_id=\"" + r.source_id +
-              "\" at index " + std::to_string(expected) +
-              " (each source_id must appear at most once in registry.json)");
-    }
-    by_index_.push_back(r);
-    by_source_id_.emplace(r.source_id, expected);
-  }
+  platform = jsonStr(doc, "platform");
+  sensor = jsonStr(doc, "sensor");
+  survey = jsonStr(doc, "survey");
+  date = jsonStr(doc, "date");
+  calibration_ref = jsonStr(doc, "calibration_ref");
 }
 
 }  // namespace marine_mbes_backscatter_store

--- a/marine_mbes_backscatter_store/src/tile_io.cpp
+++ b/marine_mbes_backscatter_store/src/tile_io.cpp
@@ -31,61 +31,26 @@
 #include "marine_tiled_raster_store/tile_io.hpp"
 
 /// @file
-/// @brief MBES backscatter persistence (ADR-0007 D6): the multi-layer,
+/// @brief MBES backscatter persistence (ADR-0007 D6, #248 amendment A.1/A.3): the
 /// SourceLayer-subdirectory save/load, delegating each tile's GeoTIFF read/write
 /// to the generic `marine_tiled_raster_store::saveTile` / `loadTile`. Each GGGS
-/// tile persists as three files: a 2-band `Float32` value tile (intensity,
-/// intensity_variance; NaN no-data on both), a 1-band `Int64` time tile
-/// (`_time.tif`, timestamp ns; no no-data tag), and a 1-band `UInt16` source tile
-/// (`_source.tif`, registry index; 0 no-data). A store-wide `registry.json`
-/// sidecar maps source indices to provenance (ADR-0005 D2/D8).
+/// tile persists as a single 3-band `Float32` value tile
+/// (mean, standard_error, sample_sd; NaN no-data on all three) — the pre-#248
+/// `_time` / `_source` companions were dropped. A store-wide `registry.json`
+/// sidecar holds coarse `StoreMetadata` (ADR-0005 #248).
 
 namespace marine_mbes_backscatter_store
 {
 
 namespace
 {
-constexpr const char * kTimeSuffix = "_time";
-constexpr const char * kSourceSuffix = "_source";
-
-/// Per-band no-data for the 2-band Float32 value tile: NaN on both intensity and
-/// variance. One entry per band, in band order.
+/// Per-band no-data for the 3-band Float32 value tile: NaN on all three bands.
+/// One entry per band, in band order.
 const std::vector<std::optional<float>> & valueBandNoData()
 {
   static const float nan = std::numeric_limits<float>::quiet_NaN();
-  static const std::vector<std::optional<float>> nodata{nan, nan};
+  static const std::vector<std::optional<float>> nodata{nan, nan, nan};
   return nodata;
-}
-
-/// No-data for the 1-band Int64 time tile: none (0 = unset, never tagged).
-const std::vector<std::optional<int64_t>> & timeBandNoData()
-{
-  static const std::vector<std::optional<int64_t>> nodata{std::nullopt};
-  return nodata;
-}
-
-/// No-data for the 1-band UInt16 source tile: 0 = no-data/unset.
-const std::vector<std::optional<uint16_t>> & sourceBandNoData()
-{
-  static const std::vector<std::optional<uint16_t>> nodata{std::optional<uint16_t>(0)};
-  return nodata;
-}
-
-/// Derive a companion path (`_time` / `_source`) from a value-tile path: insert
-/// @p suffix before the `.tif` extension. e.g. `5_1_2.tif` -> `5_1_2_time.tif`.
-std::string companionPath(const std::string & value_path, const char * suffix)
-{
-  namespace fs = std::filesystem;
-  const fs::path p(value_path);
-  return (p.parent_path() / (p.stem().string() + suffix + p.extension().string())).string();
-}
-
-/// True if @p stem ends with @p suffix (companion-tile detection on directory scan).
-bool stemEndsWith(const std::string & stem, const char * suffix)
-{
-  const std::string s(suffix);
-  return stem.size() >= s.size() &&
-         stem.compare(stem.size() - s.size(), s.size(), s) == 0;
 }
 }  // namespace
 
@@ -99,8 +64,7 @@ std::string tileFilename(const gggs::GridIndex & grid)
 std::string layerDirName(SourceLayer layer)
 {
   switch (layer) {
-    case SourceLayer::Processed: return "processed";
-    case SourceLayer::Draft: return "draft";
+    case SourceLayer::Cube: return "cube";
   }
   throw std::runtime_error("layerDirName: unknown SourceLayer");
 }
@@ -108,66 +72,21 @@ std::string layerDirName(SourceLayer layer)
 void saveTile(const MbesTile & tile, const std::string & path)
 {
   namespace mtrs = marine_tiled_raster_store;
-  // Write ordering: value tile first, then time, then source.  The three files
-  // are not written atomically — a crash mid-sequence leaves a partial set on
-  // disk.  Writing the value tile first is intentional: it is the load-bearing
-  // file (intensity + variance), and load() 0-fills a missing _time / _source
-  // companion, so a crashed write degrades gracefully rather than losing the
-  // backscatter value.
+  // A single 3-band Float32 value tile per grid (#248): the pre-#248 _time /
+  // _source companions were dropped (ADR-0007 amendment A.3).
   mtrs::saveTile<float>(tile.valueRaster(), path, valueBandNoData());
-  mtrs::saveTile<int64_t>(
-    tile.timeRaster(), companionPath(path, kTimeSuffix), timeBandNoData());
-  mtrs::saveTile<uint16_t>(
-    tile.sourceRaster(), companionPath(path, kSourceSuffix), sourceBandNoData());
 }
 
 MbesTile loadTile(const std::string & path, const gggs::Level & level)
 {
   namespace mtrs = marine_tiled_raster_store;
-  namespace fs = std::filesystem;
-
   MbesTile::Raster value =
     mtrs::loadTile<float>(path, level, MbesTile::value_band_count);
-  const gggs::GridIndex grid = value.index();
-
-  // Companion tiles: load if present, else fill with 0 (degraded-mode recovery
-  // after a partial write — the value tile survives without its companions).
-  const std::string time_path = companionPath(path, kTimeSuffix);
-  MbesTile::TimeRaster time =
-    fs::is_regular_file(time_path)
-    ? mtrs::loadTile<int64_t>(time_path, level, MbesTile::time_band_count)
-    : MbesTile::TimeRaster(grid, MbesTile::time_band_count, int64_t{0});
-
-  // Enforce GridIndex consistency: a mis-renamed companion (manual store
-  // reorganisation or tampering) would combine cell-for-cell data from different
-  // geographic tiles, silently associating wrong timestamps with intensities.
-  if (fs::is_regular_file(time_path) && !(time.index() == grid)) {
-    throw std::runtime_error(
-            "loadTile: companion \"" + time_path +
-            "\" has a GridIndex that does not match the value tile at \"" + path +
-            "\".  The companion file may have been mis-renamed or the store is"
-            " inconsistent.");
-  }
-
-  const std::string source_path = companionPath(path, kSourceSuffix);
-  MbesTile::SourceRaster source =
-    fs::is_regular_file(source_path)
-    ? mtrs::loadTile<uint16_t>(source_path, level, MbesTile::source_band_count)
-    : MbesTile::SourceRaster(grid, MbesTile::source_band_count, uint16_t{0});
-
-  if (fs::is_regular_file(source_path) && !(source.index() == grid)) {
-    throw std::runtime_error(
-            "loadTile: companion \"" + source_path +
-            "\" has a GridIndex that does not match the value tile at \"" + path +
-            "\".  The companion file may have been mis-renamed or the store is"
-            " inconsistent.");
-  }
-
-  return MbesTile(std::move(value), std::move(time), std::move(source));
+  return MbesTile(std::move(value));
 }
 
 std::size_t save(
-  MbesBackscatterStore & store, const std::string & dir, const SourceRegistry * registry)
+  MbesBackscatterStore & store, const std::string & dir, const StoreMetadata * metadata)
 {
   namespace fs = std::filesystem;
   std::size_t written = 0;
@@ -191,17 +110,17 @@ std::size_t save(
       ++written;
     }
   }
-  // The registry is a store-wide sidecar (not per-layer): persist it once at the
-  // end. Written unconditionally when present so a freshly-registered source is
-  // saved even when no tile is dirty.
-  if (registry != nullptr) {
-    registry->saveRegistry(dir);
+  // The metadata is a store-wide sidecar (not per-layer): persist it once at the
+  // end. Written unconditionally when present so coarse provenance is saved even
+  // when no tile is dirty.
+  if (metadata != nullptr) {
+    metadata->save(dir);
   }
   return written;
 }
 
 std::size_t load(
-  MbesBackscatterStore & store, const std::string & dir, SourceRegistry * registry)
+  MbesBackscatterStore & store, const std::string & dir, StoreMetadata * metadata)
 {
   namespace fs = std::filesystem;
   std::size_t loaded = 0;
@@ -214,20 +133,13 @@ std::size_t load(
       if (!entry.is_regular_file() || entry.path().extension() != ".tif") {
         continue;
       }
-      // Skip the companion tiles — they are loaded alongside their value tile,
-      // not as standalone value tiles (a bare *.tif glob would otherwise
-      // mis-load _time / _source as value tiles).
-      const std::string stem = entry.path().stem().string();
-      if (stemEndsWith(stem, kTimeSuffix) || stemEndsWith(stem, kSourceSuffix)) {
-        continue;
-      }
       MbesTile tile = loadTile(entry.path().string(), store.level());
       store.getOrCreateTile(layer, tile.index()) = std::move(tile);
       ++loaded;
     }
   }
-  if (registry != nullptr) {
-    registry->loadRegistry(dir);
+  if (metadata != nullptr) {
+    metadata->load(dir);
   }
   return loaded;
 }

--- a/marine_mbes_backscatter_store/src/tile_io.cpp
+++ b/marine_mbes_backscatter_store/src/tile_io.cpp
@@ -64,7 +64,7 @@ std::string tileFilename(const gggs::GridIndex & grid)
 std::string layerDirName(SourceLayer layer)
 {
   switch (layer) {
-    case SourceLayer::Cube: return "cube";
+    case SourceLayer::Survey: return "survey";
   }
   throw std::runtime_error("layerDirName: unknown SourceLayer");
 }

--- a/marine_mbes_backscatter_store/src/tile_io.cpp
+++ b/marine_mbes_backscatter_store/src/tile_io.cpp
@@ -23,6 +23,7 @@
 
 #include <cstdint>
 #include <filesystem>
+#include <iostream>
 #include <limits>
 #include <optional>
 #include <string>
@@ -51,6 +52,52 @@ const std::vector<std::optional<float>> & valueBandNoData()
   static const float nan = std::numeric_limits<float>::quiet_NaN();
   static const std::vector<std::optional<float>> nodata{nan, nan, nan};
   return nodata;
+}
+
+/// True for a pre-#248 companion raster (`*_time.tif` / `*_source.tif`) that may
+/// linger in a `survey/` dir. The per-cell `_time`/`_source` companions were
+/// dropped by #248 (ADR-0007 amendment A.3); a straggler must be skipped, not
+/// fed to `loadTile` (it would throw on the band-count mismatch and abort the
+/// whole load). Mirrors the bathy store's guard.
+bool isDroppedCompanionTile(const std::string & filename)
+{
+  const auto hasSuffix = [&filename](const std::string & suffix) {
+      return filename.size() >= suffix.size() &&
+             filename.compare(filename.size() - suffix.size(), suffix.size(), suffix) == 0;
+    };
+  return hasSuffix("_time.tif") || hasSuffix("_source.tif");
+}
+
+/// Diagnostic (MBES is not a costmap input): warn when a store dir holds content
+/// but exposes no recognized `survey/` layer subdir, so a silently-empty load is
+/// observable. Silent for a fresh/absent or metadata-only store. Mirrors the
+/// bathy store's guard.
+void warnIfUnrecognizedStoreLayout(const std::string & dir, bool any_layer_dir_present)
+{
+  namespace fs = std::filesystem;
+  if (any_layer_dir_present) {
+    return;
+  }
+  std::error_code ec;
+  if (!fs::is_directory(dir, ec)) {
+    return;   // fresh/absent store — nothing to warn about
+  }
+  bool has_store_content = false;
+  for (const auto & entry : fs::directory_iterator(dir, ec)) {
+    if (entry.is_directory() ||
+      (entry.is_regular_file() && entry.path().extension() == ".tif"))
+    {
+      has_store_content = true;
+      break;
+    }
+  }
+  if (!has_store_content) {
+    return;   // empty store, or metadata-only sidecar — legitimately nothing loaded
+  }
+  std::cerr << "[marine_mbes_backscatter_store] WARNING: store directory '" << dir
+            << "' has content but no recognized 'survey/' layer subdirectory — "
+            << "NOTHING was loaded. A pre-#248 old-layout store "
+            << "(draft/processed) is not migrated (#221/#248); regenerate it.\n";
 }
 }  // namespace
 
@@ -124,13 +171,24 @@ std::size_t load(
 {
   namespace fs = std::filesystem;
   std::size_t loaded = 0;
+  bool any_layer_dir_present = false;
   for (const SourceLayer layer : source_layers_by_priority) {
     const fs::path layer_dir = fs::path(dir) / layerDirName(layer);
     if (!fs::is_directory(layer_dir)) {
       continue;
     }
+    any_layer_dir_present = true;
     for (const auto & entry : fs::directory_iterator(layer_dir)) {
       if (!entry.is_regular_file() || entry.path().extension() != ".tif") {
+        continue;
+      }
+      // Skip dropped pre-#248 companions (`*_time.tif`/`*_source.tif`) that may
+      // linger in a survey/ dir; feeding one to loadTile would throw on the
+      // band-count mismatch and abort the whole load.
+      if (isDroppedCompanionTile(entry.path().filename().string())) {
+        std::cerr << "[marine_mbes_backscatter_store] WARNING: skipping dropped "
+                  << "companion raster (not a value tile; #248): " << entry.path()
+                  << "\n";
         continue;
       }
       MbesTile tile = loadTile(entry.path().string(), store.level());
@@ -138,6 +196,9 @@ std::size_t load(
       ++loaded;
     }
   }
+  // Observability: a store dir with content but no recognized layer subdir loaded
+  // nothing (e.g. a pre-#248 draft/processed store). Diagnostic-only for MBES.
+  warnIfUnrecognizedStoreLayout(dir, any_layer_dir_present);
   if (metadata != nullptr) {
     metadata->load(dir);
   }

--- a/marine_mbes_backscatter_store/test/test_query.cpp
+++ b/marine_mbes_backscatter_store/test/test_query.cpp
@@ -35,15 +35,15 @@ using marine_mbes_backscatter_store::MbesBackscatterStore;
 using marine_mbes_backscatter_store::MbesCell;
 using marine_mbes_backscatter_store::SourceLayer;
 
-TEST(Query, BestSourceReturnsCube)
+TEST(Query, BestSourceReturnsSurvey)
 {
   MbesBackscatterStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Cube, cell, MbesCell{-12.0f, 2.0f, 3.0f});
+  store.set(SourceLayer::Survey, cell, MbesCell{-12.0f, 2.0f, 3.0f});
 
   const auto best = bestSource(store, cell);
   ASSERT_TRUE(best.has_value());
-  EXPECT_EQ(best->source, SourceLayer::Cube);
+  EXPECT_EQ(best->source, SourceLayer::Survey);
   EXPECT_FLOAT_EQ(best->mean, -12.0f);
   EXPECT_FLOAT_EQ(best->standard_error, 2.0f);
   EXPECT_FLOAT_EQ(best->sample_sd, 3.0f);
@@ -56,7 +56,7 @@ TEST(Query, BestSourceNulloptWhenNoData)
   EXPECT_FALSE(bestSource(store, cell).has_value());
 
   // A written-but-no-data cell (NaN mean) is still unknown.
-  store.set(SourceLayer::Cube, cell, MbesCell{});
+  store.set(SourceLayer::Survey, cell, MbesCell{});
   EXPECT_FALSE(bestSource(store, cell).has_value());
 }
 
@@ -64,7 +64,7 @@ TEST(Query, ForEachCellBestSourceVisitsRegion)
 {
   MbesBackscatterStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Cube, cell, MbesCell{-20.0f, 0.5f, 1.0f});
+  store.set(SourceLayer::Survey, cell, MbesCell{-20.0f, 0.5f, 1.0f});
 
   std::size_t visited = 0;
   std::size_t with_data = 0;
@@ -85,7 +85,7 @@ TEST(Query, ForEachCellBestSourceSkipsCellsOutsideBox)
 {
   // A cell written well outside the queried box must not be visited.
   MbesBackscatterStore store(5);
-  store.set(SourceLayer::Cube, store.cellIndex(45.0, -73.0), MbesCell{-20.0f, 0.5f, 1.0f});
+  store.set(SourceLayer::Survey, store.cellIndex(45.0, -73.0), MbesCell{-20.0f, 0.5f, 1.0f});
 
   std::size_t with_data = 0;
   forEachCellBestSource(

--- a/marine_mbes_backscatter_store/test/test_query.cpp
+++ b/marine_mbes_backscatter_store/test/test_query.cpp
@@ -28,36 +28,25 @@
 #include "marine_mbes_backscatter_store/mbes_store.hpp"
 #include "marine_mbes_backscatter_store/query.hpp"
 
+using marine_mbes_backscatter_store::BackscatterSample;
 using marine_mbes_backscatter_store::bestSource;
 using marine_mbes_backscatter_store::forEachCellBestSource;
-using marine_mbes_backscatter_store::IntensitySample;
 using marine_mbes_backscatter_store::MbesBackscatterStore;
 using marine_mbes_backscatter_store::MbesCell;
 using marine_mbes_backscatter_store::SourceLayer;
 
-TEST(Query, BestSourcePrefersProcessedOverDraft)
+TEST(Query, BestSourceReturnsCube)
 {
   MbesBackscatterStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Draft, cell, MbesCell{-12.0f, 2.0f, 2LL});
-  store.set(SourceLayer::Processed, cell, MbesCell{-10.0f, 0.1f, 1LL});
+  store.set(SourceLayer::Cube, cell, MbesCell{-12.0f, 2.0f, 3.0f});
 
   const auto best = bestSource(store, cell);
   ASSERT_TRUE(best.has_value());
-  EXPECT_EQ(best->source, SourceLayer::Processed);
-  EXPECT_FLOAT_EQ(best->intensity, -10.0f);
-}
-
-TEST(Query, BestSourceFallsBackToDraft)
-{
-  MbesBackscatterStore store(5);
-  const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Draft, cell, MbesCell{-12.0f, 2.0f, 2LL});
-
-  const auto best = bestSource(store, cell);
-  ASSERT_TRUE(best.has_value());
-  EXPECT_EQ(best->source, SourceLayer::Draft);
-  EXPECT_FLOAT_EQ(best->intensity, -12.0f);
+  EXPECT_EQ(best->source, SourceLayer::Cube);
+  EXPECT_FLOAT_EQ(best->mean, -12.0f);
+  EXPECT_FLOAT_EQ(best->standard_error, 2.0f);
+  EXPECT_FLOAT_EQ(best->sample_sd, 3.0f);
 }
 
 TEST(Query, BestSourceNulloptWhenNoData)
@@ -66,8 +55,8 @@ TEST(Query, BestSourceNulloptWhenNoData)
   const auto cell = store.cellIndex(43.0, -70.5);
   EXPECT_FALSE(bestSource(store, cell).has_value());
 
-  // A written-but-no-data cell (NaN intensity) is still unknown.
-  store.set(SourceLayer::Draft, cell, MbesCell{});
+  // A written-but-no-data cell (NaN mean) is still unknown.
+  store.set(SourceLayer::Cube, cell, MbesCell{});
   EXPECT_FALSE(bestSource(store, cell).has_value());
 }
 
@@ -75,13 +64,13 @@ TEST(Query, ForEachCellBestSourceVisitsRegion)
 {
   MbesBackscatterStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Draft, cell, MbesCell{-20.0f, 0.5f, 1LL});
+  store.set(SourceLayer::Cube, cell, MbesCell{-20.0f, 0.5f, 1.0f});
 
   std::size_t visited = 0;
   std::size_t with_data = 0;
   forEachCellBestSource(
     store, gggs::geoPoint(42.999, -70.501), gggs::geoPoint(43.001, -70.499),
-    [&](const gggs::CellIndex &, const std::optional<IntensitySample> & sample) {
+    [&](const gggs::CellIndex &, const std::optional<BackscatterSample> & sample) {
       ++visited;
       if (sample) {
         ++with_data;
@@ -96,12 +85,12 @@ TEST(Query, ForEachCellBestSourceSkipsCellsOutsideBox)
 {
   // A cell written well outside the queried box must not be visited.
   MbesBackscatterStore store(5);
-  store.set(SourceLayer::Draft, store.cellIndex(45.0, -73.0), MbesCell{-20.0f, 0.5f, 1LL});
+  store.set(SourceLayer::Cube, store.cellIndex(45.0, -73.0), MbesCell{-20.0f, 0.5f, 1.0f});
 
   std::size_t with_data = 0;
   forEachCellBestSource(
     store, gggs::geoPoint(42.999, -70.501), gggs::geoPoint(43.001, -70.499),
-    [&](const gggs::CellIndex &, const std::optional<IntensitySample> & sample) {
+    [&](const gggs::CellIndex &, const std::optional<BackscatterSample> & sample) {
       if (sample) {
         ++with_data;
       }

--- a/marine_mbes_backscatter_store/test/test_store.cpp
+++ b/marine_mbes_backscatter_store/test/test_store.cpp
@@ -34,69 +34,68 @@ TEST(Store, SetGetRoundTrip)
 {
   MbesBackscatterStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Draft, cell, MbesCell{-18.5f, 0.25f, 2'000'000'000LL, 3u});
+  store.set(SourceLayer::Cube, cell, MbesCell{-18.5f, 0.25f, 0.75f});
 
-  const auto got = store.get(SourceLayer::Draft, cell);
+  const auto got = store.get(SourceLayer::Cube, cell);
   ASSERT_TRUE(got.has_value());
-  EXPECT_FLOAT_EQ(got->intensity, -18.5f);
-  EXPECT_FLOAT_EQ(got->intensity_variance, 0.25f);
-  EXPECT_EQ(got->timestamp, 2'000'000'000LL);
-  EXPECT_EQ(got->source_index, 3u);
+  EXPECT_FLOAT_EQ(got->mean, -18.5f);
+  EXPECT_FLOAT_EQ(got->standard_error, 0.25f);
+  EXPECT_FLOAT_EQ(got->sample_sd, 0.75f);
 }
 
-TEST(Store, DraftRecencyNewestWins)
+TEST(Store, CubeRecencyNewestWins)
 {
-  // ADR-0007 D7: Draft is newest-valid-wins — a second write at the same cell
-  // overwrites the first (the store does no accumulation).
+  // ADR-0007 D7: newest-valid-wins — a second write at the same cell overwrites
+  // the first (the store does no accumulation).
   MbesBackscatterStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Draft, cell, MbesCell{-20.0f, 1.0f, 1LL, 1u});
-  store.set(SourceLayer::Draft, cell, MbesCell{-15.0f, 0.5f, 2LL, 2u});
+  store.set(SourceLayer::Cube, cell, MbesCell{-20.0f, 1.0f, 2.0f});
+  store.set(SourceLayer::Cube, cell, MbesCell{-15.0f, 0.5f, 1.0f});
 
-  const auto got = store.get(SourceLayer::Draft, cell);
+  const auto got = store.get(SourceLayer::Cube, cell);
   ASSERT_TRUE(got.has_value());
-  EXPECT_FLOAT_EQ(got->intensity, -15.0f);          // second write wins
-  EXPECT_FLOAT_EQ(got->intensity_variance, 0.5f);
-  EXPECT_EQ(got->timestamp, 2LL);
-  EXPECT_EQ(got->source_index, 2u);
+  EXPECT_FLOAT_EQ(got->mean, -15.0f);          // second write wins
+  EXPECT_FLOAT_EQ(got->standard_error, 0.5f);
+  EXPECT_FLOAT_EQ(got->sample_sd, 1.0f);
 }
 
 TEST(Store, UnknownCellReturnsNullopt)
 {
   MbesBackscatterStore store(5);
-  EXPECT_FALSE(store.get(SourceLayer::Processed, store.cellIndex(43.0, -70.5)).has_value());
+  EXPECT_FALSE(store.get(SourceLayer::Cube, store.cellIndex(43.0, -70.5)).has_value());
 }
 
-TEST(Store, LayersAreIndependent)
-{
-  // A draft write must not touch the processed layer at the same cell.
-  MbesBackscatterStore store(5);
-  const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Processed, cell, MbesCell{-10.0f, 0.1f, 1LL});
-  store.set(SourceLayer::Draft, cell, MbesCell{-12.0f, 2.0f, 2LL});
-  EXPECT_FLOAT_EQ(store.get(SourceLayer::Processed, cell)->intensity, -10.0f);
-  EXPECT_FLOAT_EQ(store.get(SourceLayer::Draft, cell)->intensity, -12.0f);
-}
-
-TEST(Store, TilesAllocatedLazilyPerLayer)
+TEST(Store, TilesAllocatedLazily)
 {
   MbesBackscatterStore store(5);
-  EXPECT_TRUE(store.tiles(SourceLayer::Draft).empty());
-  EXPECT_TRUE(store.tiles(SourceLayer::Processed).empty());
+  EXPECT_TRUE(store.tiles(SourceLayer::Cube).empty());
 
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), MbesCell{-30.0f, 0.5f, 1LL});
-  EXPECT_EQ(store.tiles(SourceLayer::Draft).size(), 1u);
-  EXPECT_TRUE(store.tiles(SourceLayer::Processed).empty());
+  store.set(SourceLayer::Cube, store.cellIndex(43.0, -70.5), MbesCell{-30.0f, 0.5f, 1.0f});
+  EXPECT_EQ(store.tiles(SourceLayer::Cube).size(), 1u);
 }
 
 TEST(Store, NoDataCellReadsBackAsNoData)
 {
   MbesBackscatterStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Draft, cell, MbesCell{});  // intensity NaN
-  const auto got = store.get(SourceLayer::Draft, cell);
+  store.set(SourceLayer::Cube, cell, MbesCell{});  // mean NaN
+  const auto got = store.get(SourceLayer::Cube, cell);
   ASSERT_TRUE(got.has_value());      // tile exists
-  EXPECT_FALSE(got->hasData());      // but the cell carries no usable intensity
+  EXPECT_FALSE(got->hasData());      // but the cell carries no usable mean
+}
+
+TEST(Store, OneSampleSentinelIsData)
+{
+  // n=1 sentinel (#248 A.1): sample_sd == 0 with a finite mean is real data
+  // (n=1, M2=0), distinct from no-data (NaN mean).
+  MbesBackscatterStore store(5);
+  const auto cell = store.cellIndex(43.0, -70.5);
+  store.set(SourceLayer::Cube, cell, MbesCell{-12.0f, 0.0f, 0.0f});
+  const auto got = store.get(SourceLayer::Cube, cell);
+  ASSERT_TRUE(got.has_value());
+  EXPECT_TRUE(got->hasData());
+  EXPECT_FLOAT_EQ(got->mean, -12.0f);
+  EXPECT_FLOAT_EQ(got->sample_sd, 0.0f);
 }
 
 TEST(Store, WrongLevelCellThrows)
@@ -104,14 +103,14 @@ TEST(Store, WrongLevelCellThrows)
   MbesBackscatterStore store(5);
   gggs::Level other(6);
   const auto level6_cell = other.cellIndex(gggs::geoPoint(43.0, -70.5));
-  EXPECT_THROW(store.set(SourceLayer::Draft, level6_cell, MbesCell{}), std::invalid_argument);
+  EXPECT_THROW(store.set(SourceLayer::Cube, level6_cell, MbesCell{}), std::invalid_argument);
 }
 
 TEST(Store, InvalidCellThrows)
 {
   MbesBackscatterStore store(5);
   EXPECT_THROW(
-    store.set(SourceLayer::Draft, gggs::CellIndex{}, MbesCell{}), std::invalid_argument);
+    store.set(SourceLayer::Cube, gggs::CellIndex{}, MbesCell{}), std::invalid_argument);
 }
 
 TEST(Store, FromCellSizeChoosesAFiniteLevel)

--- a/marine_mbes_backscatter_store/test/test_store.cpp
+++ b/marine_mbes_backscatter_store/test/test_store.cpp
@@ -34,25 +34,25 @@ TEST(Store, SetGetRoundTrip)
 {
   MbesBackscatterStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Cube, cell, MbesCell{-18.5f, 0.25f, 0.75f});
+  store.set(SourceLayer::Survey, cell, MbesCell{-18.5f, 0.25f, 0.75f});
 
-  const auto got = store.get(SourceLayer::Cube, cell);
+  const auto got = store.get(SourceLayer::Survey, cell);
   ASSERT_TRUE(got.has_value());
   EXPECT_FLOAT_EQ(got->mean, -18.5f);
   EXPECT_FLOAT_EQ(got->standard_error, 0.25f);
   EXPECT_FLOAT_EQ(got->sample_sd, 0.75f);
 }
 
-TEST(Store, CubeRecencyNewestWins)
+TEST(Store, SurveyRecencyNewestWins)
 {
   // ADR-0007 D7: newest-valid-wins — a second write at the same cell overwrites
   // the first (the store does no accumulation).
   MbesBackscatterStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Cube, cell, MbesCell{-20.0f, 1.0f, 2.0f});
-  store.set(SourceLayer::Cube, cell, MbesCell{-15.0f, 0.5f, 1.0f});
+  store.set(SourceLayer::Survey, cell, MbesCell{-20.0f, 1.0f, 2.0f});
+  store.set(SourceLayer::Survey, cell, MbesCell{-15.0f, 0.5f, 1.0f});
 
-  const auto got = store.get(SourceLayer::Cube, cell);
+  const auto got = store.get(SourceLayer::Survey, cell);
   ASSERT_TRUE(got.has_value());
   EXPECT_FLOAT_EQ(got->mean, -15.0f);          // second write wins
   EXPECT_FLOAT_EQ(got->standard_error, 0.5f);
@@ -62,24 +62,24 @@ TEST(Store, CubeRecencyNewestWins)
 TEST(Store, UnknownCellReturnsNullopt)
 {
   MbesBackscatterStore store(5);
-  EXPECT_FALSE(store.get(SourceLayer::Cube, store.cellIndex(43.0, -70.5)).has_value());
+  EXPECT_FALSE(store.get(SourceLayer::Survey, store.cellIndex(43.0, -70.5)).has_value());
 }
 
 TEST(Store, TilesAllocatedLazily)
 {
   MbesBackscatterStore store(5);
-  EXPECT_TRUE(store.tiles(SourceLayer::Cube).empty());
+  EXPECT_TRUE(store.tiles(SourceLayer::Survey).empty());
 
-  store.set(SourceLayer::Cube, store.cellIndex(43.0, -70.5), MbesCell{-30.0f, 0.5f, 1.0f});
-  EXPECT_EQ(store.tiles(SourceLayer::Cube).size(), 1u);
+  store.set(SourceLayer::Survey, store.cellIndex(43.0, -70.5), MbesCell{-30.0f, 0.5f, 1.0f});
+  EXPECT_EQ(store.tiles(SourceLayer::Survey).size(), 1u);
 }
 
 TEST(Store, NoDataCellReadsBackAsNoData)
 {
   MbesBackscatterStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Cube, cell, MbesCell{});  // mean NaN
-  const auto got = store.get(SourceLayer::Cube, cell);
+  store.set(SourceLayer::Survey, cell, MbesCell{});  // mean NaN
+  const auto got = store.get(SourceLayer::Survey, cell);
   ASSERT_TRUE(got.has_value());      // tile exists
   EXPECT_FALSE(got->hasData());      // but the cell carries no usable mean
 }
@@ -90,8 +90,8 @@ TEST(Store, OneSampleSentinelIsData)
   // (n=1, M2=0), distinct from no-data (NaN mean).
   MbesBackscatterStore store(5);
   const auto cell = store.cellIndex(43.0, -70.5);
-  store.set(SourceLayer::Cube, cell, MbesCell{-12.0f, 0.0f, 0.0f});
-  const auto got = store.get(SourceLayer::Cube, cell);
+  store.set(SourceLayer::Survey, cell, MbesCell{-12.0f, 0.0f, 0.0f});
+  const auto got = store.get(SourceLayer::Survey, cell);
   ASSERT_TRUE(got.has_value());
   EXPECT_TRUE(got->hasData());
   EXPECT_FLOAT_EQ(got->mean, -12.0f);
@@ -103,14 +103,14 @@ TEST(Store, WrongLevelCellThrows)
   MbesBackscatterStore store(5);
   gggs::Level other(6);
   const auto level6_cell = other.cellIndex(gggs::geoPoint(43.0, -70.5));
-  EXPECT_THROW(store.set(SourceLayer::Cube, level6_cell, MbesCell{}), std::invalid_argument);
+  EXPECT_THROW(store.set(SourceLayer::Survey, level6_cell, MbesCell{}), std::invalid_argument);
 }
 
 TEST(Store, InvalidCellThrows)
 {
   MbesBackscatterStore store(5);
   EXPECT_THROW(
-    store.set(SourceLayer::Cube, gggs::CellIndex{}, MbesCell{}), std::invalid_argument);
+    store.set(SourceLayer::Survey, gggs::CellIndex{}, MbesCell{}), std::invalid_argument);
 }
 
 TEST(Store, FromCellSizeChoosesAFiniteLevel)

--- a/marine_mbes_backscatter_store/test/test_tile_io.cpp
+++ b/marine_mbes_backscatter_store/test/test_tile_io.cpp
@@ -21,25 +21,20 @@
 
 #include <gtest/gtest.h>
 
-#include <cstdint>
+#include <cmath>
 #include <filesystem>
-#include <fstream>
 #include <stdexcept>
 #include <string>
 
-#include <nlohmann/json.hpp>
-
+#include "marine_mbes_backscatter_store/mbes_cell.hpp"
 #include "marine_mbes_backscatter_store/mbes_store.hpp"
 #include "marine_mbes_backscatter_store/registry.hpp"
 #include "marine_mbes_backscatter_store/tile_io.hpp"
-#include "marine_tiled_raster_store/tile_io.hpp"
-#include "marine_tiled_raster_store/tiled_raster_tile.hpp"
 
 using marine_mbes_backscatter_store::MbesBackscatterStore;
 using marine_mbes_backscatter_store::MbesCell;
 using marine_mbes_backscatter_store::SourceLayer;
-using marine_mbes_backscatter_store::SourceRecord;
-using marine_mbes_backscatter_store::SourceRegistry;
+using marine_mbes_backscatter_store::StoreMetadata;
 
 namespace fs = std::filesystem;
 
@@ -64,113 +59,124 @@ protected:
 TEST_F(TileIoTest, RoundTripPreservesCells)
 {
   MbesBackscatterStore store(5);
-  // ns stamps with sub-second precision the Int64 time tile preserves exactly.
-  const int64_t ts_draft = 1'780'000'000'123'456'789LL;
-  const int64_t ts_proc = 1'790'000'000'987'654'321LL;
   store.set(
-    SourceLayer::Draft, store.cellIndex(43.0, -70.5),
-    MbesCell{-18.5f, 0.375f, ts_draft, 7u});
+    SourceLayer::Cube, store.cellIndex(43.0, -70.5), MbesCell{-18.5f, 0.375f, 0.75f});
   store.set(
-    SourceLayer::Processed, store.cellIndex(44.0, -71.0),
-    MbesCell{-12.5f, 0.125f, ts_proc, 0u});
+    SourceLayer::Cube, store.cellIndex(44.0, -71.0), MbesCell{-12.5f, 0.125f, 0.25f});
 
   EXPECT_EQ(marine_mbes_backscatter_store::save(store, dir_.string()), 2u);
 
   MbesBackscatterStore reloaded(5);
   EXPECT_EQ(marine_mbes_backscatter_store::load(reloaded, dir_.string()), 2u);
 
-  const auto draft = reloaded.get(SourceLayer::Draft, reloaded.cellIndex(43.0, -70.5));
-  ASSERT_TRUE(draft.has_value());
-  EXPECT_FLOAT_EQ(draft->intensity, -18.5f);
-  EXPECT_FLOAT_EQ(draft->intensity_variance, 0.375f);
-  EXPECT_EQ(draft->timestamp, ts_draft);       // int64 ns survives exactly
-  EXPECT_EQ(draft->source_index, 7u);
+  const auto a = reloaded.get(SourceLayer::Cube, reloaded.cellIndex(43.0, -70.5));
+  ASSERT_TRUE(a.has_value());
+  EXPECT_FLOAT_EQ(a->mean, -18.5f);
+  EXPECT_FLOAT_EQ(a->standard_error, 0.375f);
+  EXPECT_FLOAT_EQ(a->sample_sd, 0.75f);
 
-  const auto processed = reloaded.get(SourceLayer::Processed, reloaded.cellIndex(44.0, -71.0));
-  ASSERT_TRUE(processed.has_value());
-  EXPECT_FLOAT_EQ(processed->intensity, -12.5f);
-  EXPECT_EQ(processed->timestamp, ts_proc);
+  const auto b = reloaded.get(SourceLayer::Cube, reloaded.cellIndex(44.0, -71.0));
+  ASSERT_TRUE(b.has_value());
+  EXPECT_FLOAT_EQ(b->mean, -12.5f);
 }
 
-TEST_F(TileIoTest, RoundTripPreservesSourceIndex)
+// --- Welford sufficient-statistics round-trip (#248 amendment A.1) ---
+
+TEST_F(TileIoTest, WelfordRoundTripReconstructsNAndM2)
 {
-  // The per-cell source index round-trips through the separate UInt16 _source.tif
-  // independently of intensity / time.
+  // The 3-band value tile encodes {mean, standard_error, sample_sd}. With a
+  // confidence scale applied to the standard error, the consumer divides the
+  // scale out (SE = standard_error / scale = sample_sd / sqrt(n)) and
+  // reconstructs the full Welford state:
+  //   n  = (sample_sd / SE)^2
+  //   M2 = sample_sd^2 * (n - 1)
+  // Choose exact-in-float values: n=9, sample_sd=3 -> SE_actual = 3/3 = 1.
+  const float scale = 2.0f;
+  const int n_true = 9;
+  const float sample_sd = 3.0f;
+  const float se_actual = sample_sd / std::sqrt(static_cast<float>(n_true));  // 1.0
+  const float stored_se = scale * se_actual;                                  // 2.0
+
   MbesBackscatterStore store(5);
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), MbesCell{-30.0f, 0.5f, 10LL, 1u});
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.4), MbesCell{-31.0f, 0.5f, 11LL, 4242u});
+  store.set(
+    SourceLayer::Cube, store.cellIndex(43.0, -70.5),
+    MbesCell{-18.5f, stored_se, sample_sd});
   EXPECT_EQ(marine_mbes_backscatter_store::save(store, dir_.string()), 1u);
 
   MbesBackscatterStore reloaded(5);
   EXPECT_EQ(marine_mbes_backscatter_store::load(reloaded, dir_.string()), 1u);
-  EXPECT_EQ(
-    reloaded.get(SourceLayer::Draft, reloaded.cellIndex(43.0, -70.5))->source_index, 1u);
-  EXPECT_EQ(
-    reloaded.get(SourceLayer::Draft, reloaded.cellIndex(43.0, -70.4))->source_index, 4242u);
+  const auto got = reloaded.get(SourceLayer::Cube, reloaded.cellIndex(43.0, -70.5));
+  ASSERT_TRUE(got.has_value());
+
+  // Divide the confidence scale out, then reconstruct.
+  const double se = static_cast<double>(got->standard_error) / scale;
+  const double n = std::pow(static_cast<double>(got->sample_sd) / se, 2.0);
+  const double m2 = std::pow(static_cast<double>(got->sample_sd), 2.0) * (n - 1.0);
+
+  EXPECT_NEAR(n, static_cast<double>(n_true), 1e-4);
+  EXPECT_NEAR(m2, static_cast<double>(sample_sd) * sample_sd * (n_true - 1), 1e-4);
 }
 
-TEST_F(TileIoTest, MissingTimeTileLoadsAsZero)
+TEST_F(TileIoTest, WelfordN1SentinelRoundTrips)
 {
-  // A missing _time.tif companion (e.g. a partial crashed write) must not fail —
-  // the timestamp band fills with 0 (degraded-mode recovery).
+  // n=1 sentinel: sample_sd == 0 with a finite mean encodes n=1, M2=0, distinct
+  // from no-data (NaN mean).
   MbesBackscatterStore store(5);
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), MbesCell{-30.0f, 0.5f, 99LL, 2u});
-  marine_mbes_backscatter_store::save(store, dir_.string());
-
-  for (const auto & e : fs::recursive_directory_iterator(dir_ / "draft")) {
-    if (e.is_regular_file() &&
-      e.path().filename().string().find("_time.tif") != std::string::npos)
-    {
-      fs::remove(e.path());
-    }
-  }
+  store.set(
+    SourceLayer::Cube, store.cellIndex(43.0, -70.5), MbesCell{-12.0f, 0.0f, 0.0f});
+  EXPECT_EQ(marine_mbes_backscatter_store::save(store, dir_.string()), 1u);
 
   MbesBackscatterStore reloaded(5);
   EXPECT_EQ(marine_mbes_backscatter_store::load(reloaded, dir_.string()), 1u);
-  const auto got = reloaded.get(SourceLayer::Draft, reloaded.cellIndex(43.0, -70.5));
+  const auto got = reloaded.get(SourceLayer::Cube, reloaded.cellIndex(43.0, -70.5));
   ASSERT_TRUE(got.has_value());
-  EXPECT_FLOAT_EQ(got->intensity, -30.0f);   // value tile still loaded
-  EXPECT_EQ(got->timestamp, 0);              // missing time tile -> 0
-  EXPECT_EQ(got->source_index, 2u);          // source tile still loaded
+
+  // Finite mean + zero sample_sd -> real data, n=1, M2=0.
+  EXPECT_TRUE(got->hasData());
+  EXPECT_FALSE(std::isnan(got->mean));
+  EXPECT_FLOAT_EQ(got->mean, -12.0f);
+  EXPECT_FLOAT_EQ(got->sample_sd, 0.0f);   // n=1 detector: sample_sd == 0
+  // M2 = sample_sd^2 * (n-1) = 0.
+  const double m2 = static_cast<double>(got->sample_sd) * got->sample_sd * (1.0 - 1.0);
+  EXPECT_DOUBLE_EQ(m2, 0.0);
+
+  // Distinct from a no-data cell (NaN mean), which is not data.
+  const MbesCell no_data{};
+  EXPECT_FALSE(no_data.hasData());
+  EXPECT_TRUE(std::isnan(no_data.mean));
 }
 
-TEST_F(TileIoTest, MissingSourceTileLoadsAsZero)
+TEST_F(TileIoTest, ConfidenceScaleDividesOutToIntegerN)
 {
-  MbesBackscatterStore store(5);
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), MbesCell{-30.0f, 0.5f, 99LL, 5u});
-  marine_mbes_backscatter_store::save(store, dir_.string());
+  // Writing standard_error as scale * SE_actual and dividing scale out on reload
+  // must recover an integer n = (sample_sd / SE_actual)^2.
+  const float scale = 4.0f;
+  const int n_true = 16;
+  const float sample_sd = 8.0f;
+  const float se_actual = sample_sd / std::sqrt(static_cast<float>(n_true));  // 2.0
+  const float stored_se = scale * se_actual;                                  // 8.0
 
-  for (const auto & e : fs::recursive_directory_iterator(dir_ / "draft")) {
-    if (e.is_regular_file() &&
-      e.path().filename().string().find("_source.tif") != std::string::npos)
-    {
-      fs::remove(e.path());
-    }
-  }
+  MbesBackscatterStore store(5);
+  store.set(
+    SourceLayer::Cube, store.cellIndex(43.0, -70.5),
+    MbesCell{-5.0f, stored_se, sample_sd});
+  marine_mbes_backscatter_store::save(store, dir_.string());
 
   MbesBackscatterStore reloaded(5);
-  EXPECT_EQ(marine_mbes_backscatter_store::load(reloaded, dir_.string()), 1u);
-  const auto got = reloaded.get(SourceLayer::Draft, reloaded.cellIndex(43.0, -70.5));
+  marine_mbes_backscatter_store::load(reloaded, dir_.string());
+  const auto got = reloaded.get(SourceLayer::Cube, reloaded.cellIndex(43.0, -70.5));
   ASSERT_TRUE(got.has_value());
-  EXPECT_EQ(got->timestamp, 99);         // time tile still loaded
-  EXPECT_EQ(got->source_index, 0u);      // missing source tile -> 0
-}
 
-TEST_F(TileIoTest, LayersWriteToSeparateSubdirectories)
-{
-  MbesBackscatterStore store(5);
-  store.set(SourceLayer::Processed, store.cellIndex(43.0, -70.5), MbesCell{-10.0f, 0.1f, 1LL});
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), MbesCell{-12.0f, 0.5f, 2LL});
-  marine_mbes_backscatter_store::save(store, dir_.string());
-
-  EXPECT_TRUE(fs::is_directory(dir_ / "processed"));
-  EXPECT_TRUE(fs::is_directory(dir_ / "draft"));
+  const double se = static_cast<double>(got->standard_error) / scale;
+  const double n = std::pow(static_cast<double>(got->sample_sd) / se, 2.0);
+  EXPECT_NEAR(n, std::round(n), 1e-4);          // integer count
+  EXPECT_EQ(static_cast<int>(std::round(n)), n_true);
 }
 
 TEST_F(TileIoTest, LoadedTilesAreCleanAndDontResave)
 {
   MbesBackscatterStore store(5);
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), MbesCell{-30.0f, 0.5f, 1LL});
+  store.set(SourceLayer::Cube, store.cellIndex(43.0, -70.5), MbesCell{-30.0f, 0.5f, 1.0f});
 
   EXPECT_EQ(marine_mbes_backscatter_store::save(store, dir_.string()), 1u);
   EXPECT_EQ(marine_mbes_backscatter_store::save(store, dir_.string()), 0u);  // incremental
@@ -180,10 +186,18 @@ TEST_F(TileIoTest, LoadedTilesAreCleanAndDontResave)
   EXPECT_EQ(marine_mbes_backscatter_store::save(reloaded, dir_.string()), 0u);
 }
 
+TEST_F(TileIoTest, SaveWritesCubeSubdirectory)
+{
+  MbesBackscatterStore store(5);
+  store.set(SourceLayer::Cube, store.cellIndex(43.0, -70.5), MbesCell{-10.0f, 0.1f, 0.2f});
+  marine_mbes_backscatter_store::save(store, dir_.string());
+  EXPECT_TRUE(fs::is_directory(dir_ / "cube"));
+}
+
 TEST_F(TileIoTest, LoadRejectsTilesFromAnotherLevel)
 {
   MbesBackscatterStore store(5);
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), MbesCell{-30.0f, 0.5f, 1LL});
+  store.set(SourceLayer::Cube, store.cellIndex(43.0, -70.5), MbesCell{-30.0f, 0.5f, 1.0f});
   marine_mbes_backscatter_store::save(store, dir_.string());
 
   MbesBackscatterStore wrong_level(6);
@@ -191,130 +205,23 @@ TEST_F(TileIoTest, LoadRejectsTilesFromAnotherLevel)
     marine_mbes_backscatter_store::load(wrong_level, dir_.string()), std::runtime_error);
 }
 
-TEST_F(TileIoTest, LoadRejectsCompanionWithWrongGrid)
+// --- Coarse StoreMetadata (registry.json) round-trip (#248) ---
+
+TEST_F(TileIoTest, StoreMetadataRoundTrip)
 {
-  // If a _time.tif companion is replaced with a file from a different grid
-  // (tampering / mis-rename), loadTile must throw rather than silently combining
-  // cell-for-cell data from two geographic locations.
-  namespace mtrs = marine_tiled_raster_store;
-  const gggs::Level level(5);
-  const gggs::GridIndex grid_a = level.gridIndex(43.0, -70.5);
-  const gggs::GridIndex grid_b = level.gridIndex(44.0, -71.0);
-  ASSERT_FALSE(grid_a == grid_b);
-
   MbesBackscatterStore store(5);
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), MbesCell{-30.0f, 0.5f, 42LL, 1u});
-  marine_mbes_backscatter_store::save(store, dir_.string());
+  store.set(SourceLayer::Cube, store.cellIndex(43.0, -70.5), MbesCell{-20.0f, 0.5f, 1.0f});
+  StoreMetadata md{"bizzyboat", "kongsberg-m3", "massabesic-2026", "2026-06-30", ""};
 
-  const std::string value_filename = marine_mbes_backscatter_store::tileFilename(grid_a);
-  const fs::path time_path =
-    dir_ / "draft" / (fs::path(value_filename).stem().string() + "_time.tif");
-  mtrs::TiledRasterTile<int64_t> wrong_time(grid_b, 1, int64_t{0});
-  wrong_time.set(0, 0, 0, 99LL);
-  mtrs::saveTile<int64_t>(wrong_time, time_path.string(), {std::nullopt});
-
-  MbesBackscatterStore reloaded(5);
-  EXPECT_THROW(
-    marine_mbes_backscatter_store::load(reloaded, dir_.string()), std::runtime_error);
-}
-
-TEST_F(TileIoTest, RegistryWriteInternRoundTrip)
-{
-  // Register two sources, save with the store, reload into a fresh registry, and
-  // verify intern idempotency, dense 1-based indices, and the round-trip.
-  MbesBackscatterStore store(5);
-  store.set(SourceLayer::Draft, store.cellIndex(43.0, -70.5), MbesCell{-20.0f, 0.5f, 1LL, 1u});
-
-  SourceRegistry registry;
-  const uint16_t a = registry.registerSource(
-    SourceRecord{"bizzy:kongsberg-m3:0", "bizzyboat", "kongsberg-m3", "mbes-backscatter",
-      "massabesic-2026", ""});
-  const uint16_t b = registry.registerSource(
-    SourceRecord{"izzy:kongsberg-m3:0", "izzyboat", "kongsberg-m3", "mbes-backscatter", "", ""});
-  const uint16_t a2 = registry.registerSource(
-    SourceRecord{"bizzy:kongsberg-m3:0", "x", "y", "", "", ""});   // idempotent
-  EXPECT_EQ(a, 1u);                  // first real index (0 reserved)
-  EXPECT_EQ(b, 2u);
-  EXPECT_EQ(a2, a);                  // same source_id -> same index, no new entry
-  EXPECT_EQ(registry.size(), 2u);
-  EXPECT_FALSE(registry.lookup(SourceRegistry::kUnset).has_value());  // index 0 is unset
-
-  marine_mbes_backscatter_store::save(store, dir_.string(), &registry);
+  marine_mbes_backscatter_store::save(store, dir_.string(), &md);
   EXPECT_TRUE(fs::is_regular_file(dir_ / "registry.json"));
-  EXPECT_FALSE(fs::exists(dir_ / "registry.json.tmp"));   // atomic publish, no scratch
+  EXPECT_FALSE(fs::exists(dir_ / "registry.json.tmp"));   // atomic publish
 
-  SourceRegistry reloaded;
+  StoreMetadata reloaded;
   marine_mbes_backscatter_store::load(store, dir_.string(), &reloaded);
-  EXPECT_EQ(reloaded.size(), 2u);
-  const auto rec = reloaded.lookup(1);
-  ASSERT_TRUE(rec.has_value());
-  EXPECT_EQ(rec->platform, "bizzyboat");
-  EXPECT_EQ(rec->sensor_class, "mbes-backscatter");
-  EXPECT_EQ(rec->campaign, "massabesic-2026");
-}
-
-// --- Fix #1: registry.cpp loadRegistry index and duplicate source_id validation ---
-
-TEST_F(TileIoTest, LoadRegistryRejectsReorderedIndex)
-{
-  // A hand-edited registry.json with a swapped/reordered "index" field must be
-  // rejected with a clear error (not silently accepted as a contiguous sequence).
-  fs::create_directories(dir_);
-  const nlohmann::json bad_registry = {
-    {"version", 1},
-    {"sources", nlohmann::json::array({
-      {{"index", 2}, {"source_id", "a"}, {"platform", "p1"}, {"sensor", "s"},
-       {"sensor_class", ""}, {"campaign", ""}, {"calibration_ref", ""}},
-      {{"index", 1}, {"source_id", "b"}, {"platform", "p2"}, {"sensor", "s"},
-       {"sensor_class", ""}, {"campaign", ""}, {"calibration_ref", ""}},
-    })}
-  };
-  {
-    std::ofstream out(dir_ / "registry.json");
-    out << bad_registry.dump(2);
-  }
-  SourceRegistry reg;
-  EXPECT_THROW(reg.loadRegistry(dir_.string()), std::runtime_error);
-}
-
-TEST_F(TileIoTest, LoadRegistryRejectsMissingIndexField)
-{
-  // An entry that lacks the "index" field entirely must also be rejected.
-  fs::create_directories(dir_);
-  const nlohmann::json bad_registry = {
-    {"version", 1},
-    {"sources", nlohmann::json::array({
-      // "index" field deliberately omitted
-      {{"source_id", "a"}, {"platform", "p1"}, {"sensor", "s"},
-       {"sensor_class", ""}, {"campaign", ""}, {"calibration_ref", ""}},
-    })}
-  };
-  {
-    std::ofstream out(dir_ / "registry.json");
-    out << bad_registry.dump(2);
-  }
-  SourceRegistry reg;
-  EXPECT_THROW(reg.loadRegistry(dir_.string()), std::runtime_error);
-}
-
-TEST_F(TileIoTest, LoadRegistryRejectsDuplicateSourceId)
-{
-  // Two entries with the same source_id at distinct contiguous indices must be
-  // rejected: duplicate source_id desynchronises by_index_ and by_source_id_.
-  fs::create_directories(dir_);
-  const nlohmann::json bad_registry = {
-    {"version", 1},
-    {"sources", nlohmann::json::array({
-      {{"index", 1}, {"source_id", "dup"}, {"platform", "p1"}, {"sensor", "s"},
-       {"sensor_class", ""}, {"campaign", ""}, {"calibration_ref", ""}},
-      {{"index", 2}, {"source_id", "dup"}, {"platform", "p2"}, {"sensor", "s"},
-       {"sensor_class", ""}, {"campaign", ""}, {"calibration_ref", ""}},
-    })}
-  };
-  {
-    std::ofstream out(dir_ / "registry.json");
-    out << bad_registry.dump(2);
-  }
-  SourceRegistry reg;
-  EXPECT_THROW(reg.loadRegistry(dir_.string()), std::runtime_error);
+  EXPECT_EQ(reloaded.platform, "bizzyboat");
+  EXPECT_EQ(reloaded.sensor, "kongsberg-m3");
+  EXPECT_EQ(reloaded.survey, "massabesic-2026");
+  EXPECT_EQ(reloaded.date, "2026-06-30");
+  EXPECT_EQ(reloaded.calibration_ref, "");   // empty until a calibration exists
 }

--- a/marine_mbes_backscatter_store/test/test_tile_io.cpp
+++ b/marine_mbes_backscatter_store/test/test_tile_io.cpp
@@ -60,22 +60,22 @@ TEST_F(TileIoTest, RoundTripPreservesCells)
 {
   MbesBackscatterStore store(5);
   store.set(
-    SourceLayer::Cube, store.cellIndex(43.0, -70.5), MbesCell{-18.5f, 0.375f, 0.75f});
+    SourceLayer::Survey, store.cellIndex(43.0, -70.5), MbesCell{-18.5f, 0.375f, 0.75f});
   store.set(
-    SourceLayer::Cube, store.cellIndex(44.0, -71.0), MbesCell{-12.5f, 0.125f, 0.25f});
+    SourceLayer::Survey, store.cellIndex(44.0, -71.0), MbesCell{-12.5f, 0.125f, 0.25f});
 
   EXPECT_EQ(marine_mbes_backscatter_store::save(store, dir_.string()), 2u);
 
   MbesBackscatterStore reloaded(5);
   EXPECT_EQ(marine_mbes_backscatter_store::load(reloaded, dir_.string()), 2u);
 
-  const auto a = reloaded.get(SourceLayer::Cube, reloaded.cellIndex(43.0, -70.5));
+  const auto a = reloaded.get(SourceLayer::Survey, reloaded.cellIndex(43.0, -70.5));
   ASSERT_TRUE(a.has_value());
   EXPECT_FLOAT_EQ(a->mean, -18.5f);
   EXPECT_FLOAT_EQ(a->standard_error, 0.375f);
   EXPECT_FLOAT_EQ(a->sample_sd, 0.75f);
 
-  const auto b = reloaded.get(SourceLayer::Cube, reloaded.cellIndex(44.0, -71.0));
+  const auto b = reloaded.get(SourceLayer::Survey, reloaded.cellIndex(44.0, -71.0));
   ASSERT_TRUE(b.has_value());
   EXPECT_FLOAT_EQ(b->mean, -12.5f);
 }
@@ -99,13 +99,13 @@ TEST_F(TileIoTest, WelfordRoundTripReconstructsNAndM2)
 
   MbesBackscatterStore store(5);
   store.set(
-    SourceLayer::Cube, store.cellIndex(43.0, -70.5),
+    SourceLayer::Survey, store.cellIndex(43.0, -70.5),
     MbesCell{-18.5f, stored_se, sample_sd});
   EXPECT_EQ(marine_mbes_backscatter_store::save(store, dir_.string()), 1u);
 
   MbesBackscatterStore reloaded(5);
   EXPECT_EQ(marine_mbes_backscatter_store::load(reloaded, dir_.string()), 1u);
-  const auto got = reloaded.get(SourceLayer::Cube, reloaded.cellIndex(43.0, -70.5));
+  const auto got = reloaded.get(SourceLayer::Survey, reloaded.cellIndex(43.0, -70.5));
   ASSERT_TRUE(got.has_value());
 
   // Divide the confidence scale out, then reconstruct.
@@ -123,12 +123,12 @@ TEST_F(TileIoTest, WelfordN1SentinelRoundTrips)
   // from no-data (NaN mean).
   MbesBackscatterStore store(5);
   store.set(
-    SourceLayer::Cube, store.cellIndex(43.0, -70.5), MbesCell{-12.0f, 0.0f, 0.0f});
+    SourceLayer::Survey, store.cellIndex(43.0, -70.5), MbesCell{-12.0f, 0.0f, 0.0f});
   EXPECT_EQ(marine_mbes_backscatter_store::save(store, dir_.string()), 1u);
 
   MbesBackscatterStore reloaded(5);
   EXPECT_EQ(marine_mbes_backscatter_store::load(reloaded, dir_.string()), 1u);
-  const auto got = reloaded.get(SourceLayer::Cube, reloaded.cellIndex(43.0, -70.5));
+  const auto got = reloaded.get(SourceLayer::Survey, reloaded.cellIndex(43.0, -70.5));
   ASSERT_TRUE(got.has_value());
 
   // Finite mean + zero sample_sd -> real data, n=1, M2=0.
@@ -158,13 +158,13 @@ TEST_F(TileIoTest, ConfidenceScaleDividesOutToIntegerN)
 
   MbesBackscatterStore store(5);
   store.set(
-    SourceLayer::Cube, store.cellIndex(43.0, -70.5),
+    SourceLayer::Survey, store.cellIndex(43.0, -70.5),
     MbesCell{-5.0f, stored_se, sample_sd});
   marine_mbes_backscatter_store::save(store, dir_.string());
 
   MbesBackscatterStore reloaded(5);
   marine_mbes_backscatter_store::load(reloaded, dir_.string());
-  const auto got = reloaded.get(SourceLayer::Cube, reloaded.cellIndex(43.0, -70.5));
+  const auto got = reloaded.get(SourceLayer::Survey, reloaded.cellIndex(43.0, -70.5));
   ASSERT_TRUE(got.has_value());
 
   const double se = static_cast<double>(got->standard_error) / scale;
@@ -176,7 +176,7 @@ TEST_F(TileIoTest, ConfidenceScaleDividesOutToIntegerN)
 TEST_F(TileIoTest, LoadedTilesAreCleanAndDontResave)
 {
   MbesBackscatterStore store(5);
-  store.set(SourceLayer::Cube, store.cellIndex(43.0, -70.5), MbesCell{-30.0f, 0.5f, 1.0f});
+  store.set(SourceLayer::Survey, store.cellIndex(43.0, -70.5), MbesCell{-30.0f, 0.5f, 1.0f});
 
   EXPECT_EQ(marine_mbes_backscatter_store::save(store, dir_.string()), 1u);
   EXPECT_EQ(marine_mbes_backscatter_store::save(store, dir_.string()), 0u);  // incremental
@@ -186,18 +186,18 @@ TEST_F(TileIoTest, LoadedTilesAreCleanAndDontResave)
   EXPECT_EQ(marine_mbes_backscatter_store::save(reloaded, dir_.string()), 0u);
 }
 
-TEST_F(TileIoTest, SaveWritesCubeSubdirectory)
+TEST_F(TileIoTest, SaveWritesSurveySubdirectory)
 {
   MbesBackscatterStore store(5);
-  store.set(SourceLayer::Cube, store.cellIndex(43.0, -70.5), MbesCell{-10.0f, 0.1f, 0.2f});
+  store.set(SourceLayer::Survey, store.cellIndex(43.0, -70.5), MbesCell{-10.0f, 0.1f, 0.2f});
   marine_mbes_backscatter_store::save(store, dir_.string());
-  EXPECT_TRUE(fs::is_directory(dir_ / "cube"));
+  EXPECT_TRUE(fs::is_directory(dir_ / "survey"));
 }
 
 TEST_F(TileIoTest, LoadRejectsTilesFromAnotherLevel)
 {
   MbesBackscatterStore store(5);
-  store.set(SourceLayer::Cube, store.cellIndex(43.0, -70.5), MbesCell{-30.0f, 0.5f, 1.0f});
+  store.set(SourceLayer::Survey, store.cellIndex(43.0, -70.5), MbesCell{-30.0f, 0.5f, 1.0f});
   marine_mbes_backscatter_store::save(store, dir_.string());
 
   MbesBackscatterStore wrong_level(6);
@@ -210,7 +210,7 @@ TEST_F(TileIoTest, LoadRejectsTilesFromAnotherLevel)
 TEST_F(TileIoTest, StoreMetadataRoundTrip)
 {
   MbesBackscatterStore store(5);
-  store.set(SourceLayer::Cube, store.cellIndex(43.0, -70.5), MbesCell{-20.0f, 0.5f, 1.0f});
+  store.set(SourceLayer::Survey, store.cellIndex(43.0, -70.5), MbesCell{-20.0f, 0.5f, 1.0f});
   StoreMetadata md{"bizzyboat", "kongsberg-m3", "massabesic-2026", "2026-06-30", ""};
 
   marine_mbes_backscatter_store::save(store, dir_.string(), &md);

--- a/marine_mbes_backscatter_store/test/test_tile_io.cpp
+++ b/marine_mbes_backscatter_store/test/test_tile_io.cpp
@@ -23,6 +23,9 @@
 
 #include <cmath>
 #include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 
@@ -224,4 +227,107 @@ TEST_F(TileIoTest, StoreMetadataRoundTrip)
   EXPECT_EQ(reloaded.survey, "massabesic-2026");
   EXPECT_EQ(reloaded.date, "2026-06-30");
   EXPECT_EQ(reloaded.calibration_ref, "");   // empty until a calibration exists
+}
+
+// --- Twin-store parity load-robustness guards (#248, mirrors bathy store) ---
+
+TEST_F(TileIoTest, MetadataLoadWarnsOnUnrecognizedSchemaVersion)
+{
+  // A pre-#248 (or foreign) registry.json whose "version" != the current schema
+  // would otherwise load as all-empty without a trace. load() must warn.
+  fs::create_directories(dir_);
+  {std::ofstream(dir_ / "registry.json") << R"({"version": 1, "site": "old"})";}
+
+  StoreMetadata md;
+  std::ostringstream captured;
+  std::streambuf * prev = std::cerr.rdbuf(captured.rdbuf());
+  md.load(dir_.string());
+  std::cerr.rdbuf(prev);
+
+  EXPECT_NE(captured.str().find("unrecognized schema version"), std::string::npos)
+    << "expected a version-mismatch warning, got: " << captured.str();
+  EXPECT_TRUE(md.empty());   // unknown-schema fields do not map — loads empty
+}
+
+TEST_F(TileIoTest, MetadataLoadIsSilentOnCurrentSchemaVersion)
+{
+  fs::create_directories(dir_);
+  StoreMetadata md{"bizzy", "m3", "massabesic-2026", "2026-06-30", ""};
+  md.save(dir_.string());
+
+  StoreMetadata loaded;
+  std::ostringstream captured;
+  std::streambuf * prev = std::cerr.rdbuf(captured.rdbuf());
+  loaded.load(dir_.string());
+  std::cerr.rdbuf(prev);
+
+  EXPECT_TRUE(captured.str().empty()) << "current-schema load must be silent";
+  EXPECT_EQ(loaded.survey, "massabesic-2026");
+}
+
+TEST_F(TileIoTest, LoadWarnsOnUnrecognizedStoreLayout)
+{
+  // A pre-#248 (draft/processed) store has no survey/ subdir, so load() reaches
+  // no tiles and returns empty. That silent-empty load must warn (diagnostic).
+  fs::create_directories(dir_ / "processed");
+  {std::ofstream(dir_ / "processed" / "5_0_0.tif") << "old-layout tile";}
+
+  MbesBackscatterStore reloaded(5);
+  std::ostringstream captured;
+  std::streambuf * prev = std::cerr.rdbuf(captured.rdbuf());
+  const std::size_t n = marine_mbes_backscatter_store::load(reloaded, dir_.string());
+  std::cerr.rdbuf(prev);
+
+  EXPECT_EQ(n, 0u);
+  EXPECT_NE(captured.str().find("no recognized"), std::string::npos)
+    << "expected an old-layout warning, got: " << captured.str();
+}
+
+TEST_F(TileIoTest, LoadDoesNotWarnOnFreshOrMetadataOnlyStore)
+{
+  auto load_stderr = [this]() {
+      MbesBackscatterStore reloaded(5);
+      std::ostringstream captured;
+      std::streambuf * prev = std::cerr.rdbuf(captured.rdbuf());
+      marine_mbes_backscatter_store::load(reloaded, dir_.string());
+      std::cerr.rdbuf(prev);
+      return captured.str();
+    };
+
+  EXPECT_TRUE(load_stderr().empty());              // absent store dir
+  fs::create_directories(dir_);
+  EXPECT_TRUE(load_stderr().empty());              // empty store dir
+
+  StoreMetadata md;
+  md.survey = "massabesic-2026";
+  md.save(dir_.string());
+  ASSERT_TRUE(fs::is_regular_file(dir_ / "registry.json"));
+  EXPECT_TRUE(load_stderr().empty()) << "metadata-only store must not warn";
+}
+
+TEST_F(TileIoTest, LoadSkipsStrayCompanionRasters)
+{
+  // A dropped pre-#248 companion (`*_time.tif`/`*_source.tif`) lingering in a
+  // new-layout survey/ dir would throw in loadTile() and abort the whole load.
+  // It must be warned-and-skipped so the valid value tiles still load.
+  MbesBackscatterStore writer(5);
+  const auto cell = writer.cellIndex(43.0, -70.5);
+  writer.set(SourceLayer::Survey, cell, MbesCell{-30.0f, 0.5f, 1.0f});
+  marine_mbes_backscatter_store::save(writer, dir_.string());
+
+  const std::string tile = marine_mbes_backscatter_store::tileFilename(cell.grid());
+  const std::string stem = tile.substr(0, tile.size() - 4);   // drop ".tif"
+  {std::ofstream(dir_ / "survey" / (stem + "_source.tif")) << "stale companion";}
+  {std::ofstream(dir_ / "survey" / (stem + "_time.tif")) << "stale companion";}
+
+  MbesBackscatterStore reloaded(5);
+  std::ostringstream captured;
+  std::streambuf * prev = std::cerr.rdbuf(captured.rdbuf());
+  const std::size_t n = marine_mbes_backscatter_store::load(reloaded, dir_.string());
+  std::cerr.rdbuf(prev);
+
+  EXPECT_EQ(n, 1u) << "the valid value tile must still load past the companions";
+  ASSERT_TRUE(reloaded.get(SourceLayer::Survey, cell).has_value());
+  EXPECT_FLOAT_EQ(reloaded.get(SourceLayer::Survey, cell)->mean, -30.0f);
+  EXPECT_NE(captured.str().find("companion raster"), std::string::npos);
 }

--- a/marine_tiled_raster_store/README.md
+++ b/marine_tiled_raster_store/README.md
@@ -42,16 +42,21 @@ originates in [ADR-0002](../docs/decisions/0002-bathymetric-data-store.md) §D5/
 
 GDAL is kept a **private** dependency: the `tile_io` functions are templates
 **explicitly instantiated** in `tile_io.cpp` for the supported element types —
-currently `double` (bathymetry: 3-band Float64) and `std::uint16_t` (sidescan
-backscatter: 1-band, #173). To add a type, add a `gdalType<>` specialization and
-an explicit instantiation in `tile_io.cpp`; nothing in the public headers
-changes.
+`double` (bathymetry: a single 2-band `Float64` value tile since #248),
+`float` (MBES backscatter: a 3-band `Float32` value tile,
+[#194](https://github.com/rolker/unh_marine_autonomy/issues/194)), and
+`std::uint16_t` (sidescan backscatter: 1-band, #173). To add a type, add a
+`gdalType<>` specialization and an explicit instantiation in `tile_io.cpp`;
+nothing in the public headers changes.
 
 ## Consumers
 
-- `marine_bathymetry_store` — instantiates `TiledRasterTile<double>` (3 bands:
-  depth / uncertainty / timestamp) and keeps its multi-layer `SourceLayer` store,
-  priority queries, and `BathyCell` on top.
+- `marine_bathymetry_store` — instantiates `TiledRasterTile<double>` as a single
+  2-band value tile (depth / uncertainty; the per-cell time / source companions
+  were dropped in #248) and keeps its `SourceLayer` store, priority queries, and
+  `BathyCell` on top.
+- `marine_mbes_backscatter_store` — `TiledRasterTile<float>` as a 3-band value
+  tile (mean / standard_error / sample_sd).
 - `marine_sidescan_mosaic` (#173) — `TiledRasterTile<std::uint16_t>` at GGGS
   level 13.
 


### PR DESCRIPTION
Closes #248

> ⚠️ **SYNCHRONIZED LANDING — do not merge alone.** This co-lands with
> **cube_bathymetry#96** (the CUBE-side consumer of the new store format). The
> `SourceLayer` rename + band-layout change is breaking; merging this before #96
> is ready leaves cube unbuildable. Merge the two together (ADR-0002 A2.5).

## Summary

Greenfield simplification of the two store formats (no migration — stores are a
regenerable cache over raw bags):

- **Layers**: bathy `chart`/`draft`/`processed` → **`reference`** (optional
  read-only prior) + **`survey`**; MBES `draft`/`processed` → single **`survey`**.
- **MBES value tile**: `{intensity, intensity_variance}` (2-band) →
  **`{mean, standard_error, sample_sd}`** (3-band) — the Welford sufficient
  statistic, so reload is lossless (`n = (sample_sd/standard_error)²`,
  `M2 = sample_sd²(n−1)`; `sample_sd==0` = single-look sentinel; SE
  confidence-scaled to match bathy `uncertainty`, divided out on reload).
- **Dropped** per-cell `_time`/`_source` rasters; `registry.json` repurposed as
  coarse store-level `StoreMetadata` (platform/sensor/survey/date).
- **`bathymetry_layer` staleness gate retired** (operator-approved): bathy is a
  surveyed static bottom, not a live feed; uncertainty→LETHAL and no-data
  guards preserved. Rationale recorded in the ADR-0002 addendum.
- **ADR addenda**: ADR-0002 (layer taxonomy + tile layout + gate retirement),
  ADR-0005 (per-cell source dropped; registry repurposed), ADR-0007 (backscatter
  bands + layer collapse).
- **Load robustness** (both stores): warn on old-layout/silently-empty loads,
  warn-and-skip stray companions, validate registry schema version.

## Verification

- **Host build + test green**: `marine_bathymetry_store`, `marine_mbes_backscatter_store`,
  and `bathymetry_layer` — **274 tests, 0 failures**. (`bathymetry_layer` needs the
  underlay `geodesy` fork — see repo note — so it's host-built, not in-container.)
- Load-bearing tests: Welford `(mean,SE,SD)↔(n,M2)` round-trip incl. n=1 sentinel
  vs NaN no-data; bathy uncertainty round-trip; gate-retirement guards.

## Review

Driven via `/run-issue`: review-issue → plan → plan-review → implement →
review-code (2 rounds). Round 2 **approved**, 0 must-fix; both Deep adversarial
lenses confirmed lossless round-trips + a clean gate retirement. Round-1 must-fix
(silent-empty nav prior → warn) and all suggestions (incl. twin-store parity)
addressed.

## Follow-up (host)

- Co-land **cube_bathymetry#96**.
- Sim-validate per ADR-0002 D7.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
