### PR TITLE
feat(marine_sidescan_mosaic): --accumulate composite into an existing store (#253, re-opened from #254)

### DIFF
--- a/.agent/work-plans/issue-253/progress.md
+++ b/.agent/work-plans/issue-253/progress.md
@@ -22,3 +22,12 @@ issue: 253
 - [ ] (suggestion) Test gap: `foldTile`'s `if (q==0) continue` no-data guard is redundant with the strict-`>` test, so `FoldTileKeepsBetterIncumbentAndSkipsNoData` doesn't distinguish the skip path. — `test_processed_accumulator.cpp:114`
 
 Sound (verified): tile is square 960×960 so foldTile bounds correct; merge is order-independent + idempotent (strict `>`, incumbent-wins-ties); grids snapshotted before fold → no iterator invalidation; saveTiles dirty-only leaves untouched tiles alone; `--accumulate` default-off preserves prior behavior. ADR-0006 D5/D7 (cross-pass best-source composite) — now actually implemented.
+
+## Address Findings
+**When**: 2026-07-01 06:45 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+- [x] (must-fix) Reload failure → data loss: now ABORTS (exit 1) before any save; corrupt-tile test confirms the tile is preserved, not overwritten.
+- [x] (must-fix) Registry source-id mismatch: guard refuses (exit 2) with a re-run hint, before decoding; same-source re-accumulate unchanged (exit 0).
+- [ ] (suggestion) `saveTile` non-atomic (temp+rename) — deferred to a `marine_tiled_raster_store` follow-up issue (shared I/O, pre-existing).
+- [ ] (suggestion) concurrency lockfile + test distinguishing the no-data-skip path — hardening follow-ups, not blocking.

--- a/.agent/work-plans/issue-253/progress.md
+++ b/.agent/work-plans/issue-253/progress.md
@@ -1,0 +1,24 @@
+---
+issue: 253
+---
+
+# Issue #253 — sidescan_tier2_processed --accumulate: composite into an existing store
+
+## Local Review (Post-PR)
+**Status**: complete
+**When**: 2026-07-01 06:20 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: changes-requested
+**PR**: #254 at `bfc5531`
+**Mode**: post-PR
+**Depth**: Standard (reason: merge logic + file-reload durability)
+**Must-fix**: 2 | **Suggestions**: 3
+
+### Findings
+- [ ] (must-fix) Reload failure → silent data loss: if `loadTile` throws (corrupt/partial/old-format/transient IO), the code only warns, then `saveTiles` OVERWRITES the tile with current-run-only data, dropping all prior accumulated coverage on that tile. Violates "never lose data". Abort the run (non-zero exit) or write to temp / preserve original on reload failure. Cross-confirmed Lens A+B. — `sidescan_tier2_processed.cpp:261-264` (effect at `:273`)
+- [ ] (must-fix) `writeRegistry` overwrites `registry.json` with only the current run's single source, but `foldTile` preserves each existing cell's original source band — so multi-run `--accumulate` with distinct `--source-id`s yields tiles with mixed source indices and a registry listing only the last. registry.cpp's own TODO(#179, ADR-0005 D8) says reimport must MERGE append-only. Masked today (all per-bag runs use source-id=1) but the feature enables silent provenance corruption. At minimum merge the registry or reject a source-id absent from the existing one. — `sidescan_tier2_processed.cpp:278`
+- [ ] (suggestion) `saveTile` is non-atomic (`driver->Create` truncates in place); a crash/disk-full mid-write leaves a corrupt tile replacing the good one — compounds the reload-failure loss and breaks the idempotency claim across a crash. Fix in shared I/O: write temp + `rename()`. (Pre-existing `marine_tiled_raster_store` code; separate follow-up.) — `marine_tiled_raster_store/src/tile_io.cpp:132`
+- [ ] (suggestion) No concurrency guard: two `--accumulate` runs on one store dir race (lost update / corrupt tile). Sequential-only is neither documented in usage nor enforced. Add a store lockfile or document it. — `sidescan_tier2_processed.cpp:242-267`
+- [ ] (suggestion) Test gap: `foldTile`'s `if (q==0) continue` no-data guard is redundant with the strict-`>` test, so `FoldTileKeepsBetterIncumbentAndSkipsNoData` doesn't distinguish the skip path. — `test_processed_accumulator.cpp:114`
+
+Sound (verified): tile is square 960×960 so foldTile bounds correct; merge is order-independent + idempotent (strict `>`, incumbent-wins-ties); grids snapshotted before fold → no iterator invalidation; saveTiles dirty-only leaves untouched tiles alone; `--accumulate` default-off preserves prior behavior. ADR-0006 D5/D7 (cross-pass best-source composite) — now actually implemented.

--- a/marine_backscatter/include/marine_backscatter/processed_accumulator.hpp
+++ b/marine_backscatter/include/marine_backscatter/processed_accumulator.hpp
@@ -66,6 +66,14 @@ public:
     const gggs::CellIndex & cell,
     std::uint16_t intensity, std::uint16_t quality, std::uint16_t source_id);
 
