### PR TITLE
docs(sonar_ecosystem): repoint next frontier at survey data exploration (#258)

### DIFF
--- a/docs/sonar_ecosystem.md
+++ b/docs/sonar_ecosystem.md
@@ -7,7 +7,8 @@ current; when an umbrella closes or a frontier shifts, update the relevant row.
 
 > Status legend: ✅ done · 🔨 in progress · 📋 designed, not built · ⚠️ blocked/degraded
 
-_Last verified: 2026-06-29 (full status audit against PR/merge state)._
+_Last verified: 2026-06-29 (full status audit against PR/merge state);
+"Where to direct efforts" frontier updated 2026-07-13 ([#258](https://github.com/rolker/unh_marine_autonomy/issues/258))._
 
 ## The two arcs
 
@@ -164,11 +165,26 @@ from the offline import ([cube#80], durable store layer), live coverage from
 nadir-stripe angle-correction ([cube#81]) is now **closed** (PR cube#84 merged, an
 empirical angular-response/ARA approach) and corrects both once enabled.
 
-**Next frontier:** the three-tools push is complete. The remaining legibility gaps
-are **Arc 2's `contact_manager` link** — the load-bearing `mark → contact_manager`
-hop ([rqt#81]) plus the CRUD/curate store (#157/#167, in flight) and a unifying
-target-arc umbrella (see the tracking-gap note above) — and the **sidescan track**
-([#171]/[#185]: live mosaic + offline EGN). See "Longer-term / supporting" below.
+**Next frontier (2026-07-13): survey data exploration —
+[#258](https://github.com/rolker/unh_marine_autonomy/issues/258).** The campaign
+is over and the question changed from "display coverage live" to "review what we
+collected" (target candidates to re-survey / ROV-dive on Massabesic, and the same
+tooling for the late-August Isles of Shoals data). The stores are averaged
+products; target work needs the **raw, un-averaged data behind a location**.
+#258 is the umbrella: a tile-indexed explorer — survey index + "which bags saw
+this spot" query CLI ([#259](https://github.com/rolker/unh_marine_autonomy/issues/259),
+stage 1) → stores-as-overview pane → multi-bag single-pass drill-down (raw
+soundings + sidescan with shadows preserved) → per-tile CUBE re-runs with custom
+parameters → surface texturing / sidescan drape. CAMP deliberately stays the
+realtime monitoring/planning tool; exploration lives in the offline explorer
+(`marine_perception_tools`, growing out of `sidescan_target_viewer`).
+
+The other legibility gaps remain: **Arc 2's `contact_manager` link** — the
+load-bearing `mark → contact_manager` hop ([rqt#81]) plus the CRUD/curate store
+(#157/#167, in flight — where a reviewed mark becomes a curated re-survey/ROV
+target) and a unifying target-arc umbrella (see the tracking-gap note above) —
+and the **sidescan track** ([#171]/[#185]: live mosaic + offline EGN). See
+"Longer-term / supporting" below.
 
 ### Longer-term / supporting
 


### PR DESCRIPTION
Part of #258 (survey data exploration umbrella) — the companion doc edit named in the umbrella's scope. Does **not** close #258 (it stays open across stages 1–5).

## What changed

`docs/sonar_ecosystem.md` "Where to direct efforts": the **Next frontier** paragraph still pointed at the Massabesic three-tools push (complete since 2026-06-29). It now points at the survey-data-exploration umbrella:

- **#258**: tile-indexed explorer — survey index + "which bags saw this spot" query CLI (#259, stage 1) → stores-as-overview → multi-bag single-pass drill-down → per-tile CUBE re-runs → surface texturing / sidescan drape
- Boundary made explicit: CAMP stays the realtime monitoring/planning tool; exploration lives in `marine_perception_tools`
- The prior legibility gaps (contact_manager link rqt#81 + #157/#167, sidescan track #171/#185) are retained, with #157 tied to the "reviewed mark → curated re-survey/ROV target" workflow
- `Last verified` line scopes the 2026-07-13 update to the frontier paragraph (no full status re-audit)

## Verification

Pre-push adversarial review (light tier): clean — #258/#259 states + summaries match, no contradictions with the rest of the map, reference-style links intact, no orphaned content.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
