### PR TITLE
docs: adopt ADR-0010 — geospatial world model (taxonomy, datum invariant, per-layer processes)

### DIFF
--- a/.agent/work-plans/issue-272/progress.md
+++ b/.agent/work-plans/issue-272/progress.md
@@ -1,0 +1,38 @@
+---
+issue: 272
+---
+
+# Issue #272 — ADR-0010: geospatial world model — taxonomy, datum invariant, per-layer processes
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-24 14:01 -0400
+**By**: Claude Code Agent (Claude Fable 5)
+**Verdict**: changes-requested → findings addressed in `fd95463`
+
+**Branch**: feature/issue-272 at `3198020` (reviewed) → `fd95463` (fixes)
+**Mode**: pre-push
+**Depth**: Deep (reason: ADR add — automatic promotion trigger)
+**Must-fix**: 4 | **Suggestions**: 8
+**Round**: 1 | **Ship**: recommended — all findings were precise prose corrections, applied same-round; no design concerns surfaced; both lenses' source-verification lists confirmed every load-bearing claim
+
+Specialists: Static skipped (no linter profile for .md — content review only);
+Governance (inline, clean — ADR-0001 convention followed, ADR-0002/0005 pointers
+in-PR, ecosystem-doc reframe recorded as follow-on); Plan Drift skipped (no
+plan); Claude Adversarial ×2 (Lens A logic/factual, Lens B systemic/safety,
+Deep prompts); Copilot off (default); Local Adversarial skipped (Ollama
+unreachable, curl exit 52).
+
+### Findings
+- [x] (must-fix) Context §2 misdescribed cross-import behavior — actual: whole-tile `insert_or_assign` clobber + stale out-of-footprint tiles, not cell-wise merge — `0010:~44` (Lens A; verified in `bathymetry_store.cpp:95-103`)
+- [x] (must-fix) D8 misattributed the "re-introduce an axis" note to A2 (it is A1's supersession, #221, and names an epoch axis) — `0010:~250` (Lens A + Lens B, cross-confirmed)
+- [x] (must-fix) D10 claimed target-resolution-bounded query exists — specified in ADR-0002 D2, never implemented — `0010:~280` (Lens A)
+- [x] (must-fix) Cost-model rework is a precondition for chart ingestion (current `max_uncertainty` gate → chart-only regions wholesale LETHAL) but read as parallel track — `0010:D7` (Lens B)
+- [x] (suggestion) D8 draft-clearing granularity ambiguous — specified cell-wise (Lens B)
+- [x] (suggestion) Nav-down regeneration gating unenforced as written — named liveness interlock (Lens B)
+- [x] (suggestion) Swap↔edition-registry atomicity + staleness surfacing unstated — registry-inside-staged-dir, age/health surfacing (Lens B)
+- [x] (suggestion) External ENC download trust/validation unstated — checksums + raster sanity check before swap (Lens B)
+- [x] (suggestion) ADR-0007 MBES backscatter has the same degradation loop — explicitly accepted (display-grade) with revisit trigger (Lens B)
+- [x] (suggestion) D3 draft row conflated ADR-0008 display transport with D6 store sync — tightened (Lens B)
+- [x] (suggestion) Read-only import gate placement under 4-layer taxonomy unstated — write-gates paragraph added to D3 (Lens B)
+- [x] (suggestion) Migration wording understated survey re-split (no per-cell provenance to split by) — wholesale survey→processed re-classification specified (Lens A); consequences migration list expanded + ADR-0005 header pointer added (Lens B)

--- a/docs/decisions/0002-bathymetric-data-store.md
+++ b/docs/decisions/0002-bathymetric-data-store.md
@@ -52,6 +52,19 @@ per-cell source-index intern table to a coarse store-level `StoreMetadata` sidec
 and the `bathymetry_layer` **per-cell staleness gate is retired** (it read the now-
 dropped per-cell time). See **Amendment A2** below.
 
+**Amended 2026-07-24 ([#272](https://github.com/rolker/unh_marine_autonomy/issues/272),
+[ADR-0010](0010-geospatial-world-model.md)):** the store is situated in the
+**geospatial world model** and the source-layer taxonomy is revised by ADR-0010:
+a **`chart` layer is re-introduced** (S57 depths flow through the store — the
+"later phase" D7 flagged; regenerated from the ENC corpus, never merged) and the
+**draft/processed quality axis is restored** (Amendment A2's collapse to a single
+`survey` layer is partially superseded on new evidence: the live and offline CUBE
+paths produce different-quality surfaces, and last-write-wins degrades the store
+under a multi-day campaign loop). Depth layers are now
+`chart | reference | draft | processed`. See ADR-0010 D3/D7/D8 for the decisions
+and rationale; A2's remaining simplifications (single value tile, coarse
+`StoreMetadata`, no per-cell staleness gate) stand.
+
 The full design is in the issue body; this ADR records the load-bearing
 architecture decisions and their rationale so they survive the issue. It is a
 **cross-cutting** decision in the sense ADR-0001 establishes for this repo's

--- a/docs/decisions/0005-multi-platform-provenance-registry.md
+++ b/docs/decisions/0005-multi-platform-provenance-registry.md
@@ -11,6 +11,13 @@ backscatter stores — **sidescan** (ADR-0006) and **MBES** (ADR-0007), both und
 #180 — and defines the provenance contract all three share. It is foundational to
 those store ADRs rather than owned by any one of them.
 
+**Amended 2026-07-24 ([#272](https://github.com/rolker/unh_marine_autonomy/issues/272),
+[ADR-0010](0010-geospatial-world-model.md)):** prose references in this ADR to
+the bathy store's quality/maturity layers read through ADR-0010 D3 — the
+taxonomy is now `chart | reference | draft | processed` (it was
+`chart/draft/processed` when this ADR was written, and `survey/reference`
+after #248). This ADR's per-cell provenance contract is unchanged.
+
 **Amended 2026-07-01 ([#248](https://github.com/rolker/unh_marine_autonomy/issues/248)):**
 for the current **single-platform** deployment the per-cell source-index axis (D2)
 is **dropped** from the bathy and MBES stores, and their `registry.json` sidecar is

--- a/docs/decisions/0010-geospatial-world-model.md
+++ b/docs/decisions/0010-geospatial-world-model.md
@@ -13,7 +13,8 @@ Cross-cutting per the ADR-0001 convention: spans `marine_bathymetry_store`,
 source layer (D3, D7) and restores the draft/processed quality axis that
 Amendment A2 ([#248](https://github.com/rolker/unh_marine_autonomy/issues/248))
 collapsed (D8) — both on new evidence recorded below, not a re-litigation of
-A2's reasoning. ADR-0002 receives a header pointer to this ADR in the same PR.
+A2's reasoning. ADR-0002 and ADR-0005 receive header pointers to this ADR in
+the same PR.
 
 **Builds on (unchanged):** ADR-0004 (unified Contact), ADR-0005 (provenance
 registry — dormant per its #248 amendment, retained as the multi-platform
@@ -38,9 +39,14 @@ exposed three structural facts, and the Massabesic season surfaced a fourth:
 
 2. **Chart data has a lifecycle unlike anything the store holds.** ENC editions
    are authoritative supersessions: a hazard removed in a new edition must
-   vanish. The store's importer merges cell-wise (lower uncertainty wins,
-   no delete-by-source — verified in `geotiff_import.cpp`), so repeated ENC
-   imports accumulate stale cells. Charts also arrive with their own
+   vanish. The import path handles repeat imports badly in both directions
+   (verified in `geotiff_import.cpp` / `bathymetry_store.cpp`): the
+   lowest-uncertainty-wins merge resolves only *within-import* pixel
+   contention into a local tile set, which `importTiles` then
+   `insert_or_assign`s **whole-tile** into the layer — so a re-import
+   silently replaces every prior same-layer cell in the tiles it touches,
+   while tiles outside the new import's footprint linger stale forever
+   (no delete-by-source). Charts also arrive with their own
    level-of-detail structure (the harbor/approach/coastal scale ladder) and
    their own quality metadata (CATZOC), neither of which the current layer
    model expresses.
@@ -117,15 +123,26 @@ Provenance layers for the depth theme, replacing ADR-0002 A2's
 |---|---|---|
 | `chart` | Official navigation products (S57 → S-100 later) | Regenerated wholesale from the corpus on edition change (D7) |
 | `reference` | Third-party priors (contour models, external grids/BAGs) | One-shot bespoke imports, σ per source |
-| `draft` | Live on-boat CUBE output | Streaming append, synced (ADR-0008), evictable, disposable (D8) |
+| `draft` | Live on-boat CUBE output | Streaming append; live view via the ADR-0008 display transport (store-level sync remains ADR-0002 D6, deferred); evictable, disposable (D8) |
 | `processed` | Off-boat deterministic re-run (`import_bag`) | Authoritative product, distributed back; clears overlapped draft (D8) |
 
 The **imagery theme keeps its own tiering**: the sidescan and MBES backscatter
 stores are deliberate siblings with cross-store arbitration at the query layer
 (ADR-0006 D8); their layer names are not force-renamed to match the depth
-theme. The existing `~/data/stores/` content maps directly: the NH GRANIT
-prior is already in `reference/` (correctly, post-A2); survey data splits per
-D8; path changes are config migration only.
+theme.
+
+**Write gates**: both prior layers are closed to normal ingest — `reference`
+keeps A2's construction-time read-only-prior gate (explicit importer opt-in,
+mechanism unchanged), and `chart` is writable **only** by the D7 regeneration
+path. Live and replay ingest write `draft`/`processed` exclusively.
+
+**Migration of existing stores**: the NH GRANIT prior is already in
+`reference/` (correctly, post-A2). The existing fused `survey/` layer carries
+no per-cell live-vs-re-run provenance (A2 dropped it), so there is nothing to
+split — it is **re-classified wholesale to `processed/`**, which is accurate:
+the current Massabesic stores were regenerated via `import_bag` (the
+authoritative path). `draft/` starts empty. Beyond that, path changes are
+config migration.
 
 ### D4 — Layers encode process; σ encodes trust
 
@@ -221,10 +238,30 @@ Export rules (`s57_to_geotiff`, new tool in `s57_tools`, feeding the existing
   shallowest-reliable walk from letting a coarse band's midpoint shadow a
   confident harbor-chart depth.
 
-First cut regenerates **only while navigation is down** (dockside/pre-mission).
+**Chart ingestion is gated on the cost-model rework.** `bathymetry_layer`'s
+current `max_uncertainty` gate treats over-uncertain cells as
+not-reliable → LETHAL, so CATZOC-grade σ entering the store would render
+chart-only regions wholesale keepout (or force a global gate relaxation that
+also weakens it for noisy draft data). The worst-case-clearance /
+confidence-gate cost model (design settled 2026-06-25: high-σ ⇒ go-slow,
+keepout only on trusted data) must land **with or before** the first chart
+cells — it is a precondition, not a parallel track.
+
+First cut regenerates **only while navigation is down** — an *enforced*
+precondition, not an assumption: the updater checks a navigation-liveness
+signal (lock/heartbeat) and refuses to swap while nav is active, cron or not.
 Live regeneration under a running consumer is deferred until atomic tile
 writes ([uma#189](https://github.com/rolker/unh_marine_autonomy/issues/189)/[#256](https://github.com/rolker/unh_marine_autonomy/issues/256))
-and a store-change invalidation in `bathymetry_layer` exist.
+and a store-change invalidation in `bathymetry_layer` exist. Two robustness
+rules for the updater: (a) the edition registry is written **inside** the
+staged layer directory so the atomic swap is the single commit point — a
+half-failed run leaves the old layer + old registry fully intact, never a
+current-registry/stale-layer split; (b) the updater surfaces chart-layer
+age/health (last successful regeneration, last download attempt) so repeated
+download failures age the layer loudly, not silently. Downloaded ENC data is
+validated before the swap — catalog checksums where NOAA provides them, plus
+a sanity check on the exported rasters (nonzero cell counts, plausible depth
+range) — so a corrupt or truncated download can never swap in.
 
 ### D8 — Quality axis restored: `draft` (live) vs `processed` (offline re-run)
 
@@ -238,13 +275,29 @@ surfaces** (Context §3), so they are different quality classes:
   distributed back to boat and operator stores.
 - Best-source priority `processed > draft` (D4), so a fresh live pass adds
   data where the re-run has none but never degrades re-run cells.
-- **Regeneration clears overlapped draft**: when a new processed import lands,
-  draft cells within its coverage are removed, so stale gap-striping never
+- **Regeneration clears overlapped draft, cell-wise**: when a new processed
+  import lands, draft cells are removed **only where the processed import has
+  data** (not the whole import footprint). Draft cells in the re-run's small
+  gated-drop holes survive — harmless under `processed > draft` and strictly
+  more data than clearing by footprint — while stale gap-striping never
   accumulates under the authoritative surface.
 
 A2's collapse was correct for its context (single platform, single coverage,
-processed once); the day-to-day campaign loop is the new workflow A2's own
-supersession note said would justify re-introducing an axis. Follow-ups, not
+processed once). ADR-0002's **A1** supersession note (#221) already recorded
+the discipline this amendment follows: an axis removed as speculative must be
+re-introduced when a workflow actually needs one (it named the
+revisit-and-compare workflow and an epoch/versioning axis; the day-to-day
+campaign loop is the workflow that arrived, and the quality axis is the
+minimal form it needs — neither note pre-authorized D8, but the reversal
+pattern is the recorded, intended one).
+
+The same live-vs-re-run degradation applies in principle to the **MBES
+backscatter store** (ADR-0007, CUBE-coupled, likewise collapsed to a single
+layer by #248). It is **accepted there for now**: backscatter is a
+display/QC product, not a navigation-safety input, so last-write-wins
+striping costs image quality, not safety. Revisit ADR-0007 (with a header
+pointer) if/when backscatter becomes a decision input or the striping
+measurably hurts mosaic QC. Follow-ups, not
 gating this ADR: quantify the live-vs-re-run delta (A/B diff of the two stores
 for one Massabesic day), and characterize/mitigate live-node backpressure in
 `cube_bathymetry` (shrinks the gap; cannot close it — determinism and
@@ -273,11 +326,13 @@ This fills the "refinement policy — staged" gap ADR-0002 D2/#151 left open.
   its depth ramp, retaining land, `restricted`, `overhead`, `caution`,
   `unsurveyed`, and point hazards — a late-rasterizing feature consumer (D2).
   Its `chart_datum`/tide machinery becomes dead code in this mode (D5).
-- **Voyage planner** (future consumer, no new query machinery): plans
+- **Voyage planner** (future consumer, no data-model change): plans
   corridors at coastal/approach levels — cheap and conservative by D9 — and
-  drops to harbor level at route endpoints, via the existing
-  target-resolution-bounded query. Our own survey data joins coarse-level
-  planning only once D9 pyramids exist.
+  drops to harbor level at route endpoints. The level-aware walk exists in
+  the query today; the **optional target-resolution bound is specified in
+  ADR-0002 D2 but not yet implemented** — a small query-API addition the
+  planner will need, not new store machinery. Our own survey data joins
+  coarse-level planning only once D9 pyramids exist.
 - **Overhead ceilings**: deferred. The end-state is an ellipsoidal-ceiling
   field (charted clearance converted at import; runtime check symmetric with
   the seafloor). Until then `s57_layer`'s raw high-water-referenced
@@ -312,8 +367,10 @@ scope.
 - **Costs**: a new library (D6), a new exporter + updater (D7), the layer
   re-split touching store, importers, and `cube_bathymetry` write paths (D8),
   the `s57_layer` split (D10), and config migration (`~/data/stores` →
-  `~/data/world`, nav2 `store_path`s, launch files). Each lands as its own
-  issue/PR.
+  `~/data/world`: nav2 `store_path`s and launch files on the boat, CAMP /
+  operator-station store paths, and dev-tooling defaults keyed to the old
+  root such as the survey index at `~/data/stores/survey_index.db`). Each
+  lands as its own issue/PR.
 - **Supersessions / housekeeping**: ADR-0002 header pointer (same PR);
   [uma#163](https://github.com/rolker/unh_marine_autonomy/issues/163)
   (chart-source layer) closed or repurposed toward D7;

--- a/docs/decisions/0010-geospatial-world-model.md
+++ b/docs/decisions/0010-geospatial-world-model.md
@@ -24,7 +24,7 @@ transport).
 ## Context
 
 The August 2026 Isles of Shoals survey returns operations to ENC-covered
-coastal waters after a season on an unchartered lake. Bringing charts back
+coastal waters after a season on an uncharted lake. Bringing charts back
 exposed three structural facts, and the Massabesic season surfaced a fourth:
 
 1. **Cross-layer override is impossible in the costmap.** `bathymetry_layer`

--- a/docs/decisions/0010-geospatial-world-model.md
+++ b/docs/decisions/0010-geospatial-world-model.md
@@ -1,0 +1,354 @@
+# ADR-0010: The Geospatial World Model — Taxonomy, Datum Invariant, and Per-Layer Processes
+
+## Status
+
+Proposed (2026-07-24). Tracked by
+[rolker/unh_marine_autonomy#272](https://github.com/rolker/unh_marine_autonomy/issues/272).
+
+Cross-cutting per the ADR-0001 convention: spans `marine_bathymetry_store`,
+`marine_tiled_raster_store`, `marine_autonomy` (GGGS), `s57_tools`,
+`mru_transform`, `cube_bathymetry`, `camp`, and the contact stores (ADR-0004).
+
+**Amends [ADR-0002](0002-bathymetric-data-store.md):** re-introduces a `chart`
+source layer (D3, D7) and restores the draft/processed quality axis that
+Amendment A2 ([#248](https://github.com/rolker/unh_marine_autonomy/issues/248))
+collapsed (D8) — both on new evidence recorded below, not a re-litigation of
+A2's reasoning. ADR-0002 receives a header pointer to this ADR in the same PR.
+
+**Builds on (unchanged):** ADR-0004 (unified Contact), ADR-0005 (provenance
+registry — dormant per its #248 amendment, retained as the multi-platform
+contract), ADR-0006/0007 (sibling backscatter stores), ADR-0008 (live tile
+transport).
+
+## Context
+
+The August 2026 Isles of Shoals survey returns operations to ENC-covered
+coastal waters after a season on an unchartered lake. Bringing charts back
+exposed three structural facts, and the Massabesic season surfaced a fourth:
+
+1. **Cross-layer override is impossible in the costmap.** `bathymetry_layer`
+   max-combines into the master grid (it can only raise cost); ordering it
+   after `s57_layer` therefore cannot let surveyed-deeper data relax charted
+   shoal cost, and switching to overwrite would clear charted rocks and wrecks
+   that ride in on the same `elevation` band
+   ([echoboats#276](https://github.com/rolker/unh_echoboats_project11/issues/276)'s
+   footgun). Per-cell best-source selection must happen **in the store**, before
+   cost is computed. ADR-0002 D7 anticipated exactly this: "Eventually S57
+   depths flow *through* the store rather than directly to the costmap."
+
+2. **Chart data has a lifecycle unlike anything the store holds.** ENC editions
+   are authoritative supersessions: a hazard removed in a new edition must
+   vanish. The store's importer merges cell-wise (lower uncertainty wins,
+   no delete-by-source — verified in `geotiff_import.cpp`), so repeated ENC
+   imports accumulate stale cells. Charts also arrive with their own
+   level-of-detail structure (the harbor/approach/coastal scale ladder) and
+   their own quality metadata (CATZOC), neither of which the current layer
+   model expresses.
+
+3. **The day-to-day survey loop degrades a single fused survey layer.** The
+   live CUBE node loses pings in bursts under subscriber-queue backpressure
+   (observed as ping-gap striping in live tiles), while the offline
+   `import_bag` re-run processes every bagged ping deterministically
+   (~0.5 % residual nav/TF-gated drops). CUBE estimates are not
+   ping-count-invariant, so the live surface is both gappier and noisier than
+   the re-run. Under A2's single last-write-wins `survey` layer, the next
+   day's live pass overwrites the previous night's authoritative re-run
+   wherever swaths overlap — **continuing to survey makes the store worse**.
+   Massabesic never exercised this loop (single coverage, processed once);
+   a multi-day campaign lives in it.
+
+4. **A TF frame is the wrong container for a chart datum.** `chart_datum` is a
+   single z-offset, but the MLLW–ellipsoid separation is a spatially varying
+   surface — decimeters of error across a coastal survey area, plus a runtime
+   dependency (grids + node on the boat) for what is fundamentally static
+   per-location data.
+
+Meanwhile the store system has grown beyond bathymetry: backscatter imagery
+(ADR-0006/0007), contacts (ADR-0004), live tile sync (ADR-0008), and now chart
+depths, overhead clearances, and chart features. This ADR names the resulting
+system, fixes its taxonomy and invariants, and records the per-layer processes.
+
+## Decision
+
+### D1 — The world model: one umbrella, not one database
+
+The collection of geospatial stores is the vehicle's **world model**: its
+persistent knowledge of the environment, organized as **raster stores (fields)
++ feature stores (features) + the provenance registry (ADR-0005)**, sharing the
+GGGS spatial index, the ellipsoidal datum invariant (D5), and the
+regenerable-from-source philosophy (every store is a cache derivable from
+source material — bags, the ENC corpus, reference inputs).
+
+Adoption is **umbrella-level only**: the on-disk root becomes `~/data/world/`,
+documentation (including `docs/sonar_ecosystem.md`) reframes around the world
+model, and consumers keep depending on the individual stores. **No package
+renames** — `marine_bathymetry_store`, `marine_tiled_raster_store`, etc. remain;
+their names describe mechanisms, not the concept.
+
+### D2 — Fields are rasters; features stay vector; rasterization happens late
+
+- **Fields** — continuous scalar surfaces (depth, uncertainty, backscatter,
+  and eventually overhead ceilings) — live in GGGS-tiled raster stores.
+- **Features** — discrete geometries with attributes and lifecycles
+  (restricted areas, caution zones, floating hazards, wrecks-as-objects,
+  contacts) — stay **vector**, rasterized only at the consumer (a costmap
+  layer, a display renderer), never at ingest.
+
+Late rasterization preserves feature identity, which is operationally
+load-bearing: an operator authorized to work inside a restricted area waives
+*that feature*; baked-in cost cells cannot be waived. The contacts pipeline
+(ADR-0004) is the existing feature-side precedent.
+
+### D3 — Taxonomy: theme × provenance
+
+```
+~/data/world/
+├── depths/       chart | reference | draft | processed     (bathymetry store)
+├── imagery/      sidescan store (two-tier, ADR-0006) +
+│                 MBES backscatter store (CUBE-coupled, ADR-0007)
+├── features/     contacts (ADR-0004); chart features thin — see D11
+└── charts/       the ENC corpus itself + edition registry (cron-managed, D7)
+```
+
+Provenance layers for the depth theme, replacing ADR-0002 A2's
+`survey`/`reference` pair:
+
+| Layer | What | Lifecycle process |
+|---|---|---|
+| `chart` | Official navigation products (S57 → S-100 later) | Regenerated wholesale from the corpus on edition change (D7) |
+| `reference` | Third-party priors (contour models, external grids/BAGs) | One-shot bespoke imports, σ per source |
+| `draft` | Live on-boat CUBE output | Streaming append, synced (ADR-0008), evictable, disposable (D8) |
+| `processed` | Off-boat deterministic re-run (`import_bag`) | Authoritative product, distributed back; clears overlapped draft (D8) |
+
+The **imagery theme keeps its own tiering**: the sidescan and MBES backscatter
+stores are deliberate siblings with cross-store arbitration at the query layer
+(ADR-0006 D8); their layer names are not force-renamed to match the depth
+theme. The existing `~/data/stores/` content maps directly: the NH GRANIT
+prior is already in `reference/` (correctly, post-A2); survey data splits per
+D8; path changes are config migration only.
+
+### D4 — Layers encode process; σ encodes trust
+
+A layer is defined by *how data enters and is maintained* (the table in D3),
+**not** by a fixed trust rank. Trust is the per-cell uncertainty σ, the
+universal quality measure every source fills (survey σ from CUBE; chart σ from
+CATZOC, D7; reference σ from each import recipe; unknown → σ = ∞).
+
+Query semantics (refining ADR-0002 D3):
+
+- **Shallowest-reliable (safety)**: unchanged — examines every layer and level,
+  selects on depth + uncertainty only, ignores layer identity (ADR-0002 D7 /
+  ADR-0005 D5 carve-out). This is the mode driving costmap cost; the costmap
+  uses best-source only as a data-existence check, so nothing below affects
+  navigation behavior.
+- **Best-source (default)**: `processed > draft` is decided here — it is the
+  D8 anti-clobber semantics and importers build against it. **Arbitration
+  within the prior class (`reference` vs `chart`) is explicitly deferred** to
+  the first consumer that needs a fused best-estimate answer (a CAMP fused
+  depth view, QC tooling, voyage-planner display — none exist yet, and some
+  candidate consumers want per-layer or per-consumer answers anyway). The
+  policy is query-time only — no on-disk footprint, changeable without
+  touching stored data. Until decided, implementations use a fixed
+  `processed > draft > reference > chart` walk as a documented placeholder.
+  Candidate policies recorded so the decision is not re-derived: (a) fixed
+  ordering (simple, predictable; wrong when a low-σ reference BAG should beat
+  a CATZOC-C chart); (b) lowest-σ wins among priors (honest; less
+  predictable); (c) per-consumer choice (likely where this lands — QC,
+  chart-comparison, and display plausibly each want different answers).
+
+### D5 — Ellipsoidal invariant: datum conversion at import; `map_tide` is the only runtime vertical reference
+
+All stored heights are WGS84-ellipsoidal (ADR-0002 D4, now made operational
+end-to-end). Datum conversion happens **once, at import time, wherever import
+runs** — per-cell VDatum separation for ENC (more accurate than any single
+offset), constant offset for lakes, native ellipsoidal for our own surveys.
+
+At runtime the entire vertical world is GNSS-ellipsoidal: clearance =
+`z(map_tide)` − stored height, with `map_tide` self-measured by
+`sea_surface_estimator`. No tide tables, no gauge feeds, no datum grids in the
+navigation loop. **The `chart_datum` TF frame exits the autonomy stack** once
+`s57_layer` stops computing depth (D10); it was also spatially wrong as a
+frame (Context §4). Overhead clearances, charted relative to high water, are
+conservative when compared raw and are handled per D10.
+
+### D6 — Vertical-datum library: ROS-free, in core_ws
+
+The datum machinery is extracted from `mru_transform` into a small **ROS-free
+library in core_ws** (placement constraint: `s57_tools` (core), CAMP (ui), and
+`mru_transform` (platforms) must all be able to depend on it):
+
+- the PROJ/VDatum grid query (geoid + regional `.gtx` → MLLW/MHHW relative to
+  ellipsoid at a lat/lon), currently inline in `chart_datum_node`;
+- the existing ROS-free resolution chain (`datum_config`: lake-param →
+  override polygons → VDatum → fallback polygons → absent), moved wholesale —
+  the precedence chain *is* the lake story and importers need it too.
+
+Consumers: the S57 exporter (per-cell, offline), CAMP (display-time
+chart-datum readouts, operator-side), and `chart_datum_node` reduced to a thin
+transitional wrapper. VDatum grids live wherever imports run — including the
+boat as **offline tooling** (D7) — but never in the runtime stack.
+[mru_transform#8](https://github.com/rolker/mru_transform/issues/8) (TF-frame
+datum hierarchy design) is updated/closed against this direction;
+mru_transform#7 (VDatum service) was delivered as `chart_datum_node` and is
+subsumed.
+
+### D7 — The chart layer is regenerated from the corpus, never merged
+
+The `chart` layer is a **derived cache over the ENC corpus** (`world/charts/`),
+maintained by an updater (cron-friendly; folds
+[s57_tools#5](https://github.com/rolker/s57_tools/issues/5)) that downloads
+ENC updates and **rebuilds the chart layer wholesale** on change — build into a
+temporary layer directory, atomic swap. Never cell-wise merged: editions are
+supersessions, and regeneration is what makes removal, re-arbitration, and
+the clipping rule below trivial. Other layers are untouched.
+
+Export rules (`s57_to_geotiff`, new tool in `s57_tools`, feeding the existing
+`import_geotiff`):
+
+- **Depth sources**: DEPARE/DRGARE polygons → band midpoint depth +
+  half-band σ floor; SOUNDG points. (Structurally the NH GRANIT recipe,
+  generalized.)
+- **CATZOC → σ** (M_QUAL, currently ignored in `marine_charts`): per the ZOC
+  table — A1 ≈ 0.5 m + 1 %d, A2/B ≈ 1.0 m + 2 %d, C ≈ 2.0 m + 5 %d, D/U →
+  large σ (never keepout-grade; see the cost-model work this feeds).
+- **Datum**: per-cell chart-datum → ellipsoid via the D6 library.
+- **Scale → GGGS level**: each ENC cell exports at the level matching its
+  compilation scale (≈0.5 mm-at-scale resolvable ground distance, mapped to
+  the nearest GGGS level). The store is already multi-level (ADR-0002 D2/#151).
+- **Largest scale governs**: each chart's raster footprint is clipped by all
+  finer-scale charts' footprints, so coarse cells are never generated where
+  finer coverage exists — standard chart practice, and it prevents the
+  shallowest-reliable walk from letting a coarse band's midpoint shadow a
+  confident harbor-chart depth.
+
+First cut regenerates **only while navigation is down** (dockside/pre-mission).
+Live regeneration under a running consumer is deferred until atomic tile
+writes ([uma#189](https://github.com/rolker/unh_marine_autonomy/issues/189)/[#256](https://github.com/rolker/unh_marine_autonomy/issues/256))
+and a store-change invalidation in `bathymetry_layer` exist.
+
+### D8 — Quality axis restored: `draft` (live) vs `processed` (offline re-run)
+
+Amends ADR-0002 A2.1. The live and offline CUBE paths produce **different
+surfaces** (Context §3), so they are different quality classes:
+
+- **`draft`** — live on-boat CUBE: immediate, feeds today's costmap and the
+  operator coverage view via ADR-0008 sync; known-gappy; disposable and
+  regenerable from bags.
+- **`processed`** — the deterministic off-boat re-run: authoritative,
+  distributed back to boat and operator stores.
+- Best-source priority `processed > draft` (D4), so a fresh live pass adds
+  data where the re-run has none but never degrades re-run cells.
+- **Regeneration clears overlapped draft**: when a new processed import lands,
+  draft cells within its coverage are removed, so stale gap-striping never
+  accumulates under the authoritative surface.
+
+A2's collapse was correct for its context (single platform, single coverage,
+processed once); the day-to-day campaign loop is the new workflow A2's own
+supersession note said would justify re-introducing an axis. Follow-ups, not
+gating this ADR: quantify the live-vs-re-run delta (A/B diff of the two stores
+for one Massabesic day), and characterize/mitigate live-node backpressure in
+`cube_bathymetry` (shrinks the gap; cannot close it — determinism and
+full-data replay remain offline properties).
+
+### D9 — LOD is a per-layer process
+
+- **`chart`**: LOD arrives built-in — the scale ladder is a
+  cartographer-curated pyramid, and chart generalization is shoal-biased, so
+  coarse levels are inherently conservative. No pyramid generation.
+- **`draft`/`processed`**: born at fine native levels; overview levels are
+  generated ([uma#188](https://github.com/rolker/unh_marine_autonomy/issues/188))
+  with **shallowest-preserving aggregation** — never a mean; the rock must
+  survive the downsample.
+- **`reference`**: as imported.
+- **Never upsample**: coarse data is never rasterized finer than its source;
+  consumers wanting finer fall through to coarser levels (the level-aware
+  query already does this).
+
+This fills the "refinement policy — staged" gap ADR-0002 D2/#151 left open.
+
+### D10 — Consumers: the costmap and the voyage planner; `s57_layer` keeps only non-depth semantics
+
+- **Costmap**: `bathymetry_layer` is the single depth authority, windowing
+  finest-available around the vehicle. `s57_layer` gains a mode suppressing
+  its depth ramp, retaining land, `restricted`, `overhead`, `caution`,
+  `unsurveyed`, and point hazards — a late-rasterizing feature consumer (D2).
+  Its `chart_datum`/tide machinery becomes dead code in this mode (D5).
+- **Voyage planner** (future consumer, no new query machinery): plans
+  corridors at coastal/approach levels — cheap and conservative by D9 — and
+  drops to harbor level at route endpoints, via the existing
+  target-resolution-bounded query. Our own survey data joins coarse-level
+  planning only once D9 pyramids exist.
+- **Overhead ceilings**: deferred. The end-state is an ellipsoidal-ceiling
+  field (charted clearance converted at import; runtime check symmetric with
+  the seafloor). Until then `s57_layer`'s raw high-water-referenced
+  comparison is conservative and sufficient.
+
+### D11 — Chart features stay thin until S-100
+
+No chart-feature ingestion into a store we own: **the ENC corpus is the
+feature store** (`marine_charts` already queries it), and the world model
+tracks only corpus membership + editions (D7's registry). Revisit at the
+S-100 transition: S-101 replaces the feature model wholesale, and S-102
+(gridded depth + uncertainty) maps natively onto the D3 raster convention —
+the thin choice leaves nothing to unwind.
+
+### D12 — What the world model is not
+
+Not a general GIS. No arbitrary-CRS support (WGS84/ellipsoidal only), no
+styling/symbology, no external spatial database, no ambition to replace GDAL
+or QGIS for analysis. The value is the opinionated subset: GGGS-tiled,
+σ-everywhere, ellipsoidal, regenerable, queryable by Nav2 and CAMP. Additions
+that don't serve a navigation, survey, or operator-display consumer are out of
+scope.
+
+## Consequences
+
+- **Positive**: per-cell best-source across surveyed and charted depth with no
+  costmap-layer override hacks; chart updates flow automatically and
+  supersede cleanly; the store stops degrading under the daily survey loop;
+  the boat's runtime is fully GNSS-ellipsoidal (no datum grids, no
+  `chart_datum` frame); one documented mental model ("world") over a system
+  that had outgrown "the bathy store".
+- **Costs**: a new library (D6), a new exporter + updater (D7), the layer
+  re-split touching store, importers, and `cube_bathymetry` write paths (D8),
+  the `s57_layer` split (D10), and config migration (`~/data/stores` →
+  `~/data/world`, nav2 `store_path`s, launch files). Each lands as its own
+  issue/PR.
+- **Supersessions / housekeeping**: ADR-0002 header pointer (same PR);
+  [uma#163](https://github.com/rolker/unh_marine_autonomy/issues/163)
+  (chart-source layer) closed or repurposed toward D7;
+  [s57_tools#23](https://github.com/rolker/s57_tools/issues/23) (clean-room
+  ENC→costmap design) answered by this ADR;
+  [echoboats#276](https://github.com/rolker/unh_echoboats_project11/issues/276)'s
+  dangling "#14" reference re-pointed at the D10 split work;
+  [s57_tools#26](https://github.com/rolker/s57_tools/issues/26) mooted for the
+  costmap chain by D5/D10; mru_transform#8 updated/closed per D6;
+  `docs/sonar_ecosystem.md` reframed (follow-on doc task).
+- **Sequencing risk**: the long pole for August is D6 + D7 (library +
+  exporter + regeneration semantics). The D10 split can precede D7 (run
+  `s57_layer` obstacles-only from day one, retiring `chart_datum` early) at
+  the cost of no charted-depth costs until the exporter lands; or
+  echoboats#276's interim (re-enable `s57_layer` whole) runs first, keeping
+  `chart_datum` temporarily. That choice is an implementation decision,
+  recorded in the issues, not fixed here.
+
+## References
+
+- Umbrella / prior ADRs: [ADR-0002](0002-bathymetric-data-store.md) (+ A2/#248),
+  [ADR-0004](0004-unified-perception-contact.md),
+  [ADR-0005](0005-multi-platform-provenance-registry.md),
+  [ADR-0006](0006-multi-platform-backscatter-store.md),
+  [ADR-0007](0007-mbes-backscatter-store.md),
+  [ADR-0008](0008-live-sonar-coverage-transport-and-render.md)
+- Issues: [uma#86](https://github.com/rolker/unh_marine_autonomy/issues/86),
+  [uma#151](https://github.com/rolker/unh_marine_autonomy/issues/151),
+  [uma#163](https://github.com/rolker/unh_marine_autonomy/issues/163),
+  [uma#188](https://github.com/rolker/unh_marine_autonomy/issues/188),
+  [uma#189](https://github.com/rolker/unh_marine_autonomy/issues/189)/[#256](https://github.com/rolker/unh_marine_autonomy/issues/256),
+  [echoboats#276](https://github.com/rolker/unh_echoboats_project11/issues/276),
+  [s57_tools#5](https://github.com/rolker/s57_tools/issues/5)/[#23](https://github.com/rolker/s57_tools/issues/23)/[#25](https://github.com/rolker/s57_tools/issues/25)/[#26](https://github.com/rolker/s57_tools/issues/26),
+  [mru_transform#7](https://github.com/rolker/mru_transform/issues/7)/[#8](https://github.com/rolker/mru_transform/issues/8)
+- Field evidence: live-tile ping-gap striping (operator observation,
+  Massabesic 2026-06/07); costmap max-combine (`bathymetry_layer.cpp`
+  `updateCosts`); merge-only import (`geotiff_import.cpp`); CATZOC unhandled
+  (`marine_charts` `s57_dataset.cpp`).


### PR DESCRIPTION
Adopts **ADR-0010: The Geospatial World Model — Taxonomy, Datum Invariant, and Per-Layer Processes**, with header amendment pointers on ADR-0002 and ADR-0005.

## What this decides

- **D1–D3** — world-model umbrella (`~/data/world/`): raster field stores + vector feature stores + provenance registry; late rasterization for features; depth layers `chart | reference | draft | processed` (imagery keeps its ADR-0006/0007 sibling tiering); write gates and wholesale `survey/`→`processed/` migration.
- **D4** — layers encode process, σ encodes trust; `processed > draft` decided; prior-class (`reference` vs `chart`) arbitration explicitly deferred with candidate policies recorded. Shallowest-reliable safety mode untouched (verified: it, not best-source, drives costmap cost).
- **D5–D6** — ellipsoidal invariant end-to-end; datum conversion at import wherever import runs; `map_tide` is the only runtime vertical reference; `chart_datum` exits the TF tree; ROS-free vertical-datum library extracted to core_ws.
- **D7** — chart layer regenerated wholesale from the cron-managed ENC corpus (never merged): scale→GGGS-level, largest-scale-governs clipping, CATZOC→σ, per-cell datum shift, enforced nav-down interlock, atomic swap with registry-inside-staged-dir, download validation. **Cost-model rework named as a precondition for chart ingestion.**
- **D8** — draft/processed quality axis restored (amends ADR-0002 A2) on new evidence: live CUBE ping-gap backpressure vs deterministic `import_bag` re-run; cell-wise draft clearing on regeneration; ADR-0007 backscatter degradation explicitly accepted (display-grade) with a revisit trigger.
- **D9–D12** — per-layer LOD (charts have built-in shoal-biased LOD; survey needs shallowest-preserving pyramids; never upsample); costmap + voyage-planner consumers and the `s57_layer` non-depth split; chart features stay thin in the ENC corpus until S-100; not-a-GIS boundary.

## Review

Pre-push review ran at **Deep** (ADR-add trigger): governance clean; two fresh-context adversarial lenses returned 4 must-fix + 8 suggestions, **all addressed in `fd95463`** (the largest: Context §2's import-mechanism description corrected to the verified whole-tile `insert_or_assign` behavior, and the chart-ingestion-gated-on-cost-model precondition made explicit). Both lenses' verification passes confirmed every load-bearing source-code and cross-ADR claim. Full timeline in `.agent/work-plans/issue-272/progress.md`.

## Follow-ups (not in this PR)

Implementation issue set (vertical-datum library, `s57_to_geotiff` exporter + chart-layer regeneration, store re-split, `s57_layer` split) and housekeeping (`docs/sonar_ecosystem.md` reframe, uma#163 close/repurpose, echoboats#276 reference fix, mru_transform#8 update) follow after this ADR merges.

Closes #272

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7U35JQmjpGKP634UmMHth