+  /// @brief Fold an already-composited tile (e.g. one reloaded from the store)
+  ///   into the accumulator using the same strict best-source-by-quality rule as
+  ///   @ref add. Lets a run **accumulate into an existing store** rather than
+  ///   overwrite it: reload each touched tile, fold it in, then save the merge.
+  ///   No-data cells (quality 0) in @p existing are skipped; ties keep whatever
+  ///   the accumulator already holds. @p existing must have @ref kBands bands.
+  void foldTile(const Tile & existing);
+
   /// @brief The composited tiles (mutable so `saveTiles` can clear dirty flags).
   std::map<gggs::GridIndex, Tile> & tiles() {return output_;}
   const std::map<gggs::GridIndex, Tile> & tiles() const {return output_;}

--- a/marine_backscatter/src/processed_accumulator.cpp
+++ b/marine_backscatter/src/processed_accumulator.cpp
@@ -54,4 +54,26 @@ void ProcessedAccumulator::add(
   }
 }
 
+void ProcessedAccumulator::foldTile(const Tile & existing)
+{
+  // Same best-source rule as add(), applied cell-by-cell from a reloaded tile.
+  // A strictly-greater test means the incumbent wins ties, so folding an existing
+  // store tile into a run that already composited the new pings keeps the higher-
+  // quality look regardless of fold order.
+  Tile & tile = ensureOutput(existing.index());
+  for (std::uint16_t row = 0; row < gggs::cell_rows_per_grid; ++row) {
+    for (std::uint16_t col = 0; col < gggs::cell_rows_per_grid; ++col) {
+      const std::uint16_t q = existing.get(row, col, kQuality);
+      if (q == 0) {
+        continue;   // no-data cell in the reloaded tile.
+      }
+      if (q > tile.get(row, col, kQuality)) {
+        tile.set(row, col, kIntensity, existing.get(row, col, kIntensity));
+        tile.set(row, col, kQuality, q);
+        tile.set(row, col, kSource, existing.get(row, col, kSource));
+      }
+    }
+  }
+}
+
 }  // namespace marine_backscatter

--- a/marine_backscatter/test/test_processed_accumulator.cpp
+++ b/marine_backscatter/test/test_processed_accumulator.cpp
@@ -21,6 +21,8 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdint>
+
 #include "geographic_msgs/msg/geo_point.hpp"
 #include "marine_autonomy/gggs.h"
 #include "marine_backscatter/processed_accumulator.hpp"
@@ -74,4 +76,61 @@ TEST(ProcessedAccumulator, InvalidCellIsNoOp)
   ProcessedAccumulator acc(level);
   acc.add(gggs::CellIndex{}, 100, 100, 1);   // default cell is invalid
   EXPECT_TRUE(acc.tiles().empty());
