### PR TITLE
feat: marine_vertical_datum — ROS-free vertical-datum library (ADR-0010 D6)

### DIFF
--- a/.agent/work-plans/issue-274/plan.md
+++ b/.agent/work-plans/issue-274/plan.md
@@ -42,16 +42,26 @@ The issue review flagged two design points to nail before coding:
    `query_datum` / `query_vdatum` out of `ChartDatumNode` and into
    `src/vdatum_query.cpp` with public header
    `include/marine_vertical_datum/vdatum_query.hpp`.
-   Public API: one `query_vdatum(double lat, double lon, const VDatumConfig&)
-   → std::optional<VDatumResult>`, plus a `VDatumConfig` struct holding
-   geoid-grid path and vdatum-grid-dir path (plain `std::string`). Expose a
-   seam for testing:
+   Public API (revised per plan-review suggestions): `VDatumConfig` struct
+   (geoid-grid path + vdatum-grid-dir path, plain `std::string`), the seam
+
    ```cpp
    using VDatumQueryFn =
      std::function<std::optional<VDatumResult>(double lat, double lon)>;
    ```
-   The library ships `make_vdatum_query(const VDatumConfig&) → VDatumQueryFn`
-   as the production factory; tests inject a stub directly.
+
+   and **`make_vdatum_query(const VDatumConfig&, DiagFn) → VDatumQueryFn` as
+   the sole production entry** — the originally planned standalone
+   per-call `query_vdatum(lat, lon, config)` is dropped (review finding:
+   it rebuilds the PROJ pipeline per call, a footgun for the per-cell S57
+   exporter). The factory caches context+pipelines in a shared RAII holder.
+   Error/diagnostic seam (review finding): setup-time problems report
+   through an optional ROS-free `DiagFn` callback (default discards);
+   setup failure returns an empty `std::function`; per-point no-coverage
+   is a plain `nullopt` with no diagnostic (normal gap condition — the
+   node's 30s-throttled RCLCPP_WARN has no place in a per-cell library).
+   `proj_context_set_enable_network(ctx, false)` is preserved (offline
+   guarantee, ADR-0010 D6/D7). Include guards renamed with the namespace.
 
 4. **Port and adapt `test_datum_config`** — copy `mru_transform`'s
    `test/test_datum_config.cpp` → `test/test_datum_config.cpp`, updating
@@ -69,9 +79,13 @@ The issue review flagged two design points to nail before coding:
      as offline tooling per ADR-0010 D6/D7 — grids never in the runtime stack).
    - How to point `VDatumConfig` at the grids.
 
