### PR TITLE
docs: add sonar_reference.md — M3 facts, QINSy route rationale, data-of-record locations

### DIFF
--- a/.agent/work-plans/issue-271/progress.md
+++ b/.agent/work-plans/issue-271/progress.md
@@ -1,0 +1,20 @@
+---
+issue: 271
+---
+
+# Issue #271 — docs(sonar_ecosystem): M3 identity/protocol, QINSy real-time route rationale, data-of-record locations
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-24 14:44 -04:00
+**By**: Claude Code Agent (Claude Fable 5)
+**Verdict**: approved
+
+**Branch**: feature/issue-271 at `2cbf205`
+**Mode**: pre-push
+**Depth**: Light (docs-only, 1 new doc + 1 link, +92 lines)
+**Must-fix**: 0 | **Suggestions**: 0
+**Round**: 1 | **Ship**: recommended — adversarial pass verified datagram claims against em_datagrams.py source; no repo pre-commit config; local model opted out (timed out on prior smaller diff today)
+
+### Findings
+- [ ] No issues found. LGTM.

--- a/docs/sonar_ecosystem.md
+++ b/docs/sonar_ecosystem.md
@@ -201,6 +201,9 @@ and the **sidescan track** ([#171]/[#185]: live mosaic + offline EGN). See
 
 ## Related
 
+- [sonar_reference.md](sonar_reference.md) — durable hardware/protocol facts
+  (M3 identity & interfaces, backscatter characteristics, QINSy real-time
+  route rationale) and data-of-record locations
 - [interfaces.md](interfaces.md) — ROS message/topic/service definitions
 - [data_flows.md](data_flows.md) — system-level data flow diagrams
 - [decisions/](decisions/) — Architecture Decision Records

--- a/docs/sonar_reference.md
+++ b/docs/sonar_reference.md
@@ -33,8 +33,8 @@ link (head factory IP `192.168.1.234`).
 The ROS-side consumer is `kongsberg_em_bridge`, which decodes the EM datagram
 export — the *datagram format* is EM-standard even though the sonar is not.
 Setup gotchas (1PPS dropdown, silent-until-enabled Export Data widget) are in
-the BizzyBoat hydro payload install log
-(`unh_echoboats_project11/bizzyboat_project11/docs/hydro_payload_install_log.md`).
+the BizzyBoat
+[hydro payload install log](https://github.com/rolker/unh_echoboats_project11/blob/jazzy/bizzyboat_project11/docs/hydro_payload_install_log.md).
 
 **Backscatter characteristics**: `reflectivity_db` is signed int16 × 0.1 dB
 from the "Raw Range and Angle 78" datagram — **raw, not angle-normalized**.
@@ -52,7 +52,8 @@ working real-time route is therefore the **M3's own EM datagram UDP export**,
 consumed directly by `kongsberg_em_bridge`. On the M3 the populated soundings
 datagram is **Raw Range and Angle 78** (`N`); the XYZ88 (`X`) datagram is
 exported but **empty** (kept in the decoder for EM2040/future sonars — see
-`kongsberg_em_bridge/em_datagrams.py`). QINSy remains the hydrographic system
+[`kongsberg_em_bridge/em_datagrams.py`](https://github.com/rolker/marine_tools/blob/jazzy/kongsberg_em_bridge/kongsberg_em_bridge/em_datagrams.py)
+in `marine_tools`). QINSy remains the hydrographic system
 of record on mercat; the ROS side taps the sensor's export in parallel rather
 than downstream of QINSy. Recorded here so nobody re-attempts the QINSy-UDP
 path.

--- a/docs/sonar_reference.md
+++ b/docs/sonar_reference.md
@@ -1,0 +1,89 @@
+# Sonar & Survey Data Reference
+
+Durable hardware, protocol, and data-location facts behind the
+[sonar ecosystem map](sonar_ecosystem.md). The map tracks *status*; this page
+records the facts that don't change with each PR — sensor identities, wire
+protocols, and where the data of record actually lives. Sourced from field
+sessions (2026 Massabesic campaign) and verified against the drivers where
+possible.
+
+## Kongsberg M3 multibeam
+
+**Identity**: the M3 is Kongsberg **Mesotech** lineage — *not* the Kongsberg
+EM echosounder line. EM-family assumptions (SIS acquisition, EM installation
+conventions) do not apply to the M3 as a product; the naming overlap is only
+in the export datagrams (below).
+
+**Specs**: 500 kHz, 256 beams, 120–140° swath, 0.2–150 m range, up to 40 Hz
+ping rate.
+
+**Acquisition**: dedicated Windows "M3" application (not SIS 5) running on
+mercat (`192.168.20.8`), with the sonar head on an isolated point-to-point
+link (head factory IP `192.168.1.234`).
+
+**Interfaces**:
+
+| Channel | Transport | Content |
+|---|---|---|
+| Control | TCP XML API, port 20001 | Head configuration/control |
+| Water column | IMB over TCP | Imagery (water-column) |
+| Soundings | `.all` EM datagrams (UDP export) | Bottom detections, 256 pts/ping |
+| Time | NMEA ZDA on UDP 31100 @ 1 Hz, plus hardware 1PPS | Head time sync |
+
+The ROS-side consumer is `kongsberg_em_bridge`, which decodes the EM datagram
+export — the *datagram format* is EM-standard even though the sonar is not.
+Setup gotchas (1PPS dropdown, silent-until-enabled Export Data widget) are in
+the BizzyBoat hydro payload install log
+(`unh_echoboats_project11/bizzyboat_project11/docs/hydro_payload_install_log.md`).
+
+**Backscatter characteristics**: `reflectivity_db` is signed int16 × 0.1 dB
+from the "Raw Range and Angle 78" datagram — **raw, not angle-normalized**.
+Measured angular falloff is ~24 dB from nadir to the swath edge (~−40 dB at
+nadir → ~−64 dB at 58°); a cos²θ Lambert model is roughly 4× too weak to
+flatten it, which is why the corrector uses an empirical per-sonar
+angular-response curve
+([cube#81](https://github.com/rolker/cube_bathymetry/issues/81)).
+
+## Real-time sounding route — why not through QINSy
+
+QINSy's generic UDP output **cannot stream processed soundings**: its
+processed product (QPD) is export-only, with no real-time network feed. The
+working real-time route is therefore the **M3's own EM datagram UDP export**,
+consumed directly by `kongsberg_em_bridge`. On the M3 the populated soundings
+datagram is **Raw Range and Angle 78** (`N`); the XYZ88 (`X`) datagram is
+exported but **empty** (kept in the decoder for EM2040/future sonars — see
+`kongsberg_em_bridge/em_datagrams.py`). QINSy remains the hydrographic system
+of record on mercat; the ROS side taps the sensor's export in parallel rather
+than downstream of QINSy. Recorded here so nobody re-attempts the QINSy-UDP
+path.
+
+## Data of record
+
+Canonical locations for the 2026 survey data (gabby/salmon home dirs unless
+noted):
+
+| What | Where | Notes |
+|---|---|---|
+| Tiled stores | `~/data/stores/{bathymetry,backscatter,sidescan}/` | Regenerable caches over the bags |
+| Survey index | `~/data/stores/survey_index.db` | v2 (134 Massabesic bags); v1 backup `survey_index.v1.db.bak` |
+| Retrofitted-bag originals | `salmon:~/data/retrofit_backups_2026-07-02/` | 10 `.orig` files — the pre-retrofit **data of record** |
+| Surface sound speed | `~/surface_sound_speed/` | 1 Hz deliverable; gap-filled freshwater Marczak (1997), global offset ≈ +1.07 m/s |
+
+Raw deployment bags are the ultimate source of truth; stores are regenerable
+caches (see the store-redesign discussion in
+[cube#96](https://github.com/rolker/cube_bathymetry/issues/96)).
+
+**Store layout constraints**:
+
+- Bathymetry and backscatter stores **cannot share a directory** — both use a
+  `processed/` layer with different dtypes (Float64 vs Float32).
+- NoData conventions: chart-bathy and backscatter tiles use **NaN**; sidescan
+  uses **0**; the Massabesic source chart raster (`massabesic_bathy.tif`)
+  uses **−9999**, converted to NaN on import.
+
+**Sound-speed data caveats**: the AML probe
+(`/bizzy/sensors/sound_speed/sound_speed`, ~20 Hz) fails via a
+healthy → NaN → silence signature; heavy outages Jun 17 – Jul 1 mean some
+bags carry zero sound-speed messages. The Garmin
+`.../garmin_sidescan/water_temperature` topic exists in bags only from
+**2026-06-15** onward.


### PR DESCRIPTION
Adds `docs/sonar_reference.md` — durable hardware/protocol/data-location facts promoted from agent memory (2026-07-24 memory-promotion audit) — and links it from the ecosystem map's Related section. The ecosystem map stays a status tracker; the new page holds the facts that don't change per-PR.

Closes #271

## Content

- **Kongsberg M3 identity & interfaces**: Mesotech lineage (not the EM line), 500 kHz / 256 beams / 120–140° swath specs, acquisition topology (Windows M3 app on mercat, isolated head link), and the four wire channels (TCP XML control :20001, IMB water column, `.all` EM datagram UDP export, ZDA+1PPS time).
- **Backscatter characteristics**: raw (not angle-normalized) int16 ×0.1 dB from Raw Range and Angle 78; measured ~24 dB nadir falloff; why cos²θ was rejected for the empirical ARA curve (cube#81).
- **QINSy real-time route rationale**: QPD is export-only, so real-time soundings come from the M3's own EM export via `kongsberg_em_bridge` — written down so nobody re-attempts the QINSy-UDP path.
- **Data of record**: store/index/backup/sound-speed locations (including the salmon retrofit-backup path), store layout constraints (bathy/backscatter dir collision, NoData conventions), and AML/water-temperature data caveats for analysts.

## Verification

Datagram claims verified against `kongsberg_em_bridge/em_datagrams.py` (N/78 populated on the M3, XYZ88 exported empty, reflectivity int16 ×0.1 dB) — including one correction found during drafting (an earlier draft implied XYZ88 carried data). Pre-push `/review-code` (Light): adversarial pass independently re-verified the same claims against source; no findings. Docs-only, no test plan.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