+}
+
+// foldTile: a reloaded store tile with a HIGHER-quality look wins the shared
+// cell, and a cell present only in the store survives the merge (issue #253).
+TEST(ProcessedAccumulator, FoldTileBestSourceMerge)
+{
+  const gggs::Level level(13);
+  const gggs::CellIndex cell = aCell(level);
+  const auto r = cell.row();
+  const auto c = cell.column();
+  const std::uint16_t r2 = (r == 0) ? 1u : static_cast<std::uint16_t>(r - 1);
+
+  ProcessedAccumulator acc(level);
+  acc.add(cell, 100, 50, 1);   // this run's look at the shared cell, quality 50
+
+  ProcessedAccumulator::Tile existing(cell.grid(), ProcessedAccumulator::kBands, 0);
+  existing.set(r, c, ProcessedAccumulator::kIntensity, 200);
+  existing.set(r, c, ProcessedAccumulator::kQuality, 90);   // better -> wins
+  existing.set(r, c, ProcessedAccumulator::kSource, 7);
+  existing.set(r2, c, ProcessedAccumulator::kIntensity, 300);
+  existing.set(r2, c, ProcessedAccumulator::kQuality, 20);   // store-only cell
+  existing.set(r2, c, ProcessedAccumulator::kSource, 8);
+
+  acc.foldTile(existing);
+
+  const auto & tile = acc.tiles().at(cell.grid());
+  EXPECT_EQ(tile.get(r, c, ProcessedAccumulator::kIntensity), 200);
+  EXPECT_EQ(tile.get(r, c, ProcessedAccumulator::kQuality), 90);
+  EXPECT_EQ(tile.get(r, c, ProcessedAccumulator::kSource), 7);
+  EXPECT_EQ(tile.get(r2, c, ProcessedAccumulator::kQuality), 20);
+  EXPECT_EQ(tile.get(r2, c, ProcessedAccumulator::kSource), 8);
+}
+
+// foldTile: a worse-quality reloaded cell is ignored, and no-data (quality 0)
+// cells in the reloaded tile are skipped (they never create spurious cells).
+TEST(ProcessedAccumulator, FoldTileKeepsBetterIncumbentAndSkipsNoData)
+{
+  const gggs::Level level(13);
+  const gggs::CellIndex cell = aCell(level);
+  const auto r = cell.row();
+  const auto c = cell.column();
+
+  ProcessedAccumulator acc(level);
+  acc.add(cell, 100, 80, 1);   // this run holds quality 80 at the shared cell
+
+  ProcessedAccumulator::Tile existing(cell.grid(), ProcessedAccumulator::kBands, 0);
+  existing.set(r, c, ProcessedAccumulator::kIntensity, 200);
+  existing.set(r, c, ProcessedAccumulator::kQuality, 30);   // worse -> ignored
+  existing.set(r, c, ProcessedAccumulator::kSource, 9);
+  // every other cell stays quality 0 (no-data) and must be skipped.
+
+  acc.foldTile(existing);
+
+  const auto & tile = acc.tiles().at(cell.grid());
+  EXPECT_EQ(tile.get(r, c, ProcessedAccumulator::kIntensity), 100);   // incumbent kept
+  EXPECT_EQ(tile.get(r, c, ProcessedAccumulator::kQuality), 80);
+  EXPECT_EQ(tile.get(r, c, ProcessedAccumulator::kSource), 1);
 }

--- a/marine_sidescan_mosaic/src/sidescan_tier2_processed.cpp
+++ b/marine_sidescan_mosaic/src/sidescan_tier2_processed.cpp
@@ -152,6 +152,41 @@ int main(int argc, char ** argv)
   const std::string campaign = argValue(argc, argv, "--campaign", "unknown");
   const bool accumulate = hasFlag(argc, argv, "--accumulate");
 
