### PR TITLE
feat(survey_index): decimated nav track table for the explorer map (#265)

### DIFF
--- a/.agent/work-plans/issue-265/plan.md
+++ b/.agent/work-plans/issue-265/plan.md
@@ -1,0 +1,133 @@
+# Plan: survey_index: decimated nav track table for the explorer map (schema bump)
+
+## Issue
+
+https://github.com/rolker/unh_marine_autonomy/issues/265
+
+## Context
+
+The survey index (`survey_index.db`, schema v1) records where each sonar looked
+via the `passes` table. The explorer map (issue #258, stages 3–5) also needs a
+lightweight nav track — a decimated sequence of vehicle positions per bag — to
+render coverage overviews without replaying full bags.
+
+The `survey_index_bag` indexer already resolves `earth`→sensor TF transforms for
+every ping. It can accumulate nav positions from the same TF buffer at negligible
+extra cost. The new `nav_track` table stores those positions pre-decimated; the
+map pane queries them by bag id or bounding box.
+
+This is a schema v1 → v2 bump. There are no migrations: the index is a regenerable
+sidecar; a v1 DB opened by a v2 tool fails with the existing "re-run the indexer"
+error already tested in `test_schema.cpp`.
+
+**Decimation strategy decision (was TBD in issue body):** **distance-based**, one
+point per ≥ N meters (default 10 m, configurable via `--nav-stride-m`). Rationale:
+visual density on the map should be uniform in space, not time; a stationary ship
+produces no extra points; the math is a single Haversine call per candidate point.
+Time-based would bunch up during station-keeping and under-sample high-speed runs.
+Hybrid adds complexity without a clear gain.
+
+**Accessor contract for #258 stages 3/5:**
+- `queryNavTrack(db, bag_id) → vector<NavPoint>` — full ordered track for one bag
+- `queryNavTrackInBox(db, lat_min, lon_min, lat_max, lon_max) → vector<NavPoint>` — all points inside a geographic bounding box (for map overview)
+
+## Approach
+
+1. **Bump schema version and add DDL** — increment `kSchemaVersion` to 2 in
+   `schema.hpp`; add `nav_track` DDL in `schema.cpp` (see table below). The
+   `openIndexDb` version gate already handles the mismatch error path.
+
+2. **Add `NavPoint` struct and accessor declarations** — add to `query.hpp`:
+   `NavPoint {bag_id, t_ns, latitude, longitude}`, `queryNavTrack(db, bag_id)`,
+   `queryNavTrackInBox(db, lat_min, lon_min, lat_max, lon_max)`.
+
+3. **Implement accessors** — add to `query.cpp`: two simple `SELECT` queries with
+   `ORDER BY t_ns`. The box query uses `latitude BETWEEN ? AND ?` and `longitude
+   BETWEEN ? AND ?` (the spatial index on `nav_track` makes this fast enough;
+   the explorer map queries one viewport at a time).
+
+4. **Collect nav positions in the indexer** — in `survey_index_bag_main.cpp`,
+   after each successful `flush_front()` call that yields a valid earth pose,
+   compare the new lat/lon to `last_accepted_pos`; if the Haversine distance is
+   ≥ `--nav-stride-m` (default 10 m) OR no position has been accepted yet, push
+   `{t_ns, lat, lon}` into a per-bag `nav_points` vector. One helper function
+   `haversineMeters(lat1, lon1, lat2, lon2) → double` (degrees in, metres out).
+
+5. **Persist nav points** — in the same per-bag `BEGIN … COMMIT` block, after
+   flushing passes, INSERT all `nav_points` into `nav_track` bound to the bag id.
+
+6. **Tests** — three test targets, no bag I/O:
+   - `test_schema.cpp`: update table-count assertion (3 → 4), add `nav_track`
+     column-count check.
+   - `test_nav_decimation.cpp`: unit-test `haversineMeters` (known pairs), and
+     the distance-gate logic (points < stride → skipped; ≥ stride → kept; first
+     point always kept).
+   - `test_query_join.cpp`: add nav_track accessor tests — insert known `nav_track`
+     rows into an in-memory DB, assert `queryNavTrack(bag_id)` and
+     `queryNavTrackInBox(box)` return the right subsets.
+
+7. **Update `docs/survey_index_schema.md`** — add schema v2 section with the
+   `nav_track` DDL, column semantics, decimation note, and accessor contract.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `include/marine_survey_index/schema.hpp` | Bump `kSchemaVersion` to 2; add `NavPoint` struct |
+| `src/schema.cpp` | Add `nav_track` DDL to `kSchemaDdl`; add spatial index |
+| `include/marine_survey_index/query.hpp` | Declare `queryNavTrack`, `queryNavTrackInBox` |
+| `src/query.cpp` | Implement both nav_track accessor functions |
+| `src/survey_index_bag_main.cpp` | Add `haversineMeters`, per-bag nav collection and INSERT |
+| `test/test_schema.cpp` | Update table-count assert 3→4; add nav_track check |
+| `test/test_nav_decimation.cpp` | New: test `haversineMeters` and distance-gate logic |
+| `test/test_query_join.cpp` | Add nav_track accessor tests |
+| `CMakeLists.txt` | Register `test_nav_decimation` target |
+| `docs/survey_index_schema.md` | Document schema v2: `nav_track` table and accessor contract |
+
+## Schema Addition (v2)
+
+```sql
+CREATE TABLE IF NOT EXISTS nav_track (
+  id         INTEGER PRIMARY KEY,
+  bag_id     INTEGER NOT NULL REFERENCES bags(id) ON DELETE CASCADE,
+  t_ns       INTEGER NOT NULL,   -- UNIX nanoseconds (earth-frame TF stamp)
+  latitude   REAL    NOT NULL,   -- WGS-84 degrees
+  longitude  REAL    NOT NULL    -- WGS-84 degrees
+);
+CREATE INDEX IF NOT EXISTS nav_track_bag  ON nav_track(bag_id, t_ns);
+CREATE INDEX IF NOT EXISTS nav_track_geo  ON nav_track(latitude, longitude);
+```
+
+`NavPoint` struct mirrors these columns plus `bag_id` for the box-query path.
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Modularity and Decoupling | Nav accessors added to `query.hpp/cpp`; indexer logic is self-contained. No new package deps. |
+| Iterative, Validated Evolution | Schema v2 is additive (new table only); v1 DBs fail loud, not silently corrupt. |
+| Standards Compliance | REP-105 (earth frame), WGS-84 lat/lon. Distance calc uses Haversine (standard). |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0005 (provenance registry / sensor_class) | No — nav track is not a sensor class, it is a vehicle position record. | N/A |
+| ADR-0008 (license / copyright headers) | Yes — new source files need MIT + UNH-CCOM header | All new `.cpp/.hpp` files include the standard header |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `kSchemaVersion` 1→2 | All existing `survey_index.db` files must be regenerated | Yes — documented in schema.md; the error message already says "re-run the indexer" |
+| `nav_track` table DDL | `docs/survey_index_schema.md` | Yes — step 7 |
+| `queryNavTrack` / `queryNavTrackInBox` API | `marine_perception_tools` (#258 stage 3/5) consumers | Noted — API is stable in this PR; #258 builds against it |
+
+## Open Questions
+
+- [ ] No open questions — plan is review-plan-ready.
+  (Decimation strategy pinned to distance-based 10 m default; accessor API defined above.)
+
+## Estimated Scope
+
+Single PR.

--- a/.agent/work-plans/issue-265/plan.md
+++ b/.agent/work-plans/issue-265/plan.md
@@ -29,7 +29,14 @@ Hybrid adds complexity without a clear gain.
 
 **Accessor contract for #258 stages 3/5:**
 - `queryNavTrack(db, bag_id) → vector<NavPoint>` — full ordered track for one bag
-- `queryNavTrackInBox(db, lat_min, lon_min, lat_max, lon_max) → vector<NavPoint>` — all points inside a geographic bounding box (for map overview)
+- `queryNavTrackInBox(db, lat_min, lon_min, lat_max, lon_max) → vector<NavPoint>` — all points inside a geographic bounding box (for map overview). Antimeridian-crossing boxes (`lon_min > lon_max`) throw, matching the existing fail-loud guard in the pass box query — full split support stays deferred, consistently.
+
+**Point provenance (review-plan finding):** track points derive from each ping's
+*sensor ground origin* (`groundOrigin(gb)`), interleaved across up to three sensor
+topics (mbes/port/stbd) in one bag, then distance-decimated across that mixed
+stream. They are *not* samples of a single vehicle frame (base_link); at a 10 m
+stride the sensor-offset differences are negligible for map rendering, but the
+schema doc must state the provenance rather than imply a vehicle-frame track.
 
 ## Approach
 
@@ -52,6 +59,8 @@ Hybrid adds complexity without a clear gain.
    ≥ `--nav-stride-m` (default 10 m) OR no position has been accepted yet, push
    `{t_ns, lat, lon}` into a per-bag `nav_points` vector. One helper function
    `haversineMeters(lat1, lon1, lat2, lon2) → double` (degrees in, metres out).
+   Validate `--nav-stride-m` (> 0, finite) in `main()`, mirroring the existing
+   `--merge-gap` guard.
 
 5. **Persist nav points** — in the same per-bag `BEGIN … COMMIT` block, after
    flushing passes, INSERT all `nav_points` into `nav_track` bound to the bag id.
@@ -73,9 +82,9 @@ Hybrid adds complexity without a clear gain.
 
 | File | Change |
 |------|--------|
-| `include/marine_survey_index/schema.hpp` | Bump `kSchemaVersion` to 2; add `NavPoint` struct |
+| `include/marine_survey_index/schema.hpp` | Bump `kSchemaVersion` to 2 |
 | `src/schema.cpp` | Add `nav_track` DDL to `kSchemaDdl`; add spatial index |
-| `include/marine_survey_index/query.hpp` | Declare `queryNavTrack`, `queryNavTrackInBox` |
+| `include/marine_survey_index/query.hpp` | Add `NavPoint` struct (next to sibling `PassRow`); declare `queryNavTrack`, `queryNavTrackInBox` |
 | `src/query.cpp` | Implement both nav_track accessor functions |
 | `src/survey_index_bag_main.cpp` | Add `haversineMeters`, per-bag nav collection and INSERT |
 | `test/test_schema.cpp` | Update table-count assert 3→4; add nav_track check |
@@ -113,7 +122,7 @@ CREATE INDEX IF NOT EXISTS nav_track_geo  ON nav_track(latitude, longitude);
 | ADR | Triggered | How addressed |
 |---|---|---|
 | ADR-0005 (provenance registry / sensor_class) | No — nav track is not a sensor class, it is a vehicle position record. | N/A |
-| ADR-0008 (license / copyright headers) | Yes — new source files need MIT + UNH-CCOM header | All new `.cpp/.hpp` files include the standard header |
+| License/copyright header convention (workspace-wide; not this repo's ADR-0008, which is *Live Sonar Coverage Transport & Render* and is untriggered) | Yes — new source files need MIT + UNH-CCOM header | All new `.cpp/.hpp` files include the standard header |
 
 ## Consequences
 

--- a/.agent/work-plans/issue-265/progress.md
+++ b/.agent/work-plans/issue-265/progress.md
@@ -121,3 +121,16 @@ CI: build green (10m). Copilot: 1 finding.
   overstated — SQLite BETWEEN handles wide bounds — but the consistency gap
   was real. Clamp added + OutOfRangeLatitudesAreClamped test. 112 tests,
   0 failures.
+
+## Integrated Review (PR #267, round 2)
+**Status**: complete
+**When**: 2026-07-16 (post-publish)
+**By**: Claude Code Agent (Claude Fable 5)
+
+CI: green on the round-1 fix (8m24s). Copilot round 2: one finding in two
+parts (same root).
+- [x] (valid, minor) NavDecimator is an installed public header but its ctor
+  accepted stride <= 0 / NaN silently (gate defeated outside the validating
+  CLI path). Ctor now throws std::invalid_argument for non-finite or
+  non-positive stride, <stdexcept> included, InvalidStrideThrows test added
+  (0, -1, NaN, +inf). 113 tests, 0 failures.

--- a/.agent/work-plans/issue-265/progress.md
+++ b/.agent/work-plans/issue-265/progress.md
@@ -108,3 +108,16 @@ rejects non-finite input without touching its reference (+ test covering
 leading and mid-stream NaN); nav_points stable-sorted by t_ns before insert
 and the stream-order gating caveat documented in the schema doc ("density
 target, not a per-pair guarantee"). 111 tests, 0 failures.
+
+## Integrated Review (PR #267, round 1)
+**Status**: complete
+**When**: 2026-07-16 (post-publish)
+**By**: Claude Code Agent (Claude Fable 5)
+
+CI: build green (10m). Copilot: 1 finding.
+- [x] (valid, minor) queryNavTrackInBox lacked the [-90, 90] latitude clamp
+  that tilesForBoundingBox applies, despite the doc claiming mirrored
+  semantics. Copilot's failure scenario ("can return an empty set") is
+  overstated — SQLite BETWEEN handles wide bounds — but the consistency gap
+  was real. Clamp added + OutOfRangeLatitudesAreClamped test. 112 tests,
+  0 failures.

--- a/.agent/work-plans/issue-265/progress.md
+++ b/.agent/work-plans/issue-265/progress.md
@@ -86,3 +86,19 @@ issue: 265
   pose/TF pathology in that bag (likely dual nav-source conflict; the same
   poses already smear its stage-1 pass footprints). The track overlay will make
   this visible in the explorer; deliberately no speed-heuristic filtering.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-16 14:57 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-265 at `ef12a4d`
+**Mode**: pre-push
+**Depth**: Deep (reason: 200+ changed lines, 12 files, schema-version change)
+**Must-fix**: 0 | **Suggestions**: 2
+**Round**: 1 | **Ship**: recommended — no must-fix findings; static clean, both adversarial lenses concur the change is sound
+
+### Findings
+- [ ] (suggestion) Non-finite ground origin poisons the decimator — `gb.valid` checks only quaternion norm, so a NaN lat/lon is accepted and defeats decimation for the rest of the bag; gate on `std::isfinite` before `accept()` — `src/survey_index_bag_main.cpp:480`
+- [ ] (suggestion) Decimation runs in read/FIFO order but accessors return `ORDER BY t_ns`; the ≥stride invariant may not survive the re-sort — sort `nav_points` by `t_ns` before insert if #258 needs it — `src/survey_index_bag_main.cpp:481`

--- a/.agent/work-plans/issue-265/progress.md
+++ b/.agent/work-plans/issue-265/progress.md
@@ -134,3 +134,16 @@ parts (same root).
   CLI path). Ctor now throws std::invalid_argument for non-finite or
   non-positive stride, <stdexcept> included, InvalidStrideThrows test added
   (0, -1, NaN, +inf). 113 tests, 0 failures.
+
+## Integrated Review (PR #267, round 3)
+**Status**: complete
+**When**: 2026-07-16 (post-publish)
+**By**: Claude Code Agent (Claude Fable 5)
+
+CI: green on the round-2 fix (8m28s). Copilot round 3: 1 finding, valid.
+- [x] (valid, minor) std::min(1.0, sqrt(a)) turns NaN input into 1.0 (NaN
+  comparisons are false) so haversineMeters(NaN, ...) returned ~pi*R instead
+  of NaN. Replaced with an explicit `root > 1.0 ? 1.0 : root` clamp that
+  preserves NaN, kept the antipodal-roundoff guard, dropped the now-unused
+  <algorithm>. Tests: NonFiniteInputPropagatesAsNan +
+  AntipodalRoundoffStaysClamped. 115 tests, 0 failures.

--- a/.agent/work-plans/issue-265/progress.md
+++ b/.agent/work-plans/issue-265/progress.md
@@ -18,3 +18,15 @@ issue: 265
 - [ ] Confirm tests are in scope: schema version detection + re-index trigger, new accessor queries, decimation logic (the test/ directory exists in marine_survey_index).
 - [ ] Ensure docs/survey_index_schema.md is updated in the same PR (not a follow-up) — the issue calls this out but plan should enforce it.
 - [ ] Define the accessor API contract clearly (bounding-box and bag-id retrieval) so marine_perception_tools (#258) can build against a stable interface.
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-07-16 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Plan**: `.agent/work-plans/issue-265/plan.md` at `92a19fd`
+**Branch**: feature/issue-265 at `92a19fd`
+**Phases**: single
+
+### Open questions
+- [ ] No open questions — plan is review-plan-ready.

--- a/.agent/work-plans/issue-265/progress.md
+++ b/.agent/work-plans/issue-265/progress.md
@@ -30,3 +30,22 @@ issue: 265
 
 ### Open questions
 - [ ] No open questions — plan is review-plan-ready.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-07-16 14:10 +00:00
+**By**: Claude Code Agent (Claude Opus)
+<!-- Independent review: plan authored by "Claude Code Agent (Claude Sonnet)";
+     this review is a fresh-context Opus sub-agent. The agent-name portion
+     matches (shared workspace identity), but the model and context differ, so
+     this is an independent review, not an author self-review. -->
+
+**Plan**: `.agent/work-plans/issue-265/plan.md` at `92a19fd`
+**PR**: PR-less (--issue mode; layer worktree, no draft PR)
+**Verdict**: approve-with-suggestions
+
+### Findings
+- [ ] (suggestion) `NavPoint` struct home is inconsistent — Files table lists it in `schema.hpp`; Approach step 2 puts it in `query.hpp`. Put it in `query.hpp` next to sibling `PassRow` and fix the Files table row — `plan.md:76`, `plan.md:40-42`
+- [ ] (suggestion) ADR citation error — "ADR-0008 (license/copyright headers)" conflates the repo's ADR-0008 (*Live Sonar Coverage Transport & Render*) with the header convention (workspace ADR-0008 / general convention). The header requirement is valid and honored; only the citation is wrong — `plan.md:116`
+- [ ] (suggestion) Nav-source frame semantics — points derive from each ping's *sensor ground origin* (`groundOrigin(gb)`), interleaved across up to 3 sensor topics (mbes/port/stbd) in one bag, then distance-decimated across that mixed stream. Plan calls them "vehicle positions." State the provenance explicitly (sensor origins, not a single base_link); negligible at 10 m stride but the doc should not imply a single vehicle frame — `plan.md:54`, `plan.md:13`
+- [ ] (suggestion) Validate `--nav-stride-m` > 0 and finite in `main()`, mirroring the existing `--merge-gap` guard (`survey_index_bag_main.cpp:350`); a 0/negative stride would keep every point — `plan.md:54`

--- a/.agent/work-plans/issue-265/progress.md
+++ b/.agent/work-plans/issue-265/progress.md
@@ -1,0 +1,20 @@
+---
+issue: 265
+---
+
+# Issue #265 — survey_index: decimated nav track table for the explorer map (schema bump)
+
+## Issue Review
+**Status**: complete
+**When**: 2026-07-16 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Issue**: #265
+**Comment**: (best-effort post follows this entry; not recorded inline)
+**Scope verdict**: well-scoped
+
+### Actions
+- [ ] Pin the decimation strategy (time-based, distance-based, or hybrid) during planning and record the decision in plan.md — it is explicitly TBD in the issue body.
+- [ ] Confirm tests are in scope: schema version detection + re-index trigger, new accessor queries, decimation logic (the test/ directory exists in marine_survey_index).
+- [ ] Ensure docs/survey_index_schema.md is updated in the same PR (not a follow-up) — the issue calls this out but plan should enforce it.
+- [ ] Define the accessor API contract clearly (bounding-box and bag-id retrieval) so marine_perception_tools (#258) can build against a stable interface.

--- a/.agent/work-plans/issue-265/progress.md
+++ b/.agent/work-plans/issue-265/progress.md
@@ -100,5 +100,11 @@ issue: 265
 **Round**: 1 | **Ship**: recommended — no must-fix findings; static clean, both adversarial lenses concur the change is sound
 
 ### Findings
-- [ ] (suggestion) Non-finite ground origin poisons the decimator — `gb.valid` checks only quaternion norm, so a NaN lat/lon is accepted and defeats decimation for the rest of the bag; gate on `std::isfinite` before `accept()` — `src/survey_index_bag_main.cpp:480`
-- [ ] (suggestion) Decimation runs in read/FIFO order but accessors return `ORDER BY t_ns`; the ≥stride invariant may not survive the re-sort — sort `nav_points` by `t_ns` before insert if #258 needs it — `src/survey_index_bag_main.cpp:481`
+- [x] (suggestion) Non-finite ground origin poisons the decimator — `gb.valid` checks only quaternion norm, so a NaN lat/lon is accepted and defeats decimation for the rest of the bag; gate on `std::isfinite` before `accept()` — `src/survey_index_bag_main.cpp:480`
+- [x] (suggestion) Decimation runs in read/FIFO order but accessors return `ORDER BY t_ns`; the ≥stride invariant may not survive the re-sort — sort `nav_points` by `t_ns` before insert if #258 needs it — `src/survey_index_bag_main.cpp:481`
+
+**Round-1 suggestions addressed** (both fixed, not deferred): NavDecimator
+rejects non-finite input without touching its reference (+ test covering
+leading and mid-stream NaN); nav_points stable-sorted by t_ns before insert
+and the stream-order gating caveat documented in the schema doc ("density
+target, not a per-pair guarantee"). 111 tests, 0 failures.

--- a/.agent/work-plans/issue-265/progress.md
+++ b/.agent/work-plans/issue-265/progress.md
@@ -45,7 +45,44 @@ issue: 265
 **Verdict**: approve-with-suggestions
 
 ### Findings
-- [ ] (suggestion) `NavPoint` struct home is inconsistent — Files table lists it in `schema.hpp`; Approach step 2 puts it in `query.hpp`. Put it in `query.hpp` next to sibling `PassRow` and fix the Files table row — `plan.md:76`, `plan.md:40-42`
-- [ ] (suggestion) ADR citation error — "ADR-0008 (license/copyright headers)" conflates the repo's ADR-0008 (*Live Sonar Coverage Transport & Render*) with the header convention (workspace ADR-0008 / general convention). The header requirement is valid and honored; only the citation is wrong — `plan.md:116`
-- [ ] (suggestion) Nav-source frame semantics — points derive from each ping's *sensor ground origin* (`groundOrigin(gb)`), interleaved across up to 3 sensor topics (mbes/port/stbd) in one bag, then distance-decimated across that mixed stream. Plan calls them "vehicle positions." State the provenance explicitly (sensor origins, not a single base_link); negligible at 10 m stride but the doc should not imply a single vehicle frame — `plan.md:54`, `plan.md:13`
-- [ ] (suggestion) Validate `--nav-stride-m` > 0 and finite in `main()`, mirroring the existing `--merge-gap` guard (`survey_index_bag_main.cpp:350`); a 0/negative stride would keep every point — `plan.md:54`
+- [x] (suggestion) `NavPoint` struct home is inconsistent — Files table lists it in `schema.hpp`; Approach step 2 puts it in `query.hpp`. Put it in `query.hpp` next to sibling `PassRow` and fix the Files table row — `plan.md:76`, `plan.md:40-42`
+- [x] (suggestion) ADR citation error — "ADR-0008 (license/copyright headers)" conflates the repo's ADR-0008 (*Live Sonar Coverage Transport & Render*) with the header convention (workspace ADR-0008 / general convention). The header requirement is valid and honored; only the citation is wrong — `plan.md:116`
+- [x] (suggestion) Nav-source frame semantics — points derive from each ping's *sensor ground origin* (`groundOrigin(gb)`), interleaved across up to 3 sensor topics (mbes/port/stbd) in one bag, then distance-decimated across that mixed stream. Plan calls them "vehicle positions." State the provenance explicitly (sensor origins, not a single base_link); negligible at 10 m stride but the doc should not imply a single vehicle frame — `plan.md:54`, `plan.md:13`
+- [x] (suggestion) Validate `--nav-stride-m` > 0 and finite in `main()`, mirroring the existing `--merge-gap` guard (`survey_index_bag_main.cpp:350`); a 0/negative stride would keep every point — `plan.md:54`
+
+## Implementation
+**Status**: complete
+**When**: 2026-07-16 (host-inline)
+**By**: Claude Code Agent (Claude Fable 5)
+
+**Branch**: feature/issue-265
+**All 4 review-plan suggestions folded into the amended plan and honored.**
+
+### What landed
+- `nav_decimation.hpp` (NEW, header-only like interval_accumulator.hpp — placed
+  in a header rather than main.cpp so the plan's bag-I/O-free tests can reach
+  it): `haversineMeters` + `NavDecimator` distance gate.
+- Schema v2: `nav_track` table + `nav_track_bag`/`nav_track_geo` indexes;
+  `kSchemaVersion = 2`.
+- `query.hpp/cpp`: `NavPoint` (next to `PassRow`), `queryNavTrack(bag_id)`,
+  `queryNavTrackInBox(box)` — box normalizes/swaps and throws on antimeridian
+  spans, mirroring `tilesForBoundingBox`.
+- Indexer: `--nav-stride-m` (default 10, validated finite > 0), collection at
+  the `flush_front` ground origin, explicit `DELETE FROM nav_track` on the
+  re-index path (bag row survives, CASCADE never fires), insert in the same
+  per-bag transaction, nav count in the per-bag log line.
+- Tests: `test_nav_decimation.cpp` (NEW, 8 tests), nav accessor fixture in
+  `test_query_join.cpp` (6 tests), schema table/column checks updated.
+- Docs: schema doc v2 section (provenance: sensor ground origins, NOT a
+  vehicle frame; decimation semantics; accessor contract); package README.
+
+### Verification
+- Worktree build green; `colcon test` 110 tests, 0 failures (cpplint fixed:
+  `<algorithm>` for std::min).
+- Real-bag E2E (scratch DB, bags untouched): 2026-06-16 bag → 346 points,
+  3.46 km / 76 min, 0.76 m/s avg, median gap exactly 10.0 m (gate correct).
+- **Data-quality finding surfaced, not masked**: 2026-06-26T13-57-35 bag shows
+  earth->sensor oscillating ~80 m at ~5 Hz (61 km/27 min "track") — a genuine
+  pose/TF pathology in that bag (likely dual nav-source conflict; the same
+  poses already smear its stage-1 pass footprints). The track overlay will make
+  this visible in the explorer; deliberately no speed-heuristic filtering.

--- a/docs/survey_index_schema.md
+++ b/docs/survey_index_schema.md
@@ -87,6 +87,10 @@ direction — without opening any bag.
   ping of the bag or ≥ the stride (default **10 m**, indexer `--nav-stride-m`)
   from the *last kept* point. Spatially uniform by construction: a
   station-keeping boat adds no points; a fast transit stays fully sampled.
+  The gate runs in bag stream order and rows are stored time-ordered; when
+  ping stamps arrive slightly out of order, an occasional consecutive-by-time
+  gap below the stride is possible — treat the stride as a density target,
+  not a per-pair guarantee.
 - **Same lifecycle as passes.** Written in the bag's atomic transaction;
   deleted and rewritten when a changed bag is re-indexed; cascades away with
   the bag row.

--- a/docs/survey_index_schema.md
+++ b/docs/survey_index_schema.md
@@ -30,7 +30,7 @@ checkpoint (2026-07-13); see `.agent/work-plans/issue-259/plan.md`.
   joining against store tiling aggregate L14 rows under their L10/L13 parents.
   Mixed levels coexist in one DB; queries carry the level in the key.
 
-## Tables (schema version 1)
+## Tables (schema version 2)
 
 ```sql
 CREATE TABLE schema_version (
@@ -59,7 +59,43 @@ CREATE TABLE passes (
 );
 CREATE INDEX passes_tile ON passes(level, tile_row, tile_col);
 CREATE INDEX passes_bag  ON passes(bag_id);
+
+CREATE TABLE nav_track (              -- added in v2 (#265)
+  id         INTEGER PRIMARY KEY,
+  bag_id     INTEGER NOT NULL REFERENCES bags(id) ON DELETE CASCADE,
+  t_ns       INTEGER NOT NULL,        -- ping header stamp (UNIX ns)
+  latitude   REAL    NOT NULL,        -- WGS-84 degrees
+  longitude  REAL    NOT NULL         -- WGS-84 degrees
+);
+CREATE INDEX nav_track_bag ON nav_track(bag_id, t_ns);
+CREATE INDEX nav_track_geo ON nav_track(latitude, longitude);
 ```
+
+## `nav_track` semantics (v2)
+
+A **decimated nav track** per bag for the explorer's overview map (#258):
+drawing the survey track — and, from consecutive time-ordered points, travel
+direction — without opening any bag.
+
+- **Provenance: sensor ground origins, not a vehicle frame.** Each point is a
+  posed ping's *sensor ground origin* (the same `earth`→sensor resolution the
+  pass footprints use), interleaved across all indexed sonar topics and then
+  distance-decimated as one stream. It is **not** a `base_link` track; at the
+  default stride the per-sensor offsets are negligible for map display, but
+  consumers must not treat the points as a single-antenna nav solution.
+- **Distance-based decimation.** A point is kept iff it is the first posed
+  ping of the bag or ≥ the stride (default **10 m**, indexer `--nav-stride-m`)
+  from the *last kept* point. Spatially uniform by construction: a
+  station-keeping boat adds no points; a fast transit stays fully sampled.
+- **Same lifecycle as passes.** Written in the bag's atomic transaction;
+  deleted and rewritten when a changed bag is re-indexed; cascades away with
+  the bag row.
+
+**Accessors** (`marine_survey_index/query.hpp`): `queryNavTrack(db, bag_id)` —
+one bag's track ordered by time; `queryNavTrackInBox(db, lat_min, lon_min,
+lat_max, lon_max)` — all points in a box ordered by bag id then time (segment
+into per-bag polylines at bag-id changes). Boxes crossing the antimeridian
+throw, matching `tilesForBoundingBox`.
 
 ## `sensor_type` vocabulary
 

--- a/marine_survey_index/CMakeLists.txt
+++ b/marine_survey_index/CMakeLists.txt
@@ -89,6 +89,9 @@ if(BUILD_TESTING)
   ament_add_gtest(test_interval_merge test/test_interval_merge.cpp)
   target_link_libraries(test_interval_merge ${PROJECT_NAME}_core)
 
+  ament_add_gtest(test_nav_decimation test/test_nav_decimation.cpp)
+  target_link_libraries(test_nav_decimation ${PROJECT_NAME}_core)
+
   ament_add_gtest(test_tile_enumeration test/test_tile_enumeration.cpp)
   target_link_libraries(test_tile_enumeration ${PROJECT_NAME}_core)
 

--- a/marine_survey_index/README.md
+++ b/marine_survey_index/README.md
@@ -21,7 +21,8 @@ ros2 run marine_survey_index survey_index_bag <bag_uri ...> [--scan DIR] \
     [--mbes-topic /bizzy/sensors/m3/detections] \
     [--port-topic ...sonar_image_port] [--stbd-topic ...sonar_image_starboard] \
     [--mbes-level 14] [--sidescan-level 14] [--level N] \
-    [--merge-gap 5.0] [--earth-frame earth] [--sound-speed 1500]
+    [--merge-gap 5.0] [--nav-stride-m 10.0] \
+    [--earth-frame earth] [--sound-speed 1500]
 ```
 
 Single interleaved chronological pass per bag (the bounded-TF-window pattern
@@ -30,7 +31,9 @@ from cube#63 / the sidescan importer): georeferences every MBES
 ground-footprint bounding box, and records per-GGGS-tile **pass intervals** in
 a SQLite sidecar. Indexing is from **ping geometry, not store acceptance** —
 pings CUBE rejected still index. Unchanged already-indexed bags are skipped
-(size+mtime ledger); changed bags are re-indexed atomically.
+(size+mtime ledger); changed bags are re-indexed atomically. A **decimated nav
+track** (one point per ≥ `--nav-stride-m` metres, default 10) is recorded per
+bag so the explorer map can draw the survey track from the index alone.
 
 The default level is **L14 (~54 m tiles)** for both sensors — a
 target-inspection neighbourhood, finer than the stores' native tiling (bathy
@@ -61,8 +64,9 @@ see [`docs/survey_index_schema.md`](../docs/survey_index_schema.md).
 ## Testing
 
 Bag-I/O-free unit tests cover the DB-open contract, the interval
-merge/split logic, footprint→tile enumeration (boundary straddling), and the
-query tile-join (sensor filters, level separation):
+merge/split logic, footprint→tile enumeration (boundary straddling), the
+query tile-join (sensor filters, level separation), and the nav-track
+decimation gate and accessors:
 
 ```bash
 colcon test --packages-select marine_survey_index

--- a/marine_survey_index/include/marine_survey_index/nav_decimation.hpp
+++ b/marine_survey_index/include/marine_survey_index/nav_decimation.hpp
@@ -31,7 +31,6 @@
 /// point are dropped, giving the `nav_track` table uniform *spatial* density —
 /// a station-keeping boat adds no points, a fast transit stays fully sampled.
 
-#include <algorithm>
 #include <cmath>
 #include <stdexcept>
 
@@ -41,7 +40,7 @@ namespace marine_survey_index
 /// Great-circle distance between two WGS-84 positions (degrees in, metres
 /// out) via the Haversine formula on a mean-radius sphere. Centimetre-level
 /// accuracy at the decimation strides used here (metres to tens of metres);
-/// not for geodetic-grade work.
+/// not for geodetic-grade work. Non-finite input propagates as NaN.
 inline double haversineMeters(double lat1_deg, double lon1_deg, double lat2_deg, double lon2_deg)
 {
   constexpr double kMeanEarthRadiusM = 6371008.8;
@@ -53,7 +52,12 @@ inline double haversineMeters(double lat1_deg, double lon1_deg, double lat2_deg,
   const double a = sin_half_dlat * sin_half_dlat +
     std::cos(lat1_deg * kDegToRad) * std::cos(lat2_deg * kDegToRad) *
     sin_half_dlon * sin_half_dlon;
-  return 2.0 * kMeanEarthRadiusM * std::asin(std::min(1.0, std::sqrt(a)));
+  // Guard antipodal roundoff (a slightly above 1) without std::min, whose
+  // NaN-comparison ordering would turn a NaN input into a "1.0" — i.e. half
+  // the Earth's circumference. This comparison is false for NaN, so NaN
+  // flows through sqrt/asin and propagates to the caller.
+  const double root = std::sqrt(a);
+  return 2.0 * kMeanEarthRadiusM * std::asin(root > 1.0 ? 1.0 : root);
 }
 
 /// Distance gate: accept() returns true for the first point and for any point

--- a/marine_survey_index/include/marine_survey_index/nav_decimation.hpp
+++ b/marine_survey_index/include/marine_survey_index/nav_decimation.hpp
@@ -1,0 +1,89 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef MARINE_SURVEY_INDEX__NAV_DECIMATION_HPP_
+#define MARINE_SURVEY_INDEX__NAV_DECIMATION_HPP_
+
+/// @file
+/// @brief Distance-based decimation gate for the indexer's nav track.
+///
+/// Header-only (like interval_accumulator.hpp) so the gate logic is unit
+/// tested without bag I/O. The indexer feeds it every posed ping's ground
+/// origin; points that advance less than the stride from the last accepted
+/// point are dropped, giving the `nav_track` table uniform *spatial* density —
+/// a station-keeping boat adds no points, a fast transit stays fully sampled.
+
+#include <algorithm>
+#include <cmath>
+
+namespace marine_survey_index
+{
+
+/// Great-circle distance between two WGS-84 positions (degrees in, metres
+/// out) via the Haversine formula on a mean-radius sphere. Centimetre-level
+/// accuracy at the decimation strides used here (metres to tens of metres);
+/// not for geodetic-grade work.
+inline double haversineMeters(double lat1_deg, double lon1_deg, double lat2_deg, double lon2_deg)
+{
+  constexpr double kMeanEarthRadiusM = 6371008.8;
+  constexpr double kDegToRad = M_PI / 180.0;
+  const double dlat = (lat2_deg - lat1_deg) * kDegToRad;
+  const double dlon = (lon2_deg - lon1_deg) * kDegToRad;
+  const double sin_half_dlat = std::sin(dlat / 2.0);
+  const double sin_half_dlon = std::sin(dlon / 2.0);
+  const double a = sin_half_dlat * sin_half_dlat +
+    std::cos(lat1_deg * kDegToRad) * std::cos(lat2_deg * kDegToRad) *
+    sin_half_dlon * sin_half_dlon;
+  return 2.0 * kMeanEarthRadiusM * std::asin(std::min(1.0, std::sqrt(a)));
+}
+
+/// Distance gate: accept() returns true for the first point and for any point
+/// at least @c stride_m from the *last accepted* point (accepted points become
+/// the new reference; rejected ones do not accumulate).
+class NavDecimator
+{
+public:
+  explicit NavDecimator(double stride_m)
+  : stride_m_(stride_m) {}
+
+  bool accept(double lat_deg, double lon_deg)
+  {
+    if (has_last_ &&
+      haversineMeters(last_lat_, last_lon_, lat_deg, lon_deg) < stride_m_)
+    {
+      return false;
+    }
+    has_last_ = true;
+    last_lat_ = lat_deg;
+    last_lon_ = lon_deg;
+    return true;
+  }
+
+private:
+  double stride_m_;
+  bool has_last_ = false;
+  double last_lat_ = 0.0;
+  double last_lon_ = 0.0;
+};
+
+}  // namespace marine_survey_index
+
+#endif  // MARINE_SURVEY_INDEX__NAV_DECIMATION_HPP_

--- a/marine_survey_index/include/marine_survey_index/nav_decimation.hpp
+++ b/marine_survey_index/include/marine_survey_index/nav_decimation.hpp
@@ -33,6 +33,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <stdexcept>
 
 namespace marine_survey_index
 {
@@ -63,8 +64,17 @@ inline double haversineMeters(double lat1_deg, double lon1_deg, double lat2_deg,
 class NavDecimator
 {
 public:
+  /// @throws std::invalid_argument unless @p stride_m is finite and > 0 —
+  ///   a zero/negative/NaN stride would accept every finite point (defeating
+  ///   decimation) and +inf would accept only the first. The CLI validates
+  ///   its flag too, but a public header must defend itself.
   explicit NavDecimator(double stride_m)
-  : stride_m_(stride_m) {}
+  : stride_m_(stride_m)
+  {
+    if (!(stride_m > 0.0) || !std::isfinite(stride_m)) {
+      throw std::invalid_argument("NavDecimator: stride_m must be finite and > 0");
+    }
+  }
 
   bool accept(double lat_deg, double lon_deg)
   {

--- a/marine_survey_index/include/marine_survey_index/nav_decimation.hpp
+++ b/marine_survey_index/include/marine_survey_index/nav_decimation.hpp
@@ -57,7 +57,9 @@ inline double haversineMeters(double lat1_deg, double lon1_deg, double lat2_deg,
 
 /// Distance gate: accept() returns true for the first point and for any point
 /// at least @c stride_m from the *last accepted* point (accepted points become
-/// the new reference; rejected ones do not accumulate).
+/// the new reference; rejected ones do not accumulate). Non-finite input is
+/// rejected without touching the reference — a NaN accepted as reference would
+/// make every later distance NaN and defeat the gate for the rest of the bag.
 class NavDecimator
 {
 public:
@@ -66,6 +68,9 @@ public:
 
   bool accept(double lat_deg, double lon_deg)
   {
+    if (!std::isfinite(lat_deg) || !std::isfinite(lon_deg)) {
+      return false;
+    }
     if (has_last_ &&
       haversineMeters(last_lat_, last_lon_, lat_deg, lon_deg) < stride_m_)
     {

--- a/marine_survey_index/include/marine_survey_index/query.hpp
+++ b/marine_survey_index/include/marine_survey_index/query.hpp
@@ -50,9 +50,34 @@ struct PassRow
   std::int64_t ping_count = 0;
 };
 
+/// One decimated nav-track point (#265). Points are each posed ping's
+/// *sensor ground origin* — interleaved across the indexed sonar topics and
+/// distance-decimated — not samples of a single vehicle frame; at the default
+/// 10 m stride the sensor-offset differences are negligible for map display.
+struct NavPoint
+{
+  std::int64_t bag_id = 0;
+  std::int64_t t_ns = 0;
+  double latitude = 0.0;
+  double longitude = 0.0;
+};
+
 /// @brief Distinct GGGS levels present in the index (optionally for one
 ///   sensor filter — same semantics as queryPasses).
 std::vector<std::uint8_t> distinctLevels(sqlite3 * db, const std::string & sensor_filter);
+
+/// @brief Full nav track for one bag, ordered by time.
+std::vector<NavPoint> queryNavTrack(sqlite3 * db, std::int64_t bag_id);
+
+/// @brief Nav-track points inside a geographic bounding box (all bags),
+///   ordered by bag id then time — ready to segment into per-bag polylines.
+///
+/// Longitudes are normalized and a reversed box is swapped, mirroring
+/// tilesForBoundingBox; boxes spanning more than 180 degrees of longitude
+/// (antimeridian-crossing) throw std::invalid_argument — the same fail-loud
+/// contract, deferred consistently.
+std::vector<NavPoint> queryNavTrackInBox(
+  sqlite3 * db, double lat_min, double lon_min, double lat_max, double lon_max);
 
 /// @brief Passes overlapping any of @p tiles, joined with their bags.
 ///

--- a/marine_survey_index/include/marine_survey_index/schema.hpp
+++ b/marine_survey_index/include/marine_survey_index/schema.hpp
@@ -40,12 +40,13 @@ namespace marine_survey_index
 /// Schema version stamped into a fresh DB and checked on every open. Bump on
 /// any incompatible change; the open then fails with a "regenerate" hint
 /// (never silently migrate — regeneration is the migration).
-constexpr int kSchemaVersion = 1;
+constexpr int kSchemaVersion = 2;
 
 /// @brief Open (creating and initializing if needed) a survey index database.
 ///
-/// Creates the `schema_version`, `bags`, and `passes` tables when absent, and
-/// verifies the stored schema version matches ::kSchemaVersion.
+/// Creates the `schema_version`, `bags`, `passes`, and `nav_track` tables
+/// when absent, and verifies the stored schema version matches
+/// ::kSchemaVersion.
 ///
 /// @param path Filesystem path (or ":memory:" for tests).
 /// @return An open handle; the caller owns it (close with `sqlite3_close`).

--- a/marine_survey_index/src/query.cpp
+++ b/marine_survey_index/src/query.cpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace marine_survey_index
@@ -85,6 +86,87 @@ std::vector<std::uint8_t> distinctLevels(sqlite3 * db, const std::string & senso
     throwSqlite(db, "distinctLevels step");
   }
   return levels;
+}
+
+std::vector<NavPoint> queryNavTrack(sqlite3 * db, std::int64_t bag_id)
+{
+  sqlite3_stmt * stmt = nullptr;
+  if (sqlite3_prepare_v2(
+      db,
+      "SELECT bag_id, t_ns, latitude, longitude FROM nav_track"
+      " WHERE bag_id = ? ORDER BY t_ns",
+      -1, &stmt, nullptr) != SQLITE_OK)
+  {
+    throwSqlite(db, "queryNavTrack prepare");
+  }
+  sqlite3_bind_int64(stmt, 1, bag_id);
+  std::vector<NavPoint> points;
+  int rc;
+  while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {
+    NavPoint p;
+    p.bag_id = sqlite3_column_int64(stmt, 0);
+    p.t_ns = sqlite3_column_int64(stmt, 1);
+    p.latitude = sqlite3_column_double(stmt, 2);
+    p.longitude = sqlite3_column_double(stmt, 3);
+    points.push_back(p);
+  }
+  sqlite3_finalize(stmt);
+  if (rc != SQLITE_DONE) {
+    throwSqlite(db, "queryNavTrack step");
+  }
+  return points;
+}
+
+std::vector<NavPoint> queryNavTrackInBox(
+  sqlite3 * db, double lat_min, double lon_min, double lat_max, double lon_max)
+{
+  // Same box semantics as tilesForBoundingBox (footprint.cpp): swap a
+  // reversed box, normalize longitudes, and fail loud on an antimeridian
+  // crossing (which presents as a >180-degree span after normalization)
+  // instead of silently returning the long way around.
+  if (lat_min > lat_max) {
+    std::swap(lat_min, lat_max);
+  }
+  lon_min = gggs::normalizeLongitude(lon_min);
+  lon_max = gggs::normalizeLongitude(lon_max);
+  if (lon_min > lon_max) {
+    std::swap(lon_min, lon_max);
+  }
+  if (lon_max - lon_min > 180.0) {
+    throw std::invalid_argument(
+      "queryNavTrackInBox: longitude span " + std::to_string(lon_max - lon_min) +
+      " deg exceeds 180 — boxes crossing the antimeridian are not supported");
+  }
+
+  sqlite3_stmt * stmt = nullptr;
+  if (sqlite3_prepare_v2(
+      db,
+      "SELECT bag_id, t_ns, latitude, longitude FROM nav_track"
+      " WHERE latitude BETWEEN ? AND ? AND longitude BETWEEN ? AND ?"
+      " ORDER BY bag_id, t_ns",
+      -1, &stmt, nullptr) != SQLITE_OK)
+  {
+    throwSqlite(db, "queryNavTrackInBox prepare");
+  }
+  sqlite3_bind_double(stmt, 1, lat_min);
+  sqlite3_bind_double(stmt, 2, lat_max);
+  sqlite3_bind_double(stmt, 3, lon_min);
+  sqlite3_bind_double(stmt, 4, lon_max);
+  std::vector<NavPoint> points;
+  int rc;
+  while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {
+    NavPoint p;
+    p.bag_id = sqlite3_column_int64(stmt, 0);
+    p.t_ns = sqlite3_column_int64(stmt, 1);
+    p.latitude = sqlite3_column_double(stmt, 2);
+    p.longitude = sqlite3_column_double(stmt, 3);
+    points.push_back(p);
+  }
+  sqlite3_finalize(stmt);
+  if (rc != SQLITE_DONE) {
+    throwSqlite(db, "queryNavTrackInBox step");
+  }
+  return points;
 }
 
 std::vector<PassRow> queryPasses(

--- a/marine_survey_index/src/query.cpp
+++ b/marine_survey_index/src/query.cpp
@@ -137,6 +137,8 @@ std::vector<NavPoint> queryNavTrackInBox(
       "queryNavTrackInBox: longitude span " + std::to_string(lon_max - lon_min) +
       " deg exceeds 180 — boxes crossing the antimeridian are not supported");
   }
+  lat_min = std::clamp(lat_min, -90.0, 90.0);
+  lat_max = std::clamp(lat_max, -90.0, 90.0);
 
   sqlite3_stmt * stmt = nullptr;
   if (sqlite3_prepare_v2(

--- a/marine_survey_index/src/schema.cpp
+++ b/marine_survey_index/src/schema.cpp
@@ -61,6 +61,16 @@ CREATE TABLE IF NOT EXISTS passes (
 );
 CREATE INDEX IF NOT EXISTS passes_tile ON passes(level, tile_row, tile_col);
 CREATE INDEX IF NOT EXISTS passes_bag  ON passes(bag_id);
+
+CREATE TABLE IF NOT EXISTS nav_track (
+  id         INTEGER PRIMARY KEY,
+  bag_id     INTEGER NOT NULL REFERENCES bags(id) ON DELETE CASCADE,
+  t_ns       INTEGER NOT NULL,
+  latitude   REAL    NOT NULL,
+  longitude  REAL    NOT NULL
+);
+CREATE INDEX IF NOT EXISTS nav_track_bag ON nav_track(bag_id, t_ns);
+CREATE INDEX IF NOT EXISTS nav_track_geo ON nav_track(latitude, longitude);
 )sql";
 
 void execOrThrow(sqlite3 * db, const char * sql)

--- a/marine_survey_index/src/survey_index_bag_main.cpp
+++ b/marine_survey_index/src/survey_index_bag_main.cpp
@@ -67,6 +67,7 @@
 
 #include "marine_survey_index/footprint.hpp"
 #include "marine_survey_index/interval_accumulator.hpp"
+#include "marine_survey_index/nav_decimation.hpp"
 #include "marine_survey_index/schema.hpp"
 
 namespace
@@ -326,13 +327,15 @@ int main(int argc, char ** argv)
       "usage: survey_index_bag [bag_uri ...] [--scan DIR] [--db survey_index.db]\n"
       "       [--mbes-topic T] [--port-topic T] [--stbd-topic T]\n"
       "       [--mbes-level N=14] [--sidescan-level N=14] [--level N (overrides both)]\n"
-      "       [--merge-gap S=5.0] [--earth-frame F=earth] [--sound-speed S=1500]\n"
+      "       [--merge-gap S=5.0] [--nav-stride-m M=10.0]\n"
+      "       [--earth-frame F=earth] [--sound-speed S=1500]\n"
       "\n"
       "Indexes where each sonar looked, per bag, into a regenerable SQLite\n"
       "sidecar. Unchanged already-indexed bags are skipped; changed bags are\n"
       "re-indexed. Default level 14 (~54 m tiles) — a target-inspection\n"
       "neighbourhood; rolls up to the stores' coarser native tiles (bathy L10,\n"
-      "sidescan L13) via the GGGS parent hierarchy.\n";
+      "sidescan L13) via the GGGS parent hierarchy. Also records a decimated\n"
+      "nav track (one point per >= --nav-stride-m metres) for the explorer map.\n";
     return 2;
   }
 
@@ -349,6 +352,15 @@ int main(int argc, char ** argv)
   const double merge_gap_s = toDouble(argValue(argc, argv, "--merge-gap", "5.0"), "--merge-gap");
   if (!(merge_gap_s >= 0.0)) {  // also rejects NaN
     std::cerr << "error: --merge-gap must be >= 0, got " << merge_gap_s << "\n";
+    return 2;
+  }
+  const double nav_stride_m =
+    toDouble(argValue(argc, argv, "--nav-stride-m", "10.0"), "--nav-stride-m");
+  // A zero/negative/NaN stride would keep every posed ping (millions of rows);
+  // +inf would keep only the first point per bag. Reject both.
+  if (!(nav_stride_m > 0.0) || !std::isfinite(nav_stride_m)) {
+    std::cerr << "error: --nav-stride-m must be a finite value > 0, got "
+              << nav_stride_m << "\n";
     return 2;
   }
   // Default L14 (~54 m tiles): the tile-of-interest scale for target review
@@ -421,6 +433,19 @@ int main(int argc, char ** argv)
       std::int64_t tf_frontier_ns = std::numeric_limits<std::int64_t>::min();
       std::size_t n_pings = 0, n_no_tf = 0, n_bad_pose = 0;
 
+      // Decimated nav track (#265): every posed ping's ground origin feeds
+      // the distance gate; accepted points land in nav_track alongside the
+      // passes. Provenance: sensor ground origins interleaved across the
+      // indexed topics — not a single vehicle frame (see the schema doc).
+      marine_survey_index::NavDecimator nav_decimator(nav_stride_m);
+      struct NavTrackPoint
+      {
+        std::int64_t t_ns;
+        double latitude;
+        double longitude;
+      };
+      std::vector<NavTrackPoint> nav_points;
+
       // A ping queued for TF resolution: everything except the earth pose is
       // computed at enqueue. `extent_port`/`extent_stbd` are the signed
       // across-track horizontal extents (m, + = starboard). For sidescan the
@@ -453,6 +478,9 @@ int main(int argc, char ** argv)
               ++n_bad_pose;
             } else {
               const auto origin = groundOrigin(gb);
+              if (nav_decimator.accept(origin.latitude, origin.longitude)) {
+                nav_points.push_back({front.ping_ns, origin.latitude, origin.longitude});
+              }
               const auto p1 = acrossTrackPoint(origin, gb.heading_rad, front.extent_port);
               const auto p2 = acrossTrackPoint(origin, gb.heading_rad, front.extent_stbd);
               const double lat_min =
@@ -612,6 +640,13 @@ int main(int argc, char ** argv)
           stepDoneOrThrow(db, del.get());
         }
         {
+          // The re-index path keeps the bag row, so the CASCADE never fires —
+          // clear the old track explicitly like the passes above.
+          StmtGuard del(prepareOrThrow(db, "DELETE FROM nav_track WHERE bag_id = ?"));
+          sqlite3_bind_int64(del.get(), 1, bag_id);
+          stepDoneOrThrow(db, del.get());
+        }
+        {
           const char * upd_sql =
             "UPDATE bags SET size_bytes = ?, mtime_ns = ?, indexed_at_ns = ? WHERE id = ?";
           StmtGuard upd(prepareOrThrow(db, upd_sql));
@@ -651,12 +686,26 @@ int main(int argc, char ** argv)
           sqlite3_reset(ins_pass.get());
         }
       }
+      {
+        const char * nav_sql =
+          "INSERT INTO nav_track (bag_id, t_ns, latitude, longitude) VALUES (?, ?, ?, ?)";
+        StmtGuard ins_nav(prepareOrThrow(db, nav_sql));
+        for (const auto & p : nav_points) {
+          sqlite3_bind_int64(ins_nav.get(), 1, bag_id);
+          sqlite3_bind_int64(ins_nav.get(), 2, p.t_ns);
+          sqlite3_bind_double(ins_nav.get(), 3, p.latitude);
+          sqlite3_bind_double(ins_nav.get(), 4, p.longitude);
+          stepDoneOrThrow(db, ins_nav.get());
+          sqlite3_reset(ins_nav.get());
+        }
+      }
       execOrThrow(db, "COMMIT;");
 
       ++n_bags_indexed;
       std::cerr << (state < 0 ? "re-indexed: " : "indexed: ") << bag_key
                 << " (" << n_pings << " pings -> " << intervals.size()
-                << " pass intervals; no-tf=" << n_no_tf
+                << " pass intervals, " << nav_points.size()
+                << " nav points; no-tf=" << n_no_tf
                 << " bad-pose=" << n_bad_pose << ")\n";
     } catch (const std::exception & e) {
       // A bad message or a SQLite failure aborts this bag only: roll back

--- a/marine_survey_index/src/survey_index_bag_main.cpp
+++ b/marine_survey_index/src/survey_index_bag_main.cpp
@@ -687,6 +687,11 @@ int main(int argc, char ** argv)
         }
       }
       {
+        // Points were gated in flush (read) order; store them time-ordered so
+        // row order matches the accessors' ORDER BY t_ns.
+        std::stable_sort(
+          nav_points.begin(), nav_points.end(),
+          [](const NavTrackPoint & a, const NavTrackPoint & b) {return a.t_ns < b.t_ns;});
         const char * nav_sql =
           "INSERT INTO nav_track (bag_id, t_ns, latitude, longitude) VALUES (?, ?, ?, ?)";
         StmtGuard ins_nav(prepareOrThrow(db, nav_sql));

--- a/marine_survey_index/test/test_nav_decimation.cpp
+++ b/marine_survey_index/test/test_nav_decimation.cpp
@@ -22,6 +22,8 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <limits>
+#include <stdexcept>
 
 #include "marine_survey_index/nav_decimation.hpp"
 
@@ -121,6 +123,14 @@ TEST(NavDecimator, StrideIsConfigurable)
   NavDecimator fine(1.0);
   ASSERT_TRUE(fine.accept(0.0, 0.0));
   EXPECT_TRUE(fine.accept(0.0, kUnderStrideDeg));  // 5.56 m >= 1 m
+}
+
+TEST(NavDecimator, InvalidStrideThrows)
+{
+  EXPECT_THROW(NavDecimator(0.0), std::invalid_argument);
+  EXPECT_THROW(NavDecimator(-1.0), std::invalid_argument);
+  EXPECT_THROW(NavDecimator(std::nan("")), std::invalid_argument);
+  EXPECT_THROW(NavDecimator(std::numeric_limits<double>::infinity()), std::invalid_argument);
 }
 
 }  // namespace

--- a/marine_survey_index/test/test_nav_decimation.cpp
+++ b/marine_survey_index/test/test_nav_decimation.cpp
@@ -62,6 +62,25 @@ TEST(HaversineMeters, LongitudeShrinksWithCosLatitude)
   EXPECT_NEAR(haversineMeters(60.0, 0.0, 60.0, 1.0), kMetersPerDegree / 2.0, 1.0);
 }
 
+TEST(HaversineMeters, NonFiniteInputPropagatesAsNan)
+{
+  const double nan = std::nan("");
+  const double inf = std::numeric_limits<double>::infinity();
+  EXPECT_TRUE(std::isnan(haversineMeters(nan, 0.0, 0.0, 0.0)));
+  EXPECT_TRUE(std::isnan(haversineMeters(0.0, nan, 0.0, 0.0)));
+  EXPECT_TRUE(std::isnan(haversineMeters(0.0, 0.0, nan, nan)));
+  EXPECT_TRUE(std::isnan(haversineMeters(inf, 0.0, 0.0, 0.0)));
+}
+
+TEST(HaversineMeters, AntipodalRoundoffStaysClamped)
+{
+  // Exactly antipodal points: a may exceed 1 by roundoff; the result must be
+  // half the mean circumference (pi * R), not NaN from asin(>1).
+  constexpr double kHalfCircumference = M_PI * 6371008.8;
+  EXPECT_NEAR(haversineMeters(0.0, 0.0, 0.0, 180.0), kHalfCircumference, 1.0);
+  EXPECT_NEAR(haversineMeters(-45.0, -90.0, 45.0, 90.0), kHalfCircumference, 1.0);
+}
+
 TEST(HaversineMeters, Symmetric)
 {
   EXPECT_DOUBLE_EQ(

--- a/marine_survey_index/test/test_nav_decimation.cpp
+++ b/marine_survey_index/test/test_nav_decimation.cpp
@@ -1,0 +1,109 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <gtest/gtest.h>
+
+#include "marine_survey_index/nav_decimation.hpp"
+
+namespace
+{
+
+using marine_survey_index::NavDecimator;
+using marine_survey_index::haversineMeters;
+
+// One degree of arc on the mean-radius sphere (R = 6371008.8 m):
+// pi * R / 180.
+constexpr double kMetersPerDegree = 111195.0797343687;
+
+// At the equator, 1e-4 deg of longitude is ~11.12 m — comfortably over a
+// 10 m stride; 5e-5 deg (~5.56 m) is comfortably under it.
+constexpr double kOverStrideDeg = 1e-4;
+constexpr double kUnderStrideDeg = 5e-5;
+
+TEST(HaversineMeters, ZeroForIdenticalPoints)
+{
+  EXPECT_DOUBLE_EQ(haversineMeters(43.02, -71.36, 43.02, -71.36), 0.0);
+}
+
+TEST(HaversineMeters, OneDegreeOfLatitude)
+{
+  EXPECT_NEAR(haversineMeters(0.0, 0.0, 1.0, 0.0), kMetersPerDegree, 0.01);
+  // Latitude arcs are great circles at any longitude and any latitude band.
+  EXPECT_NEAR(haversineMeters(42.0, -71.0, 43.0, -71.0), kMetersPerDegree, 0.01);
+}
+
+TEST(HaversineMeters, LongitudeShrinksWithCosLatitude)
+{
+  EXPECT_NEAR(haversineMeters(0.0, 0.0, 0.0, 1.0), kMetersPerDegree, 0.01);
+  // At 60 N a longitude degree is half an equatorial one (cos 60 = 0.5);
+  // the chord-vs-arc difference at 1 degree is under a metre.
+  EXPECT_NEAR(haversineMeters(60.0, 0.0, 60.0, 1.0), kMetersPerDegree / 2.0, 1.0);
+}
+
+TEST(HaversineMeters, Symmetric)
+{
+  EXPECT_DOUBLE_EQ(
+    haversineMeters(43.02, -71.36, 43.03, -71.35),
+    haversineMeters(43.03, -71.35, 43.02, -71.36));
+}
+
+TEST(NavDecimator, FirstPointAlwaysAccepted)
+{
+  NavDecimator gate(10.0);
+  EXPECT_TRUE(gate.accept(43.02, -71.36));
+}
+
+TEST(NavDecimator, BelowStrideRejectedAtOrAboveAccepted)
+{
+  NavDecimator gate(10.0);
+  ASSERT_TRUE(gate.accept(0.0, 0.0));
+  EXPECT_FALSE(gate.accept(0.0, kUnderStrideDeg));
+  EXPECT_TRUE(gate.accept(0.0, kOverStrideDeg));
+}
+
+TEST(NavDecimator, ReferenceIsLastAcceptedNotLastSeen)
+{
+  // Two sub-stride steps must not accumulate into an acceptance: after the
+  // rejection at 5.56 m, the reference is still the origin, so a second
+  // point 11.12 m from the origin is what finally passes.
+  NavDecimator gate(10.0);
+  ASSERT_TRUE(gate.accept(0.0, 0.0));
+  ASSERT_FALSE(gate.accept(0.0, kUnderStrideDeg));
+  EXPECT_TRUE(gate.accept(0.0, 2.0 * kUnderStrideDeg));
+}
+
+TEST(NavDecimator, StationKeepingAddsNoPoints)
+{
+  NavDecimator gate(10.0);
+  ASSERT_TRUE(gate.accept(43.02, -71.36));
+  for (int i = 0; i < 100; ++i) {
+    EXPECT_FALSE(gate.accept(43.02, -71.36));
+  }
+}
+
+TEST(NavDecimator, StrideIsConfigurable)
+{
+  NavDecimator fine(1.0);
+  ASSERT_TRUE(fine.accept(0.0, 0.0));
+  EXPECT_TRUE(fine.accept(0.0, kUnderStrideDeg));  // 5.56 m >= 1 m
+}
+
+}  // namespace

--- a/marine_survey_index/test/test_nav_decimation.cpp
+++ b/marine_survey_index/test/test_nav_decimation.cpp
@@ -21,6 +21,8 @@
 
 #include <gtest/gtest.h>
 
+#include <cmath>
+
 #include "marine_survey_index/nav_decimation.hpp"
 
 namespace
@@ -97,6 +99,21 @@ TEST(NavDecimator, StationKeepingAddsNoPoints)
   for (int i = 0; i < 100; ++i) {
     EXPECT_FALSE(gate.accept(43.02, -71.36));
   }
+}
+
+TEST(NavDecimator, NonFiniteInputRejectedWithoutPoisoningReference)
+{
+  const double nan = std::nan("");
+  NavDecimator gate(10.0);
+  // A leading NaN must not become the reference.
+  EXPECT_FALSE(gate.accept(nan, 0.0));
+  ASSERT_TRUE(gate.accept(0.0, 0.0));
+  // A mid-stream NaN is dropped and the finite reference survives: the
+  // sub-stride point after it is still rejected, the over-stride accepted.
+  EXPECT_FALSE(gate.accept(0.0, nan));
+  EXPECT_FALSE(gate.accept(nan, nan));
+  EXPECT_FALSE(gate.accept(0.0, kUnderStrideDeg));
+  EXPECT_TRUE(gate.accept(0.0, kOverStrideDeg));
 }
 
 TEST(NavDecimator, StrideIsConfigurable)

--- a/marine_survey_index/test/test_query_join.cpp
+++ b/marine_survey_index/test/test_query_join.cpp
@@ -154,6 +154,79 @@ TEST_F(QueryJoin, EmptyTileSetReturnsEmpty)
   EXPECT_TRUE(marine_survey_index::queryPasses(db_, {}, "").empty());
 }
 
+class NavTrackQuery : public QueryJoin
+{
+protected:
+  void SetUp() override
+  {
+    QueryJoin::SetUp();
+    // bagA: three points marching east; bagB: one point nearby and one far
+    // away (outside any box around kLat/kLon). Inserted out of time order to
+    // prove the accessors sort.
+    insertNav(1, 300, kLat, kLon + 0.0002);
+    insertNav(1, 100, kLat, kLon);
+    insertNav(1, 200, kLat, kLon + 0.0001);
+    insertNav(2, 150, kLat + 0.0001, kLon);
+    insertNav(2, 250, kLat + 1.0, kLon + 1.0);
+  }
+
+  void insertNav(int bag_id, std::int64_t t_ns, double lat, double lon)
+  {
+    exec(
+      "INSERT INTO nav_track (bag_id, t_ns, latitude, longitude) VALUES (" +
+      std::to_string(bag_id) + ", " + std::to_string(t_ns) + ", " +
+      std::to_string(lat) + ", " + std::to_string(lon) + ")");
+  }
+};
+
+TEST_F(NavTrackQuery, PerBagTrackIsTimeOrderedAndBagFiltered)
+{
+  const auto track = marine_survey_index::queryNavTrack(db_, 1);
+  ASSERT_EQ(track.size(), 3u);
+  EXPECT_EQ(track[0].t_ns, 100);
+  EXPECT_EQ(track[1].t_ns, 200);
+  EXPECT_EQ(track[2].t_ns, 300);
+  for (const auto & p : track) {
+    EXPECT_EQ(p.bag_id, 1);
+  }
+  EXPECT_DOUBLE_EQ(track[0].latitude, kLat);
+  EXPECT_DOUBLE_EQ(track[0].longitude, kLon);
+}
+
+TEST_F(NavTrackQuery, UnknownBagYieldsEmptyTrack)
+{
+  EXPECT_TRUE(marine_survey_index::queryNavTrack(db_, 999).empty());
+}
+
+TEST_F(NavTrackQuery, BoxQueryReturnsInsidePointsOrderedByBagThenTime)
+{
+  const auto points = marine_survey_index::queryNavTrackInBox(
+    db_, kLat - 0.01, kLon - 0.01, kLat + 0.01, kLon + 0.01);
+  ASSERT_EQ(points.size(), 4u);   // bagB's far point excluded
+  EXPECT_EQ(points[0].bag_id, 1);
+  EXPECT_EQ(points[0].t_ns, 100);
+  EXPECT_EQ(points[1].t_ns, 200);
+  EXPECT_EQ(points[2].t_ns, 300);
+  EXPECT_EQ(points[3].bag_id, 2);
+  EXPECT_EQ(points[3].t_ns, 150);
+}
+
+TEST_F(NavTrackQuery, ReversedBoxIsSwapped)
+{
+  const auto points = marine_survey_index::queryNavTrackInBox(
+    db_, kLat + 0.01, kLon + 0.01, kLat - 0.01, kLon - 0.01);
+  EXPECT_EQ(points.size(), 4u);
+}
+
+TEST_F(NavTrackQuery, AntimeridianBoxThrows)
+{
+  // 170 E .. -170 E normalizes to a >180-degree span: the same fail-loud
+  // contract as tilesForBoundingBox.
+  EXPECT_THROW(
+    marine_survey_index::queryNavTrackInBox(db_, 40.0, 170.0, 45.0, -170.0),
+    std::invalid_argument);
+}
+
 TEST_F(QueryJoin, WrongLevelSameRowColDoesNotMatch)
 {
   // A tile key is (level, row, col) — the same row/col at a different level

--- a/marine_survey_index/test/test_query_join.cpp
+++ b/marine_survey_index/test/test_query_join.cpp
@@ -218,6 +218,15 @@ TEST_F(NavTrackQuery, ReversedBoxIsSwapped)
   EXPECT_EQ(points.size(), 4u);
 }
 
+TEST_F(NavTrackQuery, OutOfRangeLatitudesAreClamped)
+{
+  // Same clamp-into-[-90, 90] semantics as tilesForBoundingBox: beyond-pole
+  // bounds behave like the poles, they do not throw or change the result.
+  const auto points = marine_survey_index::queryNavTrackInBox(
+    db_, -100.0, kLon - 0.01, 100.0, kLon + 0.01);
+  EXPECT_EQ(points.size(), 4u);   // far point excluded by longitude only
+}
+
 TEST_F(NavTrackQuery, AntimeridianBoxThrows)
 {
   // 170 E .. -170 E normalizes to a >180-degree span: the same fail-loud

--- a/marine_survey_index/test/test_schema.cpp
+++ b/marine_survey_index/test/test_schema.cpp
@@ -63,8 +63,10 @@ TEST(Schema, FreshOpenCreatesTablesAndVersion)
     singleInt(
       db,
       "SELECT count(*) FROM sqlite_master WHERE type='table'"
-      " AND name IN ('schema_version','bags','passes')"),
-    3);
+      " AND name IN ('schema_version','bags','passes','nav_track')"),
+    4);
+  // The v2 nav_track shape: id, bag_id, t_ns, latitude, longitude.
+  EXPECT_EQ(singleInt(db, "SELECT count(*) FROM pragma_table_info('nav_track')"), 5);
   sqlite3_close(db);
 }
 


### PR DESCRIPTION
## Summary

Closes #265. Part of #258 — feeds the explorer map's nav-track overlay (rolker/marine_perception_tools#24).

Schema **v1 → v2**: new `nav_track` table holding a **distance-decimated nav track** per bag (default one point per ≥ 10 m, `--nav-stride-m`), recorded during the indexer's existing single interleaved pass at negligible cost and written in the same per-bag atomic transaction as the passes. No migration — the index is a regenerable sidecar; a v1 DB fails loud with the existing "re-run the indexer" hint.

## What's in it

- `nav_decimation.hpp` (new, header-only): `haversineMeters` + `NavDecimator` distance gate. Rejects non-finite input without poisoning its reference (a NaN reference would defeat the gate for the rest of the bag).
- Indexer: `--nav-stride-m` (validated finite > 0), collection at each posed ping's ground origin, explicit `DELETE FROM nav_track` on the re-index path (the bag row survives, so the CASCADE never fires), points stored time-ordered, nav count in the per-bag log line.
- Accessors for the explorer (`query.hpp`): `queryNavTrack(bag_id)` and `queryNavTrackInBox(box)` — box queries normalize/swap and **throw on antimeridian-crossing spans**, mirroring `tilesForBoundingBox`'s fail-loud contract.
- Docs: schema doc v2 section — point provenance (**sensor ground origins interleaved across topics, not a vehicle-frame track**), decimation semantics ("density target, not a per-pair guarantee"), accessor contract. Package README updated.
- Tests: new `test_nav_decimation.cpp` (9), nav accessor fixture in `test_query_join.cpp` (6 — ordering, bag filter, box subset, reversed box, antimeridian throw), schema table/column checks. **111 tests, 0 failures.**

## Verification on real bags (scratch DB; bags untouched)

- 2026-06-16 bag: 235k pings → 346 points, 3.46 km / 76 min at 0.76 m/s, median consecutive gap exactly 10.0 m.
- 2026-06-26T13-57-35 bag: faithfully records the **known failing-FCU-gyro event** (earth→sensor oscillating ~80 m at ~5 Hz). Deliberately no speed-heuristic filtering — the track overlay will make that data-quality artifact visible, which is the point of the explorer.

## Lifecycle

Plan reviewed (approve-with-suggestions, all 4 folded in) and pre-push code review approved (2 suggestions, both fixed): `.agent/work-plans/issue-265/`.

After merge: re-index the Massabesic campaign (37 bags, ~minutes) to regenerate `survey_index.db` at v2.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ANNoHvkpbXKK7oFBFf5pru
