### PR TITLE
Remove raster background-chart argument from operator_ui_launch (CAMP OSM base map)

### DIFF
--- a/.agent/work-plans/issue-284/progress.md
+++ b/.agent/work-plans/issue-284/progress.md
@@ -1,0 +1,23 @@
+---
+issue: 284
+---
+
+# Issue #284 — operator_ui_launch: remove raster background-chart argument (CAMP OSM base map)
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-30 14:09 -04:00
+**By**: Claude Code Agent (Claude Fable 5)
+**Verdict**: approved
+
+**Branch**: feature/issue-284 at `6780ec9`
+**Mode**: pre-push
+**Depth**: Light (reason: 1 file, +2/-13, launch-config only)
+**Must-fix**: 0 | **Suggestions**: 2
+**Round**: 1 | **Ship**: recommended — no must-fix; both suggestions are documentation notes handled in commit/PR body
+
+### Findings
+- [x] (suggestion) camp2 '/workspace/' → 'workspace/' is a behavior change (old join discarded share prefix); acknowledge in PR body — `marine_autonomy/launch/operator_ui_launch.py:115` (covered in commit 6780ec9 message)
+- [x] (suggestion) background_chart:=... CLI invocations are now silently ignored (no launch error); conscious acceptance, noted in PR body — `marine_autonomy/launch/operator_ui_launch.py:37`
+
+Static analysis: flake8 findings are all pre-existing file style on untouched/verbatim lines; none introduced. Local Adversarial: off (user request).

--- a/marine_autonomy/launch/operator_ui_launch.py
+++ b/marine_autonomy/launch/operator_ui_launch.py
@@ -37,7 +37,6 @@ from launch.substitutions import LaunchConfiguration
 def generate_launch_description():
     namespace = LaunchConfiguration('namespace')
     robot_namespace = LaunchConfiguration('robot_namespace')
-    background_chart = LaunchConfiguration('background_chart')
     rqt = LaunchConfiguration('rqt')
     rqt_perspective = LaunchConfiguration('rqt_perspective')
     rviz = LaunchConfiguration('rviz')
@@ -49,13 +48,6 @@ def generate_launch_description():
     )
     robot_namespace_arg = DeclareLaunchArgument(
         "robot_namespace", default_value="ben"
-    )
-    background_chart_arg = DeclareLaunchArgument(
-        "background_chart",
-         default_value=PathJoinSubstitution([
-              FindPackageShare('camp'),
-               'workspace/13283/13283_2.KAP'
-         ])
     )
     rqt_arg = DeclareLaunchArgument(
         "rqt", default_value="false"
@@ -107,8 +99,7 @@ def generate_launch_description():
         executable='CCOMAutonomousMissionPlanner',
         name='camp',
         arguments=[
-           PathJoinSubstitution([ FindPackageShare('camp'), 'workspace/']),
-           background_chart],
+           PathJoinSubstitution([ FindPackageShare('camp'), 'workspace/'])],
         namespace=namespace,
         parameters=[{'robot_namespace': robot_namespace}],
         respawn=True,
@@ -121,8 +112,7 @@ def generate_launch_description():
         executable='CCOMAutonomousMissionPlanner',
         name='camp2',
         arguments=[
-           PathJoinSubstitution([ FindPackageShare('camp'), '/workspace/']),
-           background_chart],
+           PathJoinSubstitution([ FindPackageShare('camp'), 'workspace/'])],
         namespace=namespace,
         parameters=[{'robot_namespace': robot_namespace}],
         condition=IfCondition(dual_camp),
@@ -132,7 +122,6 @@ def generate_launch_description():
     return LaunchDescription([
         namespace_arg,
         robot_namespace_arg,
-        background_chart_arg,
         rqt_arg,
         rqt_perspective_arg,
         rviz_arg,


### PR DESCRIPTION
Closes #284.

## What

Removes the `background_chart` launch argument and its unconditional
positional passthrough to both CAMP nodes in `operator_ui_launch.py`. CAMP
provides an OSM base map, so the bundled Portsmouth Harbor raster
(`workspace/13283/13283_2.KAP`) no longer loads on every operator session.

## Behavior notes

- **camp2 workspace path fix**: camp2_node previously joined `'/workspace/'`
  (leading slash), and `PathJoinSubstitution` follows `os.path.join`
  semantics — the absolute component discarded the camp share prefix, so
  dual-CAMP mode received a literal `/workspace/` path. Both nodes now share
  the same correct `'workspace/'` join.
- **Silent-ignore of stale invocations**: `ros2 launch … background_chart:=…`
  does not error after removal — the launch CLI sets undeclared
  configurations without validation. The chart simply no longer loads; this
  is the intended retirement of the raster path.
- Downstream repos still passing `background_chart` into this launch file
  keep working (undeclared include arguments are ignored); their dead
  plumbing is tracked per-repo in rolker/unh_marine_simulation#80 and
  rolker/unh_echoboats_project11#400.

## Test plan

- `python3 -m py_compile` clean.
- `ros2 launch --print` on the modified file: both CAMP nodes receive exactly
  one positional argument (the camp workspace path), no chart argument;
  rqt/rviz nodes unchanged.
- Pre-push review (Light tier): 0 must-fix, 2 suggestions — both are the
  documentation notes above.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