+  // Provenance guard (#253 review; ADR-0005 D8 / #179). foldTile preserves each
+  // existing cell's original source band, but writeRegistry() is a write-once
+  // single-source writer — so accumulating a DIFFERENT source-id into a store
+  // leaves tiles carrying mixed source indices while registry.json names only
+  // this run's source, silently corrupting provenance. Until the registry is an
+  // append-only merge (#179), refuse the mismatch rather than corrupt it. Fail
+  // fast, before decoding.
+  if (accumulate) {
+    const std::string reg_path =
+      (std::filesystem::path(out_dir) / "registry.json").string();
+    std::ifstream reg(reg_path);
+    std::string line;
+    while (std::getline(reg, line)) {
+      const auto key = line.find("\"source_id\"");
+      if (key == std::string::npos) {
+        continue;
+      }
+      const auto colon = line.find(':', key);
+      if (colon == std::string::npos) {
+        continue;
+      }
+      const int existing_sid = std::atoi(line.c_str() + colon + 1);
+      if (existing_sid > 0 && existing_sid != source_id_arg) {
+        std::cerr << "error: --accumulate: existing store registry " << reg_path
+                  << " has source_id " << existing_sid << ", but this run uses "
+                  << source_id_arg << ".\n"
+                  << "  A multi-source registry merge is not yet implemented "
+                  << "(ADR-0005 D8 / #179); re-run with --source-id " << existing_sid
+                  << " or use a fresh out_dir to avoid corrupting provenance.\n";
+        return 2;
+      }
+      break;   // registry v1 is single-source: first source_id is authoritative.
+    }
+  }
+
   std::ifstream in(tier1_path, std::ios::binary);
   if (!in) {
     std::cerr << "error: cannot open " << tier1_path << "\n";
@@ -259,8 +294,16 @@ int main(int argc, char ** argv)
         acc.foldTile(existing);
         ++folded;
       } catch (const std::exception & e) {
-        std::cerr << "warning: --accumulate could not reload " << path << ": "
-                  << e.what() << " -- this tile will be OVERWRITTEN, not merged\n";
+        // Never destroy prior coverage on a read hiccup. If we cannot reload an
+        // existing tile, saving would OVERWRITE it with this run's partial
+        // composite and silently drop its accumulated coverage — so abort before
+        // any tile is written. (Nothing has been saved yet at this point.)
+        std::cerr << "error: --accumulate could not reload existing tile " << path
+                  << ": " << e.what() << "\n"
+                  << "  refusing to continue: saving now would OVERWRITE this tile and lose its\n"
+                  << "  prior coverage. Inspect/remove the tile, or re-run WITHOUT --accumulate\n"
+                  << "  to intentionally overwrite. No tiles were written.\n";
+        return 1;
       }
     }
     std::cerr << "accumulate: folded " << folded << " existing tile(s) from " << out_dir << "\n";

