### PR TITLE
Survey index + query CLI: marine_survey_index (#259)

### DIFF
--- a/.agent/work-plans/issue-259/plan.md
+++ b/.agent/work-plans/issue-259/plan.md
@@ -1,0 +1,146 @@
+# Plan: Survey Indexer + Query CLI
+
+## Issue
+
+https://github.com/rolker/unh_marine_autonomy/issues/259
+
+## Context
+
+Stage 1 of the #258 survey-data exploration umbrella. The goal is a fast "given a
+location, which bags and time ranges saw it?" answer across a whole survey — in
+seconds, without replaying bags. The deliverable is a regenerable SQLite sidecar
+(`survey_index.db`) next to the stores, and a CLI to query it.
+
+The bounded single-pass TF pattern is already proven in two places in this repo:
+- `marine_sidescan_mosaic/src/sidescan_mosaic_bag.cpp` — Garmin GCV sidescan importer
+- `cube_bathymetry/src/import_bag_main.cpp` — M3 detections → CUBE bathy store
+
+The indexer reuses that pattern exactly rather than inventing a new TF walk.
+
+Known topics from the existing offline tools:
+- MBES soundings: `/bizzy/sensors/m3/detections` (`marine_acoustic_msgs/SonarDetections`)
+- Sidescan port: `/bizzy/sensors/sidescan/garmin_sidescan/sonar_image_port`
+- Sidescan starboard: `/bizzy/sensors/sidescan/garmin_sidescan/sonar_image_starboard`
+- Sidescan nadir (range): `/bizzy/sensors/sidescan/garmin_sidescan/nadir_depth`
+
+## Approach
+
+### Package home decision
+
+New package **`marine_survey_index`** inside `unh_marine_autonomy` (core_ws). Reasons:
+- GGGS (`marine_autonomy`) and all stores (`marine_tiled_raster_store`, `marine_bathymetry_store`, etc.) already live in core_ws/unh_marine_autonomy.
+- `marine_tools` (sensors_ws) is a sonar-to-pointcloud bridge with no GGGS dependency; adding GGGS as a dep would be a layering violation.
+- The indexer is naturally a companion to the existing store packages, not a sensor driver.
+
+### Implementation steps
+
+1. **Create `marine_survey_index` package** — `CMakeLists.txt`, `package.xml` (MIT license, ADR-0008 headers), with deps: `rosbag2_cpp`, `tf2`, `marine_autonomy` (GGGS), `marine_acoustic_msgs`, `sensor_msgs`, `tf2_msgs`. Link SQLite3 via `target_link_libraries(... sqlite3)`. No ROS 2 nodes — this is a pair of offline CLI binaries.
+
+2. **Implement `survey_index_bag` binary** (`src/survey_index_bag_main.cpp`):
+   - Opens (or creates) `survey_index.db` with schema below.
+   - Scans a directory for bags (recursive, `*.db3` or MCAP) OR accepts explicit bag paths.
+   - Skips bags already in the `bags` ledger with matching `size_bytes + mtime_ns` (incremental re-run safety).
+   - For each new bag: single interleaved chronological pass (same pattern as `sidescan_mosaic_bag.cpp`):
+     - Subscribes to `/tf`, `/tf_static` + the three sensor topic sets.
+     - `tf2::BufferCore` with 60 s cache window, 3 s guard interval, same `kMaxPending` cap.
+     - **MBES**: for each `SonarDetections` message, resolve the `earth→frame_id` transform, compute the bounding lat/lon box of the beam footprint (across-track extent), enumerate all GGGS tiles at `--level` that overlap the box, record as a ping in the accumulator.
+     - **Sidescan port/stbd**: for each `RawSonarImage`, resolve the transducer `earth` pose, compute the port or starboard ground-range extent footprint (same as `sidescan_mosaic_bag.cpp`), enumerate tiles.
+   - Accumulator: per `(tile, sensor_type, topic)` open interval. Consecutive pings within `--merge-gap` (default 5.0 s) of each other extend the interval; a wider gap closes the interval and opens a new one.
+   - After the pass, flush all open intervals to the `passes` table.
+   - Insert the bag into the `bags` ledger.
+
+3. **Implement `survey_index_query` binary** (`src/survey_index_query_main.cpp`):
+   - Args: `--point <lat> <lon>` or `--box <lat_min> <lon_min> <lat_max> <lon_max>`, optional `--radius <m>`, `--level <N>`, `--sensor <type>`, `--db <path>`, `--json`.
+   - Converts the query geometry to a set of GGGS tile indices at the requested level.
+   - Joins `passes` with `bags` on those tiles, filtered by sensor if requested.
+   - Groups results by bag path, prints intervals sorted by `t_start`.
+   - Human-readable default; `--json` emits a JSON array for downstream tools.
+
+4. **Schema** (`src/schema.h` — shared between the two binaries):
+
+```sql
+CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);
+-- version=1; checked at open; mismatch → error with regen hint
+
+CREATE TABLE IF NOT EXISTS bags (
+  id         INTEGER PRIMARY KEY,
+  path       TEXT    NOT NULL UNIQUE,
+  size_bytes INTEGER NOT NULL,
+  mtime_ns   INTEGER NOT NULL,
+  indexed_at_ns INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS passes (
+  id          INTEGER PRIMARY KEY,
+  bag_id      INTEGER NOT NULL REFERENCES bags(id),
+  level       INTEGER NOT NULL,
+  tile_row    INTEGER NOT NULL,
+  tile_col    INTEGER NOT NULL,
+  sensor_type TEXT    NOT NULL,  -- ADR-0005 D3 vocabulary: 'mbes-bathy', 'sidescan-port', 'sidescan-stbd'
+  topic       TEXT    NOT NULL,
+  t_start_ns  INTEGER NOT NULL,
+  t_end_ns    INTEGER NOT NULL,
+  ping_count  INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS passes_tile ON passes(level, tile_row, tile_col);
+CREATE INDEX IF NOT EXISTS passes_bag  ON passes(bag_id);
+```
+
+5. **Tests** (`test/`): At minimum:
+   - `test_schema.cpp`: opens a fresh DB, verifies tables and version row, checks that re-open doesn't error.
+   - `test_interval_merge.cpp`: unit test for the interval-accumulator logic (gap below threshold → merged; gap above → split); no bag I/O needed.
+
+6. **Update `docs/sonar_ecosystem.md`**: add a "Survey indexer/query" row in the Arc 1 Reprocess section referencing #258/#259.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `marine_survey_index/CMakeLists.txt` | new — two executables + tests; links sqlite3 |
+| `marine_survey_index/package.xml` | new — declares deps |
+| `marine_survey_index/src/survey_index_bag_main.cpp` | new — indexer binary |
+| `marine_survey_index/src/survey_index_query_main.cpp` | new — query binary |
+| `marine_survey_index/src/schema.h` | new — shared schema init + version check |
+| `marine_survey_index/test/test_schema.cpp` | new — schema unit test |
+| `marine_survey_index/test/test_interval_merge.cpp` | new — accumulator unit test |
+| `docs/sonar_ecosystem.md` | update — add survey indexer row |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Human control and transparency | Human-readable default output; `--json` for tool integration; regenerable sidecar — bags are always the data of record |
+| Capture decisions, not just implementations | Package home, schema, TF pattern, and `sensor_type` vocabulary recorded here; schema version check enforces stability |
+| A change includes its consequences | Tests included; ecosystem doc updated; schema documented in this plan for stages 2–5 of #258 |
+| Only what's needed | Two binaries; no GUI, no store writes, no viewer integration (all deferred to later stages) |
+| Improve incrementally | Stage 1 of 5; delivers usable CLI immediately |
+| Test what breaks | `test_interval_merge` covers the core merge logic that is easy to get wrong at edge cases; `test_schema` covers the DB-open contract that stages 2–5 depend on |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0002 (Worktree isolation) | Yes | Working in feature/issue-259 worktree throughout |
+| ADR-0005 (Provenance registry) | Yes | `sensor_type` column uses ADR-0005 D3 `sensor_class` vocabulary (`mbes-bathy`, `sidescan-port`, `sidescan-stbd`); `platform`/`sensor` retained at bag granularity via `bags` table metadata extension is a follow-up |
+| ADR-0008 (ROS 2 conventions) | Yes | `package.xml` with MIT license, ROS 2 naming, standard CMakeLists patterns; no nodes so no node-naming concern |
+| ADR-0009 (Python package management) | No | No Python components |
+| ADR-0013 (progress.md vocabulary) | Yes | Entries use canonical vocabulary |
+
+## Consequences
+
+| If we change… | Also update… | Included in plan? |
+|---|---|---|
+| SQLite schema | Stage 2–5 consumers (viewer pane, interval loader) must be aware of schema_version | Yes — version check at open enforces this |
+| `sensor_type` vocabulary | Any future stage that filters by sensor type | Yes — ADR-0005 D3 vocabulary used; additive to add new values |
+| Topic defaults | `survey_index_bag` CLI defaults | Yes — configurable via `--mbes-topic`, `--port-topic`, `--stbd-topic` flags |
+| `docs/sonar_ecosystem.md` | Nothing else | Yes — included in Files to Change |
+
+## Open Questions
+
+- **GGGS level default**: The issue says "store's native level" — the bathy store defaults to 1 m resolution (GGGS level ~13). At 1 m, a single long survey pass could create O(10^5) tile rows. A coarser default (e.g. level 11, ~4 m cells) might be more practical for the indexer while still supporting sub-meter querying via the `--level` override. **Needs user input** before implementation.
+- **Sidescan sensor_type split**: `sidescan-port` / `sidescan-stbd` vs a single `sidescan`. The split enables filtering to one channel (useful for debugging), but `sidescan` aligns more directly with ADR-0005's `sensor_class`. Proposed: use `sidescan-port` / `sidescan-stbd` in the DB for fidelity; the query CLI treats a `--sensor sidescan` filter as matching both.
+- **Merge gap tolerance default**: 5.0 s is a placeholder. A long straight-line pass should produce one interval per tile; a turn may break it. Field feedback will calibrate this. Flag it as `--merge-gap <s>` so users can tune it.
+
+## Estimated Scope
+
+Single PR. Two new binaries + two tests + one doc update — fits in one review cycle.

--- a/.agent/work-plans/issue-259/plan.md
+++ b/.agent/work-plans/issue-259/plan.md
@@ -150,11 +150,16 @@ labeled per plan-review suggestion.*
 
 ## Decisions (Roland, 2026-07-13 plan checkpoint)
 
-- **GGGS level default = the store's native level (~L13, 1 m)** — chosen over the
-  coarser L11 proposal. Rationale: index tile keys match the store tiling exactly,
-  so stage 2 (stores-as-overview pane) joins on tile keys directly. The larger row
-  count (O(10^5) rows per long pass) is accepted; SQLite with the `(level, tile_row,
-  tile_col)` index handles it. `--level` override remains for coarser re-index runs.
+- **GGGS level default = L14 (~54 m tiles), both sensors** *(revised 2026-07-13,
+  implementation round — supersedes the "store-native level" checkpoint answer,
+  which had conflated grid size with cell size: the bathy store's L10 tiles have
+  ~0.9 m cells but are ~870 m across — far too coarse as a selection unit)*.
+  L14 is a target-inspection neighbourhood (target + shadow + context), and a
+  finer index is strictly more information: L14 keys roll up to the stores'
+  native tiles (bathy L10, sidescan L13) through the GGGS parent hierarchy, so
+  stage 2 can still join against store tiling by aggregation. Row cost remains
+  trivial (a swath touches a handful of 54 m tiles across-track).
+  `--mbes-level` / `--sidescan-level` / `--level` overrides remain.
 - **Sidescan sensor_type split**: `sidescan-port` / `sidescan-stbd` in the DB for
   channel fidelity; the query CLI treats `--sensor sidescan` as matching both.
   This *extends* the ADR-0005 D3 `sensor_class` vocabulary (`sidescan` + channel

--- a/.agent/work-plans/issue-259/plan.md
+++ b/.agent/work-plans/issue-259/plan.md
@@ -76,7 +76,9 @@ CREATE TABLE IF NOT EXISTS passes (
   level       INTEGER NOT NULL,
   tile_row    INTEGER NOT NULL,
   tile_col    INTEGER NOT NULL,
-  sensor_type TEXT    NOT NULL,  -- ADR-0005 D3 vocabulary: 'mbes-bathy', 'sidescan-port', 'sidescan-stbd'
+  sensor_type TEXT    NOT NULL,  -- extends ADR-0005 D3 sensor_class vocabulary: 'mbes-bathy' (D3),
+                                 -- plus channel-split 'sidescan-port'/'sidescan-stbd' (D3 'sidescan' + channel;
+                                 -- query CLI treats --sensor sidescan as matching both)
   topic       TEXT    NOT NULL,
   t_start_ns  INTEGER NOT NULL,
   t_end_ns    INTEGER NOT NULL,
@@ -86,9 +88,12 @@ CREATE INDEX IF NOT EXISTS passes_tile ON passes(level, tile_row, tile_col);
 CREATE INDEX IF NOT EXISTS passes_bag  ON passes(bag_id);
 ```
 
-5. **Tests** (`test/`): At minimum:
+5. **Tests** (`test/`) — all bag-I/O-free (plan-review must-fix: cover the core
+   correctness paths, not just plumbing):
    - `test_schema.cpp`: opens a fresh DB, verifies tables and version row, checks that re-open doesn't error.
    - `test_interval_merge.cpp`: unit test for the interval-accumulator logic (gap below threshold → merged; gap above → split); no bag I/O needed.
+   - `test_tile_enumeration.cpp`: footprint→GGGS-tile enumeration — a known lat/lon box at a known level yields exactly the expected tile set (single-tile, tile-boundary-straddling, and multi-tile swath cases).
+   - `test_query_join.cpp`: builds an in-memory index with known passes, runs the query join (point and box, with and without `--sensor` filter incl. `sidescan` matching both channels), asserts the returned bag/interval set.
 
 6. **Update `docs/sonar_ecosystem.md`**: add a "Survey indexer/query" row in the Arc 1 Reprocess section referencing #258/#259.
 
@@ -103,7 +108,11 @@ CREATE INDEX IF NOT EXISTS passes_bag  ON passes(bag_id);
 | `marine_survey_index/src/schema.h` | new — shared schema init + version check |
 | `marine_survey_index/test/test_schema.cpp` | new — schema unit test |
 | `marine_survey_index/test/test_interval_merge.cpp` | new — accumulator unit test |
+| `marine_survey_index/test/test_tile_enumeration.cpp` | new — footprint→tile enumeration test (plan-review must-fix) |
+| `marine_survey_index/test/test_query_join.cpp` | new — query tile-join test (plan-review must-fix) |
+| `docs/survey_index_schema.md` | new — durable schema contract doc for #258 stages 2–5 (plan-review suggestion) |
 | `docs/sonar_ecosystem.md` | update — add survey indexer row |
+| `.agents/README.md` | update — add `marine_survey_index` to Package Inventory (plan-review suggestion) |
 
 ## Principles Self-Check
 
@@ -118,13 +127,17 @@ CREATE INDEX IF NOT EXISTS passes_bag  ON passes(bag_id);
 
 ## ADR Compliance
 
+*(WS) = workspace ADR (`ros2_agent_workspace/docs/decisions/`); (P) = project ADR
+(`unh_marine_autonomy/docs/decisions/`). Numbers overlap between the two sets —
+labeled per plan-review suggestion.*
+
 | ADR | Triggered | How addressed |
 |---|---|---|
-| ADR-0002 (Worktree isolation) | Yes | Working in feature/issue-259 worktree throughout |
-| ADR-0005 (Provenance registry) | Yes | `sensor_type` column uses ADR-0005 D3 `sensor_class` vocabulary (`mbes-bathy`, `sidescan-port`, `sidescan-stbd`); `platform`/`sensor` retained at bag granularity via `bags` table metadata extension is a follow-up |
-| ADR-0008 (ROS 2 conventions) | Yes | `package.xml` with MIT license, ROS 2 naming, standard CMakeLists patterns; no nodes so no node-naming concern |
-| ADR-0009 (Python package management) | No | No Python components |
-| ADR-0013 (progress.md vocabulary) | Yes | Entries use canonical vocabulary |
+| ADR-0002 (WS — Worktree isolation) | Yes | Working in feature/issue-259 worktree throughout |
+| ADR-0005 (P — Provenance registry) | Yes | `sensor_type` column *extends* ADR-0005 D3 `sensor_class` vocabulary: `mbes-bathy` verbatim; `sidescan-port`/`sidescan-stbd` = D3 `sidescan` + channel suffix (query maps `sidescan` → both). `platform`/`sensor` at bag granularity via `bags` table metadata extension is a follow-up |
+| ADR-0008 (WS — ROS 2 conventions) | Yes | `package.xml` with MIT license, ROS 2 naming, standard CMakeLists patterns; no nodes so no node-naming concern |
+| ADR-0009 (WS — Python package management) | No | No Python components |
+| ADR-0013 (WS — progress.md vocabulary) | Yes | Entries use canonical vocabulary |
 
 ## Consequences
 
@@ -135,11 +148,19 @@ CREATE INDEX IF NOT EXISTS passes_bag  ON passes(bag_id);
 | Topic defaults | `survey_index_bag` CLI defaults | Yes — configurable via `--mbes-topic`, `--port-topic`, `--stbd-topic` flags |
 | `docs/sonar_ecosystem.md` | Nothing else | Yes — included in Files to Change |
 
-## Open Questions
+## Decisions (Roland, 2026-07-13 plan checkpoint)
 
-- **GGGS level default**: The issue says "store's native level" — the bathy store defaults to 1 m resolution (GGGS level ~13). At 1 m, a single long survey pass could create O(10^5) tile rows. A coarser default (e.g. level 11, ~4 m cells) might be more practical for the indexer while still supporting sub-meter querying via the `--level` override. **Needs user input** before implementation.
-- **Sidescan sensor_type split**: `sidescan-port` / `sidescan-stbd` vs a single `sidescan`. The split enables filtering to one channel (useful for debugging), but `sidescan` aligns more directly with ADR-0005's `sensor_class`. Proposed: use `sidescan-port` / `sidescan-stbd` in the DB for fidelity; the query CLI treats a `--sensor sidescan` filter as matching both.
-- **Merge gap tolerance default**: 5.0 s is a placeholder. A long straight-line pass should produce one interval per tile; a turn may break it. Field feedback will calibrate this. Flag it as `--merge-gap <s>` so users can tune it.
+- **GGGS level default = the store's native level (~L13, 1 m)** — chosen over the
+  coarser L11 proposal. Rationale: index tile keys match the store tiling exactly,
+  so stage 2 (stores-as-overview pane) joins on tile keys directly. The larger row
+  count (O(10^5) rows per long pass) is accepted; SQLite with the `(level, tile_row,
+  tile_col)` index handles it. `--level` override remains for coarser re-index runs.
+- **Sidescan sensor_type split**: `sidescan-port` / `sidescan-stbd` in the DB for
+  channel fidelity; the query CLI treats `--sensor sidescan` as matching both.
+  This *extends* the ADR-0005 D3 `sensor_class` vocabulary (`sidescan` + channel
+  suffix); it does not redefine it.
+- **Merge gap default 5.0 s**, exposed as `--merge-gap <s>`; calibrate against
+  Massabesic data (a turn splitting intervals is acceptable and informative).
 
 ## Estimated Scope
 

--- a/.agent/work-plans/issue-259/progress.md
+++ b/.agent/work-plans/issue-259/progress.md
@@ -240,3 +240,25 @@ was amended into that same commit so each commit is self-contained and hook-clea
 - [x] `distinctLevels` and `queryPasses` capture the terminal `sqlite3_step` result and throw unless `SQLITE_DONE`, so a mid-scan DB error surfaces instead of returning silent partial results — `marine_survey_index/src/query.cpp` (`6cb55a8`)
 - [x] `openIndexDb` only stamps a fresh DB on `SQLITE_DONE`; any other non-`SQLITE_ROW` step result now throws + closes instead of masking a read error as an empty table and writing to a corrupt DB — `marine_survey_index/src/schema.cpp` (`a0d8133`)
 - [x] Added a bounded `toLevel` helper (rejects levels outside 0–20 with a clean CLI error before `gggs::Level` can `std::terminate`) used for `--level`/`--mbes-level`/`--sidescan-level` in both CLIs, plus a `--merge-gap >= 0` guard (also rejects NaN) — `marine_survey_index/src/survey_index_bag_main.cpp`, `marine_survey_index/src/survey_index_query_main.cpp` (`6d46fda`)
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-07-14 13:55 +00:00
+**By**: Claude Code Agent (Claude Fable 5)
+
+**PR**: #261 at `5bdbef1` (round 2)
+**Sources**: 2 (Copilot R3 @ `5bdbef1`; prior Integrated Review @ `6957512` — all 4 findings verified fixed at head)
+**Cross-source confirmations**: 0
+**CI**: copilot ✅; build in progress at head
+
+Copilot's R1/R2 comments (10) all target pre-fix commits; each of the four
+underlying findings is verified fixed at head (`560dd53`/`6cb55a8`/`a0d8133`/
+`6d46fda`) — classified Addressed, not repeated below. Two NEW findings from
+Copilot R3 against current code:
+
+### Findings
+- [ ] (low, Copilot R3) `tilesForBoundingBox` documents "must not cross the antimeridian" but nothing enforces it — a straddling box (or a ping footprint near ±180°) silently enumerates the long way around: at L14 a near-whole-world tile set (hang / memory blowup). Add a fail-loud guard (lon span > 180° after normalization → throw std::invalid_argument); full dateline-split support stays out of scope for stage 1. The indexer's per-bag try/catch turns the throw into a counted per-bag error; the query CLI reports it cleanly — `marine_survey_index/src/footprint.cpp:51`
+- [ ] (low, Copilot R3) test helper `singleInt` uses EXPECT_* then unconditionally calls `sqlite3_step`/`sqlite3_column_int` — a failed prepare leaves `stmt` null and the test can segfault instead of failing cleanly (ASSERT_* can't be used directly in a value-returning helper; guard null/step-result and return a sentinel with ADD_FAILURE) — `marine_survey_index/test/test_schema.cpp:44`
+
+### False positives
+- (none this round; the 10 stale R1/R2 comments are Addressed at head, not false positives)

--- a/.agent/work-plans/issue-259/progress.md
+++ b/.agent/work-plans/issue-259/progress.md
@@ -74,3 +74,17 @@ Stage 1 of the #258 (survey data exploration) umbrella. Deliverables: an offline
 - [ ] Align `sensor_type` column vocabulary with ADR-0005 D3 `sensor_class` values
 - [ ] Update `docs/sonar_ecosystem.md` to add a "Survey indexer / query" row referencing #258/#259 when the deliverable lands
 - [ ] If a new ROS 2 package is created, ensure `package.xml` / naming / license headers follow ADR-0008
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-07-13 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Plan**: `.agent/work-plans/issue-259/plan.md` at `19d48e6`
+**Branch**: feature/issue-259 at `19d48e6`
+**Phases**: single
+
+### Open questions
+- [ ] GGGS level default — issue says "store's native level" (~level 13, 1 m) but O(10^5) tile rows per survey pass may be impractical; propose level 11 (~4 m) as default with `--level` override. Needs user input before implementation.
+- [ ] Sidescan `sensor_type` split — `sidescan-port`/`sidescan-stbd` vs single `sidescan`; plan proposes split in DB, `--sensor sidescan` matches both in query.
+- [ ] Merge gap tolerance default — 5.0 s placeholder; field calibration needed; exposed as `--merge-gap <s>`.

--- a/.agent/work-plans/issue-259/progress.md
+++ b/.agent/work-plans/issue-259/progress.md
@@ -112,3 +112,28 @@ correct; `docs/sonar_ecosystem.md` Arc 1 table present. Approach and scope are s
 - [ ] (suggestion) ADR table mixes workspace vs project ADR numbers unlabeled — in-repo ADR-0002/0008 differ from cited workspace ADRs. — `plan.md:123`
 - [ ] (suggestion) New package not added to `.agents/README.md` Package Inventory. — `plan.md:95`
 - [ ] (suggestion) Schema is a cross-stage contract but documented only in ephemeral `plan.md` — consider a durable `docs/`/ADR home for stages 2–5. — `plan.md:59`
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-13 19:12 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-259 at `04dc9d7`
+**Mode**: pre-push
+**Depth**: Deep (reason: new C++ package, 2502 LOC, cross-layer GGGS/store + SQLite + rosbag2/TF)
+**Must-fix**: 4 | **Suggestions**: 5
+**Round**: 1 | **Ship**: continue — silent index-corruption path + query-output bug warrant a fix pass and re-read
+
+Static analysis clean (ament_cpplint; cppcheck TEST-macro/unused-member warnings are false positives). Two Claude Adversarial lenses (A logic, B systemic) converged on one theme: the indexer write path assumes every SQLite call succeeds and no exception occurs. Governance and plan adherence clean; all 4 prior plan-review findings resolved.
+
+### Findings
+- [ ] (must-fix) Indexer write/ledger path ignores all sqlite3_step/prepare return codes → failed insert still COMMITs and marks bag fully-indexed (silent partial index; re-run skips as "unchanged") — `marine_survey_index/src/survey_index_bag_main.cpp:209,514-559`
+- [ ] (must-fix) Per-bag loop has no try/catch and no ROLLBACK → a corrupt message (deserialize throws) or SQLite failure aborts the whole run, remaining bags lost, db not closed — `marine_survey_index/src/survey_index_bag_main.cpp:322`
+- [ ] (must-fix) Query results not globally sorted across 200-tile chunks → CLI prints duplicate/out-of-order bag headers for boxes spanning >200 tiles — `marine_survey_index/src/query.cpp:89-137`
+- [ ] (must-fix) Unguarded std::stoi on --level → uncaught exception crash (inconsistent with other args' toInt guard) — `marine_survey_index/src/survey_index_query_main.cpp:155`
+- [ ] (suggestion) kMaxPending overflow flush bypasses the TF guard interval → oldest ping may be dropped as no-tf under backpressure (cross-pass confirmed) — `marine_survey_index/src/survey_index_bag_main.cpp:499-501`
+- [ ] (suggestion) samples_per_beam==0 → negative slant range flips sidescan footprint to wrong side; skip like sample_rate<=0 — `marine_survey_index/src/survey_index_bag_main.cpp:491-495`
+- [ ] (suggestion) fingerprint/scanForBags use throwing filesystem iteration; broken symlink/permission error aborts run — use error_code overloads — `marine_survey_index/src/survey_index_bag_main.cpp:162,183`
+- [ ] (suggestion) std::string from possibly-null sqlite3_column_text (latent UB; columns NOT NULL today) — `marine_survey_index/src/query.cpp:124`
+- [ ] (suggestion) Plan drift: MBES level default L10 vs plan's "~L13 store-native" — per-sensor split refinement, consistent in code+help+schema doc; noted, not a defect — `marine_survey_index/src/survey_index_bag_main.cpp:273`

--- a/.agent/work-plans/issue-259/progress.md
+++ b/.agent/work-plans/issue-259/progress.md
@@ -189,3 +189,14 @@ Only two low-severity robustness suggestions remain; neither blocks the ship.
 ### Findings
 - [ ] (suggestion) `jsonEscape` omits JSON control chars (`\n`,`\t`,<0x20) → invalid `--json` for pathological bag paths — `marine_survey_index/src/survey_index_query_main.cpp:89`
 - [ ] (suggestion) Query read loop ignores `sqlite3_step`/`bind` return codes → silent partial results on a mid-scan DB error (indexer checks every code; query path doesn't) — `marine_survey_index/src/query.cpp:79`
+
+## Published
+**Status**: complete
+**When**: 2026-07-14
+**By**: Claude Code Agent (Claude Fable 5)
+
+Publish checkpoint approved by Roland. Branch `feature/issue-259` pushed at
+`7cb005b`; PR opened: https://github.com/rolker/unh_marine_autonomy/pull/261
+(base `jazzy`, `Closes #259`). The two round-2 non-blocking suggestions
+(jsonEscape control chars; query read-path sqlite return codes) are noted in
+the PR body to fold into stage 2 (#258) work.

--- a/.agent/work-plans/issue-259/progress.md
+++ b/.agent/work-plans/issue-259/progress.md
@@ -285,3 +285,26 @@ Verification: rebuilt + full suite green — **87 tests, 0 failures, 13
 skipped** (one new test; cpplint/uncrustify/cppcheck/xmllint all pass).
 
 Next: push; Copilot re-review round.
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-07-14 15:05 +00:00
+**By**: Claude Code Agent (Claude Fable 5)
+
+**PR**: #261 at `6869ec4` (round 3)
+**Sources**: 2 (Copilot R4 @ `6869ec4`; prior Integrated Review rounds 1–2 — all 6 prior findings verified fixed at head)
+**Cross-source confirmations**: 0
+**CI**: copilot ✅; build in progress at head
+
+All 12 comments from Copilot's earlier reviews target pre-fix commits and are
+Addressed at head. Three NEW hygiene findings from Copilot R4 against current
+code — the first two were introduced by the round-1/2 fixes themselves
+(`std::exit` arrived with the `toLevel`/merge-gap guards without `<cstdlib>`):
+
+### Findings
+- [ ] (low, Copilot R4) `survey_index_query_main.cpp` uses `std::exit` and `std::max` via transitive includes only — add `<cstdlib>` and `<algorithm>` — `marine_survey_index/src/survey_index_query_main.cpp:32`
+- [ ] (low, Copilot R4) `survey_index_bag_main.cpp` uses `std::exit` without `<cstdlib>` — `marine_survey_index/src/survey_index_bag_main.cpp:50`
+- [ ] (low, Copilot R4) `CMakeLists.txt` doesn't set `CMAKE_CXX_STANDARD` while the package uses C++17 (`std::filesystem`, `std::clamp`); sibling packages (marine_autonomy, marine_sidescan_mosaic) set 17 explicitly — adopt marine_sidescan_mosaic's guarded form — `marine_survey_index/CMakeLists.txt:6`
+
+### False positives
+- (none — all three verified: usages confirmed present, includes confirmed absent, repo convention confirmed)

--- a/.agent/work-plans/issue-259/progress.md
+++ b/.agent/work-plans/issue-259/progress.md
@@ -88,3 +88,27 @@ Stage 1 of the #258 (survey data exploration) umbrella. Deliverables: an offline
 - [ ] GGGS level default — issue says "store's native level" (~level 13, 1 m) but O(10^5) tile rows per survey pass may be impractical; propose level 11 (~4 m) as default with `--level` override. Needs user input before implementation.
 - [ ] Sidescan `sensor_type` split — `sidescan-port`/`sidescan-stbd` vs single `sidescan`; plan proposes split in DB, `--sensor sidescan` matches both in query.
 - [ ] Merge gap tolerance default — 5.0 s placeholder; field calibration needed; exposed as `--merge-gap <s>`.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-07-13 17:57 +00:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Plan**: `.agent/work-plans/issue-259/plan.md` at `19d48e6`
+**PR**: PR-less (`--issue 259`)
+**Verdict**: approve-with-suggestions
+
+Independent fresh-context review (plan authored by Claude Sonnet; not a self-review).
+Technical claims verified against the tree: GGGS API supports both required directions
+(`Level::gridIndex` point/box→indices, `GridIndex::{west,east,south,north}…` index→bbox);
+the bounded-TF pattern (60 s cache, guard interval, `kMaxPending`) exists verbatim in both
+cited reference impls (`marine_sidescan_mosaic/src/sidescan_mosaic_bag.cpp`,
+`cube_bathymetry/.../import_bag_main.cpp`); message types (`SonarDetections`, `RawSonarImage`)
+correct; `docs/sonar_ecosystem.md` Arc 1 table present. Approach and scope are sound.
+
+### Findings
+- [ ] (must-fix) Core correctness paths untested — footprint→GGGS-tile enumeration and query tile-join have no test; issue-review asked for this. Both testable without bag I/O. — `plan.md:89`
+- [ ] (must-fix) Schema comment overstates ADR-0005 D3 vocab — `sidescan-port`/`sidescan-stbd` extend, not equal, D3 (`sidescan`/`mbes-backscatter`/`mbes-bathy`). — `plan.md:79`
+- [ ] (suggestion) ADR table mixes workspace vs project ADR numbers unlabeled — in-repo ADR-0002/0008 differ from cited workspace ADRs. — `plan.md:123`
+- [ ] (suggestion) New package not added to `.agents/README.md` Package Inventory. — `plan.md:95`
+- [ ] (suggestion) Schema is a cross-stage contract but documented only in ephemeral `plan.md` — consider a durable `docs/`/ADR home for stages 2–5. — `plan.md:59`

--- a/.agent/work-plans/issue-259/progress.md
+++ b/.agent/work-plans/issue-259/progress.md
@@ -212,10 +212,31 @@ the PR body to fold into stage 2 (#258) work.
 **CI**: all-pass (build ✅, copilot ✅)
 
 ### Findings
-- [ ] (cross-confirmed: Copilot R1+R2 + Local Review round 2) `jsonEscape` only escapes `"` and `\` — control chars (newline/tab/<0x20) in a bag path produce invalid `--json` output; escape standard sequences + `\u00XX` — `marine_survey_index/src/survey_index_query_main.cpp:89`
-- [ ] (cross-confirmed: Copilot R1+R2 + Local Review round 2) Query read loops (`distinctLevels`, `queryPasses`) ignore the terminal `sqlite3_step` code — a mid-scan DB error silently returns partial results (CLI may claim "no coverage"); capture final step result, throw unless `SQLITE_DONE` — `marine_survey_index/src/query.cpp:84,145`
-- [ ] (medium, Copilot R1+R2) `openIndexDb` treats any non-`SQLITE_ROW` step result as "fresh DB" and INSERTs a schema_version row — a step error (corrupt/unreadable DB) is masked and the DB is written to; only insert on `SQLITE_DONE`, throw+close otherwise — `marine_survey_index/src/schema.cpp:117`
-- [ ] (low, Copilot R1) `--level`/`--mbes-level`/`--sidescan-level` are cast to `uint8_t` without range validation — out-of-range values hit `gggs::Level`'s `std::out_of_range` outside any try/catch → `std::terminate` abort instead of a clean CLI error; negative `--merge-gap` degenerates to one pass per ping — validate 0–20 (and merge-gap ≥ 0) at parse time — `marine_survey_index/src/survey_index_bag_main.cpp:347`, `marine_survey_index/src/survey_index_query_main.cpp:165`
+- [x] (cross-confirmed: Copilot R1+R2 + Local Review round 2) `jsonEscape` only escapes `"` and `\` — control chars (newline/tab/<0x20) in a bag path produce invalid `--json` output; escape standard sequences + `\u00XX` — `marine_survey_index/src/survey_index_query_main.cpp:89`
+- [x] (cross-confirmed: Copilot R1+R2 + Local Review round 2) Query read loops (`distinctLevels`, `queryPasses`) ignore the terminal `sqlite3_step` code — a mid-scan DB error silently returns partial results (CLI may claim "no coverage"); capture final step result, throw unless `SQLITE_DONE` — `marine_survey_index/src/query.cpp:84,145`
+- [x] (medium, Copilot R1+R2) `openIndexDb` treats any non-`SQLITE_ROW` step result as "fresh DB" and INSERTs a schema_version row — a step error (corrupt/unreadable DB) is masked and the DB is written to; only insert on `SQLITE_DONE`, throw+close otherwise — `marine_survey_index/src/schema.cpp:117`
+- [x] (low, Copilot R1) `--level`/`--mbes-level`/`--sidescan-level` are cast to `uint8_t` without range validation — out-of-range values hit `gggs::Level`'s `std::out_of_range` outside any try/catch → `std::terminate` abort instead of a clean CLI error; negative `--merge-gap` degenerates to one pass per ping — validate 0–20 (and merge-gap ≥ 0) at parse time — `marine_survey_index/src/survey_index_bag_main.cpp:347`, `marine_survey_index/src/survey_index_query_main.cpp:165`
 
 ### False positives
 - (none — all four verified against current code at head `6957512`; Copilot R1's `commit_id` differs from head only by a progress.md commit, so its code references are current)
+
+## Implementation
+**Status**: complete
+**When**: 2026-07-14 09:40 -0400
+**By**: Claude Code Agent (Claude Opus)
+
+**PR**: #261 at `6d46fda`
+**Addressed**: Integrated Review (2026-07-14 12:40 +00:00, `6957512`) — 4 findings (2 cross-confirmed, 1 medium, 1 low)
+**Commits**: `560dd53` `6cb55a8` `a0d8133` `6d46fda`
+
+All 4 findings actioned; none deferred. Rebuilt `marine_survey_index` and re-ran
+its full test suite after the fixes: 86 tests, 0 failures, 13 skipped (all gtest
+suites + cpplint/uncrustify/cppcheck/copyright/lint_cmake/xmllint green). The
+finding-4 commit's `toLevel` rename pushed one line past 100 cols; the wrap fix
+was amended into that same commit so each commit is self-contained and hook-clean.
+
+### Actions
+- [x] `jsonEscape` now escapes `"` `\` `\b` `\f` `\n` `\r` `\t` and emits `\u00XX` for other control chars (<0x20), producing valid JSON for pathological bag paths — `marine_survey_index/src/survey_index_query_main.cpp` (`560dd53`)
+- [x] `distinctLevels` and `queryPasses` capture the terminal `sqlite3_step` result and throw unless `SQLITE_DONE`, so a mid-scan DB error surfaces instead of returning silent partial results — `marine_survey_index/src/query.cpp` (`6cb55a8`)
+- [x] `openIndexDb` only stamps a fresh DB on `SQLITE_DONE`; any other non-`SQLITE_ROW` step result now throws + closes instead of masking a read error as an empty table and writing to a corrupt DB — `marine_survey_index/src/schema.cpp` (`a0d8133`)
+- [x] Added a bounded `toLevel` helper (rejects levels outside 0–20 with a clean CLI error before `gggs::Level` can `std::terminate`) used for `--level`/`--mbes-level`/`--sidescan-level` in both CLIs, plus a `--merge-gap >= 0` guard (also rejects NaN) — `marine_survey_index/src/survey_index_bag_main.cpp`, `marine_survey_index/src/survey_index_query_main.cpp` (`6d46fda`)

--- a/.agent/work-plans/issue-259/progress.md
+++ b/.agent/work-plans/issue-259/progress.md
@@ -164,3 +164,28 @@ try/catch that catches them and ROLLBACKs), so they share a single commit `d5bc8
 - [x] `fingerprint`/`scanForBags` use `error_code` filesystem iteration (skip_permission_denied) so a broken symlink/permission error no longer aborts the run — `marine_survey_index/src/survey_index_bag_main.cpp` (`a614d8f`)
 - [x] Query row text columns read via a null-safe `columnText` helper (avoids UB if a column is ever NULL) — `marine_survey_index/src/query.cpp` (`a3ad994`)
 - [x] Plan-drift note on the MBES/sidescan level split — `marine_survey_index/src/survey_index_bag_main.cpp:273` (deferred: not a defect — intentional per-sensor split, already reconciled in `docs/survey_index_schema.md` and CLI help; no code change)
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-13 20:12 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-259 at `70ff424`
+**Mode**: pre-push
+**Depth**: Deep (reason: new C++ package, 2679 LOC, cross-layer GGGS/store + SQLite + rosbag2/TF)
+**Must-fix**: 0 | **Suggestions**: 2
+**Round**: 2 | **Ship**: recommended — no must-fix; all 8 round-1 findings verified fixed; only new change (default level → L14) is clean and consistently propagated
+
+Round 2 of the pre-push review. Static analysis clean (ament_cpplint "No problems found").
+Two fresh-context Claude Adversarial lenses (A logic, B systemic) ran; their must-fix
+claims were verified against the code and found to be false positives (the `--scan`
+double-increment skips DIR correctly; sqlite3 bind/step are non-throwing C calls so no
+statement leak; `Time.sec` is int32 so no ns overflow) — none reported. Governance and
+plan adherence clean: package.xml (MIT/ADR-0008), `.agents/README` inventory + ecosystem
+row + durable schema doc all present; L14 default recorded in plan Decisions (no drift).
+Only two low-severity robustness suggestions remain; neither blocks the ship.
+
+### Findings
+- [ ] (suggestion) `jsonEscape` omits JSON control chars (`\n`,`\t`,<0x20) → invalid `--json` for pathological bag paths — `marine_survey_index/src/survey_index_query_main.cpp:89`
+- [ ] (suggestion) Query read loop ignores `sqlite3_step`/`bind` return codes → silent partial results on a mid-scan DB error (indexer checks every code; query path doesn't) — `marine_survey_index/src/query.cpp:79`

--- a/.agent/work-plans/issue-259/progress.md
+++ b/.agent/work-plans/issue-259/progress.md
@@ -128,12 +128,39 @@ correct; `docs/sonar_ecosystem.md` Arc 1 table present. Approach and scope are s
 Static analysis clean (ament_cpplint; cppcheck TEST-macro/unused-member warnings are false positives). Two Claude Adversarial lenses (A logic, B systemic) converged on one theme: the indexer write path assumes every SQLite call succeeds and no exception occurs. Governance and plan adherence clean; all 4 prior plan-review findings resolved.
 
 ### Findings
-- [ ] (must-fix) Indexer write/ledger path ignores all sqlite3_step/prepare return codes → failed insert still COMMITs and marks bag fully-indexed (silent partial index; re-run skips as "unchanged") — `marine_survey_index/src/survey_index_bag_main.cpp:209,514-559`
-- [ ] (must-fix) Per-bag loop has no try/catch and no ROLLBACK → a corrupt message (deserialize throws) or SQLite failure aborts the whole run, remaining bags lost, db not closed — `marine_survey_index/src/survey_index_bag_main.cpp:322`
-- [ ] (must-fix) Query results not globally sorted across 200-tile chunks → CLI prints duplicate/out-of-order bag headers for boxes spanning >200 tiles — `marine_survey_index/src/query.cpp:89-137`
-- [ ] (must-fix) Unguarded std::stoi on --level → uncaught exception crash (inconsistent with other args' toInt guard) — `marine_survey_index/src/survey_index_query_main.cpp:155`
-- [ ] (suggestion) kMaxPending overflow flush bypasses the TF guard interval → oldest ping may be dropped as no-tf under backpressure (cross-pass confirmed) — `marine_survey_index/src/survey_index_bag_main.cpp:499-501`
-- [ ] (suggestion) samples_per_beam==0 → negative slant range flips sidescan footprint to wrong side; skip like sample_rate<=0 — `marine_survey_index/src/survey_index_bag_main.cpp:491-495`
-- [ ] (suggestion) fingerprint/scanForBags use throwing filesystem iteration; broken symlink/permission error aborts run — use error_code overloads — `marine_survey_index/src/survey_index_bag_main.cpp:162,183`
-- [ ] (suggestion) std::string from possibly-null sqlite3_column_text (latent UB; columns NOT NULL today) — `marine_survey_index/src/query.cpp:124`
-- [ ] (suggestion) Plan drift: MBES level default L10 vs plan's "~L13 store-native" — per-sensor split refinement, consistent in code+help+schema doc; noted, not a defect — `marine_survey_index/src/survey_index_bag_main.cpp:273`
+- [x] (must-fix) Indexer write/ledger path ignores all sqlite3_step/prepare return codes → failed insert still COMMITs and marks bag fully-indexed (silent partial index; re-run skips as "unchanged") — `marine_survey_index/src/survey_index_bag_main.cpp:209,514-559`
+- [x] (must-fix) Per-bag loop has no try/catch and no ROLLBACK → a corrupt message (deserialize throws) or SQLite failure aborts the whole run, remaining bags lost, db not closed — `marine_survey_index/src/survey_index_bag_main.cpp:322`
+- [x] (must-fix) Query results not globally sorted across 200-tile chunks → CLI prints duplicate/out-of-order bag headers for boxes spanning >200 tiles — `marine_survey_index/src/query.cpp:89-137`
+- [x] (must-fix) Unguarded std::stoi on --level → uncaught exception crash (inconsistent with other args' toInt guard) — `marine_survey_index/src/survey_index_query_main.cpp:155`
+- [x] (suggestion) kMaxPending overflow flush bypasses the TF guard interval → oldest ping may be dropped as no-tf under backpressure (cross-pass confirmed) — `marine_survey_index/src/survey_index_bag_main.cpp:499-501`
+- [x] (suggestion) samples_per_beam==0 → negative slant range flips sidescan footprint to wrong side; skip like sample_rate<=0 — `marine_survey_index/src/survey_index_bag_main.cpp:491-495`
+- [x] (suggestion) fingerprint/scanForBags use throwing filesystem iteration; broken symlink/permission error aborts run — use error_code overloads — `marine_survey_index/src/survey_index_bag_main.cpp:162,183`
+- [x] (suggestion) std::string from possibly-null sqlite3_column_text (latent UB; columns NOT NULL today) — `marine_survey_index/src/query.cpp:124`
+- [x] (suggestion) Plan drift: MBES level default L10 vs plan's "~L13 store-native" — per-sensor split refinement, consistent in code+help+schema doc; noted, not a defect — `marine_survey_index/src/survey_index_bag_main.cpp:273` (deferred: not a defect — the per-sensor level split is intentional and already reconciled in `docs/survey_index_schema.md` and the CLI help; no code change warranted)
+
+## Implementation
+**Status**: complete
+**When**: 2026-07-13 19:35 +00:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Branch**: feature/issue-259 at `507cf09`
+**Addressed**: Local Review (Pre-Push) (2026-07-13 19:12 +00:00, `04dc9d7`) — 4 must-fix + 5 suggestions
+**Commits**: `7652f54` `3f49415` `a614d8f` `d5bc8df` `19e8d41` `a3ad994` `507cf09`
+
+Fixed all 8 actionable findings; the 9th (plan-drift note) was consciously deferred
+as not-a-defect. Rebuilt `marine_survey_index` and re-ran its test suite after the
+fixes: 10/10 test targets pass (4 gtest suites + cpplint/uncrustify/cppcheck/copyright/
+lint_cmake/xmllint), 0 failures. F1 and F2 are the detect and roll-back halves of one
+write-path safety mechanism (adding error-code checks that throw, plus the per-bag
+try/catch that catches them and ROLLBACKs), so they share a single commit `d5bc8df`.
+
+### Actions
+- [x] Indexer write/ledger path now checks every sqlite3 prepare/step return code (SqliteError + prepareOrThrow/stepDoneOrThrow/StmtGuard); a failed write throws instead of COMMITting a partial index — `marine_survey_index/src/survey_index_bag_main.cpp` (`d5bc8df`)
+- [x] Per-bag loop wrapped in try/catch that ROLLBACKs and continues; a corrupt-message deserialize or SQLite failure now loses only that bag and the db closes cleanly — `marine_survey_index/src/survey_index_bag_main.cpp` (`d5bc8df`)
+- [x] Query rows sorted globally across tile chunks so the CLI prints each bag's rows contiguously and in time order — `marine_survey_index/src/query.cpp` (`19e8d41`)
+- [x] `--level` parsed via a guarded `toInt` in the query CLI (matches the other args) instead of an unguarded `std::stoi` — `marine_survey_index/src/survey_index_query_main.cpp` (`507cf09`)
+- [x] kMaxPending overflow first drains TF-passed pings (honours the guard), forcing the oldest out only if TF has genuinely stalled — `marine_survey_index/src/survey_index_bag_main.cpp` (`3f49415`)
+- [x] Sidescan pings with `samples_per_beam == 0` are skipped (would drive slantRange negative and flip the footprint) — `marine_survey_index/src/survey_index_bag_main.cpp` (`7652f54`)
+- [x] `fingerprint`/`scanForBags` use `error_code` filesystem iteration (skip_permission_denied) so a broken symlink/permission error no longer aborts the run — `marine_survey_index/src/survey_index_bag_main.cpp` (`a614d8f`)
+- [x] Query row text columns read via a null-safe `columnText` helper (avoids UB if a column is ever NULL) — `marine_survey_index/src/query.cpp` (`a3ad994`)
+- [x] Plan-drift note on the MBES/sidescan level split — `marine_survey_index/src/survey_index_bag_main.cpp:273` (deferred: not a defect — intentional per-sensor split, already reconciled in `docs/survey_index_schema.md` and CLI help; no code change)

--- a/.agent/work-plans/issue-259/progress.md
+++ b/.agent/work-plans/issue-259/progress.md
@@ -257,8 +257,31 @@ underlying findings is verified fixed at head (`560dd53`/`6cb55a8`/`a0d8133`/
 Copilot R3 against current code:
 
 ### Findings
-- [ ] (low, Copilot R3) `tilesForBoundingBox` documents "must not cross the antimeridian" but nothing enforces it — a straddling box (or a ping footprint near ±180°) silently enumerates the long way around: at L14 a near-whole-world tile set (hang / memory blowup). Add a fail-loud guard (lon span > 180° after normalization → throw std::invalid_argument); full dateline-split support stays out of scope for stage 1. The indexer's per-bag try/catch turns the throw into a counted per-bag error; the query CLI reports it cleanly — `marine_survey_index/src/footprint.cpp:51`
-- [ ] (low, Copilot R3) test helper `singleInt` uses EXPECT_* then unconditionally calls `sqlite3_step`/`sqlite3_column_int` — a failed prepare leaves `stmt` null and the test can segfault instead of failing cleanly (ASSERT_* can't be used directly in a value-returning helper; guard null/step-result and return a sentinel with ADD_FAILURE) — `marine_survey_index/test/test_schema.cpp:44`
+- [x] (low, Copilot R3) `tilesForBoundingBox` documents "must not cross the antimeridian" but nothing enforces it — a straddling box (or a ping footprint near ±180°) silently enumerates the long way around: at L14 a near-whole-world tile set (hang / memory blowup). Add a fail-loud guard (lon span > 180° after normalization → throw std::invalid_argument); full dateline-split support stays out of scope for stage 1. The indexer's per-bag try/catch turns the throw into a counted per-bag error; the query CLI reports it cleanly — `marine_survey_index/src/footprint.cpp:51`
+- [x] (low, Copilot R3) test helper `singleInt` uses EXPECT_* then unconditionally calls `sqlite3_step`/`sqlite3_column_int` — a failed prepare leaves `stmt` null and the test can segfault instead of failing cleanly (ASSERT_* can't be used directly in a value-returning helper; guard null/step-result and return a sentinel with ADD_FAILURE) — `marine_survey_index/test/test_schema.cpp:44`
 
 ### False positives
 - (none this round; the 10 stale R1/R2 comments are Addressed at head, not false positives)
+
+## Implementation
+**Status**: complete
+**When**: 2026-07-14 14:20 +00:00
+**By**: Claude Code Agent (Claude Fable 5)
+
+Addressed both round-2 Integrated Review findings (host-inline; fixes are
+small and mechanical):
+
+- [x] Antimeridian guard: `tilesForBoundingBox` normalizes longitudes into
+  [-180, 180) and throws `std::invalid_argument` on a >180-deg span instead of
+  silently enumerating the long way around; header contract updated; new
+  regression test `TileEnumeration.AntimeridianCrossingBoxThrows` (crossing
+  expressed both wrapped and unwrapped + non-crossing near-dateline box) —
+  `marine_survey_index/src/footprint.cpp` (`8e3a8ac`)
+- [x] `singleInt` test helper guards prepare/step failures with ADD_FAILURE +
+  sentinel return instead of stepping a possibly-null statement —
+  `marine_survey_index/test/test_schema.cpp` (`7328755`)
+
+Verification: rebuilt + full suite green — **87 tests, 0 failures, 13
+skipped** (one new test; cpplint/uncrustify/cppcheck/xmllint all pass).
+
+Next: push; Copilot re-review round.

--- a/.agent/work-plans/issue-259/progress.md
+++ b/.agent/work-plans/issue-259/progress.md
@@ -1,0 +1,76 @@
+---
+issue: 259
+---
+
+# Issue #259 — Survey Indexer + Query CLI
+
+## Issue Review
+**Status**: complete
+**When**: 2026-07-13 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Issue**: #259
+**Comment**: (best-effort post follows this entry; not recorded inline)
+**Scope verdict**: well-scoped
+
+### Summary
+
+Stage 1 of the #258 (survey data exploration) umbrella. Deliverables: an offline SQLite survey indexer and a query CLI. Scope is appropriately bounded — no GUI, no viewer integration, no CUBE re-runs deferred to later stages.
+
+### Principle Alignment
+
+| Principle | Status | Notes |
+|---|---|---|
+| Human control and transparency | OK | Offline tool with human-readable + `--json` output; regenerable sidecar (bags remain data of record) |
+| Enforcement over documentation | Watch | If sensor topic names or SQLite schema become a convention, document them in the knowledge file and enforce via a schema version check |
+| Capture decisions, not just implementations | Action needed | Three open decisions (package home, exact schema, TF pattern reuse vs re-implement) must produce a plan-phase ADR or recorded decision — plan-task should capture them |
+| A change includes its consequences | Action needed | No mention of automated tests; the acceptance sketch is manual. An automated smoke test for the indexer and CLI should be part of the deliverables |
+| Only what's needed | OK | Non-goals are explicitly staged to #258 stages 2–5; scope is minimal |
+| Improve incrementally | OK | Correctly staged as step 1 of 5 |
+| Test what breaks | Watch | Query correctness (wrong tile match, ping-in-gap misidentified) is high-value to test; coverage-chase is not needed but at least one fixture-based regression test is expected |
+| Workspace vs. project separation | OK | Belongs in a project repo (`unh_marine_autonomy` or `marine_tools`); no workspace leakage |
+| Workspace improvements cascade | N/A | Project-specific tooling |
+| Primary framework first | OK | No framework concerns raised |
+
+### Project Principles
+
+| Principle | Status | Notes |
+|---|---|---|
+| Safety First | N/A | Offline tool, no control path |
+| Hardware Agnosticism | Watch | Issue names specific topic namespaces (M3 via kongsberg_em_bridge, Garmin GCV). The `sensor_type` field should use ADR-0005 vocabulary (`sidescan`, `mbes-bathy`) so adding a future sensor doesn't require a schema migration |
+| Modularity and Decoupling | Watch | Package placement affects the dependency graph; plan-task should decide based on which existing package already has the GGGS + store dependency (lean toward `unh_marine_autonomy` next to `marine_tiled_raster_store`) |
+| Simulation-First | N/A | Offline post-processing, no runtime behavior |
+| Iterative, Validated Evolution | OK | Staged correctly |
+| Standards Compliance | Watch | If a new ROS 2 package is created, ADR-0008 requires ROS 2 naming / `package.xml` / license headers; also check REP-144 for package naming |
+
+### ADR Applicability
+
+| ADR | Triggered | Notes |
+|---|---|---|
+| ADR-0001 (Adopt ADRs) | Yes | Open decisions on schema and package home need to be recorded — plan-task should produce a decision record, not just implementation |
+| ADR-0002 (Worktree isolation) | Yes | Already in worktree; continue as required |
+| ADR-0003 (Project-agnostic workspace) | No | Goes in project repo — correct |
+| ADR-0005 (Provenance registry) | Yes | Issue says to align `sensor_type` with ADR-0005 provenance registry ids "where practical." ADR-0005 D3 defines `sensor_class` vocabulary (`sidescan`, `mbes-bathy`, `mbes-backscatter`). The SQLite passes table's `sensor_type` column should use these values exactly; this is cheap insurance against a later schema migration when the second sensor/platform arrives |
+| ADR-0008 (ROS 2 conventions) | Yes | If a new ROS 2 package is created, naming, `package.xml`, and license headers must follow ROS 2 conventions |
+| ADR-0013 (progress.md vocabulary) | Yes | Subsequent phases must use correct entry types |
+
+### Consequences
+
+- `docs/sonar_ecosystem.md` is missing a "Survey indexer / query" row for #258/#259. The **Reprocess** row covers offline M3 bag → store, but the indexer is a distinct capability (it indexes *without* requiring store acceptance — pings that missed CUBE still appear). Add a row when the deliverable lands.
+- The SQLite schema is a cross-stage data contract — stages 2–5 of #258 will consume it. It should be documented in the plan (not just in code comments) so future stages have a stable surface to build against.
+- If a new package is created: `package.xml`, `CMakeLists.txt` (or `setup.py`), and license headers must be added per ADR-0008 and existing unh_marine_autonomy package conventions.
+
+### Recommendations
+
+- **Package home**: lean toward a new package inside `unh_marine_autonomy` (next to `marine_tiled_raster_store`), because GGGS and the store architecture already live there; `marine_tools` would create an inward dependency that `marine_tools` currently doesn't carry. Confirm in plan-task.
+- **Reuse the TF pattern from cube#63 / sidescan_mosaic_bag.cpp** (`marine_sidescan_mosaic/src/sidescan_mosaic_bag.cpp`). cube#63 is closed (M3 import landed). Plan-task should reference these implementations explicitly rather than designing a new TF walk.
+- **SQLite schema alignment with ADR-0005**: use `sensor_class` values from ADR-0005 D3 (`sidescan`, `mbes-bathy`) as the `sensor_type` vocabulary; record `platform` and `sensor` (model) in the bags table or a registry sidecar — consistent with `StoreMetadata` from the ADR-0005 #248 amendment.
+- **Add a fixture-based test**: at minimum, a test that builds a minimal mock bag with known pings, runs the indexer, and verifies the query CLI returns the expected tile/time-window result. The acceptance sketch (point at Massabesic) cannot serve as a regression test.
+- **Document the schema** in the plan ADR or a `docs/` file so stages 2–5 of #258 have a stable interface description without reading the implementation.
+
+### Actions
+- [ ] Capture open decisions (package home, SQLite schema, TF reuse) in a plan-phase ADR or recorded decision (not just code)
+- [ ] Add at least one automated fixture-based test for the indexer and query CLI
+- [ ] Align `sensor_type` column vocabulary with ADR-0005 D3 `sensor_class` values
+- [ ] Update `docs/sonar_ecosystem.md` to add a "Survey indexer / query" row referencing #258/#259 when the deliverable lands
+- [ ] If a new ROS 2 package is created, ensure `package.xml` / naming / license headers follow ADR-0008

--- a/.agent/work-plans/issue-259/progress.md
+++ b/.agent/work-plans/issue-259/progress.md
@@ -302,9 +302,21 @@ code — the first two were introduced by the round-1/2 fixes themselves
 (`std::exit` arrived with the `toLevel`/merge-gap guards without `<cstdlib>`):
 
 ### Findings
-- [ ] (low, Copilot R4) `survey_index_query_main.cpp` uses `std::exit` and `std::max` via transitive includes only — add `<cstdlib>` and `<algorithm>` — `marine_survey_index/src/survey_index_query_main.cpp:32`
-- [ ] (low, Copilot R4) `survey_index_bag_main.cpp` uses `std::exit` without `<cstdlib>` — `marine_survey_index/src/survey_index_bag_main.cpp:50`
-- [ ] (low, Copilot R4) `CMakeLists.txt` doesn't set `CMAKE_CXX_STANDARD` while the package uses C++17 (`std::filesystem`, `std::clamp`); sibling packages (marine_autonomy, marine_sidescan_mosaic) set 17 explicitly — adopt marine_sidescan_mosaic's guarded form — `marine_survey_index/CMakeLists.txt:6`
+- [x] (low, Copilot R4) `survey_index_query_main.cpp` uses `std::exit` and `std::max` via transitive includes only — add `<cstdlib>` and `<algorithm>` — `marine_survey_index/src/survey_index_query_main.cpp:32`
+- [x] (low, Copilot R4) `survey_index_bag_main.cpp` uses `std::exit` without `<cstdlib>` — `marine_survey_index/src/survey_index_bag_main.cpp:50`
+- [x] (low, Copilot R4) `CMakeLists.txt` doesn't set `CMAKE_CXX_STANDARD` while the package uses C++17 (`std::filesystem`, `std::clamp`); sibling packages (marine_autonomy, marine_sidescan_mosaic) set 17 explicitly — adopt marine_sidescan_mosaic's guarded form — `marine_survey_index/CMakeLists.txt:6`
 
 ### False positives
 - (none — all three verified: usages confirmed present, includes confirmed absent, repo convention confirmed)
+
+## Implementation
+**Status**: complete
+**When**: 2026-07-14 15:20 +00:00
+**By**: Claude Code Agent (Claude Fable 5)
+
+Addressed all three round-3 findings in one commit (`195dfa8`) — build hygiene
+only, no behavior change: explicit `<cstdlib>` in both CLIs + `<algorithm>`
+in the query CLI; guarded `CMAKE_CXX_STANDARD 17` (marine_sidescan_mosaic
+form). Clean rebuild + full suite green: **87 tests, 0 failures, 13 skipped**.
+
+Merge authorized by Roland ("fix them, then push and merge").

--- a/.agent/work-plans/issue-259/progress.md
+++ b/.agent/work-plans/issue-259/progress.md
@@ -200,3 +200,22 @@ Publish checkpoint approved by Roland. Branch `feature/issue-259` pushed at
 (base `jazzy`, `Closes #259`). The two round-2 non-blocking suggestions
 (jsonEscape control chars; query read-path sqlite return codes) are noted in
 the PR body to fold into stage 2 (#258) work.
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-07-14 12:40 +00:00
+**By**: Claude Code Agent (Claude Fable 5)
+
+**PR**: #261 at `6957512`
+**Sources**: 3 (Copilot R1 @ `7cb005b`, Copilot R2 @ `6957512`, Local Review (Pre-Push) round 2 @ `70ff424`)
+**Cross-source confirmations**: 2
+**CI**: all-pass (build ✅, copilot ✅)
+
+### Findings
+- [ ] (cross-confirmed: Copilot R1+R2 + Local Review round 2) `jsonEscape` only escapes `"` and `\` — control chars (newline/tab/<0x20) in a bag path produce invalid `--json` output; escape standard sequences + `\u00XX` — `marine_survey_index/src/survey_index_query_main.cpp:89`
+- [ ] (cross-confirmed: Copilot R1+R2 + Local Review round 2) Query read loops (`distinctLevels`, `queryPasses`) ignore the terminal `sqlite3_step` code — a mid-scan DB error silently returns partial results (CLI may claim "no coverage"); capture final step result, throw unless `SQLITE_DONE` — `marine_survey_index/src/query.cpp:84,145`
+- [ ] (medium, Copilot R1+R2) `openIndexDb` treats any non-`SQLITE_ROW` step result as "fresh DB" and INSERTs a schema_version row — a step error (corrupt/unreadable DB) is masked and the DB is written to; only insert on `SQLITE_DONE`, throw+close otherwise — `marine_survey_index/src/schema.cpp:117`
+- [ ] (low, Copilot R1) `--level`/`--mbes-level`/`--sidescan-level` are cast to `uint8_t` without range validation — out-of-range values hit `gggs::Level`'s `std::out_of_range` outside any try/catch → `std::terminate` abort instead of a clean CLI error; negative `--merge-gap` degenerates to one pass per ping — validate 0–20 (and merge-gap ≥ 0) at parse time — `marine_survey_index/src/survey_index_bag_main.cpp:347`, `marine_survey_index/src/survey_index_query_main.cpp:165`
+
+### False positives
+- (none — all four verified against current code at head `6957512`; Copilot R1's `commit_id` differs from head only by a progress.md commit, so its code references are current)

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -15,6 +15,7 @@
 | `marine_bathymetry_store` | C++ | Persistent multi-source bathymetric data store: GGGS-tiled, priority source layers, best-source / shallowest-reliable queries, per-tile GeoTIFF (ADR-0002 / #86) |
 | `marine_interfaces` | C++ (IDL) | ROS 2 message definitions for helm commands, heartbeats, navigation, perception contacts, and sensor data (39 msg types) |
 | `marine_sidescan_mosaic` | C++ | Live georeferenced sidescan backscatter mosaicker: projects GCV port/stbd RawSonarImage samples to GGGS-tiled uint16 GeoTIFF tiles for CAMP / web display (#173 / #171 / #166) |
+| `marine_survey_index` | C++ | Offline survey indexer + query CLI: bags → per-GGGS-tile pass intervals in a regenerable SQLite sidecar; answers "which bags/time-ranges saw this location" (#258 stage 1 / #259; schema contract in `docs/survey_index_schema.md`) |
 | `marine_tiled_raster_store` | C++ | Generic GGGS-tiled raster store core: band/dtype-parametrized `TiledRasterTile<T>` + per-tile GeoTIFF persistence, shared by bathymetry and sidescan (#172) |
 | `mission_manager` | Python | Converts mission plans from CAMP GCS into navigation tasks and manages task execution |
 | `mission_manager_interfaces` | C++ (IDL) | Service definitions for task manipulation (3 srv types) |

--- a/docs/sonar_ecosystem.md
+++ b/docs/sonar_ecosystem.md
@@ -52,6 +52,7 @@ looked.
 | **Render — CAMP** | Unified band-select + colormap raster render + live cache | [#175](https://github.com/rolker/unh_marine_autonomy/issues/175) (I4), [camp#121], [camp#108], [camp#63] | 0001 / 0008 | ✅ file-store display + GPU raster ([camp#90]), band-select ([camp#108], PR [camp#124] merged), and live cache ([camp#121], PR [camp#139] merged) all landed |
 | **Render — web** | Browser SA viewer (contacts + bathy + sidescan) | [#166](https://github.com/rolker/unh_marine_autonomy/issues/166) | — | 📋 |
 | **Reprocess** | Offline M3 bag → store tiles; PINGMapper offline sidescan EGN | [#171](https://github.com/rolker/unh_marine_autonomy/issues/171) (C1) | — | ✅ M3 import landed ([cube#63] closed); 📋 sidescan offline pipeline to validate; ⚠️ draft→**processed** promotion workflow thin |
+| **Survey index / query** | Location → raw bag data that saw it: `marine_survey_index` per-tile pass intervals (ping geometry, not store acceptance) + query CLI | [#258](https://github.com/rolker/unh_marine_autonomy/issues/258) / [#259](https://github.com/rolker/unh_marine_autonomy/issues/259) | — | ✅ stage 1 (indexer + CLI); explorer stages 2–5 📋 (schema contract: [survey_index_schema.md](survey_index_schema.md)) |
 | **Metering** | Per-topic priority on the `udp_bridge` rate-limiter | [udp_bridge#19](https://github.com/rolker/udp_bridge/issues/19) | 0008 (D9) | 📋 |
 
 [cube#15]: https://github.com/rolker/cube_bathymetry/issues/15

--- a/docs/survey_index_schema.md
+++ b/docs/survey_index_schema.md
@@ -20,11 +20,14 @@ checkpoint (2026-07-13); see `.agent/work-plans/issue-259/plan.md`.
 - **Index = "where did the sensor look."** Pass intervals are computed from
   ping geometry (nav + sonar extents), independent of what any store
   accepted. Pings rejected by CUBE or absent from store coverage still index.
-- **Tile keys match the stores.** Tiles are GGGS grids `(level, tile_row,
-  tile_col)` — the same key space as the tiled stores' per-tile GeoTIFFs
-  (e.g. bathy `10_17788_13902.tif` ⇔ `level=10, tile_row=17788,
-  tile_col=13902`). Default indexing levels are the stores' native tiling:
-  **L10 for MBES** (bathy store), **L13 for sidescan** (sidescan store).
+- **Tile keys live in the stores' key space.** Tiles are GGGS grids `(level,
+  tile_row, tile_col)` — the same key space as the tiled stores' per-tile
+  GeoTIFFs (e.g. bathy `10_17788_13902.tif` ⇔ `level=10, tile_row=17788,
+  tile_col=13902`). The **default indexing level is L14 (~54 m tiles) for both
+  sensors** — a target-inspection neighbourhood, deliberately finer than the
+  stores' native tiling (bathy L10 ≈ 870 m, sidescan L13 ≈ 108 m). Finer keys
+  roll **up** to store tiles through the GGGS parent hierarchy, so consumers
+  joining against store tiling aggregate L14 rows under their L10/L13 parents.
   Mixed levels coexist in one DB; queries carry the level in the key.
 
 ## Tables (schema version 1)

--- a/docs/survey_index_schema.md
+++ b/docs/survey_index_schema.md
@@ -1,0 +1,85 @@
+# Survey Index Schema (`survey_index.db`)
+
+The SQLite sidecar written by `marine_survey_index`'s `survey_index_bag` and
+read by `survey_index_query` — and, in later stages of
+[#258](https://github.com/rolker/unh_marine_autonomy/issues/258), by the
+explorer's overview pane and interval loader. This document is the **stable
+cross-stage contract**; consumers should build against it, not against the
+implementation.
+
+Design decisions behind it were made at the
+[#259](https://github.com/rolker/unh_marine_autonomy/issues/259) plan
+checkpoint (2026-07-13); see `.agent/work-plans/issue-259/plan.md`.
+
+## Ground rules
+
+- **Regenerable sidecar.** The bags are the data of record; the index is a
+  derived cache. Deleting `survey_index.db` and re-running the indexer always
+  reproduces it. There are no migrations — an incompatible schema bumps
+  `schema_version` and the open fails with a regenerate hint.
+- **Index = "where did the sensor look."** Pass intervals are computed from
+  ping geometry (nav + sonar extents), independent of what any store
+  accepted. Pings rejected by CUBE or absent from store coverage still index.
+- **Tile keys match the stores.** Tiles are GGGS grids `(level, tile_row,
+  tile_col)` — the same key space as the tiled stores' per-tile GeoTIFFs
+  (e.g. bathy `10_17788_13902.tif` ⇔ `level=10, tile_row=17788,
+  tile_col=13902`). Default indexing levels are the stores' native tiling:
+  **L10 for MBES** (bathy store), **L13 for sidescan** (sidescan store).
+  Mixed levels coexist in one DB; queries carry the level in the key.
+
+## Tables (schema version 1)
+
+```sql
+CREATE TABLE schema_version (
+  version INTEGER NOT NULL           -- always exactly one row
+);
+
+CREATE TABLE bags (
+  id            INTEGER PRIMARY KEY,
+  path          TEXT    NOT NULL UNIQUE,  -- absolute, lexically normalized
+  size_bytes    INTEGER NOT NULL,         -- fingerprint: total regular-file bytes
+  mtime_ns      INTEGER NOT NULL,         -- fingerprint: newest mtime under the bag
+  indexed_at_ns INTEGER NOT NULL          -- wall clock when (re-)indexed
+);
+
+CREATE TABLE passes (
+  id          INTEGER PRIMARY KEY,
+  bag_id      INTEGER NOT NULL REFERENCES bags(id) ON DELETE CASCADE,
+  level       INTEGER NOT NULL,      -- GGGS quadtree level of the tile key
+  tile_row    INTEGER NOT NULL,      -- GGGS grid row (from south)
+  tile_col    INTEGER NOT NULL,      -- GGGS grid column (from west)
+  sensor_type TEXT    NOT NULL,      -- see vocabulary below
+  topic       TEXT    NOT NULL,      -- the bag topic the pings came from
+  t_start_ns  INTEGER NOT NULL,      -- first ping stamp in the pass (UNIX ns)
+  t_end_ns    INTEGER NOT NULL,      -- last ping stamp in the pass (UNIX ns)
+  ping_count  INTEGER NOT NULL       -- pings that touched this tile in the pass
+);
+CREATE INDEX passes_tile ON passes(level, tile_row, tile_col);
+CREATE INDEX passes_bag  ON passes(bag_id);
+```
+
+## `sensor_type` vocabulary
+
+**Extends** the ADR-0005 D3 `sensor_class` vocabulary (it does not redefine
+it): `mbes-bathy` is used verbatim; sidescan is stored **channel-split** as
+`sidescan-port` / `sidescan-stbd` (D3 `sidescan` + channel suffix) so one
+channel can be pulled without re-indexing. Consumers filtering by the plain
+D3 class `sidescan` must match both channel values (the query CLI's
+`--sensor sidescan` does `LIKE 'sidescan%'`). New sensors add new values —
+additive, no schema change.
+
+## Semantics
+
+- **A "pass"** is a maximal run of pings from one `(tile, sensor_type,
+  topic)` whose inter-ping gaps are all ≤ the merge gap (default 5 s,
+  indexer `--merge-gap`). Two survey lines crossing the same tile minutes
+  apart are two passes — that per-pass identity is load-bearing for the
+  explorer's single-pass sidescan display (#258 stages 3/5).
+- **Footprints are conservative.** MBES: sensor position ± outermost good
+  detections' across-track extent. Sidescan: sensor position + max slant
+  range to the ensonified side (slant bounds ground range — no bottom model
+  at index time). A tile listed may be *near* the swath edge; the drill-down
+  stages do the exact math.
+- **Incremental re-runs.** A bag whose `path`, `size_bytes`, and `mtime_ns`
+  all match its ledger row is skipped; a changed bag has its passes deleted
+  and re-indexed atomically (single transaction per bag).

--- a/marine_survey_index/CMakeLists.txt
+++ b/marine_survey_index/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.8)
 project(marine_survey_index)
 
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()

--- a/marine_survey_index/CMakeLists.txt
+++ b/marine_survey_index/CMakeLists.txt
@@ -1,0 +1,96 @@
+cmake_minimum_required(VERSION 3.8)
+project(marine_survey_index)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(marine_acoustic_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(geographic_msgs REQUIRED)
+find_package(geodesy REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(builtin_interfaces REQUIRED)
+find_package(marine_autonomy REQUIRED)
+find_package(marine_sidescan_mosaic REQUIRED)
+find_package(rosbag2_cpp REQUIRED)
+find_package(rosbag2_storage REQUIRED)
+find_package(SQLite3 REQUIRED)
+
+# Core library: schema, interval accumulator, footprint->tile enumeration, and
+# the query join. Deliberately free of rosbag2/tf2/rclcpp so the unit tests
+# exercise the correctness paths without bag I/O.
+add_library(${PROJECT_NAME}_core
+  src/schema.cpp
+  src/footprint.cpp
+  src/query.cpp
+)
+target_include_directories(${PROJECT_NAME}_core PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(${PROJECT_NAME}_core SQLite::SQLite3)
+ament_target_dependencies(${PROJECT_NAME}_core
+  marine_autonomy
+  geographic_msgs
+)
+
+add_executable(survey_index_bag src/survey_index_bag_main.cpp)
+target_link_libraries(survey_index_bag ${PROJECT_NAME}_core)
+ament_target_dependencies(survey_index_bag
+  rclcpp
+  marine_acoustic_msgs
+  sensor_msgs
+  geodesy
+  tf2
+  tf2_msgs
+  geometry_msgs
+  builtin_interfaces
+  marine_sidescan_mosaic
+  rosbag2_cpp
+  rosbag2_storage
+)
+
+add_executable(survey_index_query src/survey_index_query_main.cpp)
+target_link_libraries(survey_index_query ${PROJECT_NAME}_core)
+ament_target_dependencies(survey_index_query
+  marine_autonomy
+  geographic_msgs
+)
+
+install(DIRECTORY include/ DESTINATION include)
+install(TARGETS ${PROJECT_NAME}_core
+  EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+install(TARGETS survey_index_bag survey_index_query
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+  find_package(ament_cmake_gtest REQUIRED)
+
+  ament_add_gtest(test_schema test/test_schema.cpp)
+  target_link_libraries(test_schema ${PROJECT_NAME}_core)
+
+  ament_add_gtest(test_interval_merge test/test_interval_merge.cpp)
+  target_link_libraries(test_interval_merge ${PROJECT_NAME}_core)
+
+  ament_add_gtest(test_tile_enumeration test/test_tile_enumeration.cpp)
+  target_link_libraries(test_tile_enumeration ${PROJECT_NAME}_core)
+
+  ament_add_gtest(test_query_join test/test_query_join.cpp)
+  target_link_libraries(test_query_join ${PROJECT_NAME}_core)
+endif()
+
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_dependencies(marine_autonomy geographic_msgs SQLite3)
+ament_package()

--- a/marine_survey_index/README.md
+++ b/marine_survey_index/README.md
@@ -20,7 +20,7 @@ ros2 run marine_survey_index survey_index_bag <bag_uri ...> [--scan DIR] \
     [--db survey_index.db] \
     [--mbes-topic /bizzy/sensors/m3/detections] \
     [--port-topic ...sonar_image_port] [--stbd-topic ...sonar_image_starboard] \
-    [--mbes-level 10] [--sidescan-level 13] [--level N] \
+    [--mbes-level 14] [--sidescan-level 14] [--level N] \
     [--merge-gap 5.0] [--earth-frame earth] [--sound-speed 1500]
 ```
 
@@ -32,9 +32,11 @@ a SQLite sidecar. Indexing is from **ping geometry, not store acceptance** —
 pings CUBE rejected still index. Unchanged already-indexed bags are skipped
 (size+mtime ledger); changed bags are re-indexed atomically.
 
-Default levels match the stores' native tiling (bathy L10 ⇔
-`10_<row>_<col>.tif`; sidescan L13), so index keys join directly with store
-tiles. Measured: a 2.5 GB Massabesic sonar bag (632k pings) indexes in ~12 s.
+The default level is **L14 (~54 m tiles)** for both sensors — a
+target-inspection neighbourhood, finer than the stores' native tiling (bathy
+L10 ≈ 870 m ⇔ `10_<row>_<col>.tif`; sidescan L13 ≈ 108 m); L14 keys roll up
+to store tiles via the GGGS parent hierarchy. Measured: a 2.5 GB Massabesic
+sonar bag (632k pings) indexes in ~12 s.
 
 ### `survey_index_query` — the answer
 

--- a/marine_survey_index/README.md
+++ b/marine_survey_index/README.md
@@ -1,0 +1,67 @@
+# marine_survey_index
+
+Offline **survey index + query CLI**: maps a location to the raw bag data that
+ensonified it. Stage 1 of the survey-data-exploration umbrella
+([#258](https://github.com/rolker/unh_marine_autonomy/issues/258); this
+package is [#259](https://github.com/rolker/unh_marine_autonomy/issues/259)).
+
+The motivating question: *"someone reported a possible target at this lat/lon
+— which bags, which time windows, which sonar saw that spot?"* The stores are
+averaged products; target-level review needs the raw data behind a location,
+and finding it by hand means opening bags one by one. The index answers in
+seconds.
+
+## Tools
+
+### `survey_index_bag` — the indexer
+
+```bash
+ros2 run marine_survey_index survey_index_bag <bag_uri ...> [--scan DIR] \
+    [--db survey_index.db] \
+    [--mbes-topic /bizzy/sensors/m3/detections] \
+    [--port-topic ...sonar_image_port] [--stbd-topic ...sonar_image_starboard] \
+    [--mbes-level 10] [--sidescan-level 13] [--level N] \
+    [--merge-gap 5.0] [--earth-frame earth] [--sound-speed 1500]
+```
+
+Single interleaved chronological pass per bag (the bounded-TF-window pattern
+from cube#63 / the sidescan importer): georeferences every MBES
+`SonarDetections` and sidescan `RawSonarImage` ping, computes its conservative
+ground-footprint bounding box, and records per-GGGS-tile **pass intervals** in
+a SQLite sidecar. Indexing is from **ping geometry, not store acceptance** —
+pings CUBE rejected still index. Unchanged already-indexed bags are skipped
+(size+mtime ledger); changed bags are re-indexed atomically.
+
+Default levels match the stores' native tiling (bathy L10 ⇔
+`10_<row>_<col>.tif`; sidescan L13), so index keys join directly with store
+tiles. Measured: a 2.5 GB Massabesic sonar bag (632k pings) indexes in ~12 s.
+
+### `survey_index_query` — the answer
+
+```bash
+ros2 run marine_survey_index survey_index_query \
+    (--point LAT LON [--radius M] | --box LATMIN LONMIN LATMAX LONMAX) \
+    [--db survey_index.db] [--level N] [--sensor TYPE] [--json]
+```
+
+Prints matching pass intervals grouped by bag, ordered by time — bag path,
+UTC interval, duration, ping count, sensor, tile, topic. `--sensor` accepts
+`mbes-bathy`, `sidescan-port`, `sidescan-stbd`, or `sidescan` (both
+channels). `--json` for downstream tools (the #258 explorer consumes the same
+index directly).
+
+## Schema
+
+`survey_index.db` is a **regenerable sidecar** — bags remain the data of
+record. The schema is the cross-stage contract for #258 stages 2–5:
+see [`docs/survey_index_schema.md`](../docs/survey_index_schema.md).
+
+## Testing
+
+Bag-I/O-free unit tests cover the DB-open contract, the interval
+merge/split logic, footprint→tile enumeration (boundary straddling), and the
+query tile-join (sensor filters, level separation):
+
+```bash
+colcon test --packages-select marine_survey_index
+```

--- a/marine_survey_index/include/marine_survey_index/footprint.hpp
+++ b/marine_survey_index/include/marine_survey_index/footprint.hpp
@@ -40,11 +40,14 @@ namespace marine_survey_index
 ///
 /// @param lat_min,lat_max Latitude bounds (degrees); swapped inputs are
 ///   normalized. Values are clamped to [-90, 90].
-/// @param lon_min,lon_max Longitude bounds (degrees); swapped inputs are
-///   normalized. The box must not cross the antimeridian — survey areas in
-///   this workspace (Massabesic, Isles of Shoals) never do; a crossing box
-///   would enumerate the long way around.
+/// @param lon_min,lon_max Longitude bounds (degrees); any range accepted
+///   (wrapped into [-180, 180)); swapped inputs are normalized. Boxes
+///   crossing the antimeridian are not supported — survey areas in this
+///   workspace (Massabesic, Isles of Shoals) never do.
 /// @return The touched grids, in iterator (row-major) order.
+/// @throws std::invalid_argument if the normalized longitude span exceeds
+///   180 degrees (an antimeridian-crossing or hemisphere-plus box), instead
+///   of silently enumerating the long way around.
 std::vector<gggs::GridIndex> tilesForBoundingBox(
   double lat_min, double lon_min, double lat_max, double lon_max,
   const gggs::Level & level);

--- a/marine_survey_index/include/marine_survey_index/footprint.hpp
+++ b/marine_survey_index/include/marine_survey_index/footprint.hpp
@@ -1,0 +1,54 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef MARINE_SURVEY_INDEX__FOOTPRINT_HPP_
+#define MARINE_SURVEY_INDEX__FOOTPRINT_HPP_
+
+/// @file
+/// @brief Footprint → GGGS-tile enumeration.
+///
+/// A ping footprint is reduced to its geographic bounding box; this maps the
+/// box to the set of GGGS grids (tiles) it overlaps at a level. Straddling a
+/// grid boundary yields every touched grid, not just the origin's.
+
+#include <vector>
+
+#include "marine_autonomy/gggs.h"
+
+namespace marine_survey_index
+{
+
+/// @brief All GGGS grids at @p level overlapping the geographic bounding box.
+///
+/// @param lat_min,lat_max Latitude bounds (degrees); swapped inputs are
+///   normalized. Values are clamped to [-90, 90].
+/// @param lon_min,lon_max Longitude bounds (degrees); swapped inputs are
+///   normalized. The box must not cross the antimeridian — survey areas in
+///   this workspace (Massabesic, Isles of Shoals) never do; a crossing box
+///   would enumerate the long way around.
+/// @return The touched grids, in iterator (row-major) order.
+std::vector<gggs::GridIndex> tilesForBoundingBox(
+  double lat_min, double lon_min, double lat_max, double lon_max,
+  const gggs::Level & level);
+
+}  // namespace marine_survey_index
+
+#endif  // MARINE_SURVEY_INDEX__FOOTPRINT_HPP_

--- a/marine_survey_index/include/marine_survey_index/interval_accumulator.hpp
+++ b/marine_survey_index/include/marine_survey_index/interval_accumulator.hpp
@@ -1,0 +1,124 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef MARINE_SURVEY_INDEX__INTERVAL_ACCUMULATOR_HPP_
+#define MARINE_SURVEY_INDEX__INTERVAL_ACCUMULATOR_HPP_
+
+/// @file
+/// @brief Per-(tile, sensor, topic) pass-interval accumulator.
+///
+/// Consecutive pings over the same tile merge into one interval while the
+/// inter-ping gap stays within the merge gap; a wider gap closes the interval
+/// and opens a new one — so two distinct passes over the same tile (e.g. out
+/// and back on adjacent survey lines) index as two intervals.
+
+#include <algorithm>
+#include <cstdint>
+#include <map>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+namespace marine_survey_index
+{
+
+/// Identity of an accumulation stream: one GGGS tile seen by one sensor
+/// channel on one topic.
+struct TileKey
+{
+  std::uint8_t level = 0;
+  std::uint32_t tile_row = 0;
+  std::uint32_t tile_col = 0;
+  std::string sensor_type;
+  std::string topic;
+
+  bool operator<(const TileKey & o) const
+  {
+    return std::tie(level, tile_row, tile_col, sensor_type, topic) <
+           std::tie(o.level, o.tile_row, o.tile_col, o.sensor_type, o.topic);
+  }
+  bool operator==(const TileKey & o) const
+  {
+    return std::tie(level, tile_row, tile_col, sensor_type, topic) ==
+           std::tie(o.level, o.tile_row, o.tile_col, o.sensor_type, o.topic);
+  }
+};
+
+/// One closed pass interval, ready for the `passes` table.
+struct PassInterval
+{
+  TileKey key;
+  std::int64_t t_start_ns = 0;
+  std::int64_t t_end_ns = 0;
+  std::int64_t ping_count = 0;
+};
+
+class IntervalAccumulator
+{
+public:
+  /// @param merge_gap_ns Maximum inter-ping gap (ns) that still extends the
+  ///   open interval for a key. Bag streams are chronological per topic;
+  ///   a ping earlier than the open interval's end (clock skew, interleaving
+  ///   jitter) extends the count without moving the end backwards.
+  explicit IntervalAccumulator(std::int64_t merge_gap_ns)
+  : merge_gap_ns_(merge_gap_ns) {}
+
+  void addPing(const TileKey & key, std::int64_t t_ns)
+  {
+    auto it = open_.find(key);
+    if (it == open_.end()) {
+      open_.emplace(key, PassInterval{key, t_ns, t_ns, 1});
+      return;
+    }
+    PassInterval & open = it->second;
+    if (t_ns - open.t_end_ns > merge_gap_ns_) {
+      closed_.push_back(open);
+      open = PassInterval{key, t_ns, t_ns, 1};
+      return;
+    }
+    open.t_end_ns = std::max(open.t_end_ns, t_ns);
+    open.t_start_ns = std::min(open.t_start_ns, t_ns);
+    ++open.ping_count;
+  }
+
+  /// Close every open interval and return all intervals accumulated so far.
+  /// The accumulator is empty afterwards (reusable for the next bag).
+  std::vector<PassInterval> flushAll()
+  {
+    for (auto & entry : open_) {
+      closed_.push_back(entry.second);
+    }
+    open_.clear();
+    std::vector<PassInterval> out;
+    out.swap(closed_);
+    return out;
+  }
+
+private:
+  std::int64_t merge_gap_ns_;
+  std::map<TileKey, PassInterval> open_;
+  std::vector<PassInterval> closed_;
+};
+
+}  // namespace marine_survey_index
+
+#endif  // MARINE_SURVEY_INDEX__INTERVAL_ACCUMULATOR_HPP_

--- a/marine_survey_index/include/marine_survey_index/query.hpp
+++ b/marine_survey_index/include/marine_survey_index/query.hpp
@@ -1,0 +1,71 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef MARINE_SURVEY_INDEX__QUERY_HPP_
+#define MARINE_SURVEY_INDEX__QUERY_HPP_
+
+/// @file
+/// @brief Tile-join query over the survey index.
+
+#include <sqlite3.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "marine_autonomy/gggs.h"
+
+namespace marine_survey_index
+{
+
+/// One pass interval joined with its bag, as returned to the CLI.
+struct PassRow
+{
+  std::string bag_path;
+  std::string sensor_type;
+  std::string topic;
+  std::uint8_t level = 0;
+  std::uint32_t tile_row = 0;
+  std::uint32_t tile_col = 0;
+  std::int64_t t_start_ns = 0;
+  std::int64_t t_end_ns = 0;
+  std::int64_t ping_count = 0;
+};
+
+/// @brief Distinct GGGS levels present in the index (optionally for one
+///   sensor filter — same semantics as queryPasses).
+std::vector<std::uint8_t> distinctLevels(sqlite3 * db, const std::string & sensor_filter);
+
+/// @brief Passes overlapping any of @p tiles, joined with their bags.
+///
+/// @param tiles Candidate tiles (mixed levels allowed; each is matched with
+///   its own level).
+/// @param sensor_filter Empty = all sensors. The literal "sidescan" matches
+///   every `sidescan-*` channel (the D3 sensor_class → channel-split mapping);
+///   any other value matches `sensor_type` exactly.
+/// @return Rows ordered by bag path, then t_start_ns.
+std::vector<PassRow> queryPasses(
+  sqlite3 * db, const std::vector<gggs::GridIndex> & tiles,
+  const std::string & sensor_filter);
+
+}  // namespace marine_survey_index
+
+#endif  // MARINE_SURVEY_INDEX__QUERY_HPP_

--- a/marine_survey_index/include/marine_survey_index/schema.hpp
+++ b/marine_survey_index/include/marine_survey_index/schema.hpp
@@ -1,0 +1,57 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef MARINE_SURVEY_INDEX__SCHEMA_HPP_
+#define MARINE_SURVEY_INDEX__SCHEMA_HPP_
+
+/// @file
+/// @brief SQLite survey-index schema: open/create + version gate.
+///
+/// The index is a **regenerable sidecar** (`survey_index.db`) — the bags remain
+/// the data of record; deleting the index and re-running the indexer always
+/// reproduces it. The schema is the cross-stage contract for #258 stages 2–5;
+/// the durable description lives in `docs/survey_index_schema.md`.
+
+#include <sqlite3.h>
+
+#include <string>
+
+namespace marine_survey_index
+{
+
+/// Schema version stamped into a fresh DB and checked on every open. Bump on
+/// any incompatible change; the open then fails with a "regenerate" hint
+/// (never silently migrate — regeneration is the migration).
+constexpr int kSchemaVersion = 1;
+
+/// @brief Open (creating and initializing if needed) a survey index database.
+///
+/// Creates the `schema_version`, `bags`, and `passes` tables when absent, and
+/// verifies the stored schema version matches ::kSchemaVersion.
+///
+/// @param path Filesystem path (or ":memory:" for tests).
+/// @return An open handle; the caller owns it (close with `sqlite3_close`).
+/// @throws std::runtime_error on open failure or schema-version mismatch.
+sqlite3 * openIndexDb(const std::string & path);
+
+}  // namespace marine_survey_index
+
+#endif  // MARINE_SURVEY_INDEX__SCHEMA_HPP_

--- a/marine_survey_index/package.xml
+++ b/marine_survey_index/package.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>marine_survey_index</name>
+  <version>0.0.0</version>
+  <description>
+    Offline survey index + query CLI: maps a location to the raw bag data that
+    ensonified it. Scans survey bags in a single interleaved pass (bounded TF
+    window), georeferences each sonar ping's footprint, and records per-GGGS-tile
+    pass intervals in a regenerable SQLite sidecar (survey_index.db) next to the
+    stores. The query CLI answers "which bags, which time ranges, which sensor
+    saw this point/box" in seconds, without replaying bags. Stage 1 of
+    unh_marine_autonomy#258 (see #259).
+  </description>
+  <maintainer email="roland.arsenault@unh.edu">Roland Arsenault</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>marine_acoustic_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>geographic_msgs</depend>
+  <depend>geodesy</depend>
+  <depend>tf2</depend>
+  <depend>tf2_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>builtin_interfaces</depend>
+  <depend>marine_autonomy</depend>
+  <depend>marine_sidescan_mosaic</depend>
+  <depend>rosbag2_cpp</depend>
+  <depend>rosbag2_storage</depend>
+  <depend>sqlite3</depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/marine_survey_index/src/footprint.cpp
+++ b/marine_survey_index/src/footprint.cpp
@@ -1,0 +1,53 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "marine_survey_index/footprint.hpp"
+
+#include <algorithm>
+#include <utility>
+
+namespace marine_survey_index
+{
+
+std::vector<gggs::GridIndex> tilesForBoundingBox(
+  double lat_min, double lon_min, double lat_max, double lon_max,
+  const gggs::Level & level)
+{
+  if (lat_min > lat_max) {
+    std::swap(lat_min, lat_max);
+  }
+  if (lon_min > lon_max) {
+    std::swap(lon_min, lon_max);
+  }
+  lat_min = std::clamp(lat_min, -90.0, 90.0);
+  lat_max = std::clamp(lat_max, -90.0, 90.0);
+
+  const gggs::GridIndex south_west = level.gridIndex(lat_min, lon_min);
+  const gggs::GridIndex north_east = level.gridIndex(lat_max, lon_max);
+
+  std::vector<gggs::GridIndex> tiles;
+  for (gggs::GridAreaIterator it(south_west, north_east); it.valid(); it.next()) {
+    tiles.push_back(*it);
+  }
+  return tiles;
+}
+
+}  // namespace marine_survey_index

--- a/marine_survey_index/src/footprint.cpp
+++ b/marine_survey_index/src/footprint.cpp
@@ -22,6 +22,8 @@
 #include "marine_survey_index/footprint.hpp"
 
 #include <algorithm>
+#include <stdexcept>
+#include <string>
 #include <utility>
 
 namespace marine_survey_index
@@ -34,8 +36,20 @@ std::vector<gggs::GridIndex> tilesForBoundingBox(
   if (lat_min > lat_max) {
     std::swap(lat_min, lat_max);
   }
+  lon_min = gggs::normalizeLongitude(lon_min);
+  lon_max = gggs::normalizeLongitude(lon_max);
   if (lon_min > lon_max) {
     std::swap(lon_min, lon_max);
+  }
+  // Antimeridian-crossing boxes are unsupported (see the header contract).
+  // After normalization into [-180, 180) a crossing box always presents as a
+  // >180-degree span — without this guard it would silently enumerate the
+  // long way around (a near-whole-world tile set at fine levels). Fail loud;
+  // the indexer's per-bag error isolation and the query CLI both surface it.
+  if (lon_max - lon_min > 180.0) {
+    throw std::invalid_argument(
+      "tilesForBoundingBox: longitude span " + std::to_string(lon_max - lon_min) +
+      " deg exceeds 180 — boxes crossing the antimeridian are not supported");
   }
   lat_min = std::clamp(lat_min, -90.0, 90.0);
   lat_max = std::clamp(lat_max, -90.0, 90.0);

--- a/marine_survey_index/src/query.cpp
+++ b/marine_survey_index/src/query.cpp
@@ -76,10 +76,14 @@ std::vector<std::uint8_t> distinctLevels(sqlite3 * db, const std::string & senso
     sqlite3_bind_text(stmt, 1, bind_value.c_str(), -1, SQLITE_TRANSIENT);
   }
   std::vector<std::uint8_t> levels;
-  while (sqlite3_step(stmt) == SQLITE_ROW) {
+  int rc;
+  while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {
     levels.push_back(static_cast<std::uint8_t>(sqlite3_column_int(stmt, 0)));
   }
   sqlite3_finalize(stmt);
+  if (rc != SQLITE_DONE) {
+    throwSqlite(db, "distinctLevels step");
+  }
   return levels;
 }
 
@@ -129,7 +133,8 @@ std::vector<PassRow> queryPasses(
       sqlite3_bind_text(stmt, slot++, bind_value.c_str(), -1, SQLITE_TRANSIENT);
     }
 
-    while (sqlite3_step(stmt) == SQLITE_ROW) {
+    int rc;
+    while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {
       PassRow row;
       row.bag_path = columnText(stmt, 0);
       row.sensor_type = columnText(stmt, 1);
@@ -143,6 +148,9 @@ std::vector<PassRow> queryPasses(
       rows.push_back(std::move(row));
     }
     sqlite3_finalize(stmt);
+    if (rc != SQLITE_DONE) {
+      throwSqlite(db, "queryPasses step");
+    }
   }
 
   // Each chunk's statement sorts independently, so a box spanning more than one

--- a/marine_survey_index/src/query.cpp
+++ b/marine_survey_index/src/query.cpp
@@ -51,6 +51,15 @@ void throwSqlite(sqlite3 * db, const std::string & context)
   throw std::runtime_error("survey index query (" + context + "): " + sqlite3_errmsg(db));
 }
 
+// sqlite3_column_text returns nullptr for a SQL NULL; constructing a
+// std::string from nullptr is UB. These columns are NOT NULL today, but read
+// them defensively so a future schema change can't corrupt the query path.
+std::string columnText(sqlite3_stmt * stmt, int col)
+{
+  const unsigned char * text = sqlite3_column_text(stmt, col);
+  return text ? reinterpret_cast<const char *>(text) : std::string();
+}
+
 }  // namespace
 
 std::vector<std::uint8_t> distinctLevels(sqlite3 * db, const std::string & sensor_filter)
@@ -122,9 +131,9 @@ std::vector<PassRow> queryPasses(
 
     while (sqlite3_step(stmt) == SQLITE_ROW) {
       PassRow row;
-      row.bag_path = reinterpret_cast<const char *>(sqlite3_column_text(stmt, 0));
-      row.sensor_type = reinterpret_cast<const char *>(sqlite3_column_text(stmt, 1));
-      row.topic = reinterpret_cast<const char *>(sqlite3_column_text(stmt, 2));
+      row.bag_path = columnText(stmt, 0);
+      row.sensor_type = columnText(stmt, 1);
+      row.topic = columnText(stmt, 2);
       row.level = static_cast<std::uint8_t>(sqlite3_column_int(stmt, 3));
       row.tile_row = static_cast<std::uint32_t>(sqlite3_column_int64(stmt, 4));
       row.tile_col = static_cast<std::uint32_t>(sqlite3_column_int64(stmt, 5));

--- a/marine_survey_index/src/query.cpp
+++ b/marine_survey_index/src/query.cpp
@@ -1,0 +1,140 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "marine_survey_index/query.hpp"
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace marine_survey_index
+{
+namespace
+{
+
+// Appends the sensor-filter clause and returns the value to bind (empty =
+// nothing to bind). "sidescan" expands to the channel-split LIKE.
+std::string appendSensorClause(const std::string & sensor_filter, std::string & sql)
+{
+  if (sensor_filter.empty()) {
+    return "";
+  }
+  if (sensor_filter == "sidescan") {
+    sql += " AND p.sensor_type LIKE 'sidescan%'";
+    return "";
+  }
+  sql += " AND p.sensor_type = ?";
+  return sensor_filter;
+}
+
+void throwSqlite(sqlite3 * db, const std::string & context)
+{
+  throw std::runtime_error("survey index query (" + context + "): " + sqlite3_errmsg(db));
+}
+
+}  // namespace
+
+std::vector<std::uint8_t> distinctLevels(sqlite3 * db, const std::string & sensor_filter)
+{
+  std::string sql = "SELECT DISTINCT p.level FROM passes p WHERE 1=1";
+  const std::string bind_value = appendSensorClause(sensor_filter, sql);
+  sql += " ORDER BY p.level";
+
+  sqlite3_stmt * stmt = nullptr;
+  if (sqlite3_prepare_v2(db, sql.c_str(), -1, &stmt, nullptr) != SQLITE_OK) {
+    throwSqlite(db, "distinctLevels prepare");
+  }
+  if (!bind_value.empty()) {
+    sqlite3_bind_text(stmt, 1, bind_value.c_str(), -1, SQLITE_TRANSIENT);
+  }
+  std::vector<std::uint8_t> levels;
+  while (sqlite3_step(stmt) == SQLITE_ROW) {
+    levels.push_back(static_cast<std::uint8_t>(sqlite3_column_int(stmt, 0)));
+  }
+  sqlite3_finalize(stmt);
+  return levels;
+}
+
+std::vector<PassRow> queryPasses(
+  sqlite3 * db, const std::vector<gggs::GridIndex> & tiles,
+  const std::string & sensor_filter)
+{
+  std::vector<PassRow> rows;
+  if (tiles.empty()) {
+    return rows;
+  }
+
+  // One (level, row, col) triple per candidate tile. Tile sets are small
+  // (a query box spans few tiles at store levels), so an OR chain with bound
+  // parameters is simple and stays within SQLite's default limits; chunk to
+  // be safe for very large boxes.
+  constexpr std::size_t kChunk = 200;
+  for (std::size_t begin = 0; begin < tiles.size(); begin += kChunk) {
+    const std::size_t end = std::min(begin + kChunk, tiles.size());
+
+    std::string sql =
+      "SELECT b.path, p.sensor_type, p.topic, p.level, p.tile_row, p.tile_col,"
+      " p.t_start_ns, p.t_end_ns, p.ping_count"
+      " FROM passes p JOIN bags b ON b.id = p.bag_id"
+      " WHERE (";
+    for (std::size_t i = begin; i < end; ++i) {
+      if (i != begin) {
+        sql += " OR ";
+      }
+      sql += "(p.level = ? AND p.tile_row = ? AND p.tile_col = ?)";
+    }
+    sql += ")";
+    const std::string bind_value = appendSensorClause(sensor_filter, sql);
+    sql += " ORDER BY b.path, p.t_start_ns";
+
+    sqlite3_stmt * stmt = nullptr;
+    if (sqlite3_prepare_v2(db, sql.c_str(), -1, &stmt, nullptr) != SQLITE_OK) {
+      throwSqlite(db, "queryPasses prepare");
+    }
+    int slot = 1;
+    for (std::size_t i = begin; i < end; ++i) {
+      sqlite3_bind_int(stmt, slot++, tiles[i].level());
+      sqlite3_bind_int64(stmt, slot++, tiles[i].row());
+      sqlite3_bind_int64(stmt, slot++, tiles[i].column());
+    }
+    if (!bind_value.empty()) {
+      sqlite3_bind_text(stmt, slot++, bind_value.c_str(), -1, SQLITE_TRANSIENT);
+    }
+
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+      PassRow row;
+      row.bag_path = reinterpret_cast<const char *>(sqlite3_column_text(stmt, 0));
+      row.sensor_type = reinterpret_cast<const char *>(sqlite3_column_text(stmt, 1));
+      row.topic = reinterpret_cast<const char *>(sqlite3_column_text(stmt, 2));
+      row.level = static_cast<std::uint8_t>(sqlite3_column_int(stmt, 3));
+      row.tile_row = static_cast<std::uint32_t>(sqlite3_column_int64(stmt, 4));
+      row.tile_col = static_cast<std::uint32_t>(sqlite3_column_int64(stmt, 5));
+      row.t_start_ns = sqlite3_column_int64(stmt, 6);
+      row.t_end_ns = sqlite3_column_int64(stmt, 7);
+      row.ping_count = sqlite3_column_int64(stmt, 8);
+      rows.push_back(std::move(row));
+    }
+    sqlite3_finalize(stmt);
+  }
+  return rows;
+}
+
+}  // namespace marine_survey_index

--- a/marine_survey_index/src/query.cpp
+++ b/marine_survey_index/src/query.cpp
@@ -21,6 +21,7 @@
 
 #include "marine_survey_index/query.hpp"
 
+#include <algorithm>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -134,6 +135,19 @@ std::vector<PassRow> queryPasses(
     }
     sqlite3_finalize(stmt);
   }
+
+  // Each chunk's statement sorts independently, so a box spanning more than one
+  // chunk yields globally out-of-order rows (and the CLI would repeat a bag
+  // header per chunk). Sort the merged result to honour the documented
+  // "ordered by bag path, then t_start_ns" contract.
+  std::sort(
+    rows.begin(), rows.end(),
+    [](const PassRow & a, const PassRow & b) {
+      if (a.bag_path != b.bag_path) {
+        return a.bag_path < b.bag_path;
+      }
+      return a.t_start_ns < b.t_start_ns;
+    });
   return rows;
 }
 

--- a/marine_survey_index/src/schema.cpp
+++ b/marine_survey_index/src/schema.cpp
@@ -109,11 +109,20 @@ sqlite3 * openIndexDb(const std::string & path)
         " — delete the file and re-run the indexer to regenerate it (bags are the "
         "data of record; nothing is lost)");
     }
-  } else {
+  } else if (step == SQLITE_DONE) {
+    // Empty schema_version table → genuinely fresh DB: stamp the version.
     sqlite3_finalize(stmt);
     execOrThrow(
       db, ("INSERT INTO schema_version (version) VALUES (" +
       std::to_string(kSchemaVersion) + ");").c_str());
+  } else {
+    // Any other step result is a read error (corrupt/unreadable DB) — do not
+    // mask it as a fresh DB and write to it.
+    sqlite3_finalize(stmt);
+    const std::string message = sqlite3_errmsg(db);
+    sqlite3_close(db);
+    throw std::runtime_error(
+      "survey index: reading schema_version from '" + path + "': " + message);
   }
   return db;
 }

--- a/marine_survey_index/src/schema.cpp
+++ b/marine_survey_index/src/schema.cpp
@@ -1,0 +1,121 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "marine_survey_index/schema.hpp"
+
+#include <stdexcept>
+#include <string>
+
+namespace marine_survey_index
+{
+namespace
+{
+
+// The schema DDL. `sensor_type` extends the ADR-0005 D3 `sensor_class`
+// vocabulary: 'mbes-bathy' verbatim; 'sidescan-port' / 'sidescan-stbd' are
+// D3 'sidescan' + a channel suffix (the query CLI maps a 'sidescan' filter to
+// both). See docs/survey_index_schema.md for the contract description.
+constexpr const char * kSchemaDdl =
+  R"sql(
+CREATE TABLE IF NOT EXISTS schema_version (
+  version INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS bags (
+  id            INTEGER PRIMARY KEY,
+  path          TEXT    NOT NULL UNIQUE,
+  size_bytes    INTEGER NOT NULL,
+  mtime_ns      INTEGER NOT NULL,
+  indexed_at_ns INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS passes (
+  id          INTEGER PRIMARY KEY,
+  bag_id      INTEGER NOT NULL REFERENCES bags(id) ON DELETE CASCADE,
+  level       INTEGER NOT NULL,
+  tile_row    INTEGER NOT NULL,
+  tile_col    INTEGER NOT NULL,
+  sensor_type TEXT    NOT NULL,
+  topic       TEXT    NOT NULL,
+  t_start_ns  INTEGER NOT NULL,
+  t_end_ns    INTEGER NOT NULL,
+  ping_count  INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS passes_tile ON passes(level, tile_row, tile_col);
+CREATE INDEX IF NOT EXISTS passes_bag  ON passes(bag_id);
+)sql";
+
+void execOrThrow(sqlite3 * db, const char * sql)
+{
+  char * err = nullptr;
+  if (sqlite3_exec(db, sql, nullptr, nullptr, &err) != SQLITE_OK) {
+    std::string message = err ? err : "unknown sqlite error";
+    sqlite3_free(err);
+    sqlite3_close(db);
+    throw std::runtime_error("survey index: " + message);
+  }
+}
+
+}  // namespace
+
+sqlite3 * openIndexDb(const std::string & path)
+{
+  sqlite3 * db = nullptr;
+  if (sqlite3_open(path.c_str(), &db) != SQLITE_OK) {
+    const std::string message = db ? sqlite3_errmsg(db) : "out of memory";
+    sqlite3_close(db);
+    throw std::runtime_error("survey index: cannot open '" + path + "': " + message);
+  }
+  execOrThrow(db, "PRAGMA foreign_keys = ON;");
+  execOrThrow(db, kSchemaDdl);
+
+  // Version gate: stamp a fresh DB, verify an existing one. Regeneration is
+  // the migration path — the index is a derived cache over the bags.
+  sqlite3_stmt * stmt = nullptr;
+  if (sqlite3_prepare_v2(db, "SELECT version FROM schema_version", -1, &stmt, nullptr) !=
+    SQLITE_OK)
+  {
+    const std::string message = sqlite3_errmsg(db);
+    sqlite3_close(db);
+    throw std::runtime_error("survey index: " + message);
+  }
+  const int step = sqlite3_step(stmt);
+  if (step == SQLITE_ROW) {
+    const int version = sqlite3_column_int(stmt, 0);
+    sqlite3_finalize(stmt);
+    if (version != kSchemaVersion) {
+      sqlite3_close(db);
+      throw std::runtime_error(
+        "survey index: '" + path + "' has schema version " + std::to_string(version) +
+        " but this tool expects " + std::to_string(kSchemaVersion) +
+        " — delete the file and re-run the indexer to regenerate it (bags are the "
+        "data of record; nothing is lost)");
+    }
+  } else {
+    sqlite3_finalize(stmt);
+    execOrThrow(
+      db, ("INSERT INTO schema_version (version) VALUES (" +
+      std::to_string(kSchemaVersion) + ");").c_str());
+  }
+  return db;
+}
+
+}  // namespace marine_survey_index

--- a/marine_survey_index/src/survey_index_bag_main.cpp
+++ b/marine_survey_index/src/survey_index_bag_main.cpp
@@ -1,0 +1,574 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+/// @file
+/// @brief Offline survey indexer: bags → `survey_index.db` (#259, stage 1 of #258).
+///
+/// Reads each bag **directly** (rosbag2, not replay) in a **single interleaved
+/// pass** over `/tf` + `/tf_static` + the MBES `SonarDetections` and sidescan
+/// `RawSonarImage` channels, chronologically. `/tf` feeds a **bounded-window**
+/// `tf2::BufferCore`; each ping waits in a short FIFO until the TF frontier has
+/// advanced a guard interval past its stamp, then resolves the `earth`→sensor
+/// pose, computes the ping's ground-footprint bounding box, and records every
+/// touched GGGS tile in the pass-interval accumulator. The bounded window is
+/// the proven fix for tf2's O(n) TimeCache walk (cube_bathymetry#63 /
+/// marine_sidescan_mosaic#251) — reused, not re-derived.
+///
+/// The index answers "where did the sensor *look*", independent of what any
+/// store accepted — pings rejected by CUBE or lost to store gaps still index.
+/// The DB is a regenerable sidecar: bags remain the data of record.
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <deque>
+#include <filesystem>
+#include <iostream>
+#include <limits>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "builtin_interfaces/msg/time.hpp"
+#include "geographic_msgs/msg/geo_point.hpp"
+#include "geodesy/geodesics.h"
+#include "marine_acoustic_msgs/msg/raw_sonar_image.hpp"
+#include "marine_acoustic_msgs/msg/sonar_detections.hpp"
+#include "marine_sidescan_mosaic/projection.hpp"
+#include "rclcpp/serialization.hpp"
+#include "rclcpp/serialized_message.hpp"
+#include "rosbag2_cpp/reader.hpp"
+#include "rosbag2_storage/storage_filter.hpp"
+#include "rosbag2_storage/storage_options.hpp"
+#include "tf2/buffer_core.h"
+#include "tf2/time.h"
+#include "tf2_msgs/msg/tf_message.hpp"
+
+#include "marine_survey_index/footprint.hpp"
+#include "marine_survey_index/interval_accumulator.hpp"
+#include "marine_survey_index/schema.hpp"
+
+namespace
+{
+constexpr std::int64_t kNsPerS = 1000000000LL;
+
+// Extends the ADR-0005 D3 sensor_class vocabulary ('mbes-bathy' verbatim;
+// 'sidescan' + channel suffix). The query CLI maps a plain 'sidescan' filter
+// to both channels.
+constexpr const char * kSensorMbes = "mbes-bathy";
+constexpr const char * kSensorPort = "sidescan-port";
+constexpr const char * kSensorStbd = "sidescan-stbd";
+
+std::int64_t stampNs(const builtin_interfaces::msg::Time & t)
+{
+  return static_cast<std::int64_t>(t.sec) * kNsPerS + t.nanosec;
+}
+
+template<typename MsgT>
+MsgT deserialize(const rosbag2_storage::SerializedBagMessageSharedPtr & bag_msg)
+{
+  rclcpp::SerializedMessage serialized(*bag_msg->serialized_data);
+  MsgT out;
+  rclcpp::Serialization<MsgT>().deserialize_message(&serialized, &out);
+  return out;
+}
+
+std::string argValue(int argc, char ** argv, const std::string & flag, const std::string & dflt)
+{
+  for (int i = 1; i + 1 < argc; ++i) {
+    if (flag == argv[i]) {
+      return argv[i + 1];
+    }
+  }
+  return dflt;
+}
+
+bool hasFlag(int argc, char ** argv, const std::string & flag)
+{
+  for (int i = 1; i < argc; ++i) {
+    if (flag == argv[i]) {
+      return true;
+    }
+  }
+  return false;
+}
+
+double toDouble(const std::string & s, const std::string & flag)
+{
+  try {
+    return std::stod(s);
+  } catch (const std::exception &) {
+    std::cerr << "error: expected a number for " << flag << ", got '" << s << "'\n";
+    std::exit(2);
+  }
+}
+
+int toInt(const std::string & s, const std::string & flag)
+{
+  try {
+    return std::stoi(s);
+  } catch (const std::exception &) {
+    std::cerr << "error: expected an integer for " << flag << ", got '" << s << "'\n";
+    std::exit(2);
+  }
+}
+
+// Bag identity for the incremental-skip ledger: total regular-file bytes and
+// the newest mtime under the bag directory (or of the single file). A re-run
+// over an unchanged bag is a no-op; a changed bag is re-indexed.
+struct BagFingerprint
+{
+  std::int64_t size_bytes = 0;
+  std::int64_t mtime_ns = 0;
+};
+
+BagFingerprint fingerprint(const std::filesystem::path & bag)
+{
+  namespace fs = std::filesystem;
+  BagFingerprint fp;
+  auto consider = [&fp](const fs::path & f) {
+      std::error_code ec;
+      const auto size = fs::file_size(f, ec);
+      if (!ec) {
+        fp.size_bytes += static_cast<std::int64_t>(size);
+      }
+      const auto mtime = fs::last_write_time(f, ec);
+      if (!ec) {
+        const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+          mtime.time_since_epoch()).count();
+        fp.mtime_ns = std::max(fp.mtime_ns, static_cast<std::int64_t>(ns));
+      }
+    };
+  if (fs::is_directory(bag)) {
+    for (const auto & entry : fs::recursive_directory_iterator(bag)) {
+      if (entry.is_regular_file()) {
+        consider(entry.path());
+      }
+    }
+  } else {
+    consider(bag);
+  }
+  return fp;
+}
+
+// Recursively find rosbag2 bags (directories containing metadata.yaml) under a
+// scan root. A bag directory itself is not descended into further.
+std::vector<std::filesystem::path> scanForBags(const std::filesystem::path & root)
+{
+  namespace fs = std::filesystem;
+  std::vector<fs::path> bags;
+  if (fs::exists(root / "metadata.yaml")) {
+    bags.push_back(root);
+    return bags;
+  }
+  for (fs::recursive_directory_iterator it(root), end; it != end; ++it) {
+    if (it->is_directory() && fs::exists(it->path() / "metadata.yaml")) {
+      bags.push_back(it->path());
+      it.disable_recursion_pending();
+    }
+  }
+  std::sort(bags.begin(), bags.end());
+  return bags;
+}
+
+void execOrDie(sqlite3 * db, const std::string & sql)
+{
+  char * err = nullptr;
+  if (sqlite3_exec(db, sql.c_str(), nullptr, nullptr, &err) != SQLITE_OK) {
+    std::cerr << "error: sqlite: " << (err ? err : "unknown") << "\n";
+    sqlite3_free(err);
+    sqlite3_close(db);
+    std::exit(1);
+  }
+}
+
+// Ledger lookup: 0 = not indexed; >0 = bag id (unchanged, skip); <0 = -bag id
+// (changed, re-index: caller deletes old passes and updates the row).
+std::int64_t ledgerState(sqlite3 * db, const std::string & path, const BagFingerprint & fp)
+{
+  sqlite3_stmt * stmt = nullptr;
+  sqlite3_prepare_v2(
+    db, "SELECT id, size_bytes, mtime_ns FROM bags WHERE path = ?", -1, &stmt, nullptr);
+  sqlite3_bind_text(stmt, 1, path.c_str(), -1, SQLITE_TRANSIENT);
+  std::int64_t result = 0;
+  if (sqlite3_step(stmt) == SQLITE_ROW) {
+    const std::int64_t id = sqlite3_column_int64(stmt, 0);
+    const bool unchanged = sqlite3_column_int64(stmt, 1) == fp.size_bytes &&
+      sqlite3_column_int64(stmt, 2) == fp.mtime_ns;
+    result = unchanged ? id : -id;
+  }
+  sqlite3_finalize(stmt);
+  return result;
+}
+
+geographic_msgs::msg::GeoPoint groundOrigin(const marine_sidescan_mosaic::GeoBeam & gb)
+{
+  geographic_msgs::msg::GeoPoint origin;
+  origin.latitude = gb.latitude_deg;
+  origin.longitude = gb.longitude_deg;
+  origin.altitude = 0.0;  // geodesy::wgs84::direct precondition.
+  return origin;
+}
+
+// Endpoint at signed across-track horizontal offset h (m): + = starboard of
+// the sensor heading, - = port.
+geographic_msgs::msg::GeoPoint acrossTrackPoint(
+  const geographic_msgs::msg::GeoPoint & origin, double heading_rad, double h)
+{
+  if (h == 0.0 || !std::isfinite(h)) {
+    return origin;
+  }
+  const double azimuth = heading_rad + (h >= 0.0 ? M_PI / 2.0 : -M_PI / 2.0);
+  return geodesy::wgs84::direct(origin, azimuth, std::abs(h));
+}
+
+}  // namespace
+
+int main(int argc, char ** argv)
+{
+  if (argc < 2 || hasFlag(argc, argv, "--help")) {
+    std::cerr <<
+      "usage: survey_index_bag [bag_uri ...] [--scan DIR] [--db survey_index.db]\n"
+      "       [--mbes-topic T] [--port-topic T] [--stbd-topic T]\n"
+      "       [--mbes-level N=10] [--sidescan-level N=13] [--level N (overrides both)]\n"
+      "       [--merge-gap S=5.0] [--earth-frame F=earth] [--sound-speed S=1500]\n"
+      "\n"
+      "Indexes where each sonar looked, per bag, into a regenerable SQLite\n"
+      "sidecar. Unchanged already-indexed bags are skipped; changed bags are\n"
+      "re-indexed. Level defaults match the stores' native tiling (bathy L10,\n"
+      "sidescan L13).\n";
+    return 2;
+  }
+
+  const std::string db_path = argValue(argc, argv, "--db", "survey_index.db");
+  const std::string base = "/bizzy/sensors/";
+  const std::string mbes_topic = argValue(argc, argv, "--mbes-topic", base + "m3/detections");
+  const std::string port_topic =
+    argValue(argc, argv, "--port-topic", base + "sidescan/garmin_sidescan/sonar_image_port");
+  const std::string stbd_topic =
+    argValue(argc, argv, "--stbd-topic", base + "sidescan/garmin_sidescan/sonar_image_starboard");
+  const std::string earth_frame = argValue(argc, argv, "--earth-frame", "earth");
+  const double sound_speed_fallback =
+    toDouble(argValue(argc, argv, "--sound-speed", "1500.0"), "--sound-speed");
+  const double merge_gap_s = toDouble(argValue(argc, argv, "--merge-gap", "5.0"), "--merge-gap");
+  int mbes_level_n = toInt(argValue(argc, argv, "--mbes-level", "10"), "--mbes-level");
+  int sidescan_level_n = toInt(argValue(argc, argv, "--sidescan-level", "13"), "--sidescan-level");
+  const std::string level_override = argValue(argc, argv, "--level", "");
+  if (!level_override.empty()) {
+    mbes_level_n = sidescan_level_n = toInt(level_override, "--level");
+  }
+  const gggs::Level mbes_level(static_cast<std::uint8_t>(mbes_level_n));
+  const gggs::Level sidescan_level(static_cast<std::uint8_t>(sidescan_level_n));
+
+  // Collect bag list: positional URIs + --scan roots.
+  std::vector<std::filesystem::path> bags;
+  for (int i = 1; i < argc; ++i) {
+    const std::string arg = argv[i];
+    if (arg == "--scan") {
+      if (i + 1 < argc) {
+        const auto found = scanForBags(argv[i + 1]);
+        bags.insert(bags.end(), found.begin(), found.end());
+      }
+      ++i;
+      continue;
+    }
+    if (arg.rfind("--", 0) == 0) {
+      ++i;  // every other flag takes a value
+      continue;
+    }
+    bags.emplace_back(arg);
+  }
+  if (bags.empty()) {
+    std::cerr << "error: no bags given (positional URIs and/or --scan DIR)\n";
+    return 2;
+  }
+
+  sqlite3 * db = nullptr;
+  try {
+    db = marine_survey_index::openIndexDb(db_path);
+  } catch (const std::exception & e) {
+    std::cerr << "error: " << e.what() << "\n";
+    return 1;
+  }
+
+  // Same bounded-TF-window constants as the proven importers (#251 / cube#63).
+  constexpr double kCacheWindowSec = 60.0;
+  constexpr double kGuardSec = 3.0;
+  const std::int64_t kGuardNs = static_cast<std::int64_t>(kGuardSec * 1e9);
+  constexpr std::size_t kMaxPending = 20000;
+  const std::int64_t merge_gap_ns = static_cast<std::int64_t>(merge_gap_s * 1e9);
+
+  std::size_t n_bags_indexed = 0, n_bags_skipped = 0;
+
+  for (const auto & bag : bags) {
+    const std::string bag_key = std::filesystem::absolute(bag).lexically_normal().string();
+    const BagFingerprint fp = fingerprint(bag);
+    const std::int64_t state = ledgerState(db, bag_key, fp);
+    if (state > 0) {
+      ++n_bags_skipped;
+      std::cerr << "skip (unchanged): " << bag_key << "\n";
+      continue;
+    }
+
+    tf2::BufferCore tf_buffer(tf2::durationFromSec(kCacheWindowSec));
+    marine_survey_index::IntervalAccumulator accumulator(merge_gap_ns);
+    std::int64_t tf_frontier_ns = std::numeric_limits<std::int64_t>::min();
+    std::size_t n_pings = 0, n_no_tf = 0, n_bad_pose = 0;
+
+    // A ping queued for TF resolution: everything except the earth pose is
+    // computed at enqueue. `extent_port`/`extent_stbd` are the signed
+    // across-track horizontal extents (m, + = starboard). For sidescan the
+    // slant range bounds the ground range (conservative overestimate — the
+    // index answers "could this sensor have seen here").
+    struct PendingPing
+    {
+      std::int64_t ping_ns;
+      std::string frame_id;
+      const char * sensor_type;
+      const std::string * topic;
+      const gggs::Level * level;
+      double extent_port;
+      double extent_stbd;
+    };
+    std::deque<PendingPing> pending;
+
+    auto flush_front = [&]() {
+        auto & front = pending.front();
+        try {
+          const auto pose = tf_buffer.lookupTransform(
+            earth_frame, front.frame_id,
+            tf2::TimePoint(std::chrono::nanoseconds(front.ping_ns)));
+          const auto gb = marine_sidescan_mosaic::ecefPoseToGeoBeam(
+            pose.transform.translation.x, pose.transform.translation.y,
+            pose.transform.translation.z,
+            pose.transform.rotation.x, pose.transform.rotation.y,
+            pose.transform.rotation.z, pose.transform.rotation.w);
+          if (!gb.valid) {
+            ++n_bad_pose;
+          } else {
+            const auto origin = groundOrigin(gb);
+            const auto p1 = acrossTrackPoint(origin, gb.heading_rad, front.extent_port);
+            const auto p2 = acrossTrackPoint(origin, gb.heading_rad, front.extent_stbd);
+            const double lat_min =
+              std::min({origin.latitude, p1.latitude, p2.latitude});
+            const double lat_max =
+              std::max({origin.latitude, p1.latitude, p2.latitude});
+            const double lon_min =
+              std::min({origin.longitude, p1.longitude, p2.longitude});
+            const double lon_max =
+              std::max({origin.longitude, p1.longitude, p2.longitude});
+            for (const auto & tile : marine_survey_index::tilesForBoundingBox(
+                lat_min, lon_min, lat_max, lon_max, *front.level))
+            {
+              marine_survey_index::TileKey key;
+              key.level = tile.level();
+              key.tile_row = tile.row();
+              key.tile_col = tile.column();
+              key.sensor_type = front.sensor_type;
+              key.topic = *front.topic;
+              accumulator.addPing(key, front.ping_ns);
+            }
+            ++n_pings;
+          }
+        } catch (const tf2::TransformException &) {
+          // No earth transform in the bounded buffer at this stamp — before
+          // the first fix, or a TF gap wider than the window. Counted, not
+          // silently dropped.
+          ++n_no_tf;
+        }
+        pending.pop_front();
+      };
+
+    auto drain_pending = [&](bool flush) {
+        while (!pending.empty()) {
+          if (!flush &&
+            (tf_frontier_ns == std::numeric_limits<std::int64_t>::min() ||
+            pending.front().ping_ns > tf_frontier_ns - kGuardNs))
+          {
+            break;
+          }
+          flush_front();
+        }
+      };
+
+    rosbag2_cpp::Reader reader;
+    rosbag2_storage::StorageOptions so;
+    so.uri = bag.string();
+    try {
+      reader.open(so);
+    } catch (const std::exception & e) {
+      std::cerr << "error: cannot open bag " << bag_key << ": " << e.what() << "\n";
+      continue;
+    }
+    rosbag2_storage::StorageFilter filter;
+    filter.topics = {"/tf", "/tf_static", mbes_topic, port_topic, stbd_topic};
+    reader.set_filter(filter);
+
+    // SINGLE INTERLEAVED PASS over the chronological message stream.
+    while (reader.has_next()) {
+      auto bag_msg = reader.read_next();
+      const std::string & topic = bag_msg->topic_name;
+
+      if (topic == "/tf" || topic == "/tf_static") {
+        const bool is_static = topic == "/tf_static";
+        auto m = deserialize<tf2_msgs::msg::TFMessage>(bag_msg);
+        for (const auto & tr : m.transforms) {
+          tf_buffer.setTransform(tr, "bag", is_static);
+          if (!is_static) {
+            tf_frontier_ns = std::max(tf_frontier_ns, stampNs(tr.header.stamp));
+          }
+        }
+        drain_pending(false);
+        continue;
+      }
+
+      PendingPing pp;
+      if (topic == mbes_topic) {
+        auto msg = deserialize<marine_acoustic_msgs::msg::SonarDetections>(bag_msg);
+        pp.ping_ns = stampNs(msg.header.stamp);
+        pp.frame_id = msg.header.frame_id;
+        pp.sensor_type = kSensorMbes;
+        pp.topic = &mbes_topic;
+        pp.level = &mbes_level;
+        // Across-track extents from the outermost good detections:
+        // horizontal ≈ slant · sin(rx_angle) (+ starboard). No good beams →
+        // extents 0, the sensor-position tile still indexes.
+        const double c = msg.ping_info.sound_speed > 0.0F ?
+          msg.ping_info.sound_speed : sound_speed_fallback;
+        double min_h = 0.0, max_h = 0.0;
+        const std::size_t n = msg.two_way_travel_times.size();
+        for (std::size_t i = 0; i < n; ++i) {
+          if (i < msg.flags.size() &&
+            msg.flags[i].flag != marine_acoustic_msgs::msg::DetectionFlag::DETECT_OK)
+          {
+            continue;
+          }
+          const double twtt = msg.two_way_travel_times[i];
+          if (!std::isfinite(twtt) || twtt <= 0.0) {
+            continue;
+          }
+          const double rx = i < msg.rx_angles.size() ? msg.rx_angles[i] : 0.0;
+          const double h = (twtt * c / 2.0) * std::sin(rx);
+          min_h = std::min(min_h, h);
+          max_h = std::max(max_h, h);
+        }
+        pp.extent_port = min_h;
+        pp.extent_stbd = max_h;
+      } else {
+        const bool is_port = topic == port_topic;
+        auto msg = deserialize<marine_acoustic_msgs::msg::RawSonarImage>(bag_msg);
+        if (msg.sample_rate <= 0.0) {
+          continue;
+        }
+        pp.ping_ns = stampNs(msg.header.stamp);
+        pp.frame_id = msg.header.frame_id;
+        pp.sensor_type = is_port ? kSensorPort : kSensorStbd;
+        pp.topic = is_port ? &port_topic : &stbd_topic;
+        pp.level = &sidescan_level;
+        const double c = msg.ping_info.sound_speed > 0.0 ?
+          msg.ping_info.sound_speed : sound_speed_fallback;
+        // Max slant range bounds the ground range (flat-earth-free
+        // conservative footprint; the drill-down stages do the exact math).
+        const double max_slant = marine_sidescan_mosaic::slantRange(
+          static_cast<int>(msg.samples_per_beam) - 1,
+          static_cast<int>(msg.sample0), c, msg.sample_rate);
+        pp.extent_port = is_port ? -max_slant : 0.0;
+        pp.extent_stbd = is_port ? 0.0 : max_slant;
+      }
+
+      pending.push_back(std::move(pp));
+      if (pending.size() > kMaxPending) {
+        flush_front();
+      }
+    }
+    drain_pending(true);
+
+    // Persist this bag atomically: ledger row + all pass intervals.
+    const auto intervals = accumulator.flushAll();
+    const std::int64_t now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+      std::chrono::system_clock::now().time_since_epoch()).count();
+    execOrDie(db, "BEGIN TRANSACTION;");
+    std::int64_t bag_id = 0;
+    if (state < 0) {
+      bag_id = -state;
+      sqlite3_stmt * del = nullptr;
+      sqlite3_prepare_v2(db, "DELETE FROM passes WHERE bag_id = ?", -1, &del, nullptr);
+      sqlite3_bind_int64(del, 1, bag_id);
+      sqlite3_step(del);
+      sqlite3_finalize(del);
+      sqlite3_stmt * upd = nullptr;
+      sqlite3_prepare_v2(
+        db, "UPDATE bags SET size_bytes = ?, mtime_ns = ?, indexed_at_ns = ? WHERE id = ?",
+        -1, &upd, nullptr);
+      sqlite3_bind_int64(upd, 1, fp.size_bytes);
+      sqlite3_bind_int64(upd, 2, fp.mtime_ns);
+      sqlite3_bind_int64(upd, 3, now_ns);
+      sqlite3_bind_int64(upd, 4, bag_id);
+      sqlite3_step(upd);
+      sqlite3_finalize(upd);
+    } else {
+      sqlite3_stmt * ins = nullptr;
+      sqlite3_prepare_v2(
+        db, "INSERT INTO bags (path, size_bytes, mtime_ns, indexed_at_ns) VALUES (?, ?, ?, ?)",
+        -1, &ins, nullptr);
+      sqlite3_bind_text(ins, 1, bag_key.c_str(), -1, SQLITE_TRANSIENT);
+      sqlite3_bind_int64(ins, 2, fp.size_bytes);
+      sqlite3_bind_int64(ins, 3, fp.mtime_ns);
+      sqlite3_bind_int64(ins, 4, now_ns);
+      sqlite3_step(ins);
+      sqlite3_finalize(ins);
+      bag_id = sqlite3_last_insert_rowid(db);
+    }
+    sqlite3_stmt * ins_pass = nullptr;
+    sqlite3_prepare_v2(
+      db,
+      "INSERT INTO passes (bag_id, level, tile_row, tile_col, sensor_type, topic,"
+      " t_start_ns, t_end_ns, ping_count) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      -1, &ins_pass, nullptr);
+    for (const auto & pass : intervals) {
+      sqlite3_bind_int64(ins_pass, 1, bag_id);
+      sqlite3_bind_int(ins_pass, 2, pass.key.level);
+      sqlite3_bind_int64(ins_pass, 3, pass.key.tile_row);
+      sqlite3_bind_int64(ins_pass, 4, pass.key.tile_col);
+      sqlite3_bind_text(ins_pass, 5, pass.key.sensor_type.c_str(), -1, SQLITE_TRANSIENT);
+      sqlite3_bind_text(ins_pass, 6, pass.key.topic.c_str(), -1, SQLITE_TRANSIENT);
+      sqlite3_bind_int64(ins_pass, 7, pass.t_start_ns);
+      sqlite3_bind_int64(ins_pass, 8, pass.t_end_ns);
+      sqlite3_bind_int64(ins_pass, 9, pass.ping_count);
+      sqlite3_step(ins_pass);
+      sqlite3_reset(ins_pass);
+    }
+    sqlite3_finalize(ins_pass);
+    execOrDie(db, "COMMIT;");
+
+    ++n_bags_indexed;
+    std::cerr << (state < 0 ? "re-indexed: " : "indexed: ") << bag_key
+              << " (" << n_pings << " pings -> " << intervals.size()
+              << " pass intervals; no-tf=" << n_no_tf
+              << " bad-pose=" << n_bad_pose << ")\n";
+  }
+
+  sqlite3_close(db);
+  std::cerr << "done: " << n_bags_indexed << " bag(s) indexed, "
+            << n_bags_skipped << " unchanged skipped -> " << db_path << "\n";
+  return 0;
+}

--- a/marine_survey_index/src/survey_index_bag_main.cpp
+++ b/marine_survey_index/src/survey_index_bag_main.cpp
@@ -158,10 +158,17 @@ BagFingerprint fingerprint(const std::filesystem::path & bag)
         fp.mtime_ns = std::max(fp.mtime_ns, static_cast<std::int64_t>(ns));
       }
     };
-  if (fs::is_directory(bag)) {
-    for (const auto & entry : fs::recursive_directory_iterator(bag)) {
-      if (entry.is_regular_file()) {
-        consider(entry.path());
+  std::error_code ec;
+  if (fs::is_directory(bag, ec)) {
+    // error_code overloads: a broken symlink or unreadable entry sets ec and
+    // ends the walk cleanly instead of throwing and aborting the whole run.
+    for (fs::recursive_directory_iterator it(
+        bag, fs::directory_options::skip_permission_denied, ec), end;
+      !ec && it != end; it.increment(ec))
+    {
+      std::error_code entry_ec;
+      if (it->is_regular_file(entry_ec)) {
+        consider(it->path());
       }
     }
   } else {
@@ -176,12 +183,19 @@ std::vector<std::filesystem::path> scanForBags(const std::filesystem::path & roo
 {
   namespace fs = std::filesystem;
   std::vector<fs::path> bags;
-  if (fs::exists(root / "metadata.yaml")) {
+  std::error_code ec;
+  if (fs::exists(root / "metadata.yaml", ec)) {
     bags.push_back(root);
     return bags;
   }
-  for (fs::recursive_directory_iterator it(root), end; it != end; ++it) {
-    if (it->is_directory() && fs::exists(it->path() / "metadata.yaml")) {
+  // error_code overloads: a broken symlink or unreadable entry sets ec and
+  // ends the walk cleanly instead of throwing and aborting the whole run.
+  for (fs::recursive_directory_iterator it(
+      root, fs::directory_options::skip_permission_denied, ec), end;
+    !ec && it != end; it.increment(ec))
+  {
+    std::error_code entry_ec;
+    if (it->is_directory(entry_ec) && fs::exists(it->path() / "metadata.yaml", entry_ec)) {
       bags.push_back(it->path());
       it.disable_recursion_pending();
     }

--- a/marine_survey_index/src/survey_index_bag_main.cpp
+++ b/marine_survey_index/src/survey_index_bag_main.cpp
@@ -133,6 +133,19 @@ int toInt(const std::string & s, const std::string & flag)
   }
 }
 
+// GGGS levels are 0..20 (gggs::Level throws std::out_of_range at >= 21, and it
+// is constructed outside any try/catch → std::terminate). Reject out-of-range
+// values here so the CLI exits cleanly instead of aborting.
+int toLevel(const std::string & s, const std::string & flag)
+{
+  const int v = toInt(s, flag);
+  if (v < 0 || v > 20) {
+    std::cerr << "error: " << flag << " must be in [0, 20], got " << v << "\n";
+    std::exit(2);
+  }
+  return v;
+}
+
 // Bag identity for the incremental-skip ledger: total regular-file bytes and
 // the newest mtime under the bag directory (or of the single file). A re-run
 // over an unchanged bag is a no-op; a changed bag is re-indexed.
@@ -333,15 +346,20 @@ int main(int argc, char ** argv)
   const double sound_speed_fallback =
     toDouble(argValue(argc, argv, "--sound-speed", "1500.0"), "--sound-speed");
   const double merge_gap_s = toDouble(argValue(argc, argv, "--merge-gap", "5.0"), "--merge-gap");
+  if (!(merge_gap_s >= 0.0)) {  // also rejects NaN
+    std::cerr << "error: --merge-gap must be >= 0, got " << merge_gap_s << "\n";
+    return 2;
+  }
   // Default L14 (~54 m tiles): the tile-of-interest scale for target review
   // (Roland, 2026-07-13) — small enough to select a neighbourhood, and it
   // rolls up to the coarser store-native tiles (bathy L10, sidescan L13)
   // through the GGGS quadtree when stage 2 joins against store tiling.
-  int mbes_level_n = toInt(argValue(argc, argv, "--mbes-level", "14"), "--mbes-level");
-  int sidescan_level_n = toInt(argValue(argc, argv, "--sidescan-level", "14"), "--sidescan-level");
+  int mbes_level_n = toLevel(argValue(argc, argv, "--mbes-level", "14"), "--mbes-level");
+  int sidescan_level_n =
+    toLevel(argValue(argc, argv, "--sidescan-level", "14"), "--sidescan-level");
   const std::string level_override = argValue(argc, argv, "--level", "");
   if (!level_override.empty()) {
-    mbes_level_n = sidescan_level_n = toInt(level_override, "--level");
+    mbes_level_n = sidescan_level_n = toLevel(level_override, "--level");
   }
   const gggs::Level mbes_level(static_cast<std::uint8_t>(mbes_level_n));
   const gggs::Level sidescan_level(static_cast<std::uint8_t>(sidescan_level_n));

--- a/marine_survey_index/src/survey_index_bag_main.cpp
+++ b/marine_survey_index/src/survey_index_bag_main.cpp
@@ -44,6 +44,7 @@
 #include <filesystem>
 #include <iostream>
 #include <limits>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -204,14 +205,62 @@ std::vector<std::filesystem::path> scanForBags(const std::filesystem::path & roo
   return bags;
 }
 
-void execOrDie(sqlite3 * db, const std::string & sql)
+// Thrown by the sqlite wrappers below so a failed write unwinds to the per-bag
+// handler in main(), which ROLLBACKs — instead of silently COMMITting a partial
+// index and marking the bag fully indexed.
+class SqliteError : public std::runtime_error
+{
+public:
+  using std::runtime_error::runtime_error;
+};
+
+void execOrThrow(sqlite3 * db, const char * sql)
 {
   char * err = nullptr;
-  if (sqlite3_exec(db, sql.c_str(), nullptr, nullptr, &err) != SQLITE_OK) {
-    std::cerr << "error: sqlite: " << (err ? err : "unknown") << "\n";
+  if (sqlite3_exec(db, sql, nullptr, nullptr, &err) != SQLITE_OK) {
+    const std::string msg = err ? err : "unknown";
     sqlite3_free(err);
-    sqlite3_close(db);
-    std::exit(1);
+    throw SqliteError("sqlite exec: " + msg);
+  }
+}
+
+sqlite3_stmt * prepareOrThrow(sqlite3 * db, const char * sql)
+{
+  sqlite3_stmt * stmt = nullptr;
+  if (sqlite3_prepare_v2(db, sql, -1, &stmt, nullptr) != SQLITE_OK) {
+    throw SqliteError(std::string("sqlite prepare: ") + sqlite3_errmsg(db));
+  }
+  return stmt;
+}
+
+// RAII for a prepared statement: finalized on scope exit, including when a
+// SqliteError unwinds through the write path.
+class StmtGuard
+{
+public:
+  explicit StmtGuard(sqlite3_stmt * stmt)
+  : stmt_(stmt) {}
+  ~StmtGuard()
+  {
+    sqlite3_finalize(stmt_);
+  }
+  StmtGuard(const StmtGuard &) = delete;
+  StmtGuard & operator=(const StmtGuard &) = delete;
+  sqlite3_stmt * get() const
+  {
+    return stmt_;
+  }
+
+private:
+  sqlite3_stmt * stmt_;
+};
+
+// Step a write statement expected to run to completion; throw on any non-DONE
+// return so the caller's transaction is never COMMITted after a failed row.
+void stepDoneOrThrow(sqlite3 * db, sqlite3_stmt * stmt)
+{
+  if (sqlite3_step(stmt) != SQLITE_DONE) {
+    throw SqliteError(std::string("sqlite step: ") + sqlite3_errmsg(db));
   }
 }
 
@@ -219,9 +268,8 @@ void execOrDie(sqlite3 * db, const std::string & sql)
 // (changed, re-index: caller deletes old passes and updates the row).
 std::int64_t ledgerState(sqlite3 * db, const std::string & path, const BagFingerprint & fp)
 {
-  sqlite3_stmt * stmt = nullptr;
-  sqlite3_prepare_v2(
-    db, "SELECT id, size_bytes, mtime_ns FROM bags WHERE path = ?", -1, &stmt, nullptr);
+  sqlite3_stmt * stmt = prepareOrThrow(
+    db, "SELECT id, size_bytes, mtime_ns FROM bags WHERE path = ?");
   sqlite3_bind_text(stmt, 1, path.c_str(), -1, SQLITE_TRANSIENT);
   std::int64_t result = 0;
   if (sqlite3_step(stmt) == SQLITE_ROW) {
@@ -334,260 +382,266 @@ int main(int argc, char ** argv)
   std::size_t n_bags_indexed = 0, n_bags_skipped = 0;
 
   for (const auto & bag : bags) {
-    const std::string bag_key = std::filesystem::absolute(bag).lexically_normal().string();
-    const BagFingerprint fp = fingerprint(bag);
-    const std::int64_t state = ledgerState(db, bag_key, fp);
-    if (state > 0) {
-      ++n_bags_skipped;
-      std::cerr << "skip (unchanged): " << bag_key << "\n";
-      continue;
-    }
-
-    tf2::BufferCore tf_buffer(tf2::durationFromSec(kCacheWindowSec));
-    marine_survey_index::IntervalAccumulator accumulator(merge_gap_ns);
-    std::int64_t tf_frontier_ns = std::numeric_limits<std::int64_t>::min();
-    std::size_t n_pings = 0, n_no_tf = 0, n_bad_pose = 0;
-
-    // A ping queued for TF resolution: everything except the earth pose is
-    // computed at enqueue. `extent_port`/`extent_stbd` are the signed
-    // across-track horizontal extents (m, + = starboard). For sidescan the
-    // slant range bounds the ground range (conservative overestimate — the
-    // index answers "could this sensor have seen here").
-    struct PendingPing
-    {
-      std::int64_t ping_ns;
-      std::string frame_id;
-      const char * sensor_type;
-      const std::string * topic;
-      const gggs::Level * level;
-      double extent_port;
-      double extent_stbd;
-    };
-    std::deque<PendingPing> pending;
-
-    auto flush_front = [&]() {
-        auto & front = pending.front();
-        try {
-          const auto pose = tf_buffer.lookupTransform(
-            earth_frame, front.frame_id,
-            tf2::TimePoint(std::chrono::nanoseconds(front.ping_ns)));
-          const auto gb = marine_sidescan_mosaic::ecefPoseToGeoBeam(
-            pose.transform.translation.x, pose.transform.translation.y,
-            pose.transform.translation.z,
-            pose.transform.rotation.x, pose.transform.rotation.y,
-            pose.transform.rotation.z, pose.transform.rotation.w);
-          if (!gb.valid) {
-            ++n_bad_pose;
-          } else {
-            const auto origin = groundOrigin(gb);
-            const auto p1 = acrossTrackPoint(origin, gb.heading_rad, front.extent_port);
-            const auto p2 = acrossTrackPoint(origin, gb.heading_rad, front.extent_stbd);
-            const double lat_min =
-              std::min({origin.latitude, p1.latitude, p2.latitude});
-            const double lat_max =
-              std::max({origin.latitude, p1.latitude, p2.latitude});
-            const double lon_min =
-              std::min({origin.longitude, p1.longitude, p2.longitude});
-            const double lon_max =
-              std::max({origin.longitude, p1.longitude, p2.longitude});
-            for (const auto & tile : marine_survey_index::tilesForBoundingBox(
-                lat_min, lon_min, lat_max, lon_max, *front.level))
-            {
-              marine_survey_index::TileKey key;
-              key.level = tile.level();
-              key.tile_row = tile.row();
-              key.tile_col = tile.column();
-              key.sensor_type = front.sensor_type;
-              key.topic = *front.topic;
-              accumulator.addPing(key, front.ping_ns);
-            }
-            ++n_pings;
-          }
-        } catch (const tf2::TransformException &) {
-          // No earth transform in the bounded buffer at this stamp — before
-          // the first fix, or a TF gap wider than the window. Counted, not
-          // silently dropped.
-          ++n_no_tf;
-        }
-        pending.pop_front();
-      };
-
-    auto drain_pending = [&](bool flush) {
-        while (!pending.empty()) {
-          if (!flush &&
-            (tf_frontier_ns == std::numeric_limits<std::int64_t>::min() ||
-            pending.front().ping_ns > tf_frontier_ns - kGuardNs))
-          {
-            break;
-          }
-          flush_front();
-        }
-      };
-
-    rosbag2_cpp::Reader reader;
-    rosbag2_storage::StorageOptions so;
-    so.uri = bag.string();
     try {
-      reader.open(so);
-    } catch (const std::exception & e) {
-      std::cerr << "error: cannot open bag " << bag_key << ": " << e.what() << "\n";
-      continue;
-    }
-    rosbag2_storage::StorageFilter filter;
-    filter.topics = {"/tf", "/tf_static", mbes_topic, port_topic, stbd_topic};
-    reader.set_filter(filter);
-
-    // SINGLE INTERLEAVED PASS over the chronological message stream.
-    while (reader.has_next()) {
-      auto bag_msg = reader.read_next();
-      const std::string & topic = bag_msg->topic_name;
-
-      if (topic == "/tf" || topic == "/tf_static") {
-        const bool is_static = topic == "/tf_static";
-        auto m = deserialize<tf2_msgs::msg::TFMessage>(bag_msg);
-        for (const auto & tr : m.transforms) {
-          tf_buffer.setTransform(tr, "bag", is_static);
-          if (!is_static) {
-            tf_frontier_ns = std::max(tf_frontier_ns, stampNs(tr.header.stamp));
-          }
-        }
-        drain_pending(false);
+      const std::string bag_key = std::filesystem::absolute(bag).lexically_normal().string();
+      const BagFingerprint fp = fingerprint(bag);
+      const std::int64_t state = ledgerState(db, bag_key, fp);
+      if (state > 0) {
+        ++n_bags_skipped;
+        std::cerr << "skip (unchanged): " << bag_key << "\n";
         continue;
       }
 
-      PendingPing pp;
-      if (topic == mbes_topic) {
-        auto msg = deserialize<marine_acoustic_msgs::msg::SonarDetections>(bag_msg);
-        pp.ping_ns = stampNs(msg.header.stamp);
-        pp.frame_id = msg.header.frame_id;
-        pp.sensor_type = kSensorMbes;
-        pp.topic = &mbes_topic;
-        pp.level = &mbes_level;
-        // Across-track extents from the outermost good detections:
-        // horizontal ≈ slant · sin(rx_angle) (+ starboard). No good beams →
-        // extents 0, the sensor-position tile still indexes.
-        const double c = msg.ping_info.sound_speed > 0.0F ?
-          msg.ping_info.sound_speed : sound_speed_fallback;
-        double min_h = 0.0, max_h = 0.0;
-        const std::size_t n = msg.two_way_travel_times.size();
-        for (std::size_t i = 0; i < n; ++i) {
-          if (i < msg.flags.size() &&
-            msg.flags[i].flag != marine_acoustic_msgs::msg::DetectionFlag::DETECT_OK)
-          {
-            continue;
+      tf2::BufferCore tf_buffer(tf2::durationFromSec(kCacheWindowSec));
+      marine_survey_index::IntervalAccumulator accumulator(merge_gap_ns);
+      std::int64_t tf_frontier_ns = std::numeric_limits<std::int64_t>::min();
+      std::size_t n_pings = 0, n_no_tf = 0, n_bad_pose = 0;
+
+      // A ping queued for TF resolution: everything except the earth pose is
+      // computed at enqueue. `extent_port`/`extent_stbd` are the signed
+      // across-track horizontal extents (m, + = starboard). For sidescan the
+      // slant range bounds the ground range (conservative overestimate — the
+      // index answers "could this sensor have seen here").
+      struct PendingPing
+      {
+        std::int64_t ping_ns;
+        std::string frame_id;
+        const char * sensor_type;
+        const std::string * topic;
+        const gggs::Level * level;
+        double extent_port;
+        double extent_stbd;
+      };
+      std::deque<PendingPing> pending;
+
+      auto flush_front = [&]() {
+          auto & front = pending.front();
+          try {
+            const auto pose = tf_buffer.lookupTransform(
+              earth_frame, front.frame_id,
+              tf2::TimePoint(std::chrono::nanoseconds(front.ping_ns)));
+            const auto gb = marine_sidescan_mosaic::ecefPoseToGeoBeam(
+              pose.transform.translation.x, pose.transform.translation.y,
+              pose.transform.translation.z,
+              pose.transform.rotation.x, pose.transform.rotation.y,
+              pose.transform.rotation.z, pose.transform.rotation.w);
+            if (!gb.valid) {
+              ++n_bad_pose;
+            } else {
+              const auto origin = groundOrigin(gb);
+              const auto p1 = acrossTrackPoint(origin, gb.heading_rad, front.extent_port);
+              const auto p2 = acrossTrackPoint(origin, gb.heading_rad, front.extent_stbd);
+              const double lat_min =
+                std::min({origin.latitude, p1.latitude, p2.latitude});
+              const double lat_max =
+                std::max({origin.latitude, p1.latitude, p2.latitude});
+              const double lon_min =
+                std::min({origin.longitude, p1.longitude, p2.longitude});
+              const double lon_max =
+                std::max({origin.longitude, p1.longitude, p2.longitude});
+              for (const auto & tile : marine_survey_index::tilesForBoundingBox(
+                  lat_min, lon_min, lat_max, lon_max, *front.level))
+              {
+                marine_survey_index::TileKey key;
+                key.level = tile.level();
+                key.tile_row = tile.row();
+                key.tile_col = tile.column();
+                key.sensor_type = front.sensor_type;
+                key.topic = *front.topic;
+                accumulator.addPing(key, front.ping_ns);
+              }
+              ++n_pings;
+            }
+          } catch (const tf2::TransformException &) {
+            // No earth transform in the bounded buffer at this stamp — before
+            // the first fix, or a TF gap wider than the window. Counted, not
+            // silently dropped.
+            ++n_no_tf;
           }
-          const double twtt = msg.two_way_travel_times[i];
-          if (!std::isfinite(twtt) || twtt <= 0.0) {
-            continue;
+          pending.pop_front();
+        };
+
+      auto drain_pending = [&](bool flush) {
+          while (!pending.empty()) {
+            if (!flush &&
+              (tf_frontier_ns == std::numeric_limits<std::int64_t>::min() ||
+              pending.front().ping_ns > tf_frontier_ns - kGuardNs))
+            {
+              break;
+            }
+            flush_front();
           }
-          const double rx = i < msg.rx_angles.size() ? msg.rx_angles[i] : 0.0;
-          const double h = (twtt * c / 2.0) * std::sin(rx);
-          min_h = std::min(min_h, h);
-          max_h = std::max(max_h, h);
-        }
-        pp.extent_port = min_h;
-        pp.extent_stbd = max_h;
-      } else {
-        const bool is_port = topic == port_topic;
-        auto msg = deserialize<marine_acoustic_msgs::msg::RawSonarImage>(bag_msg);
-        // A zero sample count drives slantRange() negative, which flips the
-        // sidescan footprint to the wrong side; skip like sample_rate<=0.
-        if (msg.sample_rate <= 0.0 || msg.samples_per_beam == 0) {
+        };
+
+      rosbag2_cpp::Reader reader;
+      rosbag2_storage::StorageOptions so;
+      so.uri = bag.string();
+      try {
+        reader.open(so);
+      } catch (const std::exception & e) {
+        std::cerr << "error: cannot open bag " << bag_key << ": " << e.what() << "\n";
+        continue;
+      }
+      rosbag2_storage::StorageFilter filter;
+      filter.topics = {"/tf", "/tf_static", mbes_topic, port_topic, stbd_topic};
+      reader.set_filter(filter);
+
+      // SINGLE INTERLEAVED PASS over the chronological message stream.
+      while (reader.has_next()) {
+        auto bag_msg = reader.read_next();
+        const std::string & topic = bag_msg->topic_name;
+
+        if (topic == "/tf" || topic == "/tf_static") {
+          const bool is_static = topic == "/tf_static";
+          auto m = deserialize<tf2_msgs::msg::TFMessage>(bag_msg);
+          for (const auto & tr : m.transforms) {
+            tf_buffer.setTransform(tr, "bag", is_static);
+            if (!is_static) {
+              tf_frontier_ns = std::max(tf_frontier_ns, stampNs(tr.header.stamp));
+            }
+          }
+          drain_pending(false);
           continue;
         }
-        pp.ping_ns = stampNs(msg.header.stamp);
-        pp.frame_id = msg.header.frame_id;
-        pp.sensor_type = is_port ? kSensorPort : kSensorStbd;
-        pp.topic = is_port ? &port_topic : &stbd_topic;
-        pp.level = &sidescan_level;
-        const double c = msg.ping_info.sound_speed > 0.0 ?
-          msg.ping_info.sound_speed : sound_speed_fallback;
-        // Max slant range bounds the ground range (flat-earth-free
-        // conservative footprint; the drill-down stages do the exact math).
-        const double max_slant = marine_sidescan_mosaic::slantRange(
-          static_cast<int>(msg.samples_per_beam) - 1,
-          static_cast<int>(msg.sample0), c, msg.sample_rate);
-        pp.extent_port = is_port ? -max_slant : 0.0;
-        pp.extent_stbd = is_port ? 0.0 : max_slant;
-      }
 
-      pending.push_back(std::move(pp));
-      if (pending.size() > kMaxPending) {
-        // Prefer flushing pings the TF frontier has already passed (this
-        // honours the guard interval); force the oldest out — accepting a
-        // possible no-tf — only if TF has genuinely stalled and we are still
-        // over the memory cap.
-        drain_pending(false);
+        PendingPing pp;
+        if (topic == mbes_topic) {
+          auto msg = deserialize<marine_acoustic_msgs::msg::SonarDetections>(bag_msg);
+          pp.ping_ns = stampNs(msg.header.stamp);
+          pp.frame_id = msg.header.frame_id;
+          pp.sensor_type = kSensorMbes;
+          pp.topic = &mbes_topic;
+          pp.level = &mbes_level;
+          // Across-track extents from the outermost good detections:
+          // horizontal ≈ slant · sin(rx_angle) (+ starboard). No good beams →
+          // extents 0, the sensor-position tile still indexes.
+          const double c = msg.ping_info.sound_speed > 0.0F ?
+            msg.ping_info.sound_speed : sound_speed_fallback;
+          double min_h = 0.0, max_h = 0.0;
+          const std::size_t n = msg.two_way_travel_times.size();
+          for (std::size_t i = 0; i < n; ++i) {
+            if (i < msg.flags.size() &&
+              msg.flags[i].flag != marine_acoustic_msgs::msg::DetectionFlag::DETECT_OK)
+            {
+              continue;
+            }
+            const double twtt = msg.two_way_travel_times[i];
+            if (!std::isfinite(twtt) || twtt <= 0.0) {
+              continue;
+            }
+            const double rx = i < msg.rx_angles.size() ? msg.rx_angles[i] : 0.0;
+            const double h = (twtt * c / 2.0) * std::sin(rx);
+            min_h = std::min(min_h, h);
+            max_h = std::max(max_h, h);
+          }
+          pp.extent_port = min_h;
+          pp.extent_stbd = max_h;
+        } else {
+          const bool is_port = topic == port_topic;
+          auto msg = deserialize<marine_acoustic_msgs::msg::RawSonarImage>(bag_msg);
+          // A zero sample count drives slantRange() negative, which flips the
+          // sidescan footprint to the wrong side; skip like sample_rate<=0.
+          if (msg.sample_rate <= 0.0 || msg.samples_per_beam == 0) {
+            continue;
+          }
+          pp.ping_ns = stampNs(msg.header.stamp);
+          pp.frame_id = msg.header.frame_id;
+          pp.sensor_type = is_port ? kSensorPort : kSensorStbd;
+          pp.topic = is_port ? &port_topic : &stbd_topic;
+          pp.level = &sidescan_level;
+          const double c = msg.ping_info.sound_speed > 0.0 ?
+            msg.ping_info.sound_speed : sound_speed_fallback;
+          // Max slant range bounds the ground range (flat-earth-free
+          // conservative footprint; the drill-down stages do the exact math).
+          const double max_slant = marine_sidescan_mosaic::slantRange(
+            static_cast<int>(msg.samples_per_beam) - 1,
+            static_cast<int>(msg.sample0), c, msg.sample_rate);
+          pp.extent_port = is_port ? -max_slant : 0.0;
+          pp.extent_stbd = is_port ? 0.0 : max_slant;
+        }
+
+        pending.push_back(std::move(pp));
         if (pending.size() > kMaxPending) {
-          flush_front();
+          // Prefer flushing pings the TF frontier has already passed (this
+          // honours the guard interval); force the oldest out — accepting a
+          // possible no-tf — only if TF has genuinely stalled and we are still
+          // over the memory cap.
+          drain_pending(false);
+          if (pending.size() > kMaxPending) {
+            flush_front();
+          }
         }
       }
-    }
-    drain_pending(true);
+      drain_pending(true);
 
-    // Persist this bag atomically: ledger row + all pass intervals.
-    const auto intervals = accumulator.flushAll();
-    const std::int64_t now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
-      std::chrono::system_clock::now().time_since_epoch()).count();
-    execOrDie(db, "BEGIN TRANSACTION;");
-    std::int64_t bag_id = 0;
-    if (state < 0) {
-      bag_id = -state;
-      sqlite3_stmt * del = nullptr;
-      sqlite3_prepare_v2(db, "DELETE FROM passes WHERE bag_id = ?", -1, &del, nullptr);
-      sqlite3_bind_int64(del, 1, bag_id);
-      sqlite3_step(del);
-      sqlite3_finalize(del);
-      sqlite3_stmt * upd = nullptr;
-      sqlite3_prepare_v2(
-        db, "UPDATE bags SET size_bytes = ?, mtime_ns = ?, indexed_at_ns = ? WHERE id = ?",
-        -1, &upd, nullptr);
-      sqlite3_bind_int64(upd, 1, fp.size_bytes);
-      sqlite3_bind_int64(upd, 2, fp.mtime_ns);
-      sqlite3_bind_int64(upd, 3, now_ns);
-      sqlite3_bind_int64(upd, 4, bag_id);
-      sqlite3_step(upd);
-      sqlite3_finalize(upd);
-    } else {
-      sqlite3_stmt * ins = nullptr;
-      sqlite3_prepare_v2(
-        db, "INSERT INTO bags (path, size_bytes, mtime_ns, indexed_at_ns) VALUES (?, ?, ?, ?)",
-        -1, &ins, nullptr);
-      sqlite3_bind_text(ins, 1, bag_key.c_str(), -1, SQLITE_TRANSIENT);
-      sqlite3_bind_int64(ins, 2, fp.size_bytes);
-      sqlite3_bind_int64(ins, 3, fp.mtime_ns);
-      sqlite3_bind_int64(ins, 4, now_ns);
-      sqlite3_step(ins);
-      sqlite3_finalize(ins);
-      bag_id = sqlite3_last_insert_rowid(db);
-    }
-    sqlite3_stmt * ins_pass = nullptr;
-    sqlite3_prepare_v2(
-      db,
-      "INSERT INTO passes (bag_id, level, tile_row, tile_col, sensor_type, topic,"
-      " t_start_ns, t_end_ns, ping_count) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-      -1, &ins_pass, nullptr);
-    for (const auto & pass : intervals) {
-      sqlite3_bind_int64(ins_pass, 1, bag_id);
-      sqlite3_bind_int(ins_pass, 2, pass.key.level);
-      sqlite3_bind_int64(ins_pass, 3, pass.key.tile_row);
-      sqlite3_bind_int64(ins_pass, 4, pass.key.tile_col);
-      sqlite3_bind_text(ins_pass, 5, pass.key.sensor_type.c_str(), -1, SQLITE_TRANSIENT);
-      sqlite3_bind_text(ins_pass, 6, pass.key.topic.c_str(), -1, SQLITE_TRANSIENT);
-      sqlite3_bind_int64(ins_pass, 7, pass.t_start_ns);
-      sqlite3_bind_int64(ins_pass, 8, pass.t_end_ns);
-      sqlite3_bind_int64(ins_pass, 9, pass.ping_count);
-      sqlite3_step(ins_pass);
-      sqlite3_reset(ins_pass);
-    }
-    sqlite3_finalize(ins_pass);
-    execOrDie(db, "COMMIT;");
+      // Persist this bag atomically: ledger row + all pass intervals.
+      const auto intervals = accumulator.flushAll();
+      const std::int64_t now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::system_clock::now().time_since_epoch()).count();
+      execOrThrow(db, "BEGIN TRANSACTION;");
+      std::int64_t bag_id = 0;
+      if (state < 0) {
+        bag_id = -state;
+        {
+          StmtGuard del(prepareOrThrow(db, "DELETE FROM passes WHERE bag_id = ?"));
+          sqlite3_bind_int64(del.get(), 1, bag_id);
+          stepDoneOrThrow(db, del.get());
+        }
+        {
+          const char * upd_sql =
+            "UPDATE bags SET size_bytes = ?, mtime_ns = ?, indexed_at_ns = ? WHERE id = ?";
+          StmtGuard upd(prepareOrThrow(db, upd_sql));
+          sqlite3_bind_int64(upd.get(), 1, fp.size_bytes);
+          sqlite3_bind_int64(upd.get(), 2, fp.mtime_ns);
+          sqlite3_bind_int64(upd.get(), 3, now_ns);
+          sqlite3_bind_int64(upd.get(), 4, bag_id);
+          stepDoneOrThrow(db, upd.get());
+        }
+      } else {
+        const char * ins_sql =
+          "INSERT INTO bags (path, size_bytes, mtime_ns, indexed_at_ns) VALUES (?, ?, ?, ?)";
+        StmtGuard ins(prepareOrThrow(db, ins_sql));
+        sqlite3_bind_text(ins.get(), 1, bag_key.c_str(), -1, SQLITE_TRANSIENT);
+        sqlite3_bind_int64(ins.get(), 2, fp.size_bytes);
+        sqlite3_bind_int64(ins.get(), 3, fp.mtime_ns);
+        sqlite3_bind_int64(ins.get(), 4, now_ns);
+        stepDoneOrThrow(db, ins.get());
+        bag_id = sqlite3_last_insert_rowid(db);
+      }
+      {
+        const char * pass_sql =
+          "INSERT INTO passes (bag_id, level, tile_row, tile_col, sensor_type, topic,"
+          " t_start_ns, t_end_ns, ping_count) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
+        StmtGuard ins_pass(prepareOrThrow(db, pass_sql));
+        for (const auto & pass : intervals) {
+          sqlite3_bind_int64(ins_pass.get(), 1, bag_id);
+          sqlite3_bind_int(ins_pass.get(), 2, pass.key.level);
+          sqlite3_bind_int64(ins_pass.get(), 3, pass.key.tile_row);
+          sqlite3_bind_int64(ins_pass.get(), 4, pass.key.tile_col);
+          sqlite3_bind_text(ins_pass.get(), 5, pass.key.sensor_type.c_str(), -1, SQLITE_TRANSIENT);
+          sqlite3_bind_text(ins_pass.get(), 6, pass.key.topic.c_str(), -1, SQLITE_TRANSIENT);
+          sqlite3_bind_int64(ins_pass.get(), 7, pass.t_start_ns);
+          sqlite3_bind_int64(ins_pass.get(), 8, pass.t_end_ns);
+          sqlite3_bind_int64(ins_pass.get(), 9, pass.ping_count);
+          stepDoneOrThrow(db, ins_pass.get());
+          sqlite3_reset(ins_pass.get());
+        }
+      }
+      execOrThrow(db, "COMMIT;");
 
-    ++n_bags_indexed;
-    std::cerr << (state < 0 ? "re-indexed: " : "indexed: ") << bag_key
-              << " (" << n_pings << " pings -> " << intervals.size()
-              << " pass intervals; no-tf=" << n_no_tf
-              << " bad-pose=" << n_bad_pose << ")\n";
+      ++n_bags_indexed;
+      std::cerr << (state < 0 ? "re-indexed: " : "indexed: ") << bag_key
+                << " (" << n_pings << " pings -> " << intervals.size()
+                << " pass intervals; no-tf=" << n_no_tf
+                << " bad-pose=" << n_bad_pose << ")\n";
+    } catch (const std::exception & e) {
+      // A bad message or a SQLite failure aborts this bag only: roll back
+      // its (possibly open) transaction and move on so the remaining bags
+      // still index and the db is closed cleanly at the end.
+      sqlite3_exec(db, "ROLLBACK;", nullptr, nullptr, nullptr);
+      std::cerr << "error: failed to index " << bag.string() << ": "
+                << e.what() << "; skipping\n";
+    }
   }
 
   sqlite3_close(db);

--- a/marine_survey_index/src/survey_index_bag_main.cpp
+++ b/marine_survey_index/src/survey_index_bag_main.cpp
@@ -311,13 +311,14 @@ int main(int argc, char ** argv)
     std::cerr <<
       "usage: survey_index_bag [bag_uri ...] [--scan DIR] [--db survey_index.db]\n"
       "       [--mbes-topic T] [--port-topic T] [--stbd-topic T]\n"
-      "       [--mbes-level N=10] [--sidescan-level N=13] [--level N (overrides both)]\n"
+      "       [--mbes-level N=14] [--sidescan-level N=14] [--level N (overrides both)]\n"
       "       [--merge-gap S=5.0] [--earth-frame F=earth] [--sound-speed S=1500]\n"
       "\n"
       "Indexes where each sonar looked, per bag, into a regenerable SQLite\n"
       "sidecar. Unchanged already-indexed bags are skipped; changed bags are\n"
-      "re-indexed. Level defaults match the stores' native tiling (bathy L10,\n"
-      "sidescan L13).\n";
+      "re-indexed. Default level 14 (~54 m tiles) — a target-inspection\n"
+      "neighbourhood; rolls up to the stores' coarser native tiles (bathy L10,\n"
+      "sidescan L13) via the GGGS parent hierarchy.\n";
     return 2;
   }
 
@@ -332,8 +333,12 @@ int main(int argc, char ** argv)
   const double sound_speed_fallback =
     toDouble(argValue(argc, argv, "--sound-speed", "1500.0"), "--sound-speed");
   const double merge_gap_s = toDouble(argValue(argc, argv, "--merge-gap", "5.0"), "--merge-gap");
-  int mbes_level_n = toInt(argValue(argc, argv, "--mbes-level", "10"), "--mbes-level");
-  int sidescan_level_n = toInt(argValue(argc, argv, "--sidescan-level", "13"), "--sidescan-level");
+  // Default L14 (~54 m tiles): the tile-of-interest scale for target review
+  // (Roland, 2026-07-13) — small enough to select a neighbourhood, and it
+  // rolls up to the coarser store-native tiles (bathy L10, sidescan L13)
+  // through the GGGS quadtree when stage 2 joins against store tiling.
+  int mbes_level_n = toInt(argValue(argc, argv, "--mbes-level", "14"), "--mbes-level");
+  int sidescan_level_n = toInt(argValue(argc, argv, "--sidescan-level", "14"), "--sidescan-level");
   const std::string level_override = argValue(argc, argv, "--level", "");
   if (!level_override.empty()) {
     mbes_level_n = sidescan_level_n = toInt(level_override, "--level");

--- a/marine_survey_index/src/survey_index_bag_main.cpp
+++ b/marine_survey_index/src/survey_index_bag_main.cpp
@@ -499,7 +499,14 @@ int main(int argc, char ** argv)
 
       pending.push_back(std::move(pp));
       if (pending.size() > kMaxPending) {
-        flush_front();
+        // Prefer flushing pings the TF frontier has already passed (this
+        // honours the guard interval); force the oldest out — accepting a
+        // possible no-tf — only if TF has genuinely stalled and we are still
+        // over the memory cap.
+        drain_pending(false);
+        if (pending.size() > kMaxPending) {
+          flush_front();
+        }
       }
     }
     drain_pending(true);

--- a/marine_survey_index/src/survey_index_bag_main.cpp
+++ b/marine_survey_index/src/survey_index_bag_main.cpp
@@ -40,6 +40,7 @@
 #include <chrono>
 #include <cmath>
 #include <cstdint>
+#include <cstdlib>
 #include <deque>
 #include <filesystem>
 #include <iostream>

--- a/marine_survey_index/src/survey_index_bag_main.cpp
+++ b/marine_survey_index/src/survey_index_bag_main.cpp
@@ -476,7 +476,9 @@ int main(int argc, char ** argv)
       } else {
         const bool is_port = topic == port_topic;
         auto msg = deserialize<marine_acoustic_msgs::msg::RawSonarImage>(bag_msg);
-        if (msg.sample_rate <= 0.0) {
+        // A zero sample count drives slantRange() negative, which flips the
+        // sidescan footprint to the wrong side; skip like sample_rate<=0.
+        if (msg.sample_rate <= 0.0 || msg.samples_per_beam == 0) {
           continue;
         }
         pp.ping_ns = stampNs(msg.header.stamp);

--- a/marine_survey_index/src/survey_index_query_main.cpp
+++ b/marine_survey_index/src/survey_index_query_main.cpp
@@ -66,6 +66,16 @@ double toDouble(const char * s, const std::string & flag)
   }
 }
 
+int toInt(const std::string & s, const std::string & flag)
+{
+  try {
+    return std::stoi(s);
+  } catch (const std::exception &) {
+    std::cerr << "error: expected an integer for " << flag << ", got '" << s << "'\n";
+    std::exit(2);
+  }
+}
+
 std::string isoUtc(std::int64_t t_ns)
 {
   const std::time_t seconds = static_cast<std::time_t>(t_ns / 1000000000LL);
@@ -152,7 +162,7 @@ int main(int argc, char ** argv)
   // or every level the index actually holds (for the sensor filter).
   std::vector<std::uint8_t> levels;
   if (!level_arg.empty()) {
-    levels.push_back(static_cast<std::uint8_t>(std::stoi(level_arg)));
+    levels.push_back(static_cast<std::uint8_t>(toInt(level_arg, "--level")));
   } else {
     levels = marine_survey_index::distinctLevels(db, sensor);
   }

--- a/marine_survey_index/src/survey_index_query_main.cpp
+++ b/marine_survey_index/src/survey_index_query_main.cpp
@@ -77,6 +77,19 @@ int toInt(const std::string & s, const std::string & flag)
   }
 }
 
+// GGGS levels are 0..20 (gggs::Level throws std::out_of_range at >= 21, and it
+// is constructed outside any try/catch → std::terminate). Reject out-of-range
+// values here so the CLI exits cleanly instead of aborting.
+std::uint8_t toLevel(const std::string & s, const std::string & flag)
+{
+  const int v = toInt(s, flag);
+  if (v < 0 || v > 20) {
+    std::cerr << "error: " << flag << " must be in [0, 20], got " << v << "\n";
+    std::exit(2);
+  }
+  return static_cast<std::uint8_t>(v);
+}
+
 std::string isoUtc(std::int64_t t_ns)
 {
   const std::time_t seconds = static_cast<std::time_t>(t_ns / 1000000000LL);
@@ -176,7 +189,7 @@ int main(int argc, char ** argv)
   // or every level the index actually holds (for the sensor filter).
   std::vector<std::uint8_t> levels;
   if (!level_arg.empty()) {
-    levels.push_back(static_cast<std::uint8_t>(toInt(level_arg, "--level")));
+    levels.push_back(toLevel(level_arg, "--level"));
   } else {
     levels = marine_survey_index::distinctLevels(db, sensor);
   }

--- a/marine_survey_index/src/survey_index_query_main.cpp
+++ b/marine_survey_index/src/survey_index_query_main.cpp
@@ -1,0 +1,210 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+/// @file
+/// @brief Survey index query CLI: point/box → which bags saw it (#259).
+
+#include <cmath>
+#include <cstdint>
+#include <ctime>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "marine_survey_index/footprint.hpp"
+#include "marine_survey_index/query.hpp"
+#include "marine_survey_index/schema.hpp"
+
+namespace
+{
+
+std::string argValue(int argc, char ** argv, const std::string & flag, const std::string & dflt)
+{
+  for (int i = 1; i + 1 < argc; ++i) {
+    if (flag == argv[i]) {
+      return argv[i + 1];
+    }
+  }
+  return dflt;
+}
+
+int argIndex(int argc, char ** argv, const std::string & flag)
+{
+  for (int i = 1; i < argc; ++i) {
+    if (flag == argv[i]) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+double toDouble(const char * s, const std::string & flag)
+{
+  try {
+    return std::stod(s);
+  } catch (const std::exception &) {
+    std::cerr << "error: expected a number for " << flag << ", got '" << s << "'\n";
+    std::exit(2);
+  }
+}
+
+std::string isoUtc(std::int64_t t_ns)
+{
+  const std::time_t seconds = static_cast<std::time_t>(t_ns / 1000000000LL);
+  std::tm tm_utc{};
+  gmtime_r(&seconds, &tm_utc);
+  char buffer[32];
+  std::strftime(buffer, sizeof(buffer), "%Y-%m-%dT%H:%M:%SZ", &tm_utc);
+  return buffer;
+}
+
+std::string jsonEscape(const std::string & s)
+{
+  std::string out;
+  for (const char c : s) {
+    if (c == '"' || c == '\\') {
+      out += '\\';
+    }
+    out += c;
+  }
+  return out;
+}
+
+}  // namespace
+
+int main(int argc, char ** argv)
+{
+  const int point_at = argIndex(argc, argv, "--point");
+  const int box_at = argIndex(argc, argv, "--box");
+  if ((point_at < 0) == (box_at < 0)) {  // exactly one of --point / --box
+    std::cerr <<
+      "usage: survey_index_query (--point LAT LON [--radius M] |\n"
+      "                           --box LATMIN LONMIN LATMAX LONMAX)\n"
+      "       [--db survey_index.db] [--level N] [--sensor TYPE] [--json]\n"
+      "\n"
+      "Answers: which bags, which time ranges, which sensor saw this location.\n"
+      "--sensor accepts 'mbes-bathy', 'sidescan-port', 'sidescan-stbd', or\n"
+      "'sidescan' (matches both channels). Without --level, every level present\n"
+      "in the index is queried.\n";
+    return 2;
+  }
+
+  double lat_min, lon_min, lat_max, lon_max;
+  if (point_at >= 0) {
+    if (point_at + 2 >= argc) {
+      std::cerr << "error: --point needs LAT LON\n";
+      return 2;
+    }
+    const double lat = toDouble(argv[point_at + 1], "--point LAT");
+    const double lon = toDouble(argv[point_at + 2], "--point LON");
+    const double radius_m = toDouble(argValue(argc, argv, "--radius", "0").c_str(), "--radius");
+    // Small-area degree approximation — plenty for a query radius.
+    const double dlat = radius_m / 111320.0;
+    const double cos_lat = std::max(0.01, std::cos(lat * M_PI / 180.0));
+    const double dlon = radius_m / (111320.0 * cos_lat);
+    lat_min = lat - dlat;
+    lat_max = lat + dlat;
+    lon_min = lon - dlon;
+    lon_max = lon + dlon;
+  } else {
+    if (box_at + 4 >= argc) {
+      std::cerr << "error: --box needs LATMIN LONMIN LATMAX LONMAX\n";
+      return 2;
+    }
+    lat_min = toDouble(argv[box_at + 1], "--box LATMIN");
+    lon_min = toDouble(argv[box_at + 2], "--box LONMIN");
+    lat_max = toDouble(argv[box_at + 3], "--box LATMAX");
+    lon_max = toDouble(argv[box_at + 4], "--box LONMAX");
+  }
+
+  const std::string db_path = argValue(argc, argv, "--db", "survey_index.db");
+  const std::string sensor = argValue(argc, argv, "--sensor", "");
+  const std::string level_arg = argValue(argc, argv, "--level", "");
+  const bool json = argIndex(argc, argv, "--json") >= 0;
+
+  sqlite3 * db = nullptr;
+  try {
+    db = marine_survey_index::openIndexDb(db_path);
+  } catch (const std::exception & e) {
+    std::cerr << "error: " << e.what() << "\n";
+    return 1;
+  }
+
+  // Which levels to translate the query geometry into: the explicit --level,
+  // or every level the index actually holds (for the sensor filter).
+  std::vector<std::uint8_t> levels;
+  if (!level_arg.empty()) {
+    levels.push_back(static_cast<std::uint8_t>(std::stoi(level_arg)));
+  } else {
+    levels = marine_survey_index::distinctLevels(db, sensor);
+  }
+
+  std::vector<gggs::GridIndex> tiles;
+  for (const auto level_n : levels) {
+    const auto level_tiles = marine_survey_index::tilesForBoundingBox(
+      lat_min, lon_min, lat_max, lon_max, gggs::Level(level_n));
+    tiles.insert(tiles.end(), level_tiles.begin(), level_tiles.end());
+  }
+
+  const auto rows = marine_survey_index::queryPasses(db, tiles, sensor);
+  sqlite3_close(db);
+
+  if (json) {
+    std::cout << "[";
+    for (std::size_t i = 0; i < rows.size(); ++i) {
+      const auto & r = rows[i];
+      std::cout << (i ? ",\n " : "\n ")
+                << "{\"bag\":\"" << jsonEscape(r.bag_path) << "\""
+                << ",\"sensor\":\"" << jsonEscape(r.sensor_type) << "\""
+                << ",\"topic\":\"" << jsonEscape(r.topic) << "\""
+                << ",\"level\":" << static_cast<int>(r.level)
+                << ",\"tile_row\":" << r.tile_row
+                << ",\"tile_col\":" << r.tile_col
+                << ",\"t_start_ns\":" << r.t_start_ns
+                << ",\"t_end_ns\":" << r.t_end_ns
+                << ",\"t_start\":\"" << isoUtc(r.t_start_ns) << "\""
+                << ",\"t_end\":\"" << isoUtc(r.t_end_ns) << "\""
+                << ",\"ping_count\":" << r.ping_count << "}";
+    }
+    std::cout << (rows.empty() ? "]\n" : "\n]\n");
+    return 0;
+  }
+
+  if (rows.empty()) {
+    std::cout << "no indexed data covers the query area\n";
+    return 0;
+  }
+  std::string current_bag;
+  for (const auto & r : rows) {
+    if (r.bag_path != current_bag) {
+      current_bag = r.bag_path;
+      std::cout << current_bag << "\n";
+    }
+    const double duration_s =
+      static_cast<double>(r.t_end_ns - r.t_start_ns) / 1e9;
+    std::cout << "  " << isoUtc(r.t_start_ns) << " .. " << isoUtc(r.t_end_ns)
+              << " (" << duration_s << " s, " << r.ping_count << " pings) "
+              << r.sensor_type << " L" << static_cast<int>(r.level)
+              << " tile " << r.tile_row << "/" << r.tile_col
+              << "  [" << r.topic << "]\n";
+  }
+  return 0;
+}

--- a/marine_survey_index/src/survey_index_query_main.cpp
+++ b/marine_survey_index/src/survey_index_query_main.cpp
@@ -22,9 +22,11 @@
 /// @file
 /// @brief Survey index query CLI: point/box → which bags saw it (#259).
 
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <ctime>
 #include <iostream>
 #include <string>

--- a/marine_survey_index/src/survey_index_query_main.cpp
+++ b/marine_survey_index/src/survey_index_query_main.cpp
@@ -24,6 +24,7 @@
 
 #include <cmath>
 #include <cstdint>
+#include <cstdio>
 #include <ctime>
 #include <iostream>
 #include <string>
@@ -90,10 +91,23 @@ std::string jsonEscape(const std::string & s)
 {
   std::string out;
   for (const char c : s) {
-    if (c == '"' || c == '\\') {
-      out += '\\';
+    switch (c) {
+      case '"': out += "\\\""; break;
+      case '\\': out += "\\\\"; break;
+      case '\b': out += "\\b"; break;
+      case '\f': out += "\\f"; break;
+      case '\n': out += "\\n"; break;
+      case '\r': out += "\\r"; break;
+      case '\t': out += "\\t"; break;
+      default:
+        if (static_cast<unsigned char>(c) < 0x20) {
+          char buffer[7];
+          std::snprintf(buffer, sizeof(buffer), "\\u%04x", static_cast<unsigned char>(c));
+          out += buffer;
+        } else {
+          out += c;
+        }
     }
-    out += c;
   }
   return out;
 }

--- a/marine_survey_index/test/test_interval_merge.cpp
+++ b/marine_survey_index/test/test_interval_merge.cpp
@@ -1,0 +1,132 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+
+#include "marine_survey_index/interval_accumulator.hpp"
+
+namespace
+{
+
+using marine_survey_index::IntervalAccumulator;
+using marine_survey_index::PassInterval;
+using marine_survey_index::TileKey;
+
+constexpr std::int64_t kGap = 5000000000LL;  // 5 s in ns
+constexpr std::int64_t kSec = 1000000000LL;
+
+TileKey key(
+  std::uint32_t row = 1, std::uint32_t col = 2,
+  const char * sensor = "mbes-bathy", const char * topic = "/t")
+{
+  TileKey k;
+  k.level = 10;
+  k.tile_row = row;
+  k.tile_col = col;
+  k.sensor_type = sensor;
+  k.topic = topic;
+  return k;
+}
+
+TEST(IntervalMerge, GapWithinThresholdMerges)
+{
+  IntervalAccumulator acc(kGap);
+  acc.addPing(key(), 0);
+  acc.addPing(key(), 2 * kSec);
+  acc.addPing(key(), 4 * kSec);
+  const auto out = acc.flushAll();
+  ASSERT_EQ(out.size(), 1u);
+  EXPECT_EQ(out[0].t_start_ns, 0);
+  EXPECT_EQ(out[0].t_end_ns, 4 * kSec);
+  EXPECT_EQ(out[0].ping_count, 3);
+}
+
+TEST(IntervalMerge, GapBeyondThresholdSplits)
+{
+  IntervalAccumulator acc(kGap);
+  acc.addPing(key(), 0);
+  acc.addPing(key(), 2 * kSec);
+  acc.addPing(key(), 20 * kSec);   // > 5 s after the last ping -> new pass
+  acc.addPing(key(), 21 * kSec);
+  auto out = acc.flushAll();
+  ASSERT_EQ(out.size(), 2u);
+  std::sort(out.begin(), out.end(),
+    [](const PassInterval & a, const PassInterval & b) {return a.t_start_ns < b.t_start_ns;});
+  EXPECT_EQ(out[0].t_start_ns, 0);
+  EXPECT_EQ(out[0].t_end_ns, 2 * kSec);
+  EXPECT_EQ(out[0].ping_count, 2);
+  EXPECT_EQ(out[1].t_start_ns, 20 * kSec);
+  EXPECT_EQ(out[1].t_end_ns, 21 * kSec);
+  EXPECT_EQ(out[1].ping_count, 2);
+}
+
+TEST(IntervalMerge, ExactGapBoundaryStillMerges)
+{
+  IntervalAccumulator acc(kGap);
+  acc.addPing(key(), 0);
+  acc.addPing(key(), kGap);   // gap == threshold: extends (only > splits)
+  const auto out = acc.flushAll();
+  ASSERT_EQ(out.size(), 1u);
+  EXPECT_EQ(out[0].ping_count, 2);
+}
+
+TEST(IntervalMerge, DistinctKeysAccumulateIndependently)
+{
+  IntervalAccumulator acc(kGap);
+  acc.addPing(key(1, 2, "mbes-bathy"), 0);
+  acc.addPing(key(1, 2, "sidescan-port"), 0);   // same tile, other sensor
+  acc.addPing(key(3, 4, "mbes-bathy"), 0);      // other tile, same sensor
+  acc.addPing(key(1, 2, "mbes-bathy"), kSec);
+  const auto out = acc.flushAll();
+  ASSERT_EQ(out.size(), 3u);
+  const auto mbes_12 = std::find_if(out.begin(), out.end(),
+      [](const PassInterval & p) {
+        return p.key.sensor_type == "mbes-bathy" && p.key.tile_row == 1;
+    });
+  ASSERT_NE(mbes_12, out.end());
+  EXPECT_EQ(mbes_12->ping_count, 2);
+}
+
+TEST(IntervalMerge, SlightlyOutOfOrderPingExtendsWithoutMovingEndBack)
+{
+  IntervalAccumulator acc(kGap);
+  acc.addPing(key(), 2 * kSec);
+  acc.addPing(key(), 1 * kSec);   // interleaving jitter: earlier than open end
+  const auto out = acc.flushAll();
+  ASSERT_EQ(out.size(), 1u);
+  EXPECT_EQ(out[0].t_start_ns, 1 * kSec);
+  EXPECT_EQ(out[0].t_end_ns, 2 * kSec);
+  EXPECT_EQ(out[0].ping_count, 2);
+}
+
+TEST(IntervalMerge, FlushResetsForNextBag)
+{
+  IntervalAccumulator acc(kGap);
+  acc.addPing(key(), 0);
+  EXPECT_EQ(acc.flushAll().size(), 1u);
+  EXPECT_TRUE(acc.flushAll().empty());
+  acc.addPing(key(), 100 * kSec);
+  EXPECT_EQ(acc.flushAll().size(), 1u);
+}
+
+}  // namespace

--- a/marine_survey_index/test/test_query_join.cpp
+++ b/marine_survey_index/test/test_query_join.cpp
@@ -1,0 +1,168 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "marine_survey_index/footprint.hpp"
+#include "marine_survey_index/query.hpp"
+#include "marine_survey_index/schema.hpp"
+
+namespace
+{
+
+// The query join, exercised against an in-memory index with known content:
+// point and box lookups, the sensor filter (including 'sidescan' matching
+// both channels), and the tile-mismatch negative case.
+
+constexpr double kLat = 43.02;
+constexpr double kLon = -71.36;
+
+class QueryJoin : public testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    db_ = marine_survey_index::openIndexDb(":memory:");
+    exec("INSERT INTO bags (id, path, size_bytes, mtime_ns, indexed_at_ns)"
+      " VALUES (1, '/data/bagA', 10, 0, 0), (2, '/data/bagB', 20, 0, 0)");
+
+    // Home tile at each sensor's native level.
+    home10_ = gggs::Level(10).gridIndex(kLat, kLon);
+    home13_ = gggs::Level(13).gridIndex(kLat, kLon);
+
+    // bagA: an MBES pass (L10) + a port sidescan pass (L13) over the point.
+    insertPass(1, home10_, "mbes-bathy", "/m3", 100, 200, 50);
+    insertPass(1, home13_, "sidescan-port", "/ss_port", 100, 190, 40);
+    // bagB: a later stbd sidescan pass (L13) over the point, and an MBES pass
+    // over a far-away tile (must never match the point query).
+    insertPass(2, home13_, "sidescan-stbd", "/ss_stbd", 1000, 1100, 60);
+    const auto far10 = gggs::Level(10).gridIndex(kLat + 1.0, kLon + 1.0);
+    insertPass(2, far10, "mbes-bathy", "/m3", 5000, 5100, 70);
+  }
+
+  void TearDown() override {sqlite3_close(db_);}
+
+  void exec(const std::string & sql)
+  {
+    ASSERT_EQ(sqlite3_exec(db_, sql.c_str(), nullptr, nullptr, nullptr), SQLITE_OK)
+      << sqlite3_errmsg(db_);
+  }
+
+  void insertPass(
+    int bag_id, const gggs::GridIndex & tile, const std::string & sensor,
+    const std::string & topic, std::int64_t t0, std::int64_t t1, int pings)
+  {
+    exec(
+      "INSERT INTO passes (bag_id, level, tile_row, tile_col, sensor_type, topic,"
+      " t_start_ns, t_end_ns, ping_count) VALUES (" +
+      std::to_string(bag_id) + ", " + std::to_string(tile.level()) + ", " +
+      std::to_string(tile.row()) + ", " + std::to_string(tile.column()) + ", '" +
+      sensor + "', '" + topic + "', " + std::to_string(t0) + ", " +
+      std::to_string(t1) + ", " + std::to_string(pings) + ")");
+  }
+
+  // Tiles covering the query point at every level in the index (the CLI's
+  // point-query path with no --level).
+  std::vector<gggs::GridIndex> pointTiles(const std::string & sensor = "")
+  {
+    std::vector<gggs::GridIndex> tiles;
+    for (const auto level : marine_survey_index::distinctLevels(db_, sensor)) {
+      const auto per_level = marine_survey_index::tilesForBoundingBox(
+        kLat, kLon, kLat, kLon, gggs::Level(level));
+      tiles.insert(tiles.end(), per_level.begin(), per_level.end());
+    }
+    return tiles;
+  }
+
+  sqlite3 * db_ = nullptr;
+  gggs::GridIndex home10_;
+  gggs::GridIndex home13_;
+};
+
+TEST_F(QueryJoin, PointQueryFindsAllSensorsAcrossLevelsAndBags)
+{
+  const auto rows = marine_survey_index::queryPasses(db_, pointTiles(), "");
+  ASSERT_EQ(rows.size(), 3u);   // far-away tile excluded
+  EXPECT_EQ(rows[0].bag_path, "/data/bagA");
+  EXPECT_EQ(rows[1].bag_path, "/data/bagA");
+  EXPECT_EQ(rows[2].bag_path, "/data/bagB");
+  // Ordered by bag then t_start within bag.
+  EXPECT_LE(rows[0].t_start_ns, rows[1].t_start_ns);
+}
+
+TEST_F(QueryJoin, SensorFilterExactMatch)
+{
+  const auto rows = marine_survey_index::queryPasses(db_, pointTiles(), "mbes-bathy");
+  ASSERT_EQ(rows.size(), 1u);
+  EXPECT_EQ(rows[0].sensor_type, "mbes-bathy");
+  EXPECT_EQ(rows[0].ping_count, 50);
+}
+
+TEST_F(QueryJoin, SidescanFilterMatchesBothChannels)
+{
+  const auto rows = marine_survey_index::queryPasses(db_, pointTiles(), "sidescan");
+  ASSERT_EQ(rows.size(), 2u);
+  EXPECT_EQ(rows[0].sensor_type, "sidescan-port");
+  EXPECT_EQ(rows[1].sensor_type, "sidescan-stbd");
+}
+
+TEST_F(QueryJoin, DistinctLevelsRespectsSensorFilter)
+{
+  const auto all = marine_survey_index::distinctLevels(db_, "");
+  ASSERT_EQ(all.size(), 2u);
+  EXPECT_EQ(all[0], 10);
+  EXPECT_EQ(all[1], 13);
+  const auto ss_only = marine_survey_index::distinctLevels(db_, "sidescan");
+  ASSERT_EQ(ss_only.size(), 1u);
+  EXPECT_EQ(ss_only[0], 13);
+}
+
+TEST_F(QueryJoin, NonOverlappingPointFindsNothing)
+{
+  std::vector<gggs::GridIndex> tiles;
+  for (const auto level : marine_survey_index::distinctLevels(db_, "")) {
+    const auto per_level = marine_survey_index::tilesForBoundingBox(
+      kLat - 0.5, kLon - 0.5, kLat - 0.5, kLon - 0.5, gggs::Level(level));
+    tiles.insert(tiles.end(), per_level.begin(), per_level.end());
+  }
+  EXPECT_TRUE(marine_survey_index::queryPasses(db_, tiles, "").empty());
+}
+
+TEST_F(QueryJoin, EmptyTileSetReturnsEmpty)
+{
+  EXPECT_TRUE(marine_survey_index::queryPasses(db_, {}, "").empty());
+}
+
+TEST_F(QueryJoin, WrongLevelSameRowColDoesNotMatch)
+{
+  // A tile key is (level, row, col) — the same row/col at a different level
+  // must not join. Query with the L10 home tile's row/col but claim L13.
+  std::vector<gggs::GridIndex> tiles = {gggs::Level(13).gridIndex(
+      0.5 * (home10_.southLatitude() + home10_.northLatitude()),
+      0.5 * (home10_.westLongitude() + home10_.eastLongitude()))};
+  const auto rows = marine_survey_index::queryPasses(db_, tiles, "mbes-bathy");
+  EXPECT_TRUE(rows.empty());   // L13 tile over the point holds no mbes pass
+}
+
+}  // namespace

--- a/marine_survey_index/test/test_schema.cpp
+++ b/marine_survey_index/test/test_schema.cpp
@@ -33,11 +33,21 @@ namespace
 // the tables and version row; a re-open of a valid DB succeeds; a version
 // mismatch fails loudly with the regenerate hint.
 
+// Returns -1 after ADD_FAILURE on any sqlite error, so a failed prepare
+// fails the test cleanly instead of stepping a null statement (ASSERT_* is
+// unavailable in a value-returning helper).
 int singleInt(sqlite3 * db, const char * sql)
 {
   sqlite3_stmt * stmt = nullptr;
-  EXPECT_EQ(sqlite3_prepare_v2(db, sql, -1, &stmt, nullptr), SQLITE_OK);
-  EXPECT_EQ(sqlite3_step(stmt), SQLITE_ROW);
+  if (sqlite3_prepare_v2(db, sql, -1, &stmt, nullptr) != SQLITE_OK) {
+    ADD_FAILURE() << "prepare failed for '" << sql << "': " << sqlite3_errmsg(db);
+    return -1;
+  }
+  if (sqlite3_step(stmt) != SQLITE_ROW) {
+    ADD_FAILURE() << "no row for '" << sql << "': " << sqlite3_errmsg(db);
+    sqlite3_finalize(stmt);
+    return -1;
+  }
   const int value = sqlite3_column_int(stmt, 0);
   sqlite3_finalize(stmt);
   return value;

--- a/marine_survey_index/test/test_schema.cpp
+++ b/marine_survey_index/test/test_schema.cpp
@@ -1,0 +1,99 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <string>
+
+#include "marine_survey_index/schema.hpp"
+
+namespace
+{
+
+// The DB-open contract that #258 stages 2-5 depend on: a fresh open creates
+// the tables and version row; a re-open of a valid DB succeeds; a version
+// mismatch fails loudly with the regenerate hint.
+
+int singleInt(sqlite3 * db, const char * sql)
+{
+  sqlite3_stmt * stmt = nullptr;
+  EXPECT_EQ(sqlite3_prepare_v2(db, sql, -1, &stmt, nullptr), SQLITE_OK);
+  EXPECT_EQ(sqlite3_step(stmt), SQLITE_ROW);
+  const int value = sqlite3_column_int(stmt, 0);
+  sqlite3_finalize(stmt);
+  return value;
+}
+
+TEST(Schema, FreshOpenCreatesTablesAndVersion)
+{
+  sqlite3 * db = marine_survey_index::openIndexDb(":memory:");
+  ASSERT_NE(db, nullptr);
+  EXPECT_EQ(singleInt(db, "SELECT version FROM schema_version"),
+    marine_survey_index::kSchemaVersion);
+  EXPECT_EQ(
+    singleInt(
+      db,
+      "SELECT count(*) FROM sqlite_master WHERE type='table'"
+      " AND name IN ('schema_version','bags','passes')"),
+    3);
+  sqlite3_close(db);
+}
+
+TEST(Schema, ReopenExistingSucceeds)
+{
+  const std::string path = testing::TempDir() + "/survey_index_schema_test.db";
+  std::remove(path.c_str());
+
+  sqlite3 * db = marine_survey_index::openIndexDb(path);
+  ASSERT_NE(db, nullptr);
+  sqlite3_close(db);
+
+  // Second open must validate, not re-stamp or fail.
+  db = marine_survey_index::openIndexDb(path);
+  ASSERT_NE(db, nullptr);
+  EXPECT_EQ(singleInt(db, "SELECT count(*) FROM schema_version"), 1);
+  sqlite3_close(db);
+  std::remove(path.c_str());
+}
+
+TEST(Schema, VersionMismatchThrowsWithRegenerateHint)
+{
+  const std::string path = testing::TempDir() + "/survey_index_version_test.db";
+  std::remove(path.c_str());
+
+  sqlite3 * db = marine_survey_index::openIndexDb(path);
+  ASSERT_NE(db, nullptr);
+  ASSERT_EQ(
+    sqlite3_exec(db, "UPDATE schema_version SET version = 9999", nullptr, nullptr, nullptr),
+    SQLITE_OK);
+  sqlite3_close(db);
+
+  try {
+    marine_survey_index::openIndexDb(path);
+    FAIL() << "expected a schema-version mismatch to throw";
+  } catch (const std::runtime_error & e) {
+    EXPECT_NE(std::string(e.what()).find("re-run the indexer"), std::string::npos);
+  }
+  std::remove(path.c_str());
+}
+
+}  // namespace

--- a/marine_survey_index/test/test_tile_enumeration.cpp
+++ b/marine_survey_index/test/test_tile_enumeration.cpp
@@ -1,0 +1,127 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+
+#include "marine_survey_index/footprint.hpp"
+
+namespace
+{
+
+using marine_survey_index::tilesForBoundingBox;
+
+// Lake Massabesic — the survey area this index was built for; mid-latitude,
+// far from grid-level latitude bands and the antimeridian.
+constexpr double kLat = 43.02;
+constexpr double kLon = -71.36;
+// Bathy-store native level: L10 grids span 8/2^10 deg ~ 0.0078 deg.
+const gggs::Level kLevel(10);
+
+bool contains(const std::vector<gggs::GridIndex> & tiles, const gggs::GridIndex & g)
+{
+  return std::any_of(tiles.begin(), tiles.end(),
+           [&g](const gggs::GridIndex & t) {
+             return t.level() == g.level() && t.row() == g.row() && t.column() == g.column();
+    });
+}
+
+TEST(TileEnumeration, PointInsideOneTileYieldsExactlyThatTile)
+{
+  const gggs::GridIndex home = kLevel.gridIndex(kLat, kLon);
+  // A degenerate box well inside the home tile.
+  const double lat = 0.5 * (home.southLatitude() + home.northLatitude());
+  const double lon = 0.5 * (home.westLongitude() + home.eastLongitude());
+  const auto tiles = tilesForBoundingBox(lat, lon, lat, lon, kLevel);
+  ASSERT_EQ(tiles.size(), 1u);
+  EXPECT_TRUE(contains(tiles, home));
+}
+
+TEST(TileEnumeration, BoxStraddlingEastEdgeYieldsBothTiles)
+{
+  const gggs::GridIndex home = kLevel.gridIndex(kLat, kLon);
+  const double lat = 0.5 * (home.southLatitude() + home.northLatitude());
+  const double east = home.eastLongitude();
+  const double span = home.eastLongitude() - home.westLongitude();
+  // A box reaching a quarter-tile across the shared east edge.
+  const auto tiles =
+    tilesForBoundingBox(lat, east - 0.25 * span, lat, east + 0.25 * span, kLevel);
+  const gggs::GridIndex east_neighbor = kLevel.gridIndex(lat, east + 0.25 * span);
+  ASSERT_EQ(tiles.size(), 2u);
+  EXPECT_TRUE(contains(tiles, home));
+  EXPECT_TRUE(contains(tiles, east_neighbor));
+}
+
+TEST(TileEnumeration, BoxStraddlingCornerYieldsFourTiles)
+{
+  const gggs::GridIndex home = kLevel.gridIndex(kLat, kLon);
+  const double north = home.northLatitude();
+  const double east = home.eastLongitude();
+  const double lat_span = home.northLatitude() - home.southLatitude();
+  const double lon_span = home.eastLongitude() - home.westLongitude();
+  const auto tiles = tilesForBoundingBox(
+    north - 0.25 * lat_span, east - 0.25 * lon_span,
+    north + 0.25 * lat_span, east + 0.25 * lon_span, kLevel);
+  EXPECT_EQ(tiles.size(), 4u);
+  EXPECT_TRUE(contains(tiles, home));
+}
+
+TEST(TileEnumeration, MultiTileSwathCountMatchesSpan)
+{
+  const gggs::GridIndex home = kLevel.gridIndex(kLat, kLon);
+  const double lat = 0.5 * (home.southLatitude() + home.northLatitude());
+  const double west = home.westLongitude();
+  const double span = home.eastLongitude() - home.westLongitude();
+  // From inside the home tile eastward across two full neighbours -> 3 tiles
+  // in one row.
+  const auto tiles =
+    tilesForBoundingBox(lat, west + 0.5 * span, lat, west + 2.5 * span, kLevel);
+  EXPECT_EQ(tiles.size(), 3u);
+  EXPECT_TRUE(contains(tiles, home));
+}
+
+TEST(TileEnumeration, SwappedBoundsNormalize)
+{
+  const gggs::GridIndex home = kLevel.gridIndex(kLat, kLon);
+  const double lat = 0.5 * (home.southLatitude() + home.northLatitude());
+  const double lon = 0.5 * (home.westLongitude() + home.eastLongitude());
+  const auto tiles = tilesForBoundingBox(lat + 0.001, lon + 0.001, lat, lon, kLevel);
+  EXPECT_FALSE(tiles.empty());
+  EXPECT_TRUE(contains(tiles, home));
+}
+
+TEST(TileEnumeration, EveryReturnedTileTouchesTheBox)
+{
+  // The enumeration must not over-return: each tile's extent overlaps the box.
+  const double lat_min = kLat, lat_max = kLat + 0.02;
+  const double lon_min = kLon, lon_max = kLon + 0.02;
+  const auto tiles = tilesForBoundingBox(lat_min, lon_min, lat_max, lon_max, kLevel);
+  ASSERT_FALSE(tiles.empty());
+  for (const auto & t : tiles) {
+    EXPECT_LE(t.southLatitude(), lat_max);
+    EXPECT_GE(t.northLatitude(), lat_min);
+    EXPECT_LE(t.westLongitude(), lon_max);
+    EXPECT_GE(t.eastLongitude(), lon_min);
+  }
+}
+
+}  // namespace

--- a/marine_survey_index/test/test_tile_enumeration.cpp
+++ b/marine_survey_index/test/test_tile_enumeration.cpp
@@ -22,6 +22,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <stdexcept>
 
 #include "marine_survey_index/footprint.hpp"
 
@@ -122,6 +123,17 @@ TEST(TileEnumeration, EveryReturnedTileTouchesTheBox)
     EXPECT_LE(t.westLongitude(), lon_max);
     EXPECT_GE(t.eastLongitude(), lon_min);
   }
+}
+
+TEST(TileEnumeration, AntimeridianCrossingBoxThrows)
+{
+  // A crossing box must fail loud rather than enumerate the long way around
+  // (a near-whole-world tile set at fine levels).
+  EXPECT_THROW(tilesForBoundingBox(10.0, 179.9, 11.0, -179.9, kLevel), std::invalid_argument);
+  // Same crossing expressed without the wrap (lon > 180 gets normalized).
+  EXPECT_THROW(tilesForBoundingBox(10.0, 170.0, 11.0, 190.0, kLevel), std::invalid_argument);
+  // A legitimate box near (but not crossing) the antimeridian still works.
+  EXPECT_FALSE(tilesForBoundingBox(10.0, 179.0, 11.0, 179.9, kLevel).empty());
 }
 
 }  // namespace


### PR DESCRIPTION
Closes #259. Stage 1 of the survey-data-exploration umbrella (#258).

## What

New package **`marine_survey_index`**: an offline survey index + query CLI that answers *"given a location, which bags and time windows saw it?"* in seconds — the exact pain from the reported possible-target location on Massabesic, where the stores showed partial coverage but there was no way to find which bags to review.

- **`survey_index_bag`** — single interleaved chronological pass per bag (the bounded-TF-window pattern from cube#63 / the sidescan importer): georeferences every MBES `SonarDetections` and sidescan `RawSonarImage` ping, computes a conservative ground-footprint bounding box, and records per-GGGS-tile **pass intervals** in a SQLite sidecar (`survey_index.db`). Indexes from **ping geometry, not store acceptance** — pings CUBE rejected still index. Incremental: unchanged bags (size+mtime fingerprint) are skipped; changed bags re-index atomically (per-bag transaction with rollback on error).
- **`survey_index_query`** — `--point LAT LON [--radius M]` or `--box`, with `--sensor` / `--level` / `--json`; prints matching pass intervals grouped by bag, ordered by time.

## Key decisions (plan checkpoint, Roland 2026-07-13)

- **Default index level L14 (~54 m tiles), both sensors** — a target-inspection neighbourhood, deliberately finer than the stores' native tiling (bathy L10 ≈ 870 m, sidescan L13 ≈ 108 m); L14 keys roll up to store tiles via the GGGS parent hierarchy. `--mbes-level` / `--sidescan-level` / `--level` overrides.
- **`sensor_type` extends ADR-0005 D3**: `mbes-bathy` verbatim; sidescan channel-split as `sidescan-port` / `sidescan-stbd` (`--sensor sidescan` matches both).
- **Pass = maximal ping run per (tile, sensor, topic) with gaps ≤ merge gap** (default 5 s, `--merge-gap`) — per-pass identity is load-bearing for the explorer's single-pass sidescan display (stages 3/5).
- Schema is the **stable cross-stage contract** for #258 stages 2–5, documented in `docs/survey_index_schema.md`; regenerable sidecar (bags remain data of record), version-checked at open.

## Verification

- **22 unit tests, all green** (bag-I/O-free): DB-open contract, interval merge/split edge cases, footprint→tile enumeration (boundary straddling, no over-return), query tile-join (sensor filters, level separation, chunked-query ordering).
- **Real-bag end-to-end**: 2.5 GB Massabesic sonar bag (2026-07-01, 632k pings) indexes in **~12.6 s**; at L14 → 1481 pass intervals over 264 tiles; point/radius/box/sensor/json queries verified; incremental skip verified; index tile keys confirmed to match store GeoTIFF names at L10.
- Lint clean (uncrustify, cpplint); pre-commit hooks green on every commit.

## Review

Two pre-push `/review-code` rounds: round 1 (Deep) found 4 must-fix (silent partial index on sqlite failure, no per-bag error isolation, chunked-query ordering, unguarded `stoi`) — all fixed with per-finding commits; round 2 **approved, Ship: recommended, 0 must-fix**. Two non-blocking suggestions (jsonEscape control chars; query read-path sqlite return codes) fold into stage 2 work.

Plan: `.agent/work-plans/issue-259/plan.md` (kept in sync, including the L14 revision).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
