### PR TITLE
SonarInfo per-sensor acoustic metadata message (ADR-0009)

### DIFF
--- a/.agent/work-plans/issue-240/plan.md
+++ b/.agent/work-plans/issue-240/plan.md
@@ -29,11 +29,17 @@ immediate follow-up (separate issue in `marine_tools`).
    block**:
    - `float32[] pulse_lengths` — per TX sector (parallel to how `PingInfo` does
      beamwidths); single-sector sonars publish one element.
+   - `float32[] bandwidths` — required to recover the effective
+     (post-matched-filter) pulse length of FM pulses (review round-1 addition).
    - `uint8[] tx_signal_types` (CW / FM up / FM down) — determines whether
-     `pulse_lengths` is the physical or effective (post-matched-filter) length.
+     `pulse_lengths` is the physical or effective length.
    - Flagged as candidates for per-ping placement (`PingInfo`) if upstreamed.
    - Every enum gets `*_UNKNOWN = 0` so a default-constructed message is honest
-     (deviation from the strawman, which had e.g. `NONE = 0` for TVG).
+     (deviation from the strawman, which had e.g. `NONE = 0` for TVG); the
+     strawman's normalization bool became tri-state `angular_normalization`,
+     and NaN sentinels are a stated producer obligation (review round-1).
+   - Publish contract = latched + republish-on-change **+ slow heartbeat**
+     (≤ 10 s) so every rosbag2 split segment captures one (review round-1).
 2. **`CMakeLists.txt`** — add the message to `MSG_FILES`.
 3. **ADR-0009** — the interface decision: topic/QoS pattern (latched
    `transient_local`, republish-on-change), intrinsic-vs-per-ping split, the