--- a/marine_sidescan_mosaic/src/sidescan_tier2_processed.cpp
+++ b/marine_sidescan_mosaic/src/sidescan_tier2_processed.cpp
@@ -38,6 +38,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <optional>
@@ -59,6 +60,17 @@ using namespace marine_sidescan_mosaic;   // NOLINT(build/namespaces) — local 
 
 namespace
 {
+// Presence test for a valueless boolean flag (e.g. --accumulate).
+bool hasFlag(int argc, char ** argv, const std::string & flag)
+{
+  for (int i = 1; i < argc; ++i) {
+    if (flag == argv[i]) {
+      return true;
+    }
+  }
+  return false;
+}
+
 std::string argValue(int argc, char ** argv, const std::string & flag, const std::string & dflt)
 {
   for (int i = 1; i + 1 < argc; ++i) {
@@ -99,7 +111,9 @@ int main(int argc, char ** argv)
       "       [--level N] [--no-nadir-policy drop|assume_zero]\n"
       "       [--tx-beamwidth-fallback-rad R]   (along-track footprint when the ping\n"
       "                                          lacks tx_beamwidths; 0=point-deposit)\n"
-      "       [--source-id N] [--platform P] [--sensor S] [--sensor-class C] [--campaign X]\n";
+      "       [--source-id N] [--platform P] [--sensor S] [--sensor-class C] [--campaign X]\n"
+      "       [--accumulate]   # composite INTO an existing store (reload+fold each\n"
+      "                        # touched tile) instead of overwriting it\n";
     return 2;
   }
   const std::string tier1_path = argv[1];
@@ -136,6 +150,7 @@ int main(int argc, char ** argv)
   const std::string sensor = argValue(argc, argv, "--sensor", "garmin-gcv20");
   const std::string sensor_class = argValue(argc, argv, "--sensor-class", "sidescan");
   const std::string campaign = argValue(argc, argv, "--campaign", "unknown");
+  const bool accumulate = hasFlag(argc, argv, "--accumulate");
 
   std::ifstream in(tier1_path, std::ios::binary);
   if (!in) {
@@ -218,6 +233,37 @@ int main(int argc, char ** argv)
       ++n_placed;
     }
     ++n_proj;
+  }
+
+  // Accumulate into an existing store: reload each tile this run touched and fold
+  // it back in (best-source) before saving, so bag-by-bag ingestion composites
+  // instead of overwriting (issue #253) — bounded RAM/disk vs one whole-campaign
+  // pass. Without --accumulate, saveTiles overwrites (the prior behavior).
+  if (accumulate) {
+    std::vector<gggs::GridIndex> grids;
+    grids.reserve(acc.tiles().size());
+    for (const auto & kv : acc.tiles()) {
+      grids.push_back(kv.first);
+    }
+    std::size_t folded = 0;
+    for (const auto & grid : grids) {
+      const std::string path =
+        (std::filesystem::path(out_dir) /
+        marine_tiled_raster_store::tileFilename(grid)).string();
+      if (!std::filesystem::exists(path)) {
+        continue;   // new coverage — nothing on disk to merge.
+      }
+      try {
+        const auto existing = marine_tiled_raster_store::loadTile<std::uint16_t>(
+          path, level, ProcessedAccumulator::kBands);
+        acc.foldTile(existing);
+        ++folded;
+      } catch (const std::exception & e) {
+        std::cerr << "warning: --accumulate could not reload " << path << ": "
+                  << e.what() << " -- this tile will be OVERWRITTEN, not merged\n";
+      }
+    }
+    std::cerr << "accumulate: folded " << folded << " existing tile(s) from " << out_dir << "\n";
   }
 
   std::size_t written = 0;


### PR DESCRIPTION
## Summary

Adds `sidescan_tier2_processed --accumulate` (issue #253) so the durable
`processed` sidescan layer can be built **bag-by-bag** instead of in one 51 GB
pass — bounded disk (one bag's Tier-1 at a time) and bounded RAM.

(Re-opened from #254, which GitHub auto-closed when its stacked base
`feature/issue-251` was deleted on the #252 merge. #251 is now in jazzy as a
merge commit, so this branch is an ancestor + the #253 commits and merges clean.)

## Change

- `ProcessedAccumulator::foldTile()` — folds a reloaded store tile in via the same
  strict best-source-by-quality rule as `add()`.
- `--accumulate`: reload each touched on-disk tile and fold it before saving
  (default off = unchanged overwrite behavior).

## Review must-fixes applied (from the PR #254 adversarial review)

- **Reload failure aborts** (exit 1) instead of overwriting — never destroys prior
  coverage on a read hiccup.
- **Provenance guard**: refuses (exit 2) a `--source-id` that differs from the
  store's existing registry (ADR-0005 D8 / #179 until a real registry merge).
- (#251's unbounded-FIFO must-fix landed in #252.)

Non-atomic tile writes tracked as follow-up #256.

## Validation

- 5/5 accumulator unit tests (incl. `foldTile` best-source + no-data).
- E2E: idempotent re-ingest (byte-identical); source-id mismatch → exit 2;
  corrupt-tile reload → exit 1 with the tile preserved; same-source → exit 0.
- Drove the full June-12..30 campaign (946 tiles) into the store.

Closes #253

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