-7. **Wire up CMakeLists.txt** — two libraries (`datum_config` and
-   `vdatum_query`); one combined install target `marine_vertical_datum`;
-   `ament_export_targets` so downstream packages can `find_package` and link.
+7. **Wire up CMakeLists.txt** — one shared library `marine_vertical_datum`
+   containing both translation units (simpler than the originally planned
+   two-libs-one-target split; PROJ and yaml-cpp link PRIVATE since the
+   public headers expose neither — rosdep key `proj` +
+   `pkg_check_modules(PROJ REQUIRED IMPORTED_TARGET proj)` per the
+   mru_transform precedent). `ament_export_targets` so downstream packages
+   can `find_package` and link.
    Grid download/install logic (mirrors `mru_transform`'s CMake block) is
    **not** included in this package — the consumer (`mru_transform`, or the
    future `chart_datum_node` wrapper) owns that. The library only links PROJ.

--- a/.agent/work-plans/issue-274/plan.md
+++ b/.agent/work-plans/issue-274/plan.md
@@ -1,0 +1,123 @@
+# Plan: New package: marine_vertical_datum (ADR-0010 D6)
+
+## Issue
+
+https://github.com/rolker/unh_marine_autonomy/issues/274
+
+## Context
+
+`mru_transform` (platforms_ws) already holds two ROS-free components:
+
+1. `datum_config.{hpp,cpp}` — the full precedence-chain resolver
+   (`lake_datum` → override polygons → VDatum → fallback polygons → absent),
+   using types `DatumSource`, `LatLon`, `DatumEntry`, `VDatumResult`, `DatumResult`
+   and functions `point_in_ring`, `load_datum_config`, `resolve_datum`.
+2. `chart_datum_node.cpp` — the PROJ/VDatum query embedded in the node:
+   `collect_grids`, `create_pipeline`, `setup_proj`, `cleanup_proj`, `query_datum`,
+   `query_vdatum`.
+
+These pieces must live in core_ws so `s57_tools` (core), CAMP (ui), and
+`chart_datum_node` (platforms) can all depend on them (ADR-0010 D6).
+`mru_transform` retains its inline copy until a follow-on issue migrates it
+(explicitly a non-goal here).
+
+The issue review flagged two design points to nail before coding:
+- Pin the VDatum mock seam (injectable callable) so CI tests are grids-free.
+- Namespace rename from `mru_transform` to `marine_vertical_datum`.
+
+## Approach
+
+1. **Create package skeleton** — `marine_vertical_datum/` at repo root with
+   `package.xml`, `CMakeLists.txt`, and `include/marine_vertical_datum/`.
+   Dependencies: `ament_cmake`, `yaml-cpp`, PROJ (via pkg-config). No `rclcpp`.
+
+2. **Port `datum_config` types and functions** — copy `datum_config.hpp` →
+   `include/marine_vertical_datum/datum_config.hpp` and `datum_config.cpp` →
+   `src/datum_config.cpp`. Rename namespace `mru_transform` → `marine_vertical_datum`
+   throughout. Keep all types and function signatures identical (consumers use
+   `marine_vertical_datum::resolve_datum`, etc.).
+
+3. **Extract PROJ query into a free function with an injectable seam** —
+   pull `collect_grids` / `create_pipeline` / `setup_proj` / `cleanup_proj` /
+   `query_datum` / `query_vdatum` out of `ChartDatumNode` and into
+   `src/vdatum_query.cpp` with public header
+   `include/marine_vertical_datum/vdatum_query.hpp`.
+   Public API: one `query_vdatum(double lat, double lon, const VDatumConfig&)
+   → std::optional<VDatumResult>`, plus a `VDatumConfig` struct holding
+   geoid-grid path and vdatum-grid-dir path (plain `std::string`). Expose a
+   seam for testing:
+   ```cpp
+   using VDatumQueryFn =
+     std::function<std::optional<VDatumResult>(double lat, double lon)>;
+   ```
+   The library ships `make_vdatum_query(const VDatumConfig&) → VDatumQueryFn`
+   as the production factory; tests inject a stub directly.
+
+4. **Port and adapt `test_datum_config`** — copy `mru_transform`'s
+   `test/test_datum_config.cpp` → `test/test_datum_config.cpp`, updating
+   namespace references. All existing cases carry over unchanged.
+
+5. **Add `test_vdatum_query` for the seam** — new test file
+   `test/test_vdatum_query.cpp`. Uses the `VDatumQueryFn` injection to drive
+   `resolve_datum` without grids. Covers: stub returns a result; stub returns
+   `nullopt` (gap-fill path); integration with `resolve_datum` picks VDatum
+   over a fallback polygon.
+
+6. **Write `README.md`** covering:
+   - Package purpose and API (one-liner per public function/type).
+   - Grid provisioning (dev machines: `projsync` + VDatum zip download; boat
+     as offline tooling per ADR-0010 D6/D7 — grids never in the runtime stack).
+   - How to point `VDatumConfig` at the grids.
+
+7. **Wire up CMakeLists.txt** — two libraries (`datum_config` and
+   `vdatum_query`); one combined install target `marine_vertical_datum`;
+   `ament_export_targets` so downstream packages can `find_package` and link.
+   Grid download/install logic (mirrors `mru_transform`'s CMake block) is
+   **not** included in this package — the consumer (`mru_transform`, or the
+   future `chart_datum_node` wrapper) owns that. The library only links PROJ.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `marine_vertical_datum/package.xml` | New: ament_cmake + yaml-cpp + PROJ deps, no rclcpp |
+| `marine_vertical_datum/CMakeLists.txt` | New: build datum_config + vdatum_query libraries, GTest, ament_export |
+| `marine_vertical_datum/include/marine_vertical_datum/datum_config.hpp` | New: port from mru_transform, namespace renamed |
+| `marine_vertical_datum/src/datum_config.cpp` | New: port from mru_transform, namespace renamed |
+| `marine_vertical_datum/include/marine_vertical_datum/vdatum_query.hpp` | New: VDatumConfig struct, VDatumQueryFn alias, make_vdatum_query, query_vdatum |
+| `marine_vertical_datum/src/vdatum_query.cpp` | New: PROJ pipeline extracted from chart_datum_node |
+| `marine_vertical_datum/test/test_datum_config.cpp` | New: port from mru_transform, namespace updated |
+| `marine_vertical_datum/test/test_vdatum_query.cpp` | New: injectable-seam coverage |
+| `marine_vertical_datum/README.md` | New: purpose, API summary, grid provisioning |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Modularity and Decoupling | Core purpose — one package, one problem; no rclcpp dep |
+| Standards Compliance | package.xml format 3, REP-2000, valid ament_cmake build |
+| Safety First | No impact on runtime nav path; library is offline/import-time tooling |
+| Iterative, Validated Evolution | mru_transform keeps inline copy; follow-on PR migrates it |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0010 (Geospatial World Model) D6 | Yes — this issue directly implements D6 | Library in core_ws, ROS-free, consumable by s57_tools/CAMP/mru_transform |
+| ADR-0008 (ROS 2 Conventions) | Yes — new package | Valid package.xml/CMakeLists.txt, no rclcpp in library deps |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| Namespace `mru_transform` → `marine_vertical_datum` | mru_transform inline copy is unchanged (non-goal) | No — follow-on |
+| Add `marine_vertical_datum` to core_ws | `core_ws/src/` (just create the directory; no repos file change needed for a local package) | Yes |
+| VDatum query now lives in core_ws library | chart_datum_node stays self-contained until follow-on migration | No — explicit non-goal |
+
+## Open Questions
+
+- [ ] No open questions — plan is review-plan-ready.
+
+## Estimated Scope
+
+Single PR. ~9 new files, ~500 lines of ported + new code plus tests.

--- a/.agent/work-plans/issue-274/progress.md
+++ b/.agent/work-plans/issue-274/progress.md
@@ -135,3 +135,22 @@ surfaced by reading the ported source (`chart_datum_node.cpp`,
 - [ ] (suggestion) Consider resetting/checking `proj_errno` per call in `query_datum` for the millions-of-cells loop (low-confidence, inherited from production node) — `marine_vertical_datum/src/vdatum_query.cpp:95`
 - [x] (suggestion) Stale ported comment "acceptance item 5 of issue #25" — should reference #274 — `marine_vertical_datum/test/test_datum_config.cpp:3`
 - [ ] (suggestion) Convention drift: no `ament_lint_auto`/`ament_lint_common`, all 6 C++ files lack copyright headers (cpplint 6×legal/copyright, uncrustify 2 files) — calibrated down: sibling mru_transform's lint is a no-op and ships headerless too, so not a blocker — `marine_vertical_datum/CMakeLists.txt`
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-07-24 16:40 -0400
+**By**: Claude Code Agent (Claude Fable 5)
+
+**PR**: #279 at `a3c0b7d`
+**Sources**: 2 (Copilot R1 @ `a3c0b7d`, Local Review (Pre-Push) @ `7640003`)
+**Cross-source confirmations**: 0
+**CI**: all-pass (build 9m15s)
+
+### Findings
+- [ ] (valid, Copilot — mechanism corrected) unchecked `proj_context_create()` failure: NOT a null-deref crash (PROJ treats NULL ctx as the default context), but alloc failure would silently fall back to the process-global default context — un-owned by the RAII holder, networking flag applied globally; add a null check → diag + empty return — `marine_vertical_datum/src/vdatum_query.cpp:158`
+- [ ] (valid, Copilot) fixed temp-dir name `mvd_test_empty_grid_dir` can collide across concurrent multi-worktree test runs on one host; use a unique (mkdtemp) directory — `marine_vertical_datum/test/test_vdatum_query.cpp:110`
+- [ ] (valid, Copilot) `mkstemp` used with only `<unistd.h>`/`<cstdio>` — compiles via transitive gtest includes on glibc only; add `<cstdlib>` (latent in mru_transform's copy too; rides the follow-on migration there) — `marine_vertical_datum/test/test_datum_config.cpp:53`
+- [ ] (valid-by-convention, Copilot) install path `include/${PROJECT_NAME}` + matching INSTALL_INTERFACE is internally consistent (no breakage) but 2 of 3 sibling store packages use plain `include` with explicit comments rejecting the doubled path; align with the sibling convention — `marine_vertical_datum/CMakeLists.txt:32`
+
+### False positives
+- (none — Copilot's C1 *mechanism* ("dereference null and crash") is wrong per PROJ's NULL-ctx-means-default convention, but the underlying unchecked-allocation concern is real, so it is classified valid with corrected rationale rather than dismissed)

--- a/.agent/work-plans/issue-274/progress.md
+++ b/.agent/work-plans/issue-274/progress.md
@@ -154,3 +154,21 @@ surfaced by reading the ported source (`chart_datum_node.cpp`,
 
 ### False positives
 - (none — Copilot's C1 *mechanism* ("dereference null and crash") is wrong per PROJ's NULL-ctx-means-default convention, but the underlying unchecked-allocation concern is real, so it is classified valid with corrected rationale rather than dismissed)
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-07-24 16:58 -0400
+**By**: Claude Code Agent (Claude Fable 5)
+
+**PR**: #279 at `04dab07`
+**Sources**: 2 (Copilot R2 @ `04dab07`, Local Review (Pre-Push) @ `7640003`)
+**Cross-source confirmations**: 1
+**CI**: all-pass (build 9m4s @ 04dab07)
+
+### Findings
+- [ ] (cross-confirmed: Copilot R2 + Local Review deferred suggestion — DEFERRED with rationale) real proj_trans query path never executed by unit tests; deferred because s57_tools#27's acceptance includes a real-NOAA-cell round-trip exercising the full PROJ path against real grids — higher fidelity than a synthetic .gtx unit test — `marine_vertical_datum/src/vdatum_query.cpp:119`
+
+### False positives
+- (Copilot R2) proj_context_create nullptr re-raise — the null-check landed in `04dab07` at the flagged location; stale duplicate of the round-1 finding
+- (Copilot R2) mkstemp missing <cstdlib> re-raise — include added in `04dab07` (line 13); stale duplicate
+- (Copilot R2) writeTemp short-write / ssize_t→size_t cast — cannot fail silently: any short or -1 write makes EXPECT_EQ(cast(written), size) fail (−1 → SIZE_MAX ≠ size), marking the test failed; truncated config can never yield a silent pass

--- a/.agent/work-plans/issue-274/progress.md
+++ b/.agent/work-plans/issue-274/progress.md
@@ -92,3 +92,26 @@ issue: 274
 
 ### Open questions
 - [ ] No open questions — plan is review-plan-ready.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-07-24 18:51 +00:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Plan**: `.agent/work-plans/issue-274/plan.md` at `f5f2e6b`
+**PR**: PR-less (`--issue` mode)
+**Verdict**: approve-with-suggestions
+
+Independent review (fresh-context #490 sub-agent, Opus; plan authored by the
+Sonnet invocation) — not an author self-review despite the shared commit
+identity. All findings are suggestions; none block implementation. They were
+surfaced by reading the ported source (`chart_datum_node.cpp`,
+`datum_config.hpp`) against the plan. All three review-issue action items
+(mock seam, PROJ dep, README) are addressed.
+
+### Findings
+- [ ] (suggestion) Pin the error/diagnostic seam for the extracted PROJ functions — they use `RCLCPP_ERROR`/`RCLCPP_WARN_THROTTLE` (`chart_datum_node.cpp:253,359`) which a ROS-free lib can't call; decide exceptions vs return-status vs dropping warnings — `plan.md:42`
+- [ ] (suggestion) Make `make_vdatum_query` the primary production entry; standalone `query_vdatum(lat,lon,VDatumConfig)` rebuilds the PROJ pipeline per call (footgun for per-cell S57 exporter) — `plan.md:45`
+- [ ] (suggestion) Rename the include guard `MRU_TRANSFORM__DATUM_CONFIG_HPP_` → `MARINE_VERTICAL_DATUM__DATUM_CONFIG_HPP_` alongside the namespace — `plan.md:36`
+- [ ] (suggestion) Use rosdep key `proj` + `pkg_check_modules(PROJ REQUIRED IMPORTED_TARGET proj)` / link `PkgConfig::PROJ` per mru_transform precedent (not `libproj-dev`) — `plan.md:83`
+- [ ] (suggestion) Preserve `proj_context_set_enable_network(ctx, false)` (`chart_datum_node.cpp:286`) in the library per ADR-0010 D6/D7 offline guarantee — `plan.md:36`

--- a/.agent/work-plans/issue-274/progress.md
+++ b/.agent/work-plans/issue-274/progress.md
@@ -115,3 +115,23 @@ surfaced by reading the ported source (`chart_datum_node.cpp`,
 - [ ] (suggestion) Rename the include guard `MRU_TRANSFORM__DATUM_CONFIG_HPP_` → `MARINE_VERTICAL_DATUM__DATUM_CONFIG_HPP_` alongside the namespace — `plan.md:36`
 - [ ] (suggestion) Use rosdep key `proj` + `pkg_check_modules(PROJ REQUIRED IMPORTED_TARGET proj)` / link `PkgConfig::PROJ` per mru_transform precedent (not `libproj-dev`) — `plan.md:83`
 - [ ] (suggestion) Preserve `proj_context_set_enable_network(ctx, false)` (`chart_datum_node.cpp:286`) in the library per ADR-0010 D6/D7 offline guarantee — `plan.md:36`
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-24 19:11 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-274 at `7640003`
+**Mode**: pre-push
+**Depth**: Deep (reason: 11 files & 1368 additions exceed 10-file/200-line thresholds; new cross-layer library per ADR-0010 D6)
+**Must-fix**: 0 | **Suggestions**: 6
+**Round**: 1 | **Ship**: recommended — no must-fix; faithful extraction (datum_config byte-identical to battle-tested source), only new-consumer suggestions remain
+
+### Findings
+- [ ] (suggestion) Strengthen thread-safety note: shared `PJ` hazard (not just context) + "one make_vdatum_query per thread" for the parallel per-cell exporter — `marine_vertical_datum/include/marine_vertical_datum/vdatum_query.hpp:60`
+- [ ] (suggestion) Sort `collect_grids` output — unspecified `recursive_directory_iterator` order makes `+grids=` precedence non-deterministic across machines — `marine_vertical_datum/src/vdatum_query.cpp:32`
+- [ ] (suggestion) Coverage gap: real `proj_trans` sign (`-z`), HUGE_VAL/isinf/isnan no-coverage detection, and `proj_torad` ordering are never executed (stubs + setup-failure only); add a gated synthetic-grid integration test — `marine_vertical_datum/test/test_vdatum_query.cpp`
+- [ ] (suggestion) Consider resetting/checking `proj_errno` per call in `query_datum` for the millions-of-cells loop (low-confidence, inherited from production node) — `marine_vertical_datum/src/vdatum_query.cpp:95`
+- [ ] (suggestion) Stale ported comment "acceptance item 5 of issue #25" — should reference #274 — `marine_vertical_datum/test/test_datum_config.cpp:3`
+- [ ] (suggestion) Convention drift: no `ament_lint_auto`/`ament_lint_common`, all 6 C++ files lack copyright headers (cpplint 6×legal/copyright, uncrustify 2 files) — calibrated down: sibling mru_transform's lint is a no-op and ships headerless too, so not a blocker — `marine_vertical_datum/CMakeLists.txt`

--- a/.agent/work-plans/issue-274/progress.md
+++ b/.agent/work-plans/issue-274/progress.md
@@ -189,3 +189,20 @@ surfaced by reading the ported source (`chart_datum_node.cpp`,
 
 ### False positives
 - (none this round)
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-07-24 17:35 -0400
+**By**: Claude Code Agent (Claude Fable 5)
+
+**PR**: #279 at `87cf44d`
+**Sources**: 2 (Copilot R4 @ `87cf44d`, Local Review (Pre-Push) @ `7640003`)
+**Cross-source confirmations**: 0
+**CI**: all-pass (build 9m28s @ 87cf44d)
+
+### Findings
+- [ ] (none — round closed with no valid findings; SHIP recommended, round 4, finding quality declining per #537 convergence guidance: R1 4 valid → R4 0 valid)
+
+### False positives
+- (Copilot R4) mkdtemp needs `<stdlib.h>` not `<cstdlib>` — platform matrix is pinned by REP-2000/jazzy to Ubuntu 24.04 glibc (CI and field identical), where `<cstdlib>` exposes the POSIX names; no stricter toolchain exists in this system, and Copilot's own R2 comment recommended `<cstdlib>/<stdlib.h>` interchangeably — churn, not signal
+- (Copilot R4) wrong geoid path degrades to silent per-point nullopt — EMPIRICALLY REFUTED: PROJ resolves `+grids=` eagerly at proj_create (probe: nonexistent grid → proj_create fails, errno 1029 "File not found or invalid"), routing through create_pipeline's null-check → DiagFn diagnostic → empty function; the lazy-failure path does not exist

--- a/.agent/work-plans/issue-274/progress.md
+++ b/.agent/work-plans/issue-274/progress.md
@@ -129,9 +129,9 @@ surfaced by reading the ported source (`chart_datum_node.cpp`,
 **Round**: 1 | **Ship**: recommended — no must-fix; faithful extraction (datum_config byte-identical to battle-tested source), only new-consumer suggestions remain
 
 ### Findings
-- [ ] (suggestion) Strengthen thread-safety note: shared `PJ` hazard (not just context) + "one make_vdatum_query per thread" for the parallel per-cell exporter — `marine_vertical_datum/include/marine_vertical_datum/vdatum_query.hpp:60`
-- [ ] (suggestion) Sort `collect_grids` output — unspecified `recursive_directory_iterator` order makes `+grids=` precedence non-deterministic across machines — `marine_vertical_datum/src/vdatum_query.cpp:32`
+- [x] (suggestion) Strengthen thread-safety note: shared `PJ` hazard (not just context) + "one make_vdatum_query per thread" for the parallel per-cell exporter — `marine_vertical_datum/include/marine_vertical_datum/vdatum_query.hpp:60`
+- [x] (suggestion) Sort `collect_grids` output — unspecified `recursive_directory_iterator` order makes `+grids=` precedence non-deterministic across machines — `marine_vertical_datum/src/vdatum_query.cpp:32`
 - [ ] (suggestion) Coverage gap: real `proj_trans` sign (`-z`), HUGE_VAL/isinf/isnan no-coverage detection, and `proj_torad` ordering are never executed (stubs + setup-failure only); add a gated synthetic-grid integration test — `marine_vertical_datum/test/test_vdatum_query.cpp`
 - [ ] (suggestion) Consider resetting/checking `proj_errno` per call in `query_datum` for the millions-of-cells loop (low-confidence, inherited from production node) — `marine_vertical_datum/src/vdatum_query.cpp:95`
-- [ ] (suggestion) Stale ported comment "acceptance item 5 of issue #25" — should reference #274 — `marine_vertical_datum/test/test_datum_config.cpp:3`
+- [x] (suggestion) Stale ported comment "acceptance item 5 of issue #25" — should reference #274 — `marine_vertical_datum/test/test_datum_config.cpp:3`
 - [ ] (suggestion) Convention drift: no `ament_lint_auto`/`ament_lint_common`, all 6 C++ files lack copyright headers (cpplint 6×legal/copyright, uncrustify 2 files) — calibrated down: sibling mru_transform's lint is a no-op and ships headerless too, so not a blocker — `marine_vertical_datum/CMakeLists.txt`

--- a/.agent/work-plans/issue-274/progress.md
+++ b/.agent/work-plans/issue-274/progress.md
@@ -80,3 +80,15 @@ issue: 274
 - [ ] Specify the VDatum mock seam design in the implementation plan (injectable callable or abstract class) so CI tests are verifiable without grids.
 - [ ] Confirm PROJ dependency declaration in package.xml / CMakeLists.txt is in scope.
 - [ ] README for grid provisioning is a required deliverable — track it alongside library code, not as a post-merge follow-up.
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-07-24 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Plan**: `.agent/work-plans/issue-274/plan.md` at `f5f2e6b`
+**Branch**: feature/issue-274 at `f5f2e6b`
+**Phases**: single
+
+### Open questions
+- [ ] No open questions — plan is review-plan-ready.

--- a/.agent/work-plans/issue-274/progress.md
+++ b/.agent/work-plans/issue-274/progress.md
@@ -172,3 +172,20 @@ surfaced by reading the ported source (`chart_datum_node.cpp`,
 - (Copilot R2) proj_context_create nullptr re-raise — the null-check landed in `04dab07` at the flagged location; stale duplicate of the round-1 finding
 - (Copilot R2) mkstemp missing <cstdlib> re-raise — include added in `04dab07` (line 13); stale duplicate
 - (Copilot R2) writeTemp short-write / ssize_t→size_t cast — cannot fail silently: any short or -1 write makes EXPECT_EQ(cast(written), size) fail (−1 → SIZE_MAX ≠ size), marking the test failed; truncated config can never yield a silent pass
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-07-24 17:12 -0400
+**By**: Claude Code Agent (Claude Fable 5)
+
+**PR**: #279 at `94af25d`
+**Sources**: 2 (Copilot R3 @ `94af25d`, Local Review (Pre-Push) @ `7640003`)
+**Cross-source confirmations**: 1
+**CI**: all-pass at prior head; re-running on this round's push
+
+### Findings
+- [x] (valid, Copilot R3) missing repo-standard alias target `${PROJECT_NAME}::${PROJECT_NAME}` (sibling precedent marine_contacts/marine_tiled_raster_store) — added — `marine_vertical_datum/CMakeLists.txt`
+- [x] (cross-confirmed: Copilot R3 + Local Review suggestion 6) missing ament_lint_auto/ament_lint_common wiring — round-1 calibration used the WRONG sibling (mru_transform, platforms_ws); uma siblings all carry it — added to CMakeLists + package.xml, MIT headers added to all 6 C++ files, uncrustify reformat + cpplint include-order/whitespace fixes; full lint suite now green (61 tests 0 failures) — `marine_vertical_datum/`
+
+### False positives
+- (none this round)

--- a/.agent/work-plans/issue-274/progress.md
+++ b/.agent/work-plans/issue-274/progress.md
@@ -1,0 +1,82 @@
+---
+issue: 274
+---
+
+# Issue #274 — New package: marine_vertical_datum (ADR-0010 D6)
+
+## Issue Review
+**Status**: complete
+**When**: 2026-07-24 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Issue**: #274
+**Comment**: (best-effort post follows this entry; not recorded inline)
+**Scope verdict**: well-scoped
+
+### Scope Assessment
+
+- **Well-scoped?** Yes. A focused library-extraction task with clear boundaries: new
+  ROS-free package, defined API (`(lat, lon) → {mllw_z, mhhw_z?, source}`), existing
+  source to port (`datum_config.{hpp,cpp}` from `mru_transform/`), and explicit
+  non-goals (no mru_transform consumer migration, no S57 parsing). Single PR sized.
+- **Right repo?** Yes. `unh_marine_autonomy` (core_ws) is correct per ADR-0010 D6's
+  placement constraint: `s57_tools` (core), CAMP (ui), and `mru_transform` (platforms)
+  must all be able to depend on a core_ws library.
+- **Dependencies?** The source (`datum_config.{hpp,cpp}`) already exists in
+  `mru_transform`. No blocking upstream issues; the `mru_transform` consumer migration
+  is explicitly deferred as a non-goal. Issue #86 (umbrella) is the parent — this is
+  one leaf on it.
+
+### Principle Alignment
+
+| Principle | Status | Notes |
+|---|---|---|
+| Human control and transparency | OK | Clear rationale, explicit non-goals, ADR-0010 D6 is the anchor |
+| Capture decisions, not just implementations | OK | ADR-0010 D6 already recorded the design decision; issue implements it |
+| A change includes its consequences | Watch | Temporary code duplication (datum_config stays in mru_transform until follow-on); issue acknowledges this explicitly — acceptable as a stated non-goal |
+| Only what's needed | OK | Minimal scope, non-goals listed, no ROS runtime deps required |
+| Improve incrementally | OK | Small extraction with clear before/after; follow-on issues handle consumer migration |
+| Test what breaks | Watch | VDatum query mock seam is mentioned but not yet designed; implementation plan should specify how the mock boundary is expressed (e.g. injectable function pointer or abstract class) so CI grids-absent testing is actually achievable |
+| Workspace vs. project separation | OK | Correctly placed in project repo, not workspace |
+| Modularity and Decoupling (project) | OK | Core purpose of this issue |
+| Standards Compliance (project) | OK | ROS-free library; package.xml/CMakeLists.txt must still follow REP-2000 / ROS 2 conventions (ADR-0008) |
+
+### ADR Applicability
+
+| ADR | Triggered | Notes |
+|---|---|---|
+| ADR-0010 (Geospatial World Model, project) | Yes — directly implements D6 | Issue is well-aligned; acceptance criteria match D6's stated outputs |
+| ADR-0008 (Follow ROS 2 Official Conventions) | Yes — new package | Must have valid package.xml/CMakeLists.txt; no rclcpp dep is fine for a pure library package |
+| ADR-0001 (Adopt ADRs) | Not triggered | Decision already captured in ADR-0010 D6 |
+| ADR-0002 (Worktree isolation) | Not triggered | Process concern, already in worktree |
+
+### Consequences
+
+- **Namespace migration**: `datum_config.hpp` currently uses `namespace mru_transform`.
+  The new library will need its own namespace (e.g. `marine_vertical_datum`). The
+  implementation plan should call this out — it affects the public API shape.
+- **PROJ dependency**: `package.xml` must declare the PROJ dependency (e.g.
+  `<depend>libproj-dev</depend>` or equivalent rosdep key). CMakeLists.txt needs
+  `find_package(PROJ REQUIRED)`. Neither is mentioned in the issue — worth confirming
+  in the plan.
+- **README for grid provisioning**: Acceptance criteria require it; the plan should
+  treat it as a deliverable alongside the library code (per "a change includes its
+  consequences").
+- When `mru_transform` later consumes the library (follow-on), `datum_config.{hpp,cpp}`
+  there can be removed — that PR should update the dependency list and delete the
+  duplicates.
+
+### Recommendations
+
+- Pin the mock-seam design before implementation: one injectable callable (e.g.
+  `std::function<std::optional<VDatumResult>(double lat, double lon)>`) is the minimal
+  seam that keeps tests grids-free on CI while leaving real PROJ wired up in production.
+- Consider whether `DatumSource`, `LatLon`, `DatumEntry`, `VDatumResult`, and
+  `DatumResult` structs should stay in a `marine_vertical_datum` namespace from day one,
+  since downstream consumers will spell that namespace and the mru_transform namespace
+  is a leaky implementation detail.
+
+### Actions
+- [ ] Specify the VDatum mock seam design in the implementation plan (injectable callable or abstract class) so CI tests are verifiable without grids.
+- [ ] Confirm PROJ dependency declaration in package.xml / CMakeLists.txt is in scope.
+- [ ] README for grid provisioning is a required deliverable — track it alongside library code, not as a post-merge follow-up.

--- a/.agent/work-plans/issue-274/progress.md
+++ b/.agent/work-plans/issue-274/progress.md
@@ -147,10 +147,10 @@ surfaced by reading the ported source (`chart_datum_node.cpp`,
 **CI**: all-pass (build 9m15s)
 
 ### Findings
-- [ ] (valid, Copilot — mechanism corrected) unchecked `proj_context_create()` failure: NOT a null-deref crash (PROJ treats NULL ctx as the default context), but alloc failure would silently fall back to the process-global default context — un-owned by the RAII holder, networking flag applied globally; add a null check → diag + empty return — `marine_vertical_datum/src/vdatum_query.cpp:158`
-- [ ] (valid, Copilot) fixed temp-dir name `mvd_test_empty_grid_dir` can collide across concurrent multi-worktree test runs on one host; use a unique (mkdtemp) directory — `marine_vertical_datum/test/test_vdatum_query.cpp:110`
-- [ ] (valid, Copilot) `mkstemp` used with only `<unistd.h>`/`<cstdio>` — compiles via transitive gtest includes on glibc only; add `<cstdlib>` (latent in mru_transform's copy too; rides the follow-on migration there) — `marine_vertical_datum/test/test_datum_config.cpp:53`
-- [ ] (valid-by-convention, Copilot) install path `include/${PROJECT_NAME}` + matching INSTALL_INTERFACE is internally consistent (no breakage) but 2 of 3 sibling store packages use plain `include` with explicit comments rejecting the doubled path; align with the sibling convention — `marine_vertical_datum/CMakeLists.txt:32`
+- [x] (valid, Copilot — mechanism corrected) unchecked `proj_context_create()` failure: NOT a null-deref crash (PROJ treats NULL ctx as the default context), but alloc failure would silently fall back to the process-global default context — un-owned by the RAII holder, networking flag applied globally; add a null check → diag + empty return — `marine_vertical_datum/src/vdatum_query.cpp:158`
+- [x] (valid, Copilot) fixed temp-dir name `mvd_test_empty_grid_dir` can collide across concurrent multi-worktree test runs on one host; use a unique (mkdtemp) directory — `marine_vertical_datum/test/test_vdatum_query.cpp:110`
+- [x] (valid, Copilot) `mkstemp` used with only `<unistd.h>`/`<cstdio>` — compiles via transitive gtest includes on glibc only; add `<cstdlib>` (latent in mru_transform's copy too; rides the follow-on migration there) — `marine_vertical_datum/test/test_datum_config.cpp:53`
+- [x] (valid-by-convention, Copilot) install path `include/${PROJECT_NAME}` + matching INSTALL_INTERFACE is internally consistent (no breakage) but 2 of 3 sibling store packages use plain `include` with explicit comments rejecting the doubled path; align with the sibling convention — `marine_vertical_datum/CMakeLists.txt:32`
 
 ### False positives
 - (none — Copilot's C1 *mechanism* ("dereference null and crash") is wrong per PROJ's NULL-ctx-means-default convention, but the underlying unchecked-allocation concern is real, so it is classified valid with corrected rationale rather than dismissed)

--- a/marine_vertical_datum/CMakeLists.txt
+++ b/marine_vertical_datum/CMakeLists.txt
@@ -1,0 +1,52 @@
+cmake_minimum_required(VERSION 3.8)
+project(marine_vertical_datum)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(PROJ REQUIRED IMPORTED_TARGET proj)
+find_package(yaml-cpp REQUIRED)
+# yaml-cpp 0.8 exports the namespaced target; older versions export a bare one.
+if(TARGET yaml-cpp::yaml-cpp)
+  set(YAML_CPP_TARGET yaml-cpp::yaml-cpp)
+else()
+  set(YAML_CPP_TARGET yaml-cpp)
+endif()
+
+# One library, no ROS dependencies. PROJ is linked PRIVATE (the public header
+# is PROJ-free by design); yaml-cpp likewise only backs load_datum_config.
+add_library(${PROJECT_NAME} SHARED
+  src/datum_config.cpp
+  src/vdatum_query.cpp
+)
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(${PROJECT_NAME} PRIVATE PkgConfig::PROJ ${YAML_CPP_TARGET})
+
+install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
+install(
+  TARGETS ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+
+  ament_add_gtest(test_datum_config test/test_datum_config.cpp)
+  target_link_libraries(test_datum_config ${PROJECT_NAME})
+
+  ament_add_gtest(test_vdatum_query test/test_vdatum_query.cpp)
+  target_link_libraries(test_vdatum_query ${PROJECT_NAME})
+endif()
+
+ament_package()

--- a/marine_vertical_datum/CMakeLists.txt
+++ b/marine_vertical_datum/CMakeLists.txt
@@ -25,11 +25,15 @@ add_library(${PROJECT_NAME} SHARED
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+  "$<INSTALL_INTERFACE:include>"
 )
 target_link_libraries(${PROJECT_NAME} PRIVATE PkgConfig::PROJ ${YAML_CPP_TARGET})
 
-install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
+# Headers install to plain include/ (not include/${PROJECT_NAME}), matching
+# the sibling store packages and avoiding the doubled
+# include/${PROJECT_NAME}/${PROJECT_NAME}/ path; the INSTALL_INTERFACE above
+# is kept consistent with this.
+install(DIRECTORY include/ DESTINATION include)
 install(
   TARGETS ${PROJECT_NAME}
   EXPORT export_${PROJECT_NAME}

--- a/marine_vertical_datum/CMakeLists.txt
+++ b/marine_vertical_datum/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(${PROJECT_NAME} SHARED
   src/datum_config.cpp
   src/vdatum_query.cpp
 )
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
@@ -44,6 +45,8 @@ install(
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 
 if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
   find_package(ament_cmake_gtest REQUIRED)
 
   ament_add_gtest(test_datum_config test/test_datum_config.cpp)

--- a/marine_vertical_datum/README.md
+++ b/marine_vertical_datum/README.md
@@ -1,0 +1,86 @@
+# marine_vertical_datum
+
+ROS-free vertical-datum resolution library
+([ADR-0010 D6](../docs/decisions/0010-geospatial-world-model.md)): answers
+"what is the chart datum (MLLW, optionally MHHW) relative to the WGS84
+ellipsoid at this point?" for chart importers (`s57_tools`), operator-side
+display (CAMP), and `mru_transform`'s `chart_datum_node`.
+
+Datum conversion happens **at import time, wherever import runs** — the
+navigation runtime never consults this library or its grids (ADR-0010 D5).
+
+## API
+
+All in `namespace marine_vertical_datum`. No `rclcpp` anywhere; PROJ and
+yaml-cpp are private link dependencies (the headers are PROJ-free).
+
+### `vdatum_query.hpp` — the VDatum/PROJ grid query
+
+| Symbol | Purpose |
+|---|---|
+| `VDatumConfig{geoid_grid, vdatum_grid_dir}` | Paths to the geoid file and the directory of regional `*_mllw*.gtx` / `*_mhhw*.gtx` grids |
+| `VDatumQueryFn` | `(lat, lon) → std::optional<VDatumResult>`; nullopt = no MLLW coverage there (a normal gap, no diagnostic) |
+| `DiagFn` | Optional setup-diagnostic sink (`std::function<void(const std::string&)>`); default discards |
+| `make_vdatum_query(config, diag)` | **The production entry.** Builds the PROJ context (networking disabled — strictly offline) and pipelines **once**; returns an empty function on setup failure (test `if (query)`). Call the factory once, then query per point — never rebuild per point. |
+
+### `datum_config.hpp` — the precedence-chain resolver
+
+| Symbol | Purpose |
+|---|---|
+| `resolve_datum(lat, lon, lake_datum, lake_datum_mhhw, vdatum, entries)` | The full chain: lake param → override polygons → VDatum result → fallback polygons → `nullopt` |
+| `load_datum_config(path)` | Parse the `datum_polygons:` YAML (see `mru_transform`'s `config/datum_polygons.example.yaml`); throws `std::runtime_error` on malformed input |
+| `point_in_ring(lat, lon, ring)` | Ray-casting point-in-polygon (boundary counts as inside; no antimeridian support) |
+| `DatumEntry`, `VDatumResult`, `DatumResult`, `DatumSource`, `LatLon` | Value types for the above |
+
+Typical import-time wiring:
+
+```cpp
+auto diag = [](const std::string & m) {std::cerr << m << "\n";};
+auto vdatum = marine_vertical_datum::make_vdatum_query(
+  {"/path/us_noaa_g2018u0.tif", "/path/vdatum"}, diag);
+auto entries = marine_vertical_datum::load_datum_config("datum_polygons.yaml");
+
+// per point / per cell:
+auto result = marine_vertical_datum::resolve_datum(
+  lat, lon, lake_datum, lake_datum_mhhw,
+  vdatum ? vdatum(lat, lon) : std::nullopt, entries);
+```
+
+Sign convention: heights are **signed metres relative to the WGS84
+ellipsoid** (negative when the datum surface is below the ellipsoid),
+matching the bathymetry store's convention.
+
+## Grid provisioning
+
+Grids live **wherever imports run** — dev machines and the boat as offline
+tooling — never on the navigation runtime (ADR-0010 D6/D7).
+
+- **Geoid** (ellipsoid → NAVD88): e.g. `us_noaa_g2018u0.tif`, via
+  `projsync --file us_noaa_g2018u0.tif` or from
+  <https://cdn.proj.org/>.
+- **VDatum regional grids** (NAVD88 → MLLW/MHHW): download the regional
+  VDatum grid bundles from NOAA (<https://vdatum.noaa.gov/>) and extract the
+  `*.gtx` files into one directory; the query scans it recursively for
+  `*_mllw*.gtx` / `*_mhhw*.gtx`.
+- Point `VDatumConfig` at both. PROJ networking is disabled in this library,
+  so nothing is fetched at query time — missing grids fail setup loudly via
+  `DiagFn`.
+
+Where VDatum has no coverage (inland lakes), use the polygon config /
+lake-datum override instead — that is the precedence chain's job.
+
+## Testing
+
+`test_datum_config` covers the precedence chain and YAML parsing;
+`test_vdatum_query` covers the injectable seam (`VDatumQueryFn` stubs) and
+the factory's grids-free failure paths. CI needs **no PROJ grids**: the seam
+makes consumers testable without them, and factory setup-validation fails
+before any grid is read.
+
+## Consumers
+
+- `s57_tools` chart exporter (per-cell chart-datum → ellipsoid at export).
+- CAMP (display-time chart-datum readouts, operator side).
+- `mru_transform` `chart_datum_node` — still carries its own inline copy;
+  migrating it onto this library is a tracked follow-on
+  (see [#274](https://github.com/rolker/unh_marine_autonomy/issues/274)).

--- a/marine_vertical_datum/include/marine_vertical_datum/datum_config.hpp
+++ b/marine_vertical_datum/include/marine_vertical_datum/datum_config.hpp
@@ -1,3 +1,24 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 // datum_config.hpp — Pure, ROS-free vertical-datum resolution (ADR-0010 D6).
 //
 // Consumers (chart importers, CAMP display, chart_datum_node) resolve the

--- a/marine_vertical_datum/include/marine_vertical_datum/datum_config.hpp
+++ b/marine_vertical_datum/include/marine_vertical_datum/datum_config.hpp
@@ -1,0 +1,90 @@
+// datum_config.hpp — Pure, ROS-free vertical-datum resolution (ADR-0010 D6).
+//
+// Consumers (chart importers, CAMP display, chart_datum_node) resolve the
+// vertical datum at a point from several sources. This header holds the
+// source-agnostic core so the full precedence chain is unit-testable without
+// rclcpp or PROJ:
+//
+//   1. lake_datum param (if set)            — wins outright everywhere
+//   2. config entries with override == true — beat VDatum
+//   3. VDatum (PROJ) result                 — where grids cover the point
+//   4. config entries with override == false (default) — fill VDatum gaps
+//   5. nothing matches                      — caller leaves chart_datum absent
+//
+// Within a pass, the first matching entry (file order) wins.
+
+#ifndef MARINE_VERTICAL_DATUM__DATUM_CONFIG_HPP_
+#define MARINE_VERTICAL_DATUM__DATUM_CONFIG_HPP_
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace marine_vertical_datum
+{
+
+enum class DatumSource
+{
+  VDATUM,
+  POLYGON_CONFIG,
+  PARAM,
+};
+
+// A geographic point in degrees.
+struct LatLon
+{
+  double lat;
+  double lon;
+};
+
+// One polygon→datum entry from the config file. Heights are signed metres in
+// the same convention as the published map→chart_datum transform: the datum's
+// height relative to the WGS84 ellipsoid (negative when below the ellipsoid).
+struct DatumEntry
+{
+  std::string name;
+  std::vector<LatLon> ring;          // polygon vertices, degrees (>= 3)
+  double chart_datum_z = 0.0;        // chart datum height rel. ellipsoid (m)
+  std::optional<double> mhhw_z;      // optional MHHW height rel. ellipsoid (m)
+  bool override_vdatum = false;      // true → consulted before VDatum
+};
+
+// Result of a VDatum/PROJ query at a point (caller passes nullopt for no
+// coverage / VDatum disabled).
+struct VDatumResult
+{
+  double mllw_z;                     // MLLW height rel. ellipsoid (m)
+  std::optional<double> mhhw_z;      // MHHW height rel. ellipsoid (m), if any
+};
+
+// The resolved datum and where it came from.
+struct DatumResult
+{
+  DatumSource source;
+  std::string name;                  // "vdatum", the polygon name, or "param"
+  double chart_datum_z;
+  std::optional<double> mhhw_z;
+};
+
+// Ray-casting point-in-polygon test. `ring` is an open polygon (the closing
+// edge from last→first vertex is implied). Points on an edge count as inside.
+// Operates in raw lat/lon degrees: correct for local polygons; rings crossing
+// the ±180° antimeridian are NOT supported.
+bool point_in_ring(double lat, double lon, const std::vector<LatLon> & ring);
+
+// Parse a polygon→datum config file (YAML). Throws std::runtime_error on a
+// missing file or malformed content.
+std::vector<DatumEntry> load_datum_config(const std::string & path);
+
+// Resolve the datum at a point following the precedence chain documented above.
+// Returns nullopt when nothing matches (caller leaves chart_datum absent).
+std::optional<DatumResult> resolve_datum(
+  double lat, double lon,
+  std::optional<double> lake_datum,
+  std::optional<double> lake_datum_mhhw,
+  const std::optional<VDatumResult> & vdatum,
+  const std::vector<DatumEntry> & entries);
+
+}  // namespace marine_vertical_datum
+
+#endif  // MARINE_VERTICAL_DATUM__DATUM_CONFIG_HPP_

--- a/marine_vertical_datum/include/marine_vertical_datum/vdatum_query.hpp
+++ b/marine_vertical_datum/include/marine_vertical_datum/vdatum_query.hpp
@@ -57,8 +57,11 @@ using DiagFn = std::function<void (const std::string &)>;
 // test with `if (query)` before use. A missing/failed MHHW pipeline is not
 // fatal: the query works and mhhw_z stays nullopt (reported via `diag`).
 //
-// The returned callable is copyable; copies share one PROJ context and are
-// NOT safe for concurrent use from multiple threads.
+// The returned callable is copyable; copies share ONE PROJ context and ONE
+// set of PJ pipeline objects, and proj_trans on a shared PJ is not
+// thread-safe — so neither the callable nor its copies may be invoked
+// concurrently. A parallel per-cell consumer must call make_vdatum_query
+// once PER THREAD (each call builds its own context + pipelines).
 VDatumQueryFn make_vdatum_query(const VDatumConfig & config, DiagFn diag = {});
 
 }  // namespace marine_vertical_datum

--- a/marine_vertical_datum/include/marine_vertical_datum/vdatum_query.hpp
+++ b/marine_vertical_datum/include/marine_vertical_datum/vdatum_query.hpp
@@ -1,3 +1,24 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 // vdatum_query.hpp — VDatum/PROJ grid query for vertical-datum resolution
 // (ADR-0010 D6), extracted from mru_transform's chart_datum_node.
 //

--- a/marine_vertical_datum/include/marine_vertical_datum/vdatum_query.hpp
+++ b/marine_vertical_datum/include/marine_vertical_datum/vdatum_query.hpp
@@ -1,0 +1,66 @@
+// vdatum_query.hpp — VDatum/PROJ grid query for vertical-datum resolution
+// (ADR-0010 D6), extracted from mru_transform's chart_datum_node.
+//
+// Answers "what is the MLLW (and optionally MHHW) height relative to the
+// WGS84 ellipsoid at this lat/lon?" from a geoid grid + regional VDatum
+// `.gtx` grids on local disk. PROJ networking is disabled — resolution is
+// strictly offline (ADR-0010 D6/D7: grids live wherever imports run, never
+// in the runtime stack).
+//
+// Usage: build the query ONCE with make_vdatum_query() and call it per
+// point. The returned callable owns the PROJ context and pipelines (shared,
+// RAII); constructing it scans the grid directory and compiles the PROJ
+// pipelines, so per-point work is a single proj_trans. Do NOT rebuild the
+// query per point — a per-cell importer over millions of cells wants one
+// factory call total.
+//
+// This header is PROJ-free: consumers only see std::function and plain
+// structs, so linking PROJ stays this library's private concern.
+
+#ifndef MARINE_VERTICAL_DATUM__VDATUM_QUERY_HPP_
+#define MARINE_VERTICAL_DATUM__VDATUM_QUERY_HPP_
+
+#include <functional>
+#include <optional>
+#include <string>
+
+#include "marine_vertical_datum/datum_config.hpp"
+
+namespace marine_vertical_datum
+{
+
+// Where the grids live. `geoid_grid` is the ellipsoid→NAVD88 geoid file
+// (e.g. us_noaa_g2018u0.tif); `vdatum_grid_dir` is scanned recursively for
+// regional NAVD88→datum `.gtx` grids named *_mllw*.gtx / *_mhhw*.gtx.
+struct VDatumConfig
+{
+  std::string geoid_grid;
+  std::string vdatum_grid_dir;
+};
+
+// The per-point query: (lat, lon) in degrees → VDatumResult, or nullopt
+// where the grids have no MLLW coverage. A per-point nullopt is a normal
+// gap condition (the precedence chain's polygon fallbacks handle it), so it
+// deliberately carries no diagnostic — only setup problems are reported.
+using VDatumQueryFn =
+  std::function<std::optional<VDatumResult>(double lat, double lon)>;
+
+// Diagnostic sink for setup-time problems (missing grids, PROJ pipeline
+// failures). ROS-free replacement for the node's RCLCPP_* logging: callers
+// route messages to their own logger; the default discards them.
+using DiagFn = std::function<void (const std::string &)>;
+
+// Production factory. Scans the grid directory, creates the PROJ context
+// (networking disabled) and MLLW/MHHW pipelines, and returns the query.
+// On setup failure (no MLLW grids, unreadable directory, pipeline creation
+// error) reports the reason via `diag` and returns an EMPTY std::function —
+// test with `if (query)` before use. A missing/failed MHHW pipeline is not
+// fatal: the query works and mhhw_z stays nullopt (reported via `diag`).
+//
+// The returned callable is copyable; copies share one PROJ context and are
+// NOT safe for concurrent use from multiple threads.
+VDatumQueryFn make_vdatum_query(const VDatumConfig & config, DiagFn diag = {});
+
+}  // namespace marine_vertical_datum
+
+#endif  // MARINE_VERTICAL_DATUM__VDATUM_QUERY_HPP_

--- a/marine_vertical_datum/package.xml
+++ b/marine_vertical_datum/package.xml
@@ -19,6 +19,8 @@
   <depend>yaml-cpp</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/marine_vertical_datum/package.xml
+++ b/marine_vertical_datum/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>marine_vertical_datum</name>
+  <version>0.1.0</version>
+  <description>
+    ROS-free vertical-datum resolution library (ADR-0010 D6): VDatum/PROJ
+    grid queries (MLLW/MHHW relative to the WGS84 ellipsoid) plus the
+    precedence-chain resolver (lake override, polygon config, VDatum,
+    polygon fallback). Used by chart importers, CAMP display, and
+    mru_transform's chart_datum_node.
+  </description>
+  <maintainer email="roland.arsenault@unh.edu">Roland Arsenault</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>proj</depend>
+  <depend>yaml-cpp</depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/marine_vertical_datum/src/datum_config.cpp
+++ b/marine_vertical_datum/src/datum_config.cpp
@@ -1,3 +1,24 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 // datum_config.cpp — Implementation of the pure datum resolution core.
 
 #include "marine_vertical_datum/datum_config.hpp"
@@ -88,8 +109,8 @@ std::vector<DatumEntry> load_datum_config(const std::string & path)
   try {
     for (const auto & node : polygons) {
       DatumEntry entry;
-      entry.name = node["name"] ? node["name"].as<std::string>()
-                                : std::string("unnamed");
+      entry.name = node["name"] ? node["name"].as<std::string>() :
+        std::string("unnamed");
 
       if (!node["chart_datum_z"]) {
         throw std::runtime_error(

--- a/marine_vertical_datum/src/datum_config.cpp
+++ b/marine_vertical_datum/src/datum_config.cpp
@@ -1,0 +1,168 @@
+// datum_config.cpp — Implementation of the pure datum resolution core.
+
+#include "marine_vertical_datum/datum_config.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include "yaml-cpp/yaml.h"
+
+namespace marine_vertical_datum
+{
+
+namespace
+{
+
+// Is the point collinear with and within the segment a–b? Treats an exact
+// (or near-exact) on-edge point as on the segment.
+bool point_on_segment(double lat, double lon, const LatLon & a, const LatLon & b)
+{
+  constexpr double kEps = 1e-9;
+  // Cross product: zero ⇒ collinear.
+  const double cross =
+    (lon - a.lon) * (b.lat - a.lat) - (lat - a.lat) * (b.lon - a.lon);
+  if (std::abs(cross) > kEps) {
+    return false;
+  }
+  // Within the segment's bounding box (with tolerance).
+  return lon >= std::min(a.lon, b.lon) - kEps &&
+         lon <= std::max(a.lon, b.lon) + kEps &&
+         lat >= std::min(a.lat, b.lat) - kEps &&
+         lat <= std::max(a.lat, b.lat) + kEps;
+}
+
+}  // namespace
+
+bool point_in_ring(double lat, double lon, const std::vector<LatLon> & ring)
+{
+  const size_t n = ring.size();
+  if (n < 3) {
+    return false;
+  }
+
+  // Boundary counts as inside.
+  for (size_t i = 0, j = n - 1; i < n; j = i++) {
+    if (point_on_segment(lat, lon, ring[i], ring[j])) {
+      return true;
+    }
+  }
+
+  // Standard ray-casting (crossing number) test.
+  bool inside = false;
+  for (size_t i = 0, j = n - 1; i < n; j = i++) {
+    const double yi = ring[i].lat, xi = ring[i].lon;
+    const double yj = ring[j].lat, xj = ring[j].lon;
+    const bool crosses = ((yi > lat) != (yj > lat)) &&
+      (lon < (xj - xi) * (lat - yi) / (yj - yi) + xi);
+    if (crosses) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+std::vector<DatumEntry> load_datum_config(const std::string & path)
+{
+  YAML::Node root;
+  try {
+    root = YAML::LoadFile(path);
+  } catch (const YAML::Exception & e) {
+    throw std::runtime_error(
+      "Failed to load datum config '" + path + "': " + e.what());
+  }
+
+  const YAML::Node polygons = root["datum_polygons"];
+  if (!polygons || !polygons.IsSequence()) {
+    throw std::runtime_error(
+      "Datum config '" + path + "' missing a 'datum_polygons' sequence");
+  }
+
+  std::vector<DatumEntry> entries;
+  // Wrap the per-entry parse so yaml-cpp type-conversion failures (e.g. a
+  // non-numeric chart_datum_z or ring vertex) surface as std::runtime_error,
+  // matching this function's documented contract. Our own validation throws
+  // std::runtime_error directly and passes through untouched.
+  try {
+    for (const auto & node : polygons) {
+      DatumEntry entry;
+      entry.name = node["name"] ? node["name"].as<std::string>()
+                                : std::string("unnamed");
+
+      if (!node["chart_datum_z"]) {
+        throw std::runtime_error(
+          "Datum entry '" + entry.name + "' is missing 'chart_datum_z'");
+      }
+      entry.chart_datum_z = node["chart_datum_z"].as<double>();
+
+      if (node["mhhw_z"]) {
+        entry.mhhw_z = node["mhhw_z"].as<double>();
+      }
+
+      entry.override_vdatum = node["override"] && node["override"].as<bool>();
+
+      const YAML::Node ring = node["ring"];
+      if (!ring || !ring.IsSequence() || ring.size() < 3) {
+        throw std::runtime_error(
+          "Datum entry '" + entry.name +
+          "' needs a 'ring' of at least 3 [lat, lon] points");
+      }
+      for (const auto & pt : ring) {
+        if (!pt.IsSequence() || pt.size() != 2) {
+          throw std::runtime_error(
+            "Datum entry '" + entry.name +
+            "' has a malformed ring vertex (expected [lat, lon])");
+        }
+        entry.ring.push_back(LatLon{pt[0].as<double>(), pt[1].as<double>()});
+      }
+
+      entries.push_back(std::move(entry));
+    }
+  } catch (const YAML::Exception & e) {
+    throw std::runtime_error(
+      "Malformed datum config '" + path + "': " + e.what());
+  }
+  return entries;
+}
+
+std::optional<DatumResult> resolve_datum(
+  double lat, double lon,
+  std::optional<double> lake_datum,
+  std::optional<double> lake_datum_mhhw,
+  const std::optional<VDatumResult> & vdatum,
+  const std::vector<DatumEntry> & entries)
+{
+  // 1. lake_datum param wins outright.
+  if (lake_datum.has_value()) {
+    return DatumResult{DatumSource::PARAM, "param", *lake_datum, lake_datum_mhhw};
+  }
+
+  // 2. config override entries (consulted before VDatum).
+  for (const auto & e : entries) {
+    if (e.override_vdatum && point_in_ring(lat, lon, e.ring)) {
+      return DatumResult{
+        DatumSource::POLYGON_CONFIG, e.name, e.chart_datum_z, e.mhhw_z};
+    }
+  }
+
+  // 3. VDatum.
+  if (vdatum.has_value()) {
+    return DatumResult{
+      DatumSource::VDATUM, "vdatum", vdatum->mllw_z, vdatum->mhhw_z};
+  }
+
+  // 4. config fallback entries (fill VDatum gaps).
+  for (const auto & e : entries) {
+    if (!e.override_vdatum && point_in_ring(lat, lon, e.ring)) {
+      return DatumResult{
+        DatumSource::POLYGON_CONFIG, e.name, e.chart_datum_z, e.mhhw_z};
+    }
+  }
+
+  // 5. Nothing matched.
+  return std::nullopt;
+}
+
+}  // namespace marine_vertical_datum

--- a/marine_vertical_datum/src/vdatum_query.cpp
+++ b/marine_vertical_datum/src/vdatum_query.cpp
@@ -6,10 +6,12 @@
 
 #include <proj.h>
 
+#include <algorithm>
 #include <cmath>
 #include <filesystem>
 #include <memory>
 #include <utility>
+#include <vector>
 
 namespace fs = std::filesystem;
 
@@ -27,20 +29,29 @@ void report(const DiagFn & diag, const std::string & message)
 }
 
 // Collect .gtx grid files under `dir` whose stem contains `suffix`
-// (e.g. "_mllw"), comma-joined for a +proj=vgridshift +grids= step.
-// Throws fs::filesystem_error on an unreadable directory.
+// (e.g. "_mllw"), comma-joined for a +proj=vgridshift +grids= step. Sorted
+// so the +grids= precedence (first grid with coverage wins on overlap) is
+// deterministic across machines — recursive_directory_iterator order is
+// filesystem-dependent. Throws fs::filesystem_error on an unreadable
+// directory.
 std::string collect_grids(const std::string & dir, const std::string & suffix)
 {
-  std::string grids;
+  std::vector<std::string> paths;
   for (const auto & entry : fs::recursive_directory_iterator(dir)) {
     if (entry.path().extension() == ".gtx" &&
       entry.path().stem().string().find(suffix) != std::string::npos)
     {
-      if (!grids.empty()) {
-        grids += ",";
-      }
-      grids += entry.path().string();
+      paths.push_back(entry.path().string());
     }
+  }
+  std::sort(paths.begin(), paths.end());
+
+  std::string grids;
+  for (const auto & path : paths) {
+    if (!grids.empty()) {
+      grids += ",";
+    }
+    grids += path;
   }
   return grids;
 }

--- a/marine_vertical_datum/src/vdatum_query.cpp
+++ b/marine_vertical_datum/src/vdatum_query.cpp
@@ -152,6 +152,13 @@ VDatumQueryFn make_vdatum_query(const VDatumConfig & config, DiagFn diag)
 
   auto pipelines = std::make_shared<ProjPipelines>();
   pipelines->context = proj_context_create();
+  if (!pipelines->context) {
+    // PROJ treats a NULL ctx as "the default context" rather than crashing,
+    // so proceeding here would silently configure and build pipelines on the
+    // process-global default context — un-owned by this holder. Refuse.
+    report(diag, "VDatum setup: proj_context_create failed");
+    return {};
+  }
   // Strictly offline (ADR-0010 D6/D7): never fetch grids over the network —
   // resolution must behave identically on a disconnected boat.
   proj_context_set_enable_network(pipelines->context, false);

--- a/marine_vertical_datum/src/vdatum_query.cpp
+++ b/marine_vertical_datum/src/vdatum_query.cpp
@@ -1,0 +1,186 @@
+// vdatum_query.cpp — PROJ pipeline setup + per-point query, extracted from
+// mru_transform's chart_datum_node (ADR-0010 D6). Setup-time problems go to
+// the caller's DiagFn; per-point no-coverage is a plain nullopt.
+
+#include "marine_vertical_datum/vdatum_query.hpp"
+
+#include <proj.h>
+
+#include <cmath>
+#include <filesystem>
+#include <memory>
+#include <utility>
+
+namespace fs = std::filesystem;
+
+namespace marine_vertical_datum
+{
+
+namespace
+{
+
+void report(const DiagFn & diag, const std::string & message)
+{
+  if (diag) {
+    diag(message);
+  }
+}
+
+// Collect .gtx grid files under `dir` whose stem contains `suffix`
+// (e.g. "_mllw"), comma-joined for a +proj=vgridshift +grids= step.
+// Throws fs::filesystem_error on an unreadable directory.
+std::string collect_grids(const std::string & dir, const std::string & suffix)
+{
+  std::string grids;
+  for (const auto & entry : fs::recursive_directory_iterator(dir)) {
+    if (entry.path().extension() == ".gtx" &&
+      entry.path().stem().string().find(suffix) != std::string::npos)
+    {
+      if (!grids.empty()) {
+        grids += ",";
+      }
+      grids += entry.path().string();
+    }
+  }
+  return grids;
+}
+
+// Owns the PROJ context and pipelines; shared by all copies of the returned
+// query so cleanup is RAII'd to the last copy.
+struct ProjPipelines
+{
+  PJ_CONTEXT * context = nullptr;
+  PJ * mllw = nullptr;
+  PJ * mhhw = nullptr;
+
+  ~ProjPipelines()
+  {
+    if (mllw) {
+      proj_destroy(mllw);
+    }
+    if (mhhw) {
+      proj_destroy(mhhw);
+    }
+    if (context) {
+      proj_context_destroy(context);
+    }
+  }
+
+  ProjPipelines() = default;
+  ProjPipelines(const ProjPipelines &) = delete;
+  ProjPipelines & operator=(const ProjPipelines &) = delete;
+};
+
+// Create a PROJ pipeline: ellipsoid → NAVD88 (geoid) → target datum (grids).
+PJ * create_pipeline(
+  PJ_CONTEXT * context, const std::string & geoid_grid,
+  const std::string & datum_grids, const DiagFn & diag)
+{
+  const std::string pipeline =
+    "+proj=pipeline "
+    "+step +proj=vgridshift +grids=" + geoid_grid + " "
+    "+step +proj=vgridshift +grids=" + datum_grids;
+
+  PJ * pj = proj_create(context, pipeline.c_str());
+  if (!pj) {
+    report(
+      diag, std::string("Failed to create PROJ pipeline: ") +
+      proj_context_errno_string(context, proj_context_errno(context)));
+  }
+  return pj;
+}
+
+// Query one pipeline; returns the negated Z (datum height below ellipsoid,
+// matching the datum_config sign convention) or false on no coverage.
+bool query_datum(PJ * pipeline, double lon_rad, double lat_rad, double & result_z)
+{
+  const PJ_COORD input = proj_coord(lon_rad, lat_rad, 0.0, 0.0);
+  const PJ_COORD output = proj_trans(pipeline, PJ_FWD, input);
+
+  if (output.xyz.z == HUGE_VAL ||
+    std::isinf(output.xyz.z) || std::isnan(output.xyz.z))
+  {
+    return false;
+  }
+
+  result_z = -output.xyz.z;
+  return true;
+}
+
+}  // namespace
+
+VDatumQueryFn make_vdatum_query(const VDatumConfig & config, DiagFn diag)
+{
+  if (config.geoid_grid.empty()) {
+    report(diag, "VDatum setup: geoid_grid is empty");
+    return {};
+  }
+  if (config.vdatum_grid_dir.empty()) {
+    report(diag, "VDatum setup: vdatum_grid_dir is empty");
+    return {};
+  }
+
+  std::string mllw_grids;
+  std::string mhhw_grids;
+  try {
+    mllw_grids = collect_grids(config.vdatum_grid_dir, "_mllw");
+    mhhw_grids = collect_grids(config.vdatum_grid_dir, "_mhhw");
+  } catch (const fs::filesystem_error & e) {
+    report(
+      diag, "VDatum setup: error scanning vdatum_grid_dir '" +
+      config.vdatum_grid_dir + "': " + e.what());
+    return {};
+  }
+
+  if (mllw_grids.empty()) {
+    report(
+      diag, "VDatum setup: no *_mllw.gtx files found in " +
+      config.vdatum_grid_dir);
+    return {};
+  }
+
+  auto pipelines = std::make_shared<ProjPipelines>();
+  pipelines->context = proj_context_create();
+  // Strictly offline (ADR-0010 D6/D7): never fetch grids over the network —
+  // resolution must behave identically on a disconnected boat.
+  proj_context_set_enable_network(pipelines->context, false);
+
+  pipelines->mllw =
+    create_pipeline(pipelines->context, config.geoid_grid, mllw_grids, diag);
+  if (!pipelines->mllw) {
+    return {};   // ProjPipelines dtor releases the context
+  }
+
+  if (!mhhw_grids.empty()) {
+    pipelines->mhhw =
+      create_pipeline(pipelines->context, config.geoid_grid, mhhw_grids, diag);
+    if (!pipelines->mhhw) {
+      report(diag, "VDatum setup: MHHW pipeline failed — mhhw_z will be absent");
+    }
+  } else {
+    report(
+      diag, "VDatum setup: no *_mhhw.gtx files found — mhhw_z will be absent");
+  }
+
+  return [pipelines](double lat, double lon) -> std::optional<VDatumResult> {
+      const double lon_rad = proj_torad(lon);
+      const double lat_rad = proj_torad(lat);
+
+      double mllw_z;
+      if (!query_datum(pipelines->mllw, lon_rad, lat_rad, mllw_z)) {
+        return std::nullopt;   // normal gap: no MLLW coverage here
+      }
+
+      VDatumResult result;
+      result.mllw_z = mllw_z;
+      if (pipelines->mhhw) {
+        double mhhw_z;
+        if (query_datum(pipelines->mhhw, lon_rad, lat_rad, mhhw_z)) {
+          result.mhhw_z = mhhw_z;
+        }
+      }
+      return result;
+    };
+}
+
+}  // namespace marine_vertical_datum

--- a/marine_vertical_datum/src/vdatum_query.cpp
+++ b/marine_vertical_datum/src/vdatum_query.cpp
@@ -1,3 +1,24 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 // vdatum_query.cpp — PROJ pipeline setup + per-point query, extracted from
 // mru_transform's chart_datum_node (ADR-0010 D6). Setup-time problems go to
 // the caller's DiagFn; per-point no-coverage is a plain nullopt.
@@ -181,24 +202,24 @@ VDatumQueryFn make_vdatum_query(const VDatumConfig & config, DiagFn diag)
   }
 
   return [pipelines](double lat, double lon) -> std::optional<VDatumResult> {
-      const double lon_rad = proj_torad(lon);
-      const double lat_rad = proj_torad(lat);
+           const double lon_rad = proj_torad(lon);
+           const double lat_rad = proj_torad(lat);
 
-      double mllw_z;
-      if (!query_datum(pipelines->mllw, lon_rad, lat_rad, mllw_z)) {
-        return std::nullopt;   // normal gap: no MLLW coverage here
-      }
+           double mllw_z;
+           if (!query_datum(pipelines->mllw, lon_rad, lat_rad, mllw_z)) {
+             return std::nullopt;  // normal gap: no MLLW coverage here
+           }
 
-      VDatumResult result;
-      result.mllw_z = mllw_z;
-      if (pipelines->mhhw) {
-        double mhhw_z;
-        if (query_datum(pipelines->mhhw, lon_rad, lat_rad, mhhw_z)) {
-          result.mhhw_z = mhhw_z;
-        }
-      }
-      return result;
-    };
+           VDatumResult result;
+           result.mllw_z = mllw_z;
+           if (pipelines->mhhw) {
+             double mhhw_z;
+             if (query_datum(pipelines->mhhw, lon_rad, lat_rad, mhhw_z)) {
+               result.mhhw_z = mhhw_z;
+             }
+           }
+           return result;
+         };
 }
 
 }  // namespace marine_vertical_datum

--- a/marine_vertical_datum/test/test_datum_config.cpp
+++ b/marine_vertical_datum/test/test_datum_config.cpp
@@ -1,6 +1,7 @@
 // Tests for the pure datum resolution core (marine_vertical_datum::datum_config).
 //
-// Covers acceptance item 5 of issue #25 in pure code: the precedence matrix
+// Ported from mru_transform for issue #274 (ADR-0010 D6). Covers, in pure
+// code: the precedence matrix
 // (param-first / override-beats-VDatum / fallback-loses-to-VDatum /
 // fallback-fills-gap / nothing→none, plus MHHW present vs absent), the
 // point-in-polygon predicate (inside / outside / boundary / overlap), and

--- a/marine_vertical_datum/test/test_datum_config.cpp
+++ b/marine_vertical_datum/test/test_datum_config.cpp
@@ -1,3 +1,24 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 // Tests for the pure datum resolution core (marine_vertical_datum::datum_config).
 //
 // Ported from mru_transform for issue #274 (ADR-0010 D6). Covers, in pure
@@ -7,6 +28,7 @@
 // point-in-polygon predicate (inside / outside / boundary / overlap), and
 // config parsing (valid / missing / malformed / override default).
 
+#include <gtest/gtest.h>
 #include <unistd.h>
 
 #include <cstdio>
@@ -14,8 +36,6 @@
 #include <optional>
 #include <string>
 #include <vector>
-
-#include <gtest/gtest.h>
 
 #include "marine_vertical_datum/datum_config.hpp"
 

--- a/marine_vertical_datum/test/test_datum_config.cpp
+++ b/marine_vertical_datum/test/test_datum_config.cpp
@@ -10,6 +10,7 @@
 #include <unistd.h>
 
 #include <cstdio>
+#include <cstdlib>
 #include <optional>
 #include <string>
 #include <vector>

--- a/marine_vertical_datum/test/test_datum_config.cpp
+++ b/marine_vertical_datum/test/test_datum_config.cpp
@@ -1,0 +1,312 @@
+// Tests for the pure datum resolution core (marine_vertical_datum::datum_config).
+//
+// Covers acceptance item 5 of issue #25 in pure code: the precedence matrix
+// (param-first / override-beats-VDatum / fallback-loses-to-VDatum /
+// fallback-fills-gap / nothing→none, plus MHHW present vs absent), the
+// point-in-polygon predicate (inside / outside / boundary / overlap), and
+// config parsing (valid / missing / malformed / override default).
+
+#include <unistd.h>
+
+#include <cstdio>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "marine_vertical_datum/datum_config.hpp"
+
+using marine_vertical_datum::DatumEntry;
+using marine_vertical_datum::DatumSource;
+using marine_vertical_datum::LatLon;
+using marine_vertical_datum::VDatumResult;
+using marine_vertical_datum::load_datum_config;
+using marine_vertical_datum::point_in_ring;
+using marine_vertical_datum::resolve_datum;
+
+namespace
+{
+
+// A unit square ring [0,1] x [0,1] in (lat, lon).
+std::vector<LatLon> unitSquare()
+{
+  return {{0.0, 0.0}, {0.0, 1.0}, {1.0, 1.0}, {1.0, 0.0}};
+}
+
+// One config entry covering a small area around (43, -71).
+DatumEntry lakeEntry(bool override_vdatum, double z = -25.0)
+{
+  DatumEntry e;
+  e.name = "lake";
+  e.ring = {{42.0, -72.0}, {42.0, -70.0}, {44.0, -70.0}, {44.0, -72.0}};
+  e.chart_datum_z = z;
+  e.override_vdatum = override_vdatum;
+  return e;
+}
+
+// Write text to a unique temp file; returns the path.
+std::string writeTemp(const std::string & contents)
+{
+  char tmpl[] = "/tmp/datum_cfg_XXXXXX";
+  const int fd = mkstemp(tmpl);
+  EXPECT_GE(fd, 0) << "mkstemp failed";
+  if (fd >= 0) {
+    const ssize_t written = write(fd, contents.data(), contents.size());
+    EXPECT_EQ(static_cast<size_t>(written), contents.size());
+    close(fd);
+  }
+  return std::string(tmpl);
+}
+
+}  // namespace
+
+// ---- point_in_ring -------------------------------------------------------
+
+TEST(PointInRing, InsideAndOutside)
+{
+  const auto ring = unitSquare();
+  EXPECT_TRUE(point_in_ring(0.5, 0.5, ring));
+  EXPECT_FALSE(point_in_ring(2.0, 0.5, ring));
+  EXPECT_FALSE(point_in_ring(0.5, -0.5, ring));
+}
+
+TEST(PointInRing, BoundaryCountsAsInside)
+{
+  const auto ring = unitSquare();
+  EXPECT_TRUE(point_in_ring(0.0, 0.5, ring));   // on an edge
+  EXPECT_TRUE(point_in_ring(0.0, 0.0, ring));   // on a vertex
+  EXPECT_TRUE(point_in_ring(1.0, 1.0, ring));   // on a vertex
+}
+
+TEST(PointInRing, DegenerateRingIsNeverInside)
+{
+  std::vector<LatLon> two = {{0.0, 0.0}, {1.0, 1.0}};
+  EXPECT_FALSE(point_in_ring(0.5, 0.5, two));
+}
+
+TEST(PointInRing, CollinearButOutsideSegmentIsNotInside)
+{
+  // Point on the line of the bottom edge (lat=0) but beyond the segment's
+  // longitude range — must be rejected by the on-segment bounding-box check
+  // and not counted as on-boundary.
+  const auto ring = unitSquare();
+  EXPECT_FALSE(point_in_ring(0.0, 2.0, ring));
+  EXPECT_FALSE(point_in_ring(0.0, -1.0, ring));
+}
+
+TEST(PointInRing, VertexLatitudeDoesNotDoubleCount)
+{
+  // A horizontal ray at the latitude of the top vertices (lat=1.0) must not be
+  // mis-counted by the half-open ray-cast convention. A point well to the left
+  // at that latitude is outside; the top edge itself is boundary (inside).
+  const auto ring = unitSquare();
+  EXPECT_FALSE(point_in_ring(1.0, -1.0, ring));   // left of the ring, on top edge's lat
+  EXPECT_TRUE(point_in_ring(1.0, 0.5, ring));     // on the top edge → inside
+}
+
+TEST(PointInRing, ConcaveRingExcludesTheNotch)
+{
+  // An L-shaped (concave) ring: the notch must read as outside even though it
+  // is within the bounding box.
+  std::vector<LatLon> ell = {
+    {0.0, 0.0}, {0.0, 2.0}, {1.0, 2.0}, {1.0, 1.0}, {2.0, 1.0}, {2.0, 0.0}};
+  EXPECT_TRUE(point_in_ring(0.5, 0.5, ell));    // in the solid corner
+  EXPECT_FALSE(point_in_ring(1.5, 1.5, ell));   // in the removed notch
+}
+
+// ---- resolve_datum precedence -------------------------------------------
+
+TEST(ResolveDatum, ParamWinsOutright)
+{
+  std::vector<DatumEntry> entries = {lakeEntry(/*override=*/true, -10.0)};
+  VDatumResult vd{-3.0, std::nullopt};
+  // Point is inside the override polygon AND has VDatum, yet param wins.
+  auto r = resolve_datum(43.0, -71.0, /*lake=*/-7.5, /*lake_mhhw=*/-7.0, vd, entries);
+  ASSERT_TRUE(r.has_value());
+  EXPECT_EQ(r->source, DatumSource::PARAM);
+  EXPECT_DOUBLE_EQ(r->chart_datum_z, -7.5);
+  ASSERT_TRUE(r->mhhw_z.has_value());
+  EXPECT_DOUBLE_EQ(*r->mhhw_z, -7.0);
+}
+
+TEST(ResolveDatum, OverrideEntryBeatsVDatum)
+{
+  std::vector<DatumEntry> entries = {lakeEntry(/*override=*/true, -10.0)};
+  VDatumResult vd{-3.0, std::nullopt};
+  auto r = resolve_datum(43.0, -71.0, std::nullopt, std::nullopt, vd, entries);
+  ASSERT_TRUE(r.has_value());
+  EXPECT_EQ(r->source, DatumSource::POLYGON_CONFIG);
+  EXPECT_EQ(r->name, "lake");
+  EXPECT_DOUBLE_EQ(r->chart_datum_z, -10.0);
+}
+
+TEST(ResolveDatum, FallbackEntryLosesToVDatum)
+{
+  std::vector<DatumEntry> entries = {lakeEntry(/*override=*/false, -10.0)};
+  VDatumResult vd{-3.0, -2.5};
+  auto r = resolve_datum(43.0, -71.0, std::nullopt, std::nullopt, vd, entries);
+  ASSERT_TRUE(r.has_value());
+  EXPECT_EQ(r->source, DatumSource::VDATUM);
+  EXPECT_DOUBLE_EQ(r->chart_datum_z, -3.0);
+  ASSERT_TRUE(r->mhhw_z.has_value());
+  EXPECT_DOUBLE_EQ(*r->mhhw_z, -2.5);
+}
+
+TEST(ResolveDatum, FallbackEntryFillsVDatumGap)
+{
+  std::vector<DatumEntry> entries = {lakeEntry(/*override=*/false, -10.0)};
+  // No VDatum coverage here.
+  auto r = resolve_datum(43.0, -71.0, std::nullopt, std::nullopt, std::nullopt, entries);
+  ASSERT_TRUE(r.has_value());
+  EXPECT_EQ(r->source, DatumSource::POLYGON_CONFIG);
+  EXPECT_DOUBLE_EQ(r->chart_datum_z, -10.0);
+  EXPECT_FALSE(r->mhhw_z.has_value());
+}
+
+TEST(ResolveDatum, NothingMatchesYieldsNone)
+{
+  std::vector<DatumEntry> entries = {lakeEntry(/*override=*/false)};
+  // Point outside the polygon, no VDatum, no param.
+  auto r = resolve_datum(10.0, 10.0, std::nullopt, std::nullopt, std::nullopt, entries);
+  EXPECT_FALSE(r.has_value());
+}
+
+TEST(ResolveDatum, EmptyEverythingYieldsNone)
+{
+  auto r = resolve_datum(43.0, -71.0, std::nullopt, std::nullopt, std::nullopt, {});
+  EXPECT_FALSE(r.has_value());
+}
+
+TEST(ResolveDatum, FirstMatchWinsOnOverlap)
+{
+  DatumEntry a = lakeEntry(/*override=*/false, -10.0);
+  a.name = "first";
+  DatumEntry b = lakeEntry(/*override=*/false, -20.0);
+  b.name = "second";
+  std::vector<DatumEntry> entries = {a, b};
+  auto r = resolve_datum(43.0, -71.0, std::nullopt, std::nullopt, std::nullopt, entries);
+  ASSERT_TRUE(r.has_value());
+  EXPECT_EQ(r->name, "first");
+}
+
+// ---- load_datum_config ---------------------------------------------------
+
+TEST(LoadDatumConfig, ValidFileParses)
+{
+  const std::string yaml =
+    "datum_polygons:\n"
+    "  - name: \"Lake A\"\n"
+    "    chart_datum_z: -25.0\n"
+    "    mhhw_z: -24.5\n"
+    "    override: true\n"
+    "    ring:\n"
+    "      - [43.0, -71.4]\n"
+    "      - [43.0, -71.3]\n"
+    "      - [42.9, -71.3]\n"
+    "      - [42.9, -71.4]\n";
+  const std::string path = writeTemp(yaml);
+  auto entries = load_datum_config(path);
+  std::remove(path.c_str());
+
+  ASSERT_EQ(entries.size(), 1u);
+  EXPECT_EQ(entries[0].name, "Lake A");
+  EXPECT_DOUBLE_EQ(entries[0].chart_datum_z, -25.0);
+  ASSERT_TRUE(entries[0].mhhw_z.has_value());
+  EXPECT_DOUBLE_EQ(*entries[0].mhhw_z, -24.5);
+  EXPECT_TRUE(entries[0].override_vdatum);
+  EXPECT_EQ(entries[0].ring.size(), 4u);
+}
+
+TEST(LoadDatumConfig, OverrideAndMhhwDefault)
+{
+  const std::string yaml =
+    "datum_polygons:\n"
+    "  - name: \"Lake B\"\n"
+    "    chart_datum_z: -5.0\n"
+    "    ring:\n"
+    "      - [1.0, 1.0]\n"
+    "      - [1.0, 2.0]\n"
+    "      - [2.0, 2.0]\n";
+  const std::string path = writeTemp(yaml);
+  auto entries = load_datum_config(path);
+  std::remove(path.c_str());
+
+  ASSERT_EQ(entries.size(), 1u);
+  EXPECT_FALSE(entries[0].override_vdatum);   // default false
+  EXPECT_FALSE(entries[0].mhhw_z.has_value());  // optional, omitted
+}
+
+TEST(LoadDatumConfig, MissingFileThrows)
+{
+  EXPECT_THROW(
+    load_datum_config("/nonexistent/path/datum.yaml"), std::runtime_error);
+}
+
+TEST(LoadDatumConfig, MissingChartDatumZThrows)
+{
+  const std::string yaml =
+    "datum_polygons:\n"
+    "  - name: \"No Z\"\n"
+    "    ring:\n"
+    "      - [1.0, 1.0]\n"
+    "      - [1.0, 2.0]\n"
+    "      - [2.0, 2.0]\n";
+  const std::string path = writeTemp(yaml);
+  EXPECT_THROW(load_datum_config(path), std::runtime_error);
+  std::remove(path.c_str());
+}
+
+TEST(LoadDatumConfig, TooFewRingPointsThrows)
+{
+  const std::string yaml =
+    "datum_polygons:\n"
+    "  - name: \"Sliver\"\n"
+    "    chart_datum_z: -5.0\n"
+    "    ring:\n"
+    "      - [1.0, 1.0]\n"
+    "      - [1.0, 2.0]\n";
+  const std::string path = writeTemp(yaml);
+  EXPECT_THROW(load_datum_config(path), std::runtime_error);
+  std::remove(path.c_str());
+}
+
+TEST(LoadDatumConfig, MissingTopLevelKeyThrows)
+{
+  const std::string path = writeTemp("some_other_key: 1\n");
+  EXPECT_THROW(load_datum_config(path), std::runtime_error);
+  std::remove(path.c_str());
+}
+
+TEST(LoadDatumConfig, MalformedRingVertexThrowsRuntimeError)
+{
+  // A ring vertex that is not a 2-element [lat, lon] sequence.
+  const std::string yaml =
+    "datum_polygons:\n"
+    "  - name: \"Bad Vertex\"\n"
+    "    chart_datum_z: -5.0\n"
+    "    ring:\n"
+    "      - [1.0, 1.0]\n"
+    "      - [1.0]\n"
+    "      - [2.0, 2.0]\n";
+  const std::string path = writeTemp(yaml);
+  EXPECT_THROW(load_datum_config(path), std::runtime_error);
+  std::remove(path.c_str());
+}
+
+TEST(LoadDatumConfig, NonNumericChartDatumZThrowsRuntimeError)
+{
+  // A yaml-cpp type-conversion failure must surface as std::runtime_error,
+  // per the function's documented contract (not a raw YAML::Exception).
+  const std::string yaml =
+    "datum_polygons:\n"
+    "  - name: \"Bad Z\"\n"
+    "    chart_datum_z: \"not-a-number\"\n"
+    "    ring:\n"
+    "      - [1.0, 1.0]\n"
+    "      - [1.0, 2.0]\n"
+    "      - [2.0, 2.0]\n";
+  const std::string path = writeTemp(yaml);
+  EXPECT_THROW(load_datum_config(path), std::runtime_error);
+  std::remove(path.c_str());
+}

--- a/marine_vertical_datum/test/test_vdatum_query.cpp
+++ b/marine_vertical_datum/test/test_vdatum_query.cpp
@@ -1,0 +1,128 @@
+// test_vdatum_query.cpp — the VDatumQueryFn seam and the production
+// factory's grids-free failure paths. No PROJ grids are needed on CI: the
+// seam tests inject stubs, and the factory tests only exercise setup
+// validation (which fails before any grid is read).
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "marine_vertical_datum/datum_config.hpp"
+#include "marine_vertical_datum/vdatum_query.hpp"
+
+namespace mvd = marine_vertical_datum;
+namespace fs = std::filesystem;
+
+namespace
+{
+
+// A square fallback polygon around the origin.
+std::vector<mvd::DatumEntry> fallback_square()
+{
+  mvd::DatumEntry entry;
+  entry.name = "fallback";
+  entry.chart_datum_z = -10.0;
+  entry.override_vdatum = false;
+  entry.ring = {
+    {-1.0, -1.0}, {-1.0, 1.0}, {1.0, 1.0}, {1.0, -1.0},
+  };
+  return {entry};
+}
+
+}  // namespace
+
+// An injected stub result reaches resolve_datum as the VDatum step and wins
+// over a covering fallback polygon (precedence step 3 before step 4).
+TEST(VDatumQuerySeam, StubResultBeatsFallbackPolygon)
+{
+  mvd::VDatumQueryFn stub = [](double, double) {
+      mvd::VDatumResult r;
+      r.mllw_z = -48.88;
+      r.mhhw_z = -47.5;
+      return std::optional<mvd::VDatumResult>(r);
+    };
+
+  const auto result = mvd::resolve_datum(
+    0.0, 0.0, std::nullopt, std::nullopt, stub(0.0, 0.0), fallback_square());
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->source, mvd::DatumSource::VDATUM);
+  EXPECT_DOUBLE_EQ(result->chart_datum_z, -48.88);
+  ASSERT_TRUE(result->mhhw_z.has_value());
+  EXPECT_DOUBLE_EQ(*result->mhhw_z, -47.5);
+}
+
+// A stub nullopt (no coverage) falls through to the fallback polygon —
+// the gap-fill path the polygon config exists for.
+TEST(VDatumQuerySeam, StubNulloptFallsThroughToPolygon)
+{
+  mvd::VDatumQueryFn stub = [](double, double) {
+      return std::optional<mvd::VDatumResult>();
+    };
+
+  const auto result = mvd::resolve_datum(
+    0.0, 0.0, std::nullopt, std::nullopt, stub(0.0, 0.0), fallback_square());
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->source, mvd::DatumSource::POLYGON_CONFIG);
+  EXPECT_EQ(result->name, "fallback");
+  EXPECT_DOUBLE_EQ(result->chart_datum_z, -10.0);
+}
+
+// Empty config fields fail setup with a diagnostic and an empty callable.
+TEST(MakeVDatumQuery, EmptyConfigFailsWithDiagnostic)
+{
+  std::vector<std::string> messages;
+  const auto query = mvd::make_vdatum_query(
+    mvd::VDatumConfig{}, [&messages](const std::string & m) {
+      messages.push_back(m);
+    });
+
+  EXPECT_FALSE(static_cast<bool>(query));
+  ASSERT_FALSE(messages.empty());
+  EXPECT_NE(messages.front().find("geoid_grid"), std::string::npos);
+}
+
+// A nonexistent grid directory fails setup (scan error), not crash.
+TEST(MakeVDatumQuery, MissingGridDirFailsWithDiagnostic)
+{
+  std::vector<std::string> messages;
+  const auto query = mvd::make_vdatum_query(
+    mvd::VDatumConfig{"geoid.tif", "/nonexistent/vdatum/dir"},
+    [&messages](const std::string & m) {messages.push_back(m);});
+
+  EXPECT_FALSE(static_cast<bool>(query));
+  ASSERT_FALSE(messages.empty());
+  EXPECT_NE(messages.front().find("scanning"), std::string::npos);
+}
+
+// An existing directory with no *_mllw.gtx grids fails setup with the
+// no-grids diagnostic.
+TEST(MakeVDatumQuery, EmptyGridDirFailsWithDiagnostic)
+{
+  const fs::path dir =
+    fs::temp_directory_path() / "mvd_test_empty_grid_dir";
+  fs::create_directories(dir);
+
+  std::vector<std::string> messages;
+  const auto query = mvd::make_vdatum_query(
+    mvd::VDatumConfig{"geoid.tif", dir.string()},
+    [&messages](const std::string & m) {messages.push_back(m);});
+
+  EXPECT_FALSE(static_cast<bool>(query));
+  ASSERT_FALSE(messages.empty());
+  EXPECT_NE(messages.front().find("_mllw"), std::string::npos);
+
+  fs::remove_all(dir);
+}
+
+// The default (empty) DiagFn is safe: failures stay silent, no crash.
+TEST(MakeVDatumQuery, DefaultDiagIsSafe)
+{
+  const auto query = mvd::make_vdatum_query(mvd::VDatumConfig{});
+  EXPECT_FALSE(static_cast<bool>(query));
+}

--- a/marine_vertical_datum/test/test_vdatum_query.cpp
+++ b/marine_vertical_datum/test/test_vdatum_query.cpp
@@ -1,3 +1,24 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 // test_vdatum_query.cpp — the VDatumQueryFn seam and the production
 // factory's grids-free failure paths. No PROJ grids are needed on CI: the
 // seam tests inject stubs, and the factory tests only exercise setup

--- a/marine_vertical_datum/test/test_vdatum_query.cpp
+++ b/marine_vertical_datum/test/test_vdatum_query.cpp
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 
 #include <cstdio>
+#include <cstdlib>
 #include <filesystem>
 #include <optional>
 #include <string>
@@ -101,12 +102,14 @@ TEST(MakeVDatumQuery, MissingGridDirFailsWithDiagnostic)
 }
 
 // An existing directory with no *_mllw.gtx grids fails setup with the
-// no-grids diagnostic.
+// no-grids diagnostic. Unique per-run directory (mkdtemp) so concurrent
+// test runs on one host (multi-worktree CI) can't collide.
 TEST(MakeVDatumQuery, EmptyGridDirFailsWithDiagnostic)
 {
-  const fs::path dir =
-    fs::temp_directory_path() / "mvd_test_empty_grid_dir";
-  fs::create_directories(dir);
+  std::string tmpl =
+    (fs::temp_directory_path() / "mvd_test_empty_grid_dir.XXXXXX").string();
+  ASSERT_NE(mkdtemp(tmpl.data()), nullptr) << "mkdtemp failed";
+  const fs::path dir(tmpl);
 
   std::vector<std::string> messages;
   const auto query = mvd::make_vdatum_query(


### PR DESCRIPTION
Implements **ADR-0010 D6** ([docs/decisions/0010-geospatial-world-model.md](https://github.com/rolker/unh_marine_autonomy/blob/jazzy/docs/decisions/0010-geospatial-world-model.md)): new **ROS-free** package `marine_vertical_datum` in core_ws — the vertical-datum machinery extracted from `mru_transform` so the S57 chart exporter (s57_tools), CAMP, and `chart_datum_node` can all consume it. Part of #86.

## What's here

- **`datum_config`** ported verbatim from `mru_transform` (namespace + include-guard rename only): the precedence chain (lake override → override polygons → VDatum → fallback polygons → absent), YAML polygon-config loader, point-in-ring.
- **`vdatum_query`** extracted from `chart_datum_node`'s inline PROJ code, reshaped per plan review:
  - **`make_vdatum_query(config, diag)` is the sole entry** — builds PROJ context + MLLW/MHHW pipelines once (shared RAII holder), returns a per-point callable; the per-call standalone was dropped as a per-cell-importer footgun.
  - **ROS-free diagnostics seam** (`DiagFn` callback) replaces `RCLCPP_*`: setup problems report through it, per-point no-coverage is a plain `nullopt` (normal gap; the precedence chain's polygon fallbacks handle it).
  - **Offline guarantee preserved**: `proj_context_set_enable_network(ctx, false)`.
  - Deterministic (sorted) grid ordering; documented thread contract (one factory call per thread for parallel consumers).
- PROJ + yaml-cpp are **private** link deps (public headers are PROJ-free); rosdep key `proj` + `PkgConfig::PROJ` per the mru_transform precedent. No `rclcpp` anywhere.
- **29 gtests**: the full ported precedence-matrix/YAML suite + new injectable-seam and grids-free factory-failure coverage. CI needs no PROJ grids.
- README: API, grid provisioning (dev + boat-as-offline-tooling; never the runtime), sign convention.

## Lifecycle

review-issue (well-scoped) → plan → plan review (approve-with-suggestions, all 5 folded in) → implement → pre-push review **approved** (Deep, Round 1, Ship: recommended, 0 must-fix; 3 of 6 suggestions applied, 3 deferred — see `.agent/work-plans/issue-274/progress.md`).

## Non-goals (follow-ons)

`mru_transform` keeps its inline copy until a follow-on migrates it onto this library; the s57_tools exporter (s57_tools#27) is the first new consumer.

Closes #274

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7U35JQmjpGKP634UmMHth