--- a/.agent/work-plans/issue-240/plan.md
+++ b/.agent/work-plans/issue-240/plan.md
@@ -1,0 +1,57 @@
+# Plan: SonarInfo message prototype (CameraInfo analog for acoustic sensors)
+
+## Issue
+
+https://github.com/rolker/unh_marine_autonomy/issues/240
+
+## Context
+
+`marine_acoustic_msgs` deliberately left the semantics of intensity samples open
+(`SonarImageData.dtype` gives bit width, not meaning; upstream marine_msgs #18/#46
+are still open). Separately, the full radiometric GeoCoder backscatter correction
+(cube#81's deferred follow-up) needs the **transmit pulse length** to compute the
+ensonified area, and no existing message carries it — the M3's N/78 datagram
+reports signal length per TX sector, but `kongsberg_em_bridge` skips the field
+because there is nowhere to put it.
+
+`SonarInfo` addresses both: a per-sensor, latched, bag-recorded metadata message —
+the acoustic analog of `sensor_msgs/CameraInfo` — prototyped locally in
+`marine_interfaces` for eventual upstreaming to `marine_acoustic_msgs`.
+
+Field-collection driver: a survey opportunity is expected the week of 2026-07-20,
+so the wire format needs to land now; the `kongsberg_em_bridge` producer is the
+immediate follow-up (separate issue in `marine_tools`).
+
+## Approach
+
+1. **`msg/SonarInfo.msg`** in the existing `marine_interfaces` package (no new
+   package). Field set = the #240 strawman plus a new **acquisition-settings
+   block**:
+   - `float32[] pulse_lengths` — per TX sector (parallel to how `PingInfo` does
+     beamwidths); single-sector sonars publish one element.
+   - `uint8[] tx_signal_types` (CW / FM up / FM down) — determines whether
+     `pulse_lengths` is the physical or effective (post-matched-filter) length.
+   - Flagged as candidates for per-ping placement (`PingInfo`) if upstreamed.
+   - Every enum gets `*_UNKNOWN = 0` so a default-constructed message is honest
+     (deviation from the strawman, which had e.g. `NONE = 0` for TVG).
+2. **`CMakeLists.txt`** — add the message to `MSG_FILES`.
+3. **ADR-0009** — the interface decision: topic/QoS pattern (latched
+   `transient_local`, republish-on-change), intrinsic-vs-per-ping split, the
+   CameraInfo relationship, raw-vs-corrected framing (working decision:
+   as-published semantics + applied corrections; revisitable), upstream intent.
+   Cites the NIWA/BWSG report and marine_msgs #18/#46.
+4. Build + lint (`marine_interfaces` only), open PR (`Closes #240`), comment on
+   #240 documenting the acquisition-settings addition to the strawman.
+
+## Out of scope (follow-ups)
+
+- `kongsberg_em_bridge` publishing `SonarInfo` (new issue in `marine_tools`).
+- Adding the topic to the platform bag-record list (`unh_echoboats_project11`).
+- Consumers (CUBE reading the ARA curve from `SonarInfo`).
+- Upstreaming to `marine_acoustic_msgs`.
+
+## Verification
+
+- `marine_interfaces` builds (rosidl generation) in the issue-240 worktree.
+- Package lint tests pass (`test.sh marine_interfaces`).
+- `ros2 interface show marine_interfaces/msg/SonarInfo` renders the message.

--- a/.agent/work-plans/issue-240/progress.md
+++ b/.agent/work-plans/issue-240/progress.md
@@ -1,0 +1,31 @@
+---
+issue: 240
+---
+
+# Issue #240 — Prototype a SonarInfo message (CameraInfo analog for acoustic-sensor calibration / intensity semantics)
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-16 10:11 -0400
+**By**: Claude Code Agent (Claude Fable 5)
+**Verdict**: changes-requested (all findings addressed in `2c31317` same session)
+
+**Branch**: feature/issue-240 at `613656f` (fixes at `2c31317`)
+**Mode**: pre-push
+**Depth**: Deep (reason: new ADR in docs/decisions/ — Deep promotion trigger; 309 lines)
+**Must-fix**: 3 | **Suggestions**: 7
+**Round**: 1 | **Ship**: recommended — all must-fixes were doc/wire-format corrections, applied and re-verified (build + lint green) in the same session
+
+### Findings
+- [x] (must-fix) NaN/bool sentinels not honest under default construction, contradicting the ADR's `*_UNKNOWN=0` honesty rule — `marine_interfaces/msg/SonarInfo.msg` (Claude Adversarial / Lens A) → conventions block added; bool → tri-state `angular_normalization`; ADR rule rescoped
+- [x] (must-fix) latched transient_local + change-only republish loses SonarInfo on rosbag2 bag splits — `docs/decisions/0009-sonar-info-message.md` (Claude Adversarial / Lens B) → publish contract now change + slow heartbeat (≤10 s)
+- [x] (must-fix) `SourceRecord.calibration_ref` is a retired name; field moved to `StoreMetadata` (ADR-0005 #248 amendment) — msg + ADR (Governance + Lens B, cross-confirmed) → both citations fixed
+- [x] (suggestion) FM effective pulse length unrecoverable without bandwidth — `float32[] bandwidths` added (Lens B)
+- [x] (suggestion) `REFERENCE_DB_RE_1UPA` re-conflated scale into the reference axis — renamed `REFERENCE_ABSOLUTE_1UPA`, axes orthogonal (Lens A)
+- [x] (suggestion) empty `tx_signal_types` fallback + parallel-array length contract unstated — documented (Lens A + Lens B)
+- [x] (suggestion) four "absent" encodings without a stated convention; `offset` meaning when `scale==0` — conventions block + offset-ignored note (Lens A)
+- [x] (suggestion) future bag-migration (.bmr) debt of the local-then-upstream path unowned — ADR Consequences now owns it (Lens B)
+- [x] (suggestion) `.agents/README.md` message count stale (39 → 46) (Governance)
+- [x] (suggestion) `docs/interfaces.md` missing SonarInfo listing (ADR-0008 messages set precedent) — section added (Governance)
+
+Static analysis: no linter profile configured for these file types (`.msg`, CMake, `.md`) — content review only. Plan drift: none (diff matches plan; plan updated inline with review-round-1 changes per plan-sync rules).

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -13,7 +13,7 @@
 | `marine_autonomy` | C++/Python | Meta-package with launch files, geodesic utilities, and system configuration |
 | `marine_autonomy_integration_tests` | Python (CMake) | Cross-package integration tests for mission and navigation flows |
 | `marine_bathymetry_store` | C++ | Persistent multi-source bathymetric data store: GGGS-tiled, priority source layers, best-source / shallowest-reliable queries, per-tile GeoTIFF (ADR-0002 / #86) |
-| `marine_interfaces` | C++ (IDL) | ROS 2 message definitions for helm commands, heartbeats, navigation, perception contacts, and sensor data (39 msg types) |
+| `marine_interfaces` | C++ (IDL) | ROS 2 message definitions for helm commands, heartbeats, navigation, perception contacts, and sensor data (46 msg types) |
 | `marine_sidescan_mosaic` | C++ | Live georeferenced sidescan backscatter mosaicker: projects GCV port/stbd RawSonarImage samples to GGGS-tiled uint16 GeoTIFF tiles for CAMP / web display (#173 / #171 / #166) |
 | `marine_survey_index` | C++ | Offline survey indexer + query CLI: bags → per-GGGS-tile pass intervals in a regenerable SQLite sidecar; answers "which bags/time-ranges saw this location" (#258 stage 1 / #259; schema contract in `docs/survey_index_schema.md`) |
 | `marine_tiled_raster_store` | C++ | Generic GGGS-tiled raster store core: band/dtype-parametrized `TiledRasterTile<T>` + per-tile GeoTIFF persistence, shared by bathymetry and sidescan (#172) |
@@ -50,7 +50,7 @@ unh_marine_autonomy/
 ├── marine_autonomy_integration_tests/
 │   └── test/                   # Launch-based integration tests
 ├── marine_interfaces/
-│   ├── msg/                    # 39 message definitions
+│   ├── msg/                    # 46 message definitions
 │   └── bmr/                    # Bag migration rules
 ├── mission_manager/
 │   ├── mission_manager/

--- a/docs/decisions/0009-sonar-info-message.md
+++ b/docs/decisions/0009-sonar-info-message.md
@@ -1,0 +1,133 @@
+# ADR-0009: `SonarInfo` — Per-Sensor Acoustic Metadata Message
+
+## Status
+
+Proposed (2026-07-16). Tracked by
+[rolker/unh_marine_autonomy#240](https://github.com/rolker/unh_marine_autonomy/issues/240).
+
+Relates to **ADR-0006/0007** (backscatter stores — `calibration_ref` is the hook
+into their provenance records) and supersedes the CSV/parameter delivery of the
+angular-response curve from
+[cube_bathymetry#81](https://github.com/rolker/cube_bathymetry/issues/81)
+(the curve rides in the message instead, once producers/consumers exist).
+
+## Context
+
+Two long-standing gaps in `marine_acoustic_msgs`
+([apl-ocean-engineering/marine_msgs](https://github.com/apl-ocean-engineering/marine_msgs))
+motivate a companion per-sensor message:
+
+**1. Intensity semantics were deliberately left open.** `SonarImageData` carries
+`dtype` (UINT8…FLOAT64) plus raw bytes — bit width, but nothing about what a
+sample *represents*. `SonarDetections.intensities` is documented "usually
+uncalibrated and crude."
+[marine_msgs#18](https://github.com/apl-ocean-engineering/marine_msgs/issues/18)
+("rife with confusion": linear amplitude vs power vs raw ADC counts vs dB;
+relative vs absolute) and
+[marine_msgs#46](https://github.com/apl-ocean-engineering/marine_msgs/issues/46)
+(require normalized radar echoes?) are both still open. The in-message fixes
+proposed there (rename a field to `relative_intensity_dB`; mandate
+normalization) bake **one** representation into a **shared** message — wrong
+across sonars. Multibeam backscatter calibration is genuinely hard (see the
+NIWA/BWSG report,
+<https://niwa.co.nz/static/BWSG_REPORT_MAY2015_web.pdf>); the message layer
+should *declare* semantics per sensor, not legislate them globally.
+
+**2. Radiometric correction inputs have nowhere to live.** The full GeoCoder
+backscatter chain (Fonseca & Calder) needs the **ensonified area**, which
+depends on the **transmit pulse length** — deferred as a follow-up when
+cube#81 landed the empirical angular-response first cut. No
+`marine_acoustic_msgs` message carries pulse length: `PingInfo` has only
+`frequency`, `sound_speed`, and beamwidths. The Kongsberg M3's Raw Range &
+Angle (N/78) datagram reports signal length per transmit sector, and
+`kongsberg_em_bridge` walks straight past it (`em_datagrams.py` unpacks
+`tx_delay`/`centre_frequency` at sector offset +8, skipping `siglen` at +4)
+because there is nowhere to publish it. Surveys are therefore not collecting
+data we are already receiving.
+
+## Decision
+
+Add **`marine_interfaces/msg/SonarInfo`** — the acoustic analog of
+`sensor_msgs/CameraInfo`: per-sensor, slowly-changing metadata on a parallel
+topic, frame-aligned with the data stream and recorded in bags.
+
+### Topic / QoS pattern
+
+- Published on a sibling topic next to the data stream (e.g. `.../sonar_info`
+  beside `.../detections`), `header.frame_id` matching the stream.
+- **Latched**: `transient_local`, depth 1, so late joiners and bag recordings
+  always capture it.
+- **Republish on change**: any field change (e.g. an operator range-scale
+  change altering pulse length) emits a fresh message. Consumers associate a
+  ping with the most recent `SonarInfo` at or before its stamp.
+
+### Field set (see the message for authoritative comments)
+
+- **Identity / calibration hook**: `sonar_model`, `calibration_ref` (points at
+  e.g. `marine_mbes_backscatter_store` `SourceRecord.calibration_ref`,
+  ADR-0007), `calibration_time`.
+- **Acquisition settings** *(new relative to the #240 strawman)*:
+  `pulse_lengths` + `tx_signal_types` (CW / FM up / FM down), one element per
+  transmit sector — the GeoCoder ensonified-area inputs. Arrays mirror how
+  `PingInfo` handles per-sector/per-beam quantities.
+- **Intensity semantics**, decomposed into the three independent axes
+  marine_msgs#18 conflates: `intensity_quantity` (raw ADC / amplitude /
+  power), `intensity_scale` (linear / dB), `intensity_reference`
+  (uncalibrated-relative / dB re 1 µPa), plus a raw→physical `scale`/`offset`
+  map. `SonarImageData.dtype` (bytes) + `SonarInfo` (meaning) together are
+  unambiguous, with no field renames forced on the shared messages.
+- **Correction state**: `tvg_model` + `tvg_absorption_db_per_km`,
+  `source_level_db`, `backscatter_angle_normalized`, the empirical
+  angular-response curve (cube#81's ARA/AVG curve as data), and a beam-pattern
+  curve.
+
+### Design rules
+
+- **Complement, don't restate, `PingInfo`**: genuinely per-ping quantities
+  (frequency, sound speed, beamwidths) stay in `PingInfo`.
+- **Raw-plus-applied framing** *(working decision — revisit before
+  upstreaming)*: `SonarInfo` describes the stream **as published** — the
+  native semantics of the samples plus the corrections already applied — so a
+  consumer knows the current state and can undo or extend the chain. The
+  alternative (describing a corrected/target representation) was considered
+  and set aside for now.
+- **`*_UNKNOWN = 0` for every enum** (a deviation from the strawman, which had
+  `NONE = 0` for TVG): a default-constructed message makes no false claims —
+  "no TVG applied" is an assertion, "unknown" is the honest default.
+- **Blended correction model** (option b from #240): one empirical
+  angular-response curve carries the whole correction for now; a separate
+  "processing parameters" message may split out later.
+- **Pulse length placement**: per-ping placement (a `PingInfo` extension) is
+  arguably more correct since pulse length tracks operator settings; it lives
+  here for now because `marine_acoustic_msgs` is consumed as an installed
+  binary and cannot be extended locally, and latched republish-on-change
+  captures setting transitions in the bag. Flagged in the message as a
+  candidate to migrate when upstreaming (where
+  [marine_msgs#24](https://github.com/apl-ocean-engineering/marine_msgs/issues/24)
+  and
+  [marine_msgs#36](https://github.com/apl-ocean-engineering/marine_msgs/issues/36)
+  already propose `PingInfo` additions).
+
+### Home and upstream intent
+
+Prototyped in the existing `marine_interfaces` package (no new package — the
+endgame is upstreaming to `marine_acoustic_msgs`, so a dedicated local package
+would be throwaway). This ADR intentionally proves the wire format with **no
+producers or consumers** in the same change.
+
+## Consequences
+
+- **Producers** (follow-ups, separate issues): `kongsberg_em_bridge` parses the
+  N/78 `siglen` field and publishes `SonarInfo` (`marine_tools`);
+  `garmin_sidescan` later. The platform bag-record topic list gains the
+  `sonar_info` topics (`unh_echoboats_project11`).
+- **Consumers** (follow-up): the CUBE estimator reads the angular-response
+  curve from `SonarInfo` instead of the `--backscatter-curve` CSV, retiring
+  the cube#81 delivery mechanism.
+- Offline GeoCoder-style processing gains its missing ensonified-area input
+  from bags recorded on future surveys; past bags remain without pulse length.
+- Upstreaming will re-open the per-ping-vs-per-sensor split for the
+  acquisition block; the raw-vs-corrected framing decision must be finalized
+  before proposing there.
+- One more message in `marine_interfaces`'s already-broad surface; acceptable
+  given the explicit upstream exit path.

--- a/docs/decisions/0009-sonar-info-message.md
+++ b/docs/decisions/0009-sonar-info-message.md
@@ -55,29 +55,41 @@ topic, frame-aligned with the data stream and recorded in bags.
 
 - Published on a sibling topic next to the data stream (e.g. `.../sonar_info`
   beside `.../detections`), `header.frame_id` matching the stream.
-- **Latched**: `transient_local`, depth 1, so late joiners and bag recordings
-  always capture it.
-- **Republish on change**: any field change (e.g. an operator range-scale
-  change altering pulse length) emits a fresh message. Consumers associate a
-  ping with the most recent `SonarInfo` at or before its stamp.
+- **Latched**: `transient_local`, depth 1, so late joiners capture it.
+- **Republish on change AND on a slow heartbeat** (period ≤ 10 s recommended):
+  any field change (e.g. an operator range-scale change altering pulse
+  length) emits a fresh message immediately. The heartbeat exists because
+  latching alone does not survive **rosbag2 bag splitting** — the recorder
+  captures the latched value when the subscription is made but does not
+  re-persist it into later split segments, so a change-only publisher would
+  leave every segment after the first without any `SonarInfo`. At heartbeat
+  rates the bandwidth cost is negligible even with the curve arrays populated.
+  Consumers associate a ping with the most recent `SonarInfo` at or before
+  its stamp.
 
 ### Field set (see the message for authoritative comments)
 
 - **Identity / calibration hook**: `sonar_model`, `calibration_ref` (points at
-  e.g. `marine_mbes_backscatter_store` `SourceRecord.calibration_ref`,
-  ADR-0007), `calibration_time`.
+  e.g. `marine_mbes_backscatter_store` `StoreMetadata.calibration_ref` —
+  store-level per the ADR-0005 #248 amendment / ADR-0007 A.3),
+  `calibration_time`.
 - **Acquisition settings** *(new relative to the #240 strawman)*:
-  `pulse_lengths` + `tx_signal_types` (CW / FM up / FM down), one element per
-  transmit sector — the GeoCoder ensonified-area inputs. Arrays mirror how
+  `pulse_lengths` + `bandwidths` + `tx_signal_types` (CW / FM up / FM down),
+  one element per transmit sector — the GeoCoder ensonified-area inputs.
+  Bandwidth is required alongside pulse length because an FM pulse's
+  *effective* (post-matched-filter) length is ~1/bandwidth; without it the
+  ensonified area of a chirp is uncomputable from the bag. Arrays mirror how
   `PingInfo` handles per-sector/per-beam quantities.
 - **Intensity semantics**, decomposed into the three independent axes
   marine_msgs#18 conflates: `intensity_quantity` (raw ADC / amplitude /
   power), `intensity_scale` (linear / dB), `intensity_reference`
-  (uncalibrated-relative / dB re 1 µPa), plus a raw→physical `scale`/`offset`
-  map. `SonarImageData.dtype` (bytes) + `SonarInfo` (meaning) together are
-  unambiguous, with no field renames forced on the shared messages.
+  (relative vs absolute-re-1 µPa **only** — whether values are dB or linear
+  is carried entirely by `intensity_scale`, keeping the axes orthogonal),
+  plus a raw→physical `scale`/`offset` map. `SonarImageData.dtype` (bytes) +
+  `SonarInfo` (meaning) together are unambiguous, with no field renames
+  forced on the shared messages.
 - **Correction state**: `tvg_model` + `tvg_absorption_db_per_km`,
-  `source_level_db`, `backscatter_angle_normalized`, the empirical
+  `source_level_db`, `angular_normalization` (tri-state), the empirical
   angular-response curve (cube#81's ARA/AVG curve as data), and a beam-pattern
   curve.
 
@@ -91,9 +103,15 @@ topic, frame-aligned with the data stream and recorded in bags.
   consumer knows the current state and can undo or extend the chain. The
   alternative (describing a corrected/target representation) was considered
   and set aside for now.
-- **`*_UNKNOWN = 0` for every enum** (a deviation from the strawman, which had
-  `NONE = 0` for TVG): a default-constructed message makes no false claims —
-  "no TVG applied" is an assertion, "unknown" is the honest default.
+- **Honest defaults, scoped by type.** Every enum has `*_UNKNOWN = 0` (a
+  deviation from the strawman, which had `NONE = 0` for TVG), and the
+  strawman's `backscatter_angle_normalized` bool became the tri-state
+  `angular_normalization` — for these fields a default-constructed message
+  makes no false claims ("not applied" is an assertion; "unknown" is the
+  honest default). Float fields cannot get the same guarantee: rosidl
+  defaults them to 0.0, a plausible physical value, so the NaN-if-unknown
+  sentinels are a **producer obligation** (set NaN explicitly), stated in the
+  message's conventions block rather than relied on from defaults.
 - **Blended correction model** (option b from #240): one empirical
   angular-response curve carries the whole correction for now; a separate
   "processing parameters" message may split out later.
@@ -129,5 +147,11 @@ producers or consumers** in the same change.
 - Upstreaming will re-open the per-ping-vs-per-sensor split for the
   acquisition block; the raw-vs-corrected framing decision must be finalized
   before proposing there.
+- **Bag-migration debt is accepted**: bags recorded in the interim carry the
+  `marine_interfaces/msg/SonarInfo` type name. When the message upstreams
+  (and/or `pulse_lengths` migrates into `PingInfo`), a
+  `marine_interfaces/bmr/` `MessageUpdateRule` must be added so those bags —
+  the data of record — remain replayable. The package already carries
+  `bmr/from_marine_msgs.bmr` as precedent.
 - One more message in `marine_interfaces`'s already-broad surface; acceptable
   given the explicit upstream exit path.

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -240,6 +240,24 @@ prune-on-absence). See [ADR-0008](decisions/0008-live-sonar-coverage-transport-a
 - `std_msgs/Header header`
 - `TileIndex[] tiles`: consumer's missing/stale "need" list
 
+### Per-sensor acoustic metadata (ADR-0009)
+
+The acoustic analog of `sensor_msgs/CameraInfo`: latched (`transient_local`)
+per-sensor metadata published beside a sonar data stream and recorded in bags,
+so offline processing has the acquisition settings (pulse length, bandwidth,
+signal type — the GeoCoder ensonified-area inputs), intensity semantics, and
+correction state. No producer yet (format-proving prototype; `kongsberg_em_bridge`
+is the planned first producer). See
+[ADR-0009](decisions/0009-sonar-info-message.md).
+
+#### `marine_interfaces/SonarInfo`
+- `std_msgs/Header header`: `frame_id` = sensor frame of the data stream
+- `string sonar_model`, `string calibration_ref`, `builtin_interfaces/Time calibration_time`: identity + calibration hook
+- `float32[] pulse_lengths`, `float32[] bandwidths`, `uint8[] tx_signal_types`: acquisition settings, one element per TX sector
+- `uint8 intensity_quantity` / `intensity_scale` / `intensity_reference`, `float32 scale`/`offset`: what the intensity samples mean (three orthogonal axes)
+- `uint8 tvg_model`, `float32 tvg_absorption_db_per_km`, `float32 source_level_db`, `uint8 angular_normalization`: applied-correction state
+- `float32[] angular_response_*`, `float32[] beam_pattern_*`: empirical correction curves as data
+
 ## Related Documentation
 - [Sonar Data Ecosystem](sonar_ecosystem.md) - Big-picture map of sonar data flow + umbrella/ADR tracker
 - [Data Flows](data_flows.md) - System-level data flow diagrams

--- a/marine_interfaces/CMakeLists.txt
+++ b/marine_interfaces/CMakeLists.txt
@@ -45,6 +45,8 @@ set(MSG_FILES
   msg/Platform.msg
   msg/PlatformList.msg
   msg/RangeBearing.msg
+  # Per-sensor acoustic metadata — CameraInfo analog (ADR-0009, #240)
+  msg/SonarInfo.msg
   msg/SoundSpeed.msg
   # Formerly project11_nav_msgs
   msg/BoundingBox.msg

--- a/marine_interfaces/msg/SonarInfo.msg
+++ b/marine_interfaces/msg/SonarInfo.msg
@@ -3,9 +3,15 @@
 # Published on a parallel latched (transient_local, depth 1) topic alongside a
 # sonar data stream (marine_acoustic_msgs RawSonarImage / SonarDetections /
 # ProjectedSonarImage), with header.frame_id matching that stream, and recorded
-# in bags so offline processing has the sensor metadata too. Publishers MUST
-# re-publish whenever any field changes (e.g. an operator range-scale change
-# altering the pulse length).
+# in bags so offline processing has the sensor metadata too.
+#
+# Publish contract: publishers MUST re-publish whenever any field changes
+# (e.g. an operator range-scale change altering the pulse length) AND at a
+# slow heartbeat (period <= 10 s recommended). The heartbeat is load-bearing:
+# rosbag2 does not re-persist a latched message into new segments when a
+# recording splits, so change-only publishing would leave later segments with
+# no SonarInfo at all. Consumers associate a ping with the most recent
+# SonarInfo at or before its stamp.
 #
 # SonarInfo complements marine_acoustic_msgs/PingInfo — it does not restate it.
 # Genuinely per-ping quantities (frequency, sound_speed, beamwidths) stay in
@@ -16,6 +22,14 @@
 # intensity samples plus the corrections already applied to them, so a consumer
 # knows the current state and can undo or extend the correction chain.
 #
+# Conventions for absent / unknown values:
+# - Enum fields: *_UNKNOWN = 0, so a default-constructed message is honest.
+# - Float fields marked "NaN if unknown": producers MUST set NaN explicitly —
+#   the rosidl default (0.0) is a plausible physical value, not a sentinel.
+# - Arrays: empty = not reported. Parallel arrays MUST be equal length when
+#   both are non-empty; consumers MUST verify before parallel indexing.
+# - calibration_ref/calibration_time: empty string / zero time = uncalibrated.
+#
 # Local prototype for eventual upstreaming to marine_acoustic_msgs
 # (apl-ocean-engineering/marine_msgs). See ADR-0009.
 
@@ -24,8 +38,7 @@ std_msgs/Header header             # frame_id = sensor frame of the data stream
 string sonar_model                 # e.g. "kongsberg-m3"
 
 # Cross-reference to an external calibration record (e.g.
-# marine_mbes_backscatter_store SourceRecord.calibration_ref).
-# Empty / zero time if uncalibrated.
+# marine_mbes_backscatter_store StoreMetadata.calibration_ref).
 string calibration_ref
 builtin_interfaces/Time calibration_time
 
@@ -40,16 +53,23 @@ builtin_interfaces/Time calibration_time
 # (PingInfo) when upstreamed.
 # ---------------------------------------------------------------------------
 
-# Transmit pulse (signal) length in seconds. For FM pulses this is the
-# transmitted sweep length; the effective length after matched filtering is
-# shorter (~1/bandwidth) — tx_signal_types tells consumers which case applies.
+# Transmit pulse (signal) length in seconds. For CW this is the effective
+# pulse length; for FM it is the transmitted sweep length, and the effective
+# length after matched filtering is ~1/bandwidth — consumers need
+# tx_signal_types and bandwidths to tell the cases apart.
 float32[] pulse_lengths
+
+# Transmit bandwidth in Hz. Parallel to pulse_lengths. For FM pulses this is
+# required to recover the effective (post-matched-filter) pulse length; for CW
+# it is informative. Empty if not reported.
+float32[] bandwidths
 
 uint8 SIGNAL_TYPE_UNKNOWN = 0
 uint8 SIGNAL_TYPE_CW = 1
 uint8 SIGNAL_TYPE_FM_UP = 2
 uint8 SIGNAL_TYPE_FM_DOWN = 3
-# Parallel to pulse_lengths. Empty if not reported.
+# Parallel to pulse_lengths. Empty if not reported — consumers MUST then treat
+# every pulse as SIGNAL_TYPE_UNKNOWN (no CW assumption).
 uint8[] tx_signal_types
 
 # ---------------------------------------------------------------------------
@@ -72,13 +92,16 @@ uint8 INTENSITY_SCALE_LINEAR = 1
 uint8 INTENSITY_SCALE_DB = 2
 uint8 intensity_scale
 
+# Relative vs absolute only — whether the values are dB or linear is carried
+# entirely by intensity_scale, keeping the axes orthogonal.
 uint8 REFERENCE_UNKNOWN = 0
 uint8 REFERENCE_UNCALIBRATED_RELATIVE = 1
-uint8 REFERENCE_DB_RE_1UPA = 2     # absolute, dB re 1 micropascal
+uint8 REFERENCE_ABSOLUTE_1UPA = 2  # absolute, referenced to 1 micropascal
 uint8 intensity_reference
 
 # Linear map from a raw sample value to the quantity/scale/reference above:
-# physical = raw * scale + offset. scale = 0 means no mapping provided.
+# physical = raw * scale + offset. scale = 0 means no mapping provided and
+# offset is then meaningless (consumers ignore it).
 float32 scale
 float32 offset
 
@@ -95,14 +118,20 @@ uint8 TVG_40LOGR = 3
 uint8 TVG_CUSTOM = 4
 uint8 tvg_model
 
-# Absorption coefficient used by the applied TVG. NaN if unknown / no TVG.
+# Absorption coefficient used by the applied TVG. NaN if unknown / no TVG
+# (producers MUST set NaN explicitly; see conventions above).
 float32 tvg_absorption_db_per_km
 
-# Transmit source level. NaN if relative / uncalibrated.
+# Transmit source level. NaN if relative / uncalibrated (producers MUST set
+# NaN explicitly; see conventions above).
 float32 source_level_db
 
-# True if an angular-response normalization has been applied to the stream.
-bool backscatter_angle_normalized
+# Whether an angular-response normalization has been applied to the stream.
+# Tri-state so a default-constructed message claims nothing.
+uint8 ANGULAR_NORMALIZATION_UNKNOWN = 0
+uint8 ANGULAR_NORMALIZATION_NOT_APPLIED = 1
+uint8 ANGULAR_NORMALIZATION_APPLIED = 2
+uint8 angular_normalization
 
 # Empirical mean angular-response curve for this sonar (ARA/AVG, e.g. the
 # cube_bathymetry#81 M3 curve): |angle from nadir| bin centres in degrees,

--- a/marine_interfaces/msg/SonarInfo.msg
+++ b/marine_interfaces/msg/SonarInfo.msg
@@ -1,0 +1,117 @@
+# Per-sensor acoustic metadata: the acoustic analog of sensor_msgs/CameraInfo.
+#
+# Published on a parallel latched (transient_local, depth 1) topic alongside a
+# sonar data stream (marine_acoustic_msgs RawSonarImage / SonarDetections /
+# ProjectedSonarImage), with header.frame_id matching that stream, and recorded
+# in bags so offline processing has the sensor metadata too. Publishers MUST
+# re-publish whenever any field changes (e.g. an operator range-scale change
+# altering the pulse length).
+#
+# SonarInfo complements marine_acoustic_msgs/PingInfo — it does not restate it.
+# Genuinely per-ping quantities (frequency, sound_speed, beamwidths) stay in
+# PingInfo; this message carries what PingInfo lacks: acquisition settings,
+# intensity semantics, and the correction state of the stream.
+#
+# This message describes the stream AS PUBLISHED: the native semantics of the
+# intensity samples plus the corrections already applied to them, so a consumer
+# knows the current state and can undo or extend the correction chain.
+#
+# Local prototype for eventual upstreaming to marine_acoustic_msgs
+# (apl-ocean-engineering/marine_msgs). See ADR-0009.
+
+std_msgs/Header header             # frame_id = sensor frame of the data stream
+
+string sonar_model                 # e.g. "kongsberg-m3"
+
+# Cross-reference to an external calibration record (e.g.
+# marine_mbes_backscatter_store SourceRecord.calibration_ref).
+# Empty / zero time if uncalibrated.
+string calibration_ref
+builtin_interfaces/Time calibration_time
+
+# ---------------------------------------------------------------------------
+# Acquisition settings
+#
+# Sonar settings required for radiometric correction (GeoCoder-style
+# ensonified-area computation) that PingInfo does not carry. One element per
+# transmit sector, in sector order; single-sector sonars publish one element.
+# Empty if the sonar does not report them. These change with operator settings
+# (range scale / mode) — republish on change. Candidates for per-ping placement
+# (PingInfo) when upstreamed.
+# ---------------------------------------------------------------------------
+
+# Transmit pulse (signal) length in seconds. For FM pulses this is the
+# transmitted sweep length; the effective length after matched filtering is
+# shorter (~1/bandwidth) — tx_signal_types tells consumers which case applies.
+float32[] pulse_lengths
+
+uint8 SIGNAL_TYPE_UNKNOWN = 0
+uint8 SIGNAL_TYPE_CW = 1
+uint8 SIGNAL_TYPE_FM_UP = 2
+uint8 SIGNAL_TYPE_FM_DOWN = 3
+# Parallel to pulse_lengths. Empty if not reported.
+uint8[] tx_signal_types
+
+# ---------------------------------------------------------------------------
+# Intensity semantics
+#
+# What the per-sample intensity values REPRESENT — the ambiguity
+# marine_acoustic_msgs left open (apl-ocean-engineering/marine_msgs#18, #46) —
+# decomposed into three independent axes. SonarImageData.dtype gives the bit
+# width; these fields give the meaning.
+# ---------------------------------------------------------------------------
+
+uint8 QUANTITY_UNKNOWN = 0
+uint8 QUANTITY_RAW_ADC = 1         # raw converter counts
+uint8 QUANTITY_AMPLITUDE = 2       # linear amplitude / magnitude (~pressure)
+uint8 QUANTITY_POWER = 3           # power / intensity (~pressure squared)
+uint8 intensity_quantity
+
+uint8 INTENSITY_SCALE_UNKNOWN = 0
+uint8 INTENSITY_SCALE_LINEAR = 1
+uint8 INTENSITY_SCALE_DB = 2
+uint8 intensity_scale
+
+uint8 REFERENCE_UNKNOWN = 0
+uint8 REFERENCE_UNCALIBRATED_RELATIVE = 1
+uint8 REFERENCE_DB_RE_1UPA = 2     # absolute, dB re 1 micropascal
+uint8 intensity_reference
+
+# Linear map from a raw sample value to the quantity/scale/reference above:
+# physical = raw * scale + offset. scale = 0 means no mapping provided.
+float32 scale
+float32 offset
+
+# ---------------------------------------------------------------------------
+# Correction state
+#
+# Corrections already applied to (or available for) the published stream.
+# ---------------------------------------------------------------------------
+
+uint8 TVG_UNKNOWN = 0
+uint8 TVG_NONE = 1                 # no time-varying gain applied
+uint8 TVG_20LOGR = 2
+uint8 TVG_40LOGR = 3
+uint8 TVG_CUSTOM = 4
+uint8 tvg_model
+
+# Absorption coefficient used by the applied TVG. NaN if unknown / no TVG.
+float32 tvg_absorption_db_per_km
+
+# Transmit source level. NaN if relative / uncalibrated.
+float32 source_level_db
+
+# True if an angular-response normalization has been applied to the stream.
+bool backscatter_angle_normalized
+
+# Empirical mean angular-response curve for this sonar (ARA/AVG, e.g. the
+# cube_bathymetry#81 M3 curve): |angle from nadir| bin centres in degrees,
+# ascending, with mean backscatter level relative to nadir. Parallel arrays;
+# empty if unavailable.
+float32[] angular_response_angle_deg
+float32[] angular_response_db_rel_nadir
+
+# Combined transmit/receive beam-pattern gain vs angle. Parallel arrays;
+# empty if unavailable.
+float32[] beam_pattern_angle_deg
+float32[] beam_pattern_gain_db


### PR DESCRIPTION
## Summary

Prototype `SonarInfo` — the acoustic analog of `sensor_msgs/CameraInfo`: latched (`transient_local`) per-sensor metadata published beside a sonar data stream and recorded in bags. Adds `msg/SonarInfo.msg` to the existing `marine_interfaces` package plus ADR-0009. Format-proving only — no producers or consumers in this change.

Closes #240

## What it carries

- **Acquisition settings** (new relative to the issue strawman): `pulse_lengths`, `bandwidths`, `tx_signal_types` per TX sector — the GeoCoder ensonified-area inputs no existing message collects. The M3's N/78 datagram already reports signal length; `kongsberg_em_bridge` currently skips it because there is nowhere to publish it (producer = follow-up issue in `marine_tools`).
- **Intensity semantics** as three orthogonal axes (quantity / scale / reference) — the marine_msgs#18 ambiguity, declared per sensor instead of legislated in the shared messages.
- **Correction state**: TVG model/absorption, source level, tri-state angular-normalization, and the cube#81 ARA curve as data.

## Design notes

- Publish contract = republish-on-change **+ slow heartbeat (≤10 s)**: latching alone does not survive rosbag2 bag splits, and bags are the data of record.
- `*_UNKNOWN = 0` for every enum; NaN sentinels are a stated producer obligation (rosidl float defaults are plausible values, not sentinels).
- ADR-0009 records the CameraInfo relationship, the PingInfo complement rule, the raw-plus-applied framing (working decision), the upstream-to-`marine_acoustic_msgs` intent, and the accepted future `.bmr` migration debt.

## Verification

- `marine_interfaces` builds (rosidl) in the issue-240 worktree; 5/5 lint tests pass; `ros2 interface show` renders.
- Deep-tier pre-push review (round 1) ran: 3 must-fix + 7 suggestions, all addressed in `2c31317` — see `.agent/work-plans/issue-240/progress.md`.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
