### PR TITLE
SonarInfo: angular-response TL provenance (tier-1 vs tier-2)

### DIFF
--- a/.agent/work-plans/issue-268/plan.md
+++ b/.agent/work-plans/issue-268/plan.md
@@ -1,0 +1,43 @@
+# Plan: SonarInfo angular-response TL provenance
+
+## Issue
+
+https://github.com/rolker/unh_marine_autonomy/issues/268
+
+## Context
+
+The CUBE estimator's `AngularResponseCurve` (cube_bathymetry#87) is
+self-describing about transmission loss: a tier-2 curve is a TL-REMOVED
+residual and the consumer must add back `40·log10(R) + 2αR` before
+subtracting it. `SonarInfo` (merged today, #240 / PR #266) carries the curve
+arrays but not that provenance, so a tier-2 curve read from the message would
+be silently mis-applied as tier-1. No curve-bearing bags exist yet, so the
+extension is free now.
+
+Part of the curve-delivery arc: producer marine_tools#71, consumer
+cube_bathymetry#102 (auto-enable on curve presence, decided 2026-07-16).
+
+## Approach
+
+1. `marine_interfaces/msg/SonarInfo.msg`, correction-state block, directly
+   after the angular-response arrays:
+   - `angular_response_tl` tri-state (`ANGULAR_RESPONSE_TL_UNKNOWN = 0` /
+     `_TL_IN = 1` / `_TL_REMOVED = 2`) — honest zero default per the
+     message's conventions.
+   - `float32 angular_response_absorption_db_per_m` — NaN if unknown /
+     tier-1 (explicit producer obligation, like the other NaN sentinels).
+   - Comment notes consumers MUST NOT apply a non-empty curve whose
+     provenance is `UNKNOWN` (mis-application corrupts the store).
+2. ADR-0009: addendum in the field-set section + a consequences line noting
+   the extension landed before any curve-bearing bags (no `.bmr` rule
+   needed).
+3. Build + lint; `ros2 interface show` renders.
+
+## Out of scope
+
+- Producer/consumer changes (marine_tools#71, cube_bathymetry#102).
+
+## Verification
+
+- `marine_interfaces` builds; 5 lint tests pass; interface renders with the
+  new fields.

--- a/.agent/work-plans/issue-268/progress.md
+++ b/.agent/work-plans/issue-268/progress.md
@@ -1,0 +1,26 @@
+---
+issue: 268
+---
+
+# Issue #268 — SonarInfo: angular-response TL provenance (tier-1 vs tier-2 curve self-description)
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-16 14:07 -0400
+**By**: Claude Code Agent (Claude Fable 5)
+**Verdict**: approved (suggestions applied in `8131611` same session)
+
+**Branch**: feature/issue-268 at `f0c2470` (polish at `8131611`)
+**Mode**: pre-push
+**Depth**: Standard (reason: ADR edit — override-trigger file; 75 lines)
+**Must-fix**: 0 | **Suggestions**: 4
+**Round**: 1 | **Ship**: recommended — no must-fix; all suggestions applied and re-verified (build + 5/5 lint)
+
+### Findings
+- [x] (suggestion) dB/m vs dB/km unit flip between absorption fields deserves an in-message note — `marine_interfaces/msg/SonarInfo.msg` (Lens A) → note added citing cube#87's verbatim-alpha contract
+- [x] (suggestion) plan promised a Consequences line (no-migration-needed) that was folded into the field-set bullet instead — ADR-0009 (Lens A) → line added adjacent to the bag-migration-debt bullet
+- [x] (suggestion) amendment not marked per the ADR-0005/0007 convention (Status callout) — ADR-0009 (Governance) → **Amended 2026-07-16 (#268)** callout added
+- [x] (suggestion) docs/interfaces.md summary mistyped the new fields as float32[] curves — fixed and regrouped with correction state (Governance)
+- [ ] (carried to marine_tools#71) producer must set angular_response_absorption_db_per_m = NaN explicitly even with empty curves (float default 0.0 violates the sentinel convention)
+
+Cleared by review: enum naming/values, TL formula agreement across msg/ADR/cube#87/derive tool, NaN-vs-0.0 divergence from the consumer struct (harmless — absorption only read on TL_REMOVED path), wire safety of mid-message insertion (zero curve-bearing bags, confirmed via producer test assertions), no build-time break for any consumer.

--- a/docs/decisions/0009-sonar-info-message.md
+++ b/docs/decisions/0009-sonar-info-message.md
@@ -5,6 +5,12 @@
 Proposed (2026-07-16). Tracked by
 [rolker/unh_marine_autonomy#240](https://github.com/rolker/unh_marine_autonomy/issues/240).
 
+**Amended 2026-07-16
+([#268](https://github.com/rolker/unh_marine_autonomy/issues/268)):**
+angular-response TL-provenance fields (`angular_response_tl`,
+`angular_response_absorption_db_per_m`) — see the "Curve TL provenance"
+bullet in the field set.
+
 Relates to **ADR-0006/0007** (backscatter stores — `calibration_ref` is the hook
 into their provenance records) and supersedes the CSV/parameter delivery of the
 angular-response curve from
@@ -162,6 +168,9 @@ producers or consumers** in the same change.
 - Upstreaming will re-open the per-ping-vs-per-sensor split for the
   acquisition block; the raw-vs-corrected framing decision must be finalized
   before proposing there.
+- The #268 TL-provenance fields landed before any curve-bearing SonarInfo was
+  ever recorded (the sole producer publishes empty curves), so that addition
+  itself needs no migration rule — unlike the eventual upstreaming below.
 - **Bag-migration debt is accepted**: bags recorded in the interim carry the
   `marine_interfaces/msg/SonarInfo` type name. When the message upstreams
   (and/or `pulse_lengths` migrates into `PingInfo`), a

--- a/docs/decisions/0009-sonar-info-message.md
+++ b/docs/decisions/0009-sonar-info-message.md
@@ -92,6 +92,21 @@ topic, frame-aligned with the data stream and recorded in bags.
   `source_level_db`, `angular_normalization` (tri-state), the empirical
   angular-response curve (cube#81's ARA/AVG curve as data), and a beam-pattern
   curve.
+- **Curve TL provenance** *(added by
+  [#268](https://github.com/rolker/unh_marine_autonomy/issues/268), same-day
+  addendum before any curve-bearing bags existed — no migration rule
+  needed)*: `angular_response_tl` (tri-state `UNKNOWN`/`TL_IN`/`TL_REMOVED`)
+  + `angular_response_absorption_db_per_m`, mirroring the estimator's
+  `AngularResponseCurve` from
+  [cube#87](https://github.com/rolker/cube_bathymetry/issues/87) — a tier-2
+  curve is a TL-removed residual whose consumer must add back
+  `40·log10(R) + 2αR` first. Consumers reject a non-empty curve with
+  `UNKNOWN` provenance rather than guess the TL model. Delivery arc:
+  producer
+  [marine_tools#71](https://github.com/rolker/marine_tools/issues/71),
+  consumer
+  [cube#102](https://github.com/rolker/cube_bathymetry/issues/102)
+  (curve presence auto-enables the correction; explicit config overrides).
 
 ### Design rules
 

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -255,8 +255,8 @@ is the planned first producer). See
 - `string sonar_model`, `string calibration_ref`, `builtin_interfaces/Time calibration_time`: identity + calibration hook
 - `float32[] pulse_lengths`, `float32[] bandwidths`, `uint8[] tx_signal_types`: acquisition settings, one element per TX sector
 - `uint8 intensity_quantity` / `intensity_scale` / `intensity_reference`, `float32 scale`/`offset`: what the intensity samples mean (three orthogonal axes)
-- `uint8 tvg_model`, `float32 tvg_absorption_db_per_km`, `float32 source_level_db`, `uint8 angular_normalization`: applied-correction state
-- `float32[] angular_response_*`, `float32[] beam_pattern_*`: empirical correction curves as data
+- `uint8 tvg_model`, `float32 tvg_absorption_db_per_km`, `float32 source_level_db`, `uint8 angular_normalization`, `uint8 angular_response_tl`, `float32 angular_response_absorption_db_per_m`: applied-correction state incl. the curve's TL provenance (tier-1 vs tier-2, #268)
+- `float32[] angular_response_angle_deg`/`_db_rel_nadir`, `float32[] beam_pattern_*`: empirical correction curves as data
 
 ## Related Documentation
 - [Sonar Data Ecosystem](sonar_ecosystem.md) - Big-picture map of sonar data flow + umbrella/ADR tracker

--- a/marine_interfaces/msg/SonarInfo.msg
+++ b/marine_interfaces/msg/SonarInfo.msg
@@ -140,6 +140,21 @@ uint8 angular_normalization
 float32[] angular_response_angle_deg
 float32[] angular_response_db_rel_nadir
 
+# Transmission-loss provenance of the curve above (cube_bathymetry#87): a
+# TL_REMOVED (tier-2) curve is a residual and the consumer must add back
+# 40*log10(R) + 2*alpha*R (alpha = angular_response_absorption_db_per_m)
+# before subtracting it; a TL_IN (tier-1) curve is subtracted as-is.
+# Consumers MUST NOT apply a non-empty curve whose provenance is UNKNOWN —
+# guessing the TL model mis-corrects every sample it touches.
+uint8 ANGULAR_RESPONSE_TL_UNKNOWN = 0
+uint8 ANGULAR_RESPONSE_TL_IN = 1
+uint8 ANGULAR_RESPONSE_TL_REMOVED = 2
+uint8 angular_response_tl
+
+# Absorption used when the curve's TL was removed. NaN if unknown or TL_IN
+# (producers MUST set NaN explicitly; see conventions above).
+float32 angular_response_absorption_db_per_m
+
 # Combined transmit/receive beam-pattern gain vs angle. Parallel arrays;
 # empty if unavailable.
 float32[] beam_pattern_angle_deg

--- a/marine_interfaces/msg/SonarInfo.msg
+++ b/marine_interfaces/msg/SonarInfo.msg
@@ -152,7 +152,10 @@ uint8 ANGULAR_RESPONSE_TL_REMOVED = 2
 uint8 angular_response_tl
 
 # Absorption used when the curve's TL was removed. NaN if unknown or TL_IN
-# (producers MUST set NaN explicitly; see conventions above).
+# (producers MUST set NaN explicitly; see conventions above). Deliberately
+# dB per METRE — unlike tvg_absorption_db_per_km above — because consumers
+# apply this alpha verbatim in 40*log10(R) + 2*alpha*R with R in metres
+# (cube_bathymetry#87 never recomputes it).
 float32 angular_response_absorption_db_per_m
 
 # Combined transmit/receive beam-pattern gain vs angle. Parallel arrays;


### PR DESCRIPTION
## Summary

Add transmission-loss provenance to the SonarInfo angular-response curve: tri-state `angular_response_tl` (`UNKNOWN`/`TL_IN`/`TL_REMOVED`) + `angular_response_absorption_db_per_m`, mirroring the estimator's `AngularResponseCurve` contract from rolker/cube_bathymetry#87 — a tier-2 curve is a TL-removed residual whose consumer must add back `40·log10(R) + 2αR` first, and a non-empty curve with `UNKNOWN` provenance is rejected rather than guessed at.

Closes #268

## Why now

Wire-format prerequisite for the curve-delivery arc (producer rolker/marine_tools#71, consumer rolker/cube_bathymetry#102 with auto-enable-on-curve-presence). SonarInfo merged only this morning and its sole producer publishes empty curves, so zero curve-bearing bags exist — the extension is free today and a bag-migration burden any day after curves start recording.

## Notes

- `angular_response_absorption_db_per_m` is deliberately dB/**m** (unlike the TVG block's dB/km): cube#87's consumer applies alpha verbatim with R in metres; the in-message comment calls out the unit flip.
- ADR-0009 amended in place per the 0005/0007 convention (Status callout + field-set bullet + no-migration-needed consequence).

## Verification

- `marine_interfaces` builds; 5/5 lint tests; `ros2 interface show` renders the new fields.
- Standard-tier pre-push review (round 1): 0 must-fix, 4 suggestions, all applied — see `.agent/work-plans/issue-268/progress.md`. One producer obligation (explicit NaN even with empty curves) carried into marine_tools#71.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
