### PR TITLE
helm_manager: curvature-preserving speed regulation from a per-platform capability envelope

### DIFF
--- a/.agent/work-plans/issue-292/plan.md
+++ b/.agent/work-plans/issue-292/plan.md
@@ -1,0 +1,122 @@
+# Plan: Curvature-preserving speed regulation in helm_manager
+
+## Issue
+
+https://github.com/rolker/unh_marine_autonomy/issues/292
+
+## Context
+
+`HelmManager::update(mode, TwistStamped)` currently clamps `v` and `ω` independently at
+`max_speed` and `max_yaw_speed`. Clipping `ω` while holding `v` widens executed turns
+silently, causing path drift. The interim fix (rolker/unh_echoboats_project11#412) plans
+with worst-case 11 m radius and wastes the tight-turning low-speed regime.
+
+The fix: when commanded `(v, ω)` exceeds the platform's capability envelope, scale `v` down
+so `ω` is achievable — preserving the commanded curvature. The capability envelope is a
+per-platform piecewise table (`ω_max` vs `v`) stored in platform config; helm code stays
+platform-agnostic. Feature is param-gated (default off) so existing platforms are unaffected.
+
+BizzyBoat's measured envelope (218 k samples, 2026-08-04) is the first instance. The curve
+is non-monotonic: `ω_max` peaks at 0.3–1.3 m/s (p95 ≈ 0.4 rad/s) and is lower at rest
+(p95 ≈ 0.26 rad/s). The parameterization must not assume monotonicity.
+
+## Approach
+
+1. **Write project ADR** — Capture three design decisions before coding: yield-v-not-ω rule,
+   non-monotonic curve parameterization, floor behavior contract.
+
+2. **Add capability curve parameters to `HelmManager`** — Four new ROS 2 parameters declared
+   in `on_configure` and handled in `updateParameters`:
+   - `capability_curve_enabled` (bool, default `false`)
+   - `capability_curve_v_omega_max` (double[], default `[]`) — flat list of `[v₀, ω_max₀, v₁, ω_max₁, …]` pairs, sorted by `v`; interpolated linearly between breakpoints
+   - `capability_curve_margin` (double, default `0.8`) — safety factor applied to all `ω_max` values
+   - `capability_curve_pivot_speed` (double, default `0.05` m/s) — floor speed used when `|ω|` exceeds capability at every speed
+
+3. **Implement `applyCurvatureRegulation(double v, double omega) -> std::pair<double,double>`** in `helm_manager.cpp`:
+   - If disabled or curve is empty: return `{v, omega}` unchanged
+   - Interpolate `ω_max` at `|v|` from the table (clamp to table boundaries outside range)
+   - If `|omega| <= omega_max_at_v * margin`: return `{v, omega}` unchanged
+   - Otherwise: binary-search (or scan) the table for the maximum `v'` where `ω_max(v') * margin >= |omega|`
+     - If found: return `{sign(v) * v', omega}` (same direction, reduced speed)
+     - If not found (floor case): return `{sign(v) * pivot_speed, sign(omega) * max_omega_max_in_table * margin}`
+   - Never flip sign of `v` or `omega`; never return `v = 0` (pivot_speed is the floor)
+
+4. **Wire into `update(mode, TwistStamped)`** — call `applyCurvatureRegulation` on `linear.x`
+   and `angular.z` before the existing `max_speed`/`max_yaw_speed` clamps. Existing clamping
+   remains as a backstop. The Helm-input path (`update(mode, Helm)`) is unaffected — the
+   Helm type has no velocity dimension to regulate.
+
+5. **Add unit tests** in `test_helm_manager.cpp` (new `HelmManagerCurvatureTest` fixture):
+   - `CurvatureRegulationDisabledByDefault` — disabled, no scaling applied
+   - `CurvatureNoScalingWithinEnvelope` — `(v, ω)` inside envelope passes through unchanged
+   - `CurvatureScalesSpeedWhenOverLimit` — `ω` exceeds `ω_max(v)` → `v` is reduced, `ω` preserved
+   - `CurvatureNonMonotonicLookup` — table peak at mid-speed; high-ω at rest or high-v finds optimal `v'`
+   - `CurvatureFloorBehavior` — `ω` exceeds all-speed capability → `v = pivot_speed`, `ω` clamped
+   - `CurvatureMarginApplied` — margin factor correctly reduces effective `ω_max`
+   - `CurvaturePreservesDirection` — negative `v` and/or `ω` handled correctly
+
+6. **Update `helm_manager/README.md`** — add a "Curvature-Preserving Speed Regulation" section
+   documenting the four new parameters, the behavior, and when to enable it.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `docs/decisions/0012-curvature-preserving-speed-regulation.md` | New ADR: yield-v-not-ω, non-monotonic parameterization, floor behavior |
+| `helm_manager/src/helm_manager.h` | Add `applyCurvatureRegulation` declaration; four new member fields |
+| `helm_manager/src/helm_manager.cpp` | Declare parameters, implement `applyCurvatureRegulation`, wire into `update(TwistStamped)` |
+| `helm_manager/test/test_helm_manager.cpp` | New `HelmManagerCurvatureTest` fixture with 7 test cases |
+| `helm_manager/README.md` | Document new parameters and curvature-regulation behavior |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Safety (project) | Floor behavior never stops the boat mid-line (pivot_speed > 0); ω clamped at achievable max rather than discarded; param-gated default-off |
+| Hardware Agnosticism (project) | Capability curve lives in platform config; helm code is platform-agnostic by design |
+| Modularity and Decoupling (project) | `applyCurvatureRegulation` is self-contained pure logic; HelmManager unchanged for existing callers |
+| Simulation-First Validation (project) | Tests cover non-monotonic lookup and floor behavior; simulation coverage in `unh_marine_simulation` is a follow-up (see Open Questions) |
+| Human control and transparency | Speed reduction is observable via existing cmd_vel output topic; param table is human-readable in YAML config |
+| A change includes its consequences | README, ADR, and tests land in the same PR |
+| Only what's needed | Four parameters, one helper method, one ADR — minimum needed |
+| Test what breaks | Non-monotonic lookup and floor behavior are the novel failure modes; tests target those directly |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0001 (project) — Adopt ADRs | Yes | New ADR 0012 captures all three design decisions |
+| ADR-0008 (workspace) — ROS 2 conventions | Yes | Parameters declared with `declare_parameter<T>`, typed, with descriptions; table uses flat double array (ROS 2 param type) |
+
+## Consequences
+
+| If we change… | Also update… | Included in plan? |
+|---|---|---|
+| `helm_manager` parameters | `helm_manager/README.md` | Yes — step 6 |
+| Curvature-regulation design | ADR in `docs/decisions/` | Yes — step 1 |
+| `helm_manager` behavior | `test_helm_manager.cpp` | Yes — step 5 |
+| This PR lands | `bizzyboat_project11/config/nav2_overlay.yaml` min_turning_radius 11.0 → 3.0 | No — cross-repo, deferred until BizzyBoat curve is tuned (addresses rolker/unh_echoboats_project11#412) |
+| This PR lands | `unh_marine_simulation` coverage for curvature and floor behavior | No — follow-up (see Open Questions) |
+
+## Documentation & Instruction Impact
+
+- **Stale docs** (must land in this PR): `helm_manager/README.md` — Parameters section becomes
+  inaccurate once the four new params exist. "Curvature-Preserving Speed Regulation" section added.
+- **Agent-instruction candidates** (proposals only — operator decides): Consider adding a note to
+  `.agents/README.md` or `.agent/knowledge/ros2_development_patterns.md` about the yield-v-not-ω
+  pattern for capability-limited platforms — it is a non-obvious design choice that has come up
+  for BizzyBoat and applies to any differential hull.
+
+## Open Questions
+
+- [ ] Simulation coverage: should `unh_marine_simulation` coverage for curvature-preserving
+  behavior and floor behavior be a blocking requirement before merging this PR, or a follow-up
+  tracked separately? The feature is param-gated default-off, so field risk is low, but the
+  issue review flagged this as "action needed."
+- [ ] BizzyBoat curve values: what `capability_curve_v_omega_max` values and `capability_curve_margin`
+  should be committed to `bizzyboat_project11/config/bizzyboat.yaml` as the initial tuned curve
+  after the FCU `MOT_STR_THR_MIX` test (rolker/unh_echoboats_project11#411) is done?
+
+## Estimated Scope
+
+Single PR.

--- a/.agent/work-plans/issue-292/plan.md
+++ b/.agent/work-plans/issue-292/plan.md
@@ -32,28 +32,63 @@ is non-monotonic: `ω_max` peaks at 0.3–1.3 m/s (p95 ≈ 0.4 rad/s) and is low
    - `capability_curve_margin` (double, default `0.8`) — safety factor applied to all `ω_max` values
    - `capability_curve_pivot_speed` (double, default `0.05` m/s) — floor speed used when `|ω|` exceeds capability at every speed
 
-3. **Implement `applyCurvatureRegulation(double v, double omega) -> std::pair<double,double>`** in `helm_manager.cpp`:
-   - If disabled or curve is empty: return `{v, omega}` unchanged
-   - Interpolate `ω_max` at `|v|` from the table (clamp to table boundaries outside range)
-   - If `|omega| <= omega_max_at_v * margin`: return `{v, omega}` unchanged
-   - Otherwise: binary-search (or scan) the table for the maximum `v'` where `ω_max(v') * margin >= |omega|`
-     - If found: return `{sign(v) * v', omega}` (same direction, reduced speed)
-     - If not found (floor case): return `{sign(v) * pivot_speed, sign(omega) * max_omega_max_in_table * margin}`
-   - Never flip sign of `v` or `omega`; never return `v = 0` (pivot_speed is the floor)
+3. **Implement the regulation as pure logic in a new header `helm_manager/src/curvature_regulation.h`**
+   (free function + config struct; directly unit-testable without ROS spin; `helm_manager.cpp` calls it):
 
-4. **Wire into `update(mode, TwistStamped)`** — call `applyCurvatureRegulation` on `linear.x`
-   and `angular.z` before the existing `max_speed`/`max_yaw_speed` clamps. Existing clamping
-   remains as a backstop. The Helm-input path (`update(mode, Helm)`) is unaffected — the
-   Helm type has no velocity dimension to regulate.
+   `applyCurvatureRegulation(double v, double omega, const CurvatureRegulationConfig&) -> std::pair<double,double>`
 
-5. **Add unit tests** in `test_helm_manager.cpp` (new `HelmManagerCurvatureTest` fixture):
-   - `CurvatureRegulationDisabledByDefault` — disabled, no scaling applied
-   - `CurvatureNoScalingWithinEnvelope` — `(v, ω)` inside envelope passes through unchanged
-   - `CurvatureScalesSpeedWhenOverLimit` — `ω` exceeds `ω_max(v)` → `v` is reduced, `ω` preserved
-   - `CurvatureNonMonotonicLookup` — table peak at mid-speed; high-ω at rest or high-v finds optimal `v'`
-   - `CurvatureFloorBehavior` — `ω` exceeds all-speed capability → `v = pivot_speed`, `ω` clamped
-   - `CurvatureMarginApplied` — margin factor correctly reduces effective `ω_max`
-   - `CurvaturePreservesDirection` — negative `v` and/or `ω` handled correctly
+   **Semantic correction (plan revision 2, supersedes the reviewed step 3):** the reviewed
+   algorithm returned `{v', ω}` — reduced speed with *unchanged* yaw — which **tightens** the
+   executed curvature (`κ = ω/v` grows as `v` shrinks) and fights the path follower. To
+   *preserve* the commanded curvature, both components scale by the same factor `s ∈ (0, 1]`:
+   `{s·v, s·ω}` keeps `v/ω` exact while reducing the required yaw rate until it is achievable.
+
+   - Let `λ(x) = margin · interp(ω_max table at |v|=x)` (linear within segments, clamp-constant
+     beyond both table ends). If disabled, curve invalid/empty, `ω == 0`, or non-finite input:
+     passthrough.
+   - Pivot command (`v == 0`): return `{0, sign(ω) · min(|ω|, λ(0))}` — yaw clamped at rest
+     capability.
+   - If `|ω| ≤ λ(|v|)`: passthrough (inside envelope).
+   - Else find the **largest** `x* ∈ (0, |v|]` with `(x/|v|)·|ω| ≤ λ(x)` — a **linear scan over
+     the piecewise-linear segments from the top (largest v) down**, with a closed-form crossing
+     solve per segment (no monotonicity assumption; first feasible hit walking down is the
+     global max). `s = x*/|v|`; return `{sign(v)·x*, s·ω}`.
+   - **Floor**: if `x* < pivot_speed` (commanded yaw extreme relative to capability), return
+     `{sign(v)·min(pivot_speed, |v|), sign(ω)·λ(that speed)}` — keep moving at the floor speed
+     with the maximum achievable yaw; curvature is sacrificed only in this documented floor case.
+   - Regulation only ever *reduces* speed (`s ≤ 1`) — never speeds the boat up to reach a
+     higher-capability band, even where the non-monotonic curve would allow it (a commanded low
+     `v` may be low for reasons the helm cannot see, e.g. obstacle proximity).
+   - Never flip the sign of `v` or `omega`.
+   - **Curve validation** (shared by `on_configure` and `updateParameters`): even element count,
+     ≥ 1 pair, strictly ascending non-negative `v`, finite non-negative `ω_max`, `margin ∈ (0, 1]`,
+     `pivot_speed ≥ 0`. Invalid config ⇒ error log + regulation disabled (fail-safe passthrough;
+     the existing max clamps remain).
+
+4. **Wire into `update(mode, TwistStamped)` at function entry** — regulate `(linear.x, angular.z)`
+   once, *before* the output-type branch, so **both** the twist-output branch and the twist→helm
+   conversion branch operate on regulated values (plan-review must-fix: the reviewed placement
+   covered only the twist-output branch). Existing `max_speed`/`max_yaw_speed` clamping remains
+   as a backstop. The Helm-input path (`update(mode, Helm)`) is unaffected — throttle/rudder are
+   normalized operator commands, not a velocity pair; silently modulating manual input is out of
+   scope.
+
+5. **Add unit tests** in new `test/test_curvature_regulation.cpp` (pure-logic, no ROS spin —
+   registered in CMakeLists like the existing gtests) plus one node-level test in
+   `test_command_conversion.cpp` proving both output branches receive regulated values:
+   - `DisabledByDefault` / `EmptyCurvePassthrough` — no scaling applied
+   - `WithinEnvelopePassthrough` — `(v, ω)` inside envelope unchanged
+   - `ScalesBothPreservingCurvature` — over-limit `(v, ω)` → both scaled by same `s`; `v/ω` exact
+   - `NonMonotonicLookupFindsGlobalMax` — table peak at mid-speed; top-down scan returns the
+     largest feasible speed, not a local one
+   - `FloorBehavior` — extreme `ω` → `v = pivot_speed`, `ω = λ(pivot_speed)`, never a full stop
+   - `PivotCommand` — `v = 0` → yaw clamped at rest capability, `v` stays 0
+   - `NeverSpeedsUp` — low commanded `v` with capability peak above it → result `≤ |v|`
+   - `MarginApplied` — margin factor reduces effective `ω_max`
+   - `PreservesDirection` — negative `v` and/or `ω` handled; signs never flip
+   - `InvalidCurveRejected` — odd-length / unsorted / negative tables disable regulation
+   - Node-level: `RegulationAppliesToBothOutputBranches` — twist-output *and* twist→helm
+     conversion both see regulated values (the plan-review must-fix, locked in by test)
 
 6. **Update `helm_manager/README.md`** — add a "Curvature-Preserving Speed Regulation" section
    documenting the four new parameters, the behavior, and when to enable it.
@@ -62,10 +97,13 @@ is non-monotonic: `ω_max` peaks at 0.3–1.3 m/s (p95 ≈ 0.4 rad/s) and is low
 
 | File | Change |
 |------|--------|
-| `docs/decisions/0012-curvature-preserving-speed-regulation.md` | New ADR: yield-v-not-ω, non-monotonic parameterization, floor behavior |
-| `helm_manager/src/helm_manager.h` | Add `applyCurvatureRegulation` declaration; four new member fields |
-| `helm_manager/src/helm_manager.cpp` | Declare parameters, implement `applyCurvatureRegulation`, wire into `update(TwistStamped)` |
-| `helm_manager/test/test_helm_manager.cpp` | New `HelmManagerCurvatureTest` fixture with 7 test cases |
+| `docs/decisions/0012-curvature-preserving-speed-regulation.md` | New ADR: proportional-scaling (curvature-preserved) rule, non-monotonic parameterization, floor behavior, never-speed-up |
+| `helm_manager/src/curvature_regulation.h` | New: pure-logic config struct, validation, `applyCurvatureRegulation` |
+| `helm_manager/src/helm_manager.h` | Config member field |
+| `helm_manager/src/helm_manager.cpp` | Declare/validate parameters (configure + hot-reload), regulate at `update(TwistStamped)` entry |
+| `helm_manager/test/test_curvature_regulation.cpp` | New pure-logic test suite (11 cases) |
+| `helm_manager/test/test_command_conversion.cpp` | Node-level both-branches regulation test |
+| `helm_manager/CMakeLists.txt` | Register `test_curvature_regulation` |
 | `helm_manager/README.md` | Document new parameters and curvature-regulation behavior |
 
 ## Principles Self-Check
@@ -85,7 +123,7 @@ is non-monotonic: `ω_max` peaks at 0.3–1.3 m/s (p95 ≈ 0.4 rad/s) and is low
 
 | ADR | Triggered | How addressed |
 |---|---|---|
-| ADR-0001 (project) — Adopt ADRs | Yes | New ADR 0012 captures all three design decisions |
+| ADR-0001 (workspace) — Adopt ADRs | Yes | New project ADR 0012 captures the design decisions |
 | ADR-0008 (workspace) — ROS 2 conventions | Yes | Parameters declared with `declare_parameter<T>`, typed, with descriptions; table uses flat double array (ROS 2 param type) |
 
 ## Consequences
@@ -95,8 +133,8 @@ is non-monotonic: `ω_max` peaks at 0.3–1.3 m/s (p95 ≈ 0.4 rad/s) and is low
 | `helm_manager` parameters | `helm_manager/README.md` | Yes — step 6 |
 | Curvature-regulation design | ADR in `docs/decisions/` | Yes — step 1 |
 | `helm_manager` behavior | `test_helm_manager.cpp` | Yes — step 5 |
-| This PR lands | `bizzyboat_project11/config/nav2_overlay.yaml` min_turning_radius 11.0 → 3.0 | No — cross-repo, deferred until BizzyBoat curve is tuned (addresses rolker/unh_echoboats_project11#412) |
-| This PR lands | `unh_marine_simulation` coverage for curvature and floor behavior | No — follow-up (see Open Questions) |
+| This PR lands | `bizzyboat_project11/config/bizzyboat.yaml` provisional 2026-08-04 curve + `nav2_overlay.yaml` min_turning_radius 11.0 → 3.0 | No — one follow-up unh_echoboats_project11 PR (supersedes rolker/unh_echoboats_project11#412's interim envelope) |
+| This PR lands | `unh_marine_simulation` coverage for curvature and floor behavior | No — follow-up issue filed at PR time; does not gate field enablement (Roland, 2026-08-05) |
 
 ## Documentation & Instruction Impact
 
@@ -109,13 +147,14 @@ is non-monotonic: `ω_max` peaks at 0.3–1.3 m/s (p95 ≈ 0.4 rad/s) and is low
 
 ## Open Questions
 
-- [ ] Simulation coverage: should `unh_marine_simulation` coverage for curvature-preserving
-  behavior and floor behavior be a blocking requirement before merging this PR, or a follow-up
-  tracked separately? The feature is param-gated default-off, so field risk is low, but the
-  issue review flagged this as "action needed."
-- [ ] BizzyBoat curve values: what `capability_curve_v_omega_max` values and `capability_curve_margin`
-  should be committed to `bizzyboat_project11/config/bizzyboat.yaml` as the initial tuned curve
-  after the FCU `MOT_STR_THR_MIX` test (rolker/unh_echoboats_project11#411) is done?
+- [x] Simulation coverage — **RESOLVED (Roland, 2026-08-05)**: follow-up issue, and it does
+  **not** gate field enablement — the boat is currently deployed and the feature will be
+  field-tested directly. File the `unh_marine_simulation` coverage issue at PR time.
+- [x] BizzyBoat curve values — **RESOLVED (Roland, 2026-08-05)**: commit the **provisional
+  measured 2026-08-04 envelope now** (p95 per speed band, margin 0.8) rather than waiting for
+  the `MOT_STR_THR_MIX` test; that test only updates numbers later, no code churn. The values
+  land in `bizzyboat_project11/config/bizzyboat.yaml` via a follow-up unh_echoboats_project11
+  PR (cross-repo, not this PR).
 
 ## Estimated Scope
 

--- a/.agent/work-plans/issue-292/progress.md
+++ b/.agent/work-plans/issue-292/progress.md
@@ -121,3 +121,19 @@ update(TwistStamped), not the Helm-input path).
 
 ### Findings
 - [ ] (suggestion) Consider ParameterDescriptor descriptions for the four new capability_curve_* params (optional; existing params lack them too — defer to a repo-wide pass) — `helm_manager/src/helm_manager.cpp:69`
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-08-05 11:35 -04:00
+**By**: Claude Code Agent (Claude Fable 5)
+
+**PR**: #293 at `1c5c1b0`
+**Sources**: 3 (Copilot R1 @ `1c5c1b0`, Local Review (Pre-Push) @ `eb0fc35`, CI rollup)
+**Cross-source confirmations**: 0
+**CI**: build pending at triage time; Copilot check green
+
+### Findings
+- [ ] (low, Copilot — VALID) validateCurvatureConfig accepts an enabled curve whose first breakpoint speed is > 0; curvatureCapabilityAt(0.0) then clamp-extends the first omega_max down to rest, overestimating rest capability on weaker-at-rest hulls. Fix: require first breakpoint at v = 0.0 for enabled curves (+ test + README note) — `helm_manager/src/curvature_regulation.h`
+
+### False positives
+- (none)

--- a/.agent/work-plans/issue-292/progress.md
+++ b/.agent/work-plans/issue-292/progress.md
@@ -76,3 +76,20 @@ Proposes adding curvature-preserving speed regulation to `helm_manager` in `unh_
 ### Open questions
 - [ ] Simulation coverage: blocking requirement before merge or follow-up? (feature is param-gated default-off, so field risk is low)
 - [ ] BizzyBoat capability curve values: what `capability_curve_v_omega_max` and `capability_curve_margin` to commit after rolker/unh_echoboats_project11#411 FCU test?
+
+## Plan Review
+**Status**: complete
+**When**: 2026-08-05 14:12 +00:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Plan**: `.agent/work-plans/issue-292/plan.md` at `8c721f2`
+**PR**: PR-less (reviewed via local plan file; `gh` unauthenticated — issue read from the `## Issue Review` entry above)
+**Verdict**: changes-requested
+
+### Findings
+- [ ] (must-fix) Step 4 wires regulation "before the max_speed/max_yaw_speed clamps", which exist only in the twist-output branch (`helm_manager.cpp:176-179`); the twist→helm conversion branch (`helm_manager.cpp:181-193`) — BizzyBoat's actual FCU path — would be left unregulated. Apply `applyCurvatureRegulation` at `update(TwistStamped)` entry so both branches use regulated `(v, ω)` — `plan.md:44`
+- [ ] (suggestion) "binary-search (or scan)" assumes monotonicity, contradicting the stated non-monotonic curve; commit to a linear scan over breakpoints (with per-segment interpolation crossing) — `plan.md:39`
+- [ ] (suggestion) Resolve the simulation-coverage open question (review-issue flagged it "before field deployment"): confirm blocking vs. tracked follow-up before merge — `plan.md:112`
+- [ ] (suggestion) ADR Compliance table mislabels project `ADR-0001` as "Adopt ADRs" (that is a workspace ADR; project 0001 is shared-scalar-colormap); new ADR is correctly project `0012` — fix the label — `plan.md:88`
+
+Note: independent cross-model review (Opus reviewing a Sonnet-authored plan in fresh context); not an author self-review despite the shared `Claude Code Agent` name.

--- a/.agent/work-plans/issue-292/progress.md
+++ b/.agent/work-plans/issue-292/progress.md
@@ -63,3 +63,16 @@ Proposes adding curvature-preserving speed regulation to `helm_manager` in `unh_
 - [ ] Add simulation coverage (unh_marine_simulation) for curvature-preserving behavior and floor behavior before field deployment
 - [ ] Write unit tests for capability curve lookup (including non-monotonic regions) and floor behavior alongside the implementation
 - [ ] Update helm_manager parameter documentation / README in the same PR as the implementation
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-08-05 14:06 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Plan**: `.agent/work-plans/issue-292/plan.md` at `8c721f2`
+**Branch**: feature/issue-292 at `8c721f2`
+**Phases**: single
+
+### Open questions
+- [ ] Simulation coverage: blocking requirement before merge or follow-up? (feature is param-gated default-off, so field risk is low)
+- [ ] BizzyBoat capability curve values: what `capability_curve_v_omega_max` and `capability_curve_margin` to commit after rolker/unh_echoboats_project11#411 FCU test?

--- a/.agent/work-plans/issue-292/progress.md
+++ b/.agent/work-plans/issue-292/progress.md
@@ -1,0 +1,65 @@
+---
+issue: 292
+---
+
+# Issue #292 — Curvature-preserving speed regulation in helm_manager
+
+## Issue Review
+**Status**: complete
+**When**: 2026-08-05 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Issue**: #292
+**Comment**: (best-effort post follows this entry; not recorded inline)
+**Scope verdict**: well-scoped
+
+### Summary
+
+Proposes adding curvature-preserving speed regulation to `helm_manager` in `unh_marine_autonomy`. When commanded `(v, ω)` exceeds the platform's capability envelope, scale `v` down (never clip `ω`) to preserve the commanded curvature. Per-platform capability curve is a parameter table; feature is param-gated (default off). Motivated by BizzyBoat's measured differential turning envelope (2026-08-04 logs).
+
+### Scope Assessment
+
+**Well-scoped?** Yes — single package (`helm_manager`), clear design, param-gated (no risk to existing platforms). The follow-on config change to `bizzyboat_project11/config/nav2_overlay.yaml` is correctly deferred.
+
+**Right repo?** Yes — `helm_manager` is in `unh_marine_autonomy`; the per-platform capability curve data lands in the platform config repo (`unh_echoboats_project11`), which is appropriate.
+
+**Dependencies**:
+- `rolker/unh_echoboats_project11#411` (FCU `MOT_STR_THR_MIX` test) — soft dependency; informs how aggressive the helm curve needs to be but doesn't block param-gated implementation.
+- `rolker/unh_echoboats_project11#412` (interim 11 m radius plan) — superseded by this issue once landed.
+- `rolker/unh_echoboats_project11#120` (IzzyBoat envelope measurement) — explicit non-goal.
+
+### Principle Alignment
+
+| Principle | Status | Notes |
+|---|---|---|
+| Safety First (project) | Watch | Floor behavior ("clamp ω, drop to near-pivot speed") when ω exceeds all-speed capability needs precise specification and simulation coverage — uncontrolled deceleration mid-survey-line is the key failure mode to test |
+| Hardware Agnosticism (project) | OK | Capability curve stays in platform config; helm code is platform-agnostic by design |
+| Modularity and Decoupling (project) | OK | Helm-level placement correctly covers all command sources |
+| Simulation-First Validation (project) | Action needed | Issue does not mention simulation testing; non-monotonic capability curve and floor behavior require unh_marine_simulation coverage before field deployment |
+| Iterative, Validated Evolution (project) | OK | Param-gated default-off is incremental; BizzyBoat's measured envelope is the data basis |
+| Human control and transparency (workspace) | OK | Param-gated with inspectable capability table; speed reduction observable via existing topics |
+| Capture decisions, not just implementations (workspace) | Action needed | Three non-obvious design decisions warrant an ADR: (1) yield-v-not-ω rule; (2) non-monotonic curve parameterization; (3) floor behavior contract |
+| A change includes its consequences (workspace) | Watch | helm_manager README/parameter docs must land in the same PR; bizzyboat config update is cross-repo and correctly deferred |
+| Only what's needed (workspace) | OK | Tight design: one parameter table, one scaling path, default-off |
+| Test what breaks (workspace) | Action needed | Non-monotonic lookup and floor behavior are novel logic; unit tests in test_helm_manager.cpp or test_command_conversion.cpp must land alongside the implementation |
+
+### ADR Applicability
+
+| ADR | Triggered | Notes |
+|---|---|---|
+| ADR-0001 — Adopt ADRs | Yes | yield-v-not-ω rule and non-monotonic curve parameterization are architectural decisions; capture in an ADR before or alongside implementation |
+| ADR-0002 — Worktree isolation | Satisfied | Already in feature/issue-292 worktree |
+| ADR-0008 — ROS 2 conventions | Yes | New parameters must be declared following ROS 2 conventions (declare_parameter, type constraints, descriptions); consult `.agent/knowledge/ros2_development_patterns.md` |
+
+### Consequences
+
+- `helm_manager` README/API docs must reflect new parameters in the same PR.
+- Unit tests for curvature-scaling path and floor behavior must land in the same PR.
+- `bizzyboat_project11/config/nav2_overlay.yaml` — drop `minimum_turning_radius` from 11.0 to ~3.0 once BizzyBoat's curve is tuned (separate PR in that repo, supersedes rolker/unh_echoboats_project11#412).
+- `package.xml` — no new dependencies anticipated (pure arithmetic), but verify.
+
+### Actions
+- [ ] Capture design decisions in an ADR: yield-v-not-ω rule, non-monotonic curve parameterization, floor behavior contract
+- [ ] Add simulation coverage (unh_marine_simulation) for curvature-preserving behavior and floor behavior before field deployment
+- [ ] Write unit tests for capability curve lookup (including non-monotonic regions) and floor behavior alongside the implementation
+- [ ] Update helm_manager parameter documentation / README in the same PR as the implementation

--- a/.agent/work-plans/issue-292/progress.md
+++ b/.agent/work-plans/issue-292/progress.md
@@ -93,3 +93,31 @@ Proposes adding curvature-preserving speed regulation to `helm_manager` in `unh_
 - [ ] (suggestion) ADR Compliance table mislabels project `ADR-0001` as "Adopt ADRs" (that is a workspace ADR; project 0001 is shared-scalar-colormap); new ADR is correctly project `0012` — fix the label — `plan.md:88`
 
 Note: independent cross-model review (Opus reviewing a Sonnet-authored plan in fresh context); not an author self-review despite the shared `Claude Code Agent` name.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-08-05 15:06 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-292 at `eb0fc35`
+**Mode**: pre-push
+**Depth**: Deep (reason: safety-relevant vehicle-control logic + new ADR + cross-layer — helm_manager runs on every platform)
+**Must-fix**: 0 | **Suggestions**: 1
+**Round**: 1 | **Ship**: recommended — no must-fix; clean linters; 33/33 helm_manager tests pass locally
+
+Static analysis: ament_cpplint + ament_uncrustify clean. Claude Adversarial: 2 passes
+(Lens A logic + Lens B systemic/safety). Local Adversarial: skipped (no Ollama server).
+Copilot: off (default). Built and ran tests: test_curvature_regulation 15/15,
+test_command_conversion 18/18 (incl. both-branch node tests).
+
+Algorithm (non-monotonic top-down feasibility scan, floor/pivot, never-speed-up,
+sign preservation) scrutinized by both lenses + lead trace — no correctness defects.
+Prior plan-review must-fix (regulate at update(TwistStamped) entry so both output
+branches carry regulated values) is implemented and locked by node-level tests.
+One cross-lens divergence (Lens A: update(Helm) input path unregulated) adjudicated
+by-design per ADR-0012 §6 ("both output branches" = the two branches inside
+update(TwistStamped), not the Helm-input path).
+
+### Findings
+- [ ] (suggestion) Consider ParameterDescriptor descriptions for the four new capability_curve_* params (optional; existing params lack them too — defer to a repo-wide pass) — `helm_manager/src/helm_manager.cpp:69`

--- a/.agent/work-plans/issue-292/progress.md
+++ b/.agent/work-plans/issue-292/progress.md
@@ -137,3 +137,19 @@ update(TwistStamped), not the Helm-input path).
 
 ### False positives
 - (none)
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-08-05 12:20 -04:00
+**By**: Claude Code Agent (Claude Fable 5)
+
+**PR**: #293 at `68bd621` (fix pushed as follow-up head `a2fefb7`)
+**Sources**: 2 (Copilot R2 @ `68bd621`, CI build pass @ `68bd621`)
+**Cross-source confirmations**: 0
+**CI**: build pass at `68bd621`; rerunning on the fix head
+
+### Findings
+- [x] (low, Copilot R2 — VALID, FIXED) unsynchronized read/write of curvature_config_ (parameter-callback writer vs command-path reader; torn std::vector read = UB under a multi-threaded executor; shipped node is single-threaded but the class is a library). Fixed: mutex-guarded write + copy-under-lock read — `helm_manager/src/helm_manager.{h,cpp}`
+
+### False positives
+- (none)

--- a/docs/decisions/0012-curvature-preserving-speed-regulation.md
+++ b/docs/decisions/0012-curvature-preserving-speed-regulation.md
@@ -1,0 +1,99 @@
+# ADR-0012: Curvature-Preserving Speed Regulation in helm_manager
+
+## Status
+
+Accepted (2026-08-05). Tracked by
+[rolker/unh_marine_autonomy#292](https://github.com/rolker/unh_marine_autonomy/issues/292).
+
+## Context
+
+`HelmManager` clamps commanded `linear.x` and `angular.z` independently at
+`max_speed` and `max_yaw_speed`. On a platform whose achievable yaw rate
+depends strongly on forward speed, independent clamping silently widens
+executed turns: the yaw component is cut while the speed component is kept,
+so the boat leaves the planned arc and the path follower must fight the
+deviation.
+
+BizzyBoat made this acute. After its steering servos failed (2026-08-03) and
+were removed, the boat became a differential (skid-steer) vehicle whose
+measured turning envelope (218k paired samples, 2026-08-04, Broadkill River
+DE) runs from ~1.4 m radius at 1 kt to ~11 m at 3.5 kt — and is
+**non-monotonic**: yaw authority peaks at 0.3–1.3 m/s (p95 ≈ 0.4 rad/s) and
+is *lower* at rest (p95 ≈ 0.26 rad/s). A single static
+`minimum_turning_radius` in the planner is wrong at most speeds; the interim
+worst-case value (11 m, rolker/unh_echoboats_project11#412) wastes the
+tight-turning low-speed regime the boat actually surveys in.
+
+IzzyBoat is differential-only and has always had the same unmeasured problem.
+Vectored-thrust hulls have a milder version. The mechanism therefore belongs
+in the shared, platform-agnostic helm layer — `helm_manager` is the velocity
+enforcement point every project11 platform runs, covering all command sources
+(Nav2, coverage planner, hover, mission manager), not just one controller.
+
+## Decision
+
+When the commanded `(v, ω)` pair exceeds the platform's capability envelope,
+`helm_manager` scales **both components by the same factor `s ∈ (0, 1]`** so
+the yaw rate becomes achievable — preserving the commanded curvature `v/ω`
+exactly. Design rules:
+
+1. **Yield speed, preserve curvature — never clip yaw alone.** Clipping `ω`
+   while holding `v` widens the turn (the failure mode this ADR removes);
+   reducing `v` while holding `ω` *tightens* it — equally a deviation from
+   the planned path. Proportional scaling is the only reduction that keeps
+   the executed arc on the planned arc; the boat simply traverses it slower.
+
+2. **The envelope is a per-platform parameter table, not code.** A flat
+   `[v₀, ω_max₀, v₁, ω_max₁, …]` list (`capability_curve_v_omega_max`),
+   linearly interpolated within segments and clamp-constant beyond both
+   ends, with a safety `capability_curve_margin` applied to all `ω_max`
+   values. The lookup makes **no monotonicity assumption** — feasibility is
+   found by a top-down linear scan with a closed-form crossing solve per
+   segment, because measured envelopes (BizzyBoat's) genuinely peak
+   mid-speed. Helm code stays platform-agnostic; curves live in platform
+   config and are re-measured when the platform changes (e.g. BizzyBoat's
+   planned combined vectored+differential mode swaps the curve, not the
+   code).
+
+3. **Regulation only ever slows the boat.** Even where the non-monotonic
+   curve offers more yaw authority at a *higher* speed than commanded, the
+   regulated speed never exceeds the commanded speed — a low commanded `v`
+   may be low for reasons the helm cannot see (obstacle proximity, docking).
+
+4. **Floor behavior: keep moving, cap the yaw.** If the commanded yaw is
+   unachievable at any speed down to `capability_curve_pivot_speed`, the
+   helm commands that floor speed with the maximum achievable yaw at it —
+   never a full stop mid-line. Curvature is knowingly sacrificed only in
+   this floor case. A true pivot command (`v = 0`) stays at `v = 0` with
+   yaw clamped to rest capability.
+
+5. **Fail-safe off.** The feature is param-gated (`capability_curve_enabled`,
+   default `false`); an invalid curve table disables regulation with an
+   error log rather than guessing. The independent `max_speed` /
+   `max_yaw_speed` clamps remain as the backstop in all cases, applied after
+   regulation.
+
+6. **Regulate once, at the command entry point.** `update(mode,
+   TwistStamped)` regulates before the output-type branch, so the
+   twist-output path and the twist→helm conversion path both carry regulated
+   values. The Helm-message input path (throttle/rudder) is operator-shaped
+   normalized input, not a velocity pair, and is deliberately not modulated.
+
+## Consequences
+
+- The planner may promise a tight `minimum_turning_radius` (~3 m for
+  BizzyBoat instead of the worst-case 11 m); the helm makes it true by
+  slowing through turns. Follow-up in unh_echoboats_project11: provisional
+  measured 2026-08-04 curve + planner radius change
+  (supersedes rolker/unh_echoboats_project11#412's interim envelope).
+- On saturating hulls (ArduPilot skid-steer clips differential at
+  `1000 − 2·throttle` µs), yielding throttle directly recovers steering
+  authority — the mechanism cooperates with, and reduces reliance on,
+  FCU-side saturation handling (`MOT_STR_THR_MIX`).
+- Regulated output is observable on the existing cmd_vel topic; a curve is
+  inspectable YAML. No new topics or interfaces.
+- Simulation coverage in `unh_marine_simulation` is a tracked follow-up and
+  does not gate field enablement (operator decision, 2026-08-05; the feature
+  is field-tested directly on the deployed platform).
+- IzzyBoat gains the mechanism by measuring its own envelope
+  (rolker/unh_echoboats_project11#120); no code change.

--- a/helm_manager/CMakeLists.txt
+++ b/helm_manager/CMakeLists.txt
@@ -85,6 +85,9 @@ if(BUILD_TESTING)
     rclcpp_lifecycle
   )
 
+  # Curvature-preserving speed regulation pure-logic tests (ADR-0012, #292)
+  ament_add_gtest(test_curvature_regulation test/test_curvature_regulation.cpp)
+
   # Command conversion and clamping tests
   ament_add_gtest(test_command_conversion test/test_command_conversion.cpp)
   target_link_libraries(test_command_conversion ${PROJECT_NAME}_lib)

--- a/helm_manager/README.md
+++ b/helm_manager/README.md
@@ -55,8 +55,9 @@ velocity pair.
 
 - `capability_curve_enabled` (`bool`, default: `false`): Master gate.
 - `capability_curve_v_omega_max` (`double[]`, default: `[]`): Flat `[v₀, ω_max₀, v₁, ω_max₁, …]`
-  pairs — achievable |yaw rate| (rad/s) at forward |speed| (m/s). Speeds strictly ascending;
-  linear interpolation within segments, clamp-constant beyond both ends. The curve may be
+  pairs — achievable |yaw rate| (rad/s) at forward |speed| (m/s). Speeds strictly ascending and
+  **starting at `v = 0.0`** (rest capability must be explicit — it is not extrapolated); linear
+  interpolation within segments, clamp-constant beyond the last breakpoint. The curve may be
   **non-monotonic** (measured envelopes can peak at mid-speed). Values come from platform
   measurement, live in platform config, and are re-measured when the platform changes.
 - `capability_curve_margin` (`double`, default: `0.8`): Safety factor in `(0, 1]` applied to

--- a/helm_manager/README.md
+++ b/helm_manager/README.md
@@ -38,3 +38,34 @@ The node is implemented as a **ROS 2 Lifecycle Node**, allowing for controlled t
 - `max_speed` (`double`, default: `1.0`): Used for scaling when converting between `Helm` throttle and `Twist` linear velocity.
 - `max_yaw_speed` (`double`, default: `1.0`): Used for scaling when converting between `Helm` rudder and `Twist` angular velocity.
 
+## Curvature-Preserving Speed Regulation
+
+Optional (default off; [ADR-0012](../docs/decisions/0012-curvature-preserving-speed-regulation.md),
+[#292](https://github.com/rolker/unh_marine_autonomy/issues/292)). On platforms whose achievable
+yaw rate depends strongly on forward speed (e.g. a differential/skid-steer hull), independently
+clamping `angular.z` silently widens executed turns. When enabled, a commanded `(v, ω)` that
+exceeds the platform's capability envelope is scaled — **both components by the same factor** —
+until the yaw rate is achievable, preserving the commanded curvature `v/ω` (turn radius) exactly:
+the boat stays on the planned arc and simply traverses it slower.
+
+Applied once at the `TwistStamped` command entry, so both the twist output and the twist→helm
+conversion carry regulated values. The `max_speed`/`max_yaw_speed` clamps remain as a backstop.
+`Helm` (throttle/rudder) input is never modulated — it is operator-shaped normalized input, not a
+velocity pair.
+
+- `capability_curve_enabled` (`bool`, default: `false`): Master gate.
+- `capability_curve_v_omega_max` (`double[]`, default: `[]`): Flat `[v₀, ω_max₀, v₁, ω_max₁, …]`
+  pairs — achievable |yaw rate| (rad/s) at forward |speed| (m/s). Speeds strictly ascending;
+  linear interpolation within segments, clamp-constant beyond both ends. The curve may be
+  **non-monotonic** (measured envelopes can peak at mid-speed). Values come from platform
+  measurement, live in platform config, and are re-measured when the platform changes.
+- `capability_curve_margin` (`double`, default: `0.8`): Safety factor in `(0, 1]` applied to
+  every `ω_max`.
+- `capability_curve_pivot_speed` (`double`, default: `0.05`): Floor speed (m/s). If the commanded
+  yaw is unachievable even at crawl, the helm commands this speed with the maximum achievable yaw
+  there — it never stops the boat mid-line. A true pivot command (`v = 0`) stays at `v = 0` with
+  yaw clamped to rest capability.
+
+Regulation never speeds the boat up (a low commanded speed may be low for reasons the helm cannot
+see), never flips signs, and disables itself with an error log if the curve table is invalid.
+

--- a/helm_manager/src/curvature_regulation.h
+++ b/helm_manager/src/curvature_regulation.h
@@ -1,0 +1,230 @@
+// Copyright 2026 University of New Hampshire
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the University of New Hampshire nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef HELM_MANAGER_CURVATURE_REGULATION_H
+#define HELM_MANAGER_CURVATURE_REGULATION_H
+
+/// Curvature-preserving speed regulation (ADR-0012, #292).
+///
+/// When a commanded (v, ω) pair exceeds the platform's speed-dependent yaw
+/// capability, both components are scaled by the same factor s ∈ (0, 1] so
+/// the yaw rate becomes achievable while the commanded curvature v/ω — the
+/// turn radius — is preserved exactly. Clipping ω alone widens the executed
+/// turn; reducing v alone tightens it; either way the boat leaves the planned
+/// arc. Proportional scaling keeps it on the arc, traversed slower.
+///
+/// The capability envelope is a per-platform piecewise-linear table of
+/// ω_max versus v. It is NOT assumed monotonic: measured envelopes
+/// (BizzyBoat's differential drivetrain, 2026-08-04) peak at mid-speed and
+/// are weaker at rest. Pure logic, no ROS dependencies — the HelmManager
+/// node owns parameter plumbing and calls into this header.
+
+#include <algorithm>
+#include <cmath>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace helm_manager
+{
+
+  struct CurvatureRegulationConfig
+  {
+  /// Master gate; default off so existing platforms are unaffected.
+    bool enabled = false;
+
+  /// Flat [v0, w0, v1, w1, ...] pairs: achievable |yaw rate| w (rad/s) at
+  /// forward |speed| v (m/s). v strictly ascending, all values finite and
+  /// non-negative. Linear interpolation within segments, clamp-constant
+  /// beyond both ends.
+    std::vector < double > curve;
+
+  /// Safety factor in (0, 1] applied to every ω_max value.
+    double margin = 0.8;
+
+  /// Floor speed (m/s): when the commanded yaw is unachievable at any speed,
+  /// keep moving at this speed with the yaw capability it offers rather than
+  /// slowing toward a stop mid-line.
+    double pivot_speed = 0.05;
+  };
+
+/// Validate a config. Returns true when usable; on failure fills `error`
+/// with a human-readable reason. An empty curve with enabled=false is valid
+/// (the feature is simply off); enabled=true requires a well-formed curve.
+  inline bool validateCurvatureConfig(
+    const CurvatureRegulationConfig & config, std::string & error)
+  {
+    if (!config.enabled) {
+      return true;
+    }
+    const auto & c = config.curve;
+    if (c.empty() || c.size() % 2 != 0) {
+      error = "capability_curve_v_omega_max must hold [v, omega_max] pairs "
+        "(got " + std::to_string(c.size()) + " values)";
+      return false;
+    }
+    for (size_t i = 0; i < c.size(); i += 2) {
+      if (!std::isfinite(c[i]) || !std::isfinite(c[i + 1]) ||
+        c[i] < 0.0 || c[i + 1] < 0.0)
+      {
+        error = "capability_curve_v_omega_max entries must be finite and "
+          "non-negative";
+        return false;
+      }
+      if (i >= 2 && c[i] <= c[i - 2]) {
+        error = "capability_curve_v_omega_max speeds must be strictly "
+          "ascending";
+        return false;
+      }
+    }
+    if (!std::isfinite(config.margin) ||
+      config.margin <= 0.0 || config.margin > 1.0)
+    {
+      error = "capability_curve_margin must be in (0, 1]";
+      return false;
+    }
+    if (!std::isfinite(config.pivot_speed) || config.pivot_speed < 0.0) {
+      error = "capability_curve_pivot_speed must be non-negative";
+      return false;
+    }
+    return true;
+  }
+
+/// Margin-scaled capability λ(x): achievable |yaw| at |speed| x, linearly
+/// interpolated within the table and clamp-constant beyond both ends.
+/// Precondition: curve validated non-empty.
+  inline double curvatureCapabilityAt(
+    const CurvatureRegulationConfig & config, double speed)
+  {
+    const auto & c = config.curve;
+    const double x = std::abs(speed);
+    if (x <= c.front()) {
+      return c[1] * config.margin;
+    }
+    if (x >= c[c.size() - 2]) {
+      return c.back() * config.margin;
+    }
+    for (size_t i = 2; i < c.size(); i += 2) {
+      if (x <= c[i]) {
+        const double va = c[i - 2], wa = c[i - 1];
+        const double vb = c[i], wb = c[i + 1];
+        const double t = (x - va) / (vb - va);
+        return (wa + t * (wb - wa)) * config.margin;
+      }
+    }
+    return c.back() * config.margin;  // unreachable; defensive
+  }
+
+/// Apply curvature-preserving regulation to a commanded (v, omega).
+///
+/// Returns the pair to command downstream. Contract (ADR-0012):
+///  - Disabled, empty curve, omega == 0, or non-finite input: passthrough.
+///  - Pivot command (v == 0): omega clamped to rest capability, v stays 0.
+///  - Inside the envelope: passthrough.
+///  - Over the envelope: both components scaled by the same s ∈ (0, 1] —
+///    curvature preserved; the scan is top-down over the piecewise segments
+///    (largest feasible speed wins; no monotonicity assumption).
+///  - Never speeds up (s <= 1), never flips a sign, never returns v = 0 for
+///    a moving command: if the feasible speed falls below pivot_speed, the
+///    result is pivot_speed (or the smaller commanded |v|) with the maximum
+///    achievable yaw at that speed — the only case curvature is sacrificed.
+  inline std::pair < double, double > applyCurvatureRegulation(
+  double v, double omega, const CurvatureRegulationConfig & config)
+{
+  if (!config.enabled || config.curve.empty() ||
+      !std::isfinite(v) || !std::isfinite(omega) || omega == 0.0)
+    {
+      return {v, omega};
+  }
+
+  const double abs_v = std::abs(v);
+  const double abs_w = std::abs(omega);
+  const double sign_v = (v < 0.0) ? -1.0 : 1.0;
+  const double sign_w = (omega < 0.0) ? -1.0 : 1.0;
+
+  if (abs_v == 0.0) {
+    // True pivot: no speed to trade, clamp yaw to rest capability.
+      const double rest = curvatureCapabilityAt(config, 0.0);
+      return {0.0, sign_w * std::min(abs_w, rest)};
+  }
+
+  if (abs_w <= curvatureCapabilityAt(config, abs_v)) {
+      return {v, omega};
+  }
+
+  // Find the largest x ∈ (0, abs_v] with (x / abs_v) * abs_w <= λ(x),
+  // i.e. f(x) = λ(x) - k·x >= 0 where k = abs_w / abs_v (the commanded
+  // curvature, in per-unit form). λ is piecewise linear, so walk the
+  // segments top-down; the first feasible point is the global maximum.
+  const double k = abs_w / abs_v;
+
+  // Segment boundaries within [0, abs_v]: 0, interior table speeds, abs_v.
+  std::vector < double > xs;
+  xs.push_back(0.0);
+  for (size_t i = 0; i < config.curve.size(); i += 2) {
+      const double bv = config.curve[i];
+      if (bv > 0.0 && bv < abs_v) {
+        xs.push_back(bv);
+      }
+  }
+  xs.push_back(abs_v);
+
+  auto f = [&](double x) {return curvatureCapabilityAt(config, x) - k * x;};
+
+  double x_star = -1.0;
+  for (size_t i = xs.size() - 1; i > 0; --i) {
+      const double a = xs[i - 1], b = xs[i];
+      const double fa = f(a), fb = f(b);
+      if (fb >= 0.0) {
+        x_star = b;
+        break;
+      }
+      if (fa >= 0.0) {
+      // f is linear on [a, b] with fa >= 0 > fb: largest feasible point is
+      // the crossing.
+        x_star = a + fa * (b - a) / (fa - fb);
+        break;
+      }
+  }
+
+  if (x_star <= 0.0 || x_star < config.pivot_speed) {
+    // Floor: commanded yaw is beyond capability even at crawl. Keep moving
+    // at the floor speed (never above the commanded speed) with the maximum
+    // achievable yaw there. Curvature is knowingly sacrificed here only.
+      const double floor_v = std::min(config.pivot_speed, abs_v);
+      return {sign_v * floor_v,
+                 sign_w * curvatureCapabilityAt(config, floor_v)};
+  }
+
+  const double s = x_star / abs_v;
+    return {sign_v * x_star, sign_w * s * abs_w};
+  }
+
+}  // namespace helm_manager
+
+#endif  // HELM_MANAGER_CURVATURE_REGULATION_H

--- a/helm_manager/src/curvature_regulation.h
+++ b/helm_manager/src/curvature_regulation.h
@@ -88,6 +88,14 @@ namespace helm_manager
         "(got " + std::to_string(c.size()) + " values)";
       return false;
     }
+    if (c[0] != 0.0) {
+      // Rest capability must be explicit: clamp-extending the first
+      // breakpoint down to v=0 would overestimate yaw authority at rest on
+      // weaker-at-rest hulls (ADR-0012) — exactly where pivot commands land.
+      error = "capability_curve_v_omega_max must start at v = 0.0 so rest "
+        "capability is explicitly defined";
+      return false;
+    }
     for (size_t i = 0; i < c.size(); i += 2) {
       if (!std::isfinite(c[i]) || !std::isfinite(c[i + 1]) ||
         c[i] < 0.0 || c[i + 1] < 0.0)

--- a/helm_manager/src/helm_manager.cpp
+++ b/helm_manager/src/helm_manager.cpp
@@ -27,6 +27,9 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include <algorithm>
+#include <string>
+#include <tuple>
+#include <vector>
 
 #include "helm_manager.h"
 #include "piloting_mode.h"
@@ -60,6 +63,15 @@ CallbackReturn HelmManager::on_configure(const rclcpp_lifecycle::State & state)
   declare_parameter<double>("max_yaw_speed", 1.0);
   max_speed_ = get_parameter("max_speed").as_double();
   max_yaw_speed_ = get_parameter("max_yaw_speed").as_double();
+
+  // Curvature-preserving speed regulation (ADR-0012, #292): per-platform
+  // capability envelope; default off so existing platforms are unaffected.
+  declare_parameter<bool>("capability_curve_enabled", false);
+  declare_parameter<std::vector<double>>(
+    "capability_curve_v_omega_max", std::vector<double>());
+  declare_parameter<double>("capability_curve_margin", 0.8);
+  declare_parameter<double>("capability_curve_pivot_speed", 0.05);
+  loadCurvatureConfig();
 
   helm_status_subscription_ = create_subscription<marine_interfaces::msg::Heartbeat>("status/helm",
       1, std::bind(&HelmManager::helmStatusCallback, this, std::placeholders::_1));
@@ -116,6 +128,7 @@ CallbackReturn HelmManager::on_shutdown(const rclcpp_lifecycle::State & state)
 
 void HelmManager::updateParameters(const std::vector<rclcpp::Parameter> & parameters)
 {
+  bool curvature_touched = false;
   for(const auto & param: parameters) {
     if(param.get_name() == "max_speed") {
       max_speed_ = param.as_double();
@@ -123,7 +136,45 @@ void HelmManager::updateParameters(const std::vector<rclcpp::Parameter> & parame
     if(param.get_name() == "max_yaw_speed") {
       max_yaw_speed_ = param.as_double();
     }
+    if(param.get_name().rfind("capability_curve_", 0) == 0) {
+      curvature_touched = true;
+    }
   }
+  if(curvature_touched) {
+    loadCurvatureConfig();
+  }
+}
+
+void HelmManager::loadCurvatureConfig()
+{
+  // The post-set-parameter callback fires during each declare_parameter in
+  // on_configure — before the full set exists. Load only once all four are
+  // declared (the explicit loadCurvatureConfig() call at the end of the
+  // declares performs the first real load).
+  if(!has_parameter("capability_curve_enabled") ||
+    !has_parameter("capability_curve_v_omega_max") ||
+    !has_parameter("capability_curve_margin") ||
+    !has_parameter("capability_curve_pivot_speed"))
+  {
+    return;
+  }
+
+  CurvatureRegulationConfig config;
+  config.enabled = get_parameter("capability_curve_enabled").as_bool();
+  config.curve = get_parameter("capability_curve_v_omega_max").as_double_array();
+  config.margin = get_parameter("capability_curve_margin").as_double();
+  config.pivot_speed = get_parameter("capability_curve_pivot_speed").as_double();
+
+  std::string error;
+  if(!validateCurvatureConfig(config, error)) {
+    // Fail-safe: refuse the bad envelope rather than guess with it; the
+    // independent max_speed/max_yaw_speed clamps remain in effect.
+    RCLCPP_ERROR(get_logger(),
+      "capability curve rejected, curvature regulation disabled: %s",
+      error.c_str());
+    config.enabled = false;
+  }
+  curvature_config_ = config;
 }
 
 
@@ -171,8 +222,16 @@ void HelmManager::update(const std::string & mode, const marine_interfaces::msg:
 void HelmManager::update(const std::string & mode, const geometry_msgs::msg::TwistStamped & msg)
 {
   if(canPublish(mode)) {
+    // Regulate once, before the output-type branch, so both the twist
+    // output and the twist->helm conversion carry regulated values
+    // (ADR-0012). The max clamps below stay as the backstop.
+    geometry_msgs::msg::TwistStamped regulated = msg;
+    std::tie(regulated.twist.linear.x, regulated.twist.angular.z) =
+      applyCurvatureRegulation(msg.twist.linear.x, msg.twist.angular.z,
+        curvature_config_);
+
     if(output_type_ == "twist" || output_type_ == "dual") {
-      geometry_msgs::msg::TwistStamped twist_clamped = msg;
+      geometry_msgs::msg::TwistStamped twist_clamped = regulated;
       twist_clamped.twist.linear.x = std::max(-max_speed_,
           std::min(max_speed_, twist_clamped.twist.linear.x));
       twist_clamped.twist.angular.z = std::max(-max_yaw_speed_,
@@ -180,14 +239,14 @@ void HelmManager::update(const std::string & mode, const geometry_msgs::msg::Twi
       twist_publisher_->publish(twist_clamped);
     } else {
       marine_interfaces::msg::Helm helm;
-      helm.header = msg.header;
-      if(std::isnan(msg.twist.linear.x)) {
+      helm.header = regulated.header;
+      if(std::isnan(regulated.twist.linear.x)) {
         helm.throttle = 0;
       } else {
-        helm.throttle = msg.twist.linear.x / max_speed_;
+        helm.throttle = regulated.twist.linear.x / max_speed_;
       }
       helm.throttle = std::max(-1.0, std::min(1.0, static_cast<double>(helm.throttle)));
-      helm.rudder = -msg.twist.angular.z / max_yaw_speed_;
+      helm.rudder = -regulated.twist.angular.z / max_yaw_speed_;
       helm.rudder = std::max(-1.0, std::min(1.0, static_cast<double>(helm.rudder)));
       helm_publisher_->publish(helm);
     }

--- a/helm_manager/src/helm_manager.cpp
+++ b/helm_manager/src/helm_manager.cpp
@@ -174,6 +174,7 @@ void HelmManager::loadCurvatureConfig()
       error.c_str());
     config.enabled = false;
   }
+  std::lock_guard<std::mutex> lock(curvature_config_mutex_);
   curvature_config_ = config;
 }
 
@@ -224,11 +225,18 @@ void HelmManager::update(const std::string & mode, const geometry_msgs::msg::Twi
   if(canPublish(mode)) {
     // Regulate once, before the output-type branch, so both the twist
     // output and the twist->helm conversion carry regulated values
-    // (ADR-0012). The max clamps below stay as the backstop.
+    // (ADR-0012). The max clamps below stay as the backstop. Copy the
+    // config under the lock (small: a handful of doubles) so the
+    // parameter-callback writer can never tear a read mid-command.
+    CurvatureRegulationConfig config;
+    {
+      std::lock_guard<std::mutex> lock(curvature_config_mutex_);
+      config = curvature_config_;
+    }
     geometry_msgs::msg::TwistStamped regulated = msg;
     std::tie(regulated.twist.linear.x, regulated.twist.angular.z) =
       applyCurvatureRegulation(msg.twist.linear.x, msg.twist.angular.z,
-        curvature_config_);
+        config);
 
     if(output_type_ == "twist" || output_type_ == "dual") {
       geometry_msgs::msg::TwistStamped twist_clamped = regulated;

--- a/helm_manager/src/helm_manager.h
+++ b/helm_manager/src/helm_manager.h
@@ -41,6 +41,8 @@
 #include "std_msgs/msg/bool.hpp"
 #include "marine_interfaces/msg/heartbeat.hpp"
 
+#include "curvature_regulation.h"
+
 namespace helm_manager
 {
 
@@ -90,6 +92,13 @@ private:
 
     double max_speed_ = 1.0;
     double max_yaw_speed_ = 1.0;
+
+    // Curvature-preserving speed regulation (ADR-0012, #292). Loaded and
+    // validated in on_configure/updateParameters; applied at the entry of
+    // update(mode, TwistStamped) so both output branches see regulated
+    // values. Invalid config disables regulation (fail-safe passthrough).
+    CurvatureRegulationConfig curvature_config_;
+    void loadCurvatureConfig();
 
     rclcpp::node_interfaces::PostSetParametersCallbackHandle::SharedPtr update_parameters_callback_;
   };

--- a/helm_manager/src/helm_manager.h
+++ b/helm_manager/src/helm_manager.h
@@ -30,6 +30,7 @@
 #define HELM_MANAGER_HELM_MANAGER_H
 
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -97,7 +98,12 @@ private:
     // validated in on_configure/updateParameters; applied at the entry of
     // update(mode, TwistStamped) so both output branches see regulated
     // values. Invalid config disables regulation (fail-safe passthrough).
+    // The mutex guards the config (incl. its vector) between the parameter
+    // callback writer and command-path readers: the shipped node spins
+    // single-threaded, but this class is a library and must not hand a
+    // torn read to a future multi-threaded executor.
     CurvatureRegulationConfig curvature_config_;
+    mutable std::mutex curvature_config_mutex_;
     void loadCurvatureConfig();
 
     rclcpp::node_interfaces::PostSetParametersCallbackHandle::SharedPtr update_parameters_callback_;

--- a/helm_manager/test/test_command_conversion.cpp
+++ b/helm_manager/test/test_command_conversion.cpp
@@ -626,3 +626,141 @@ TEST_F(ParameterUpdateTest, MaxYawSpeedUpdateAffectsConversion)
   ASSERT_TRUE(twist_received_);
   EXPECT_NEAR(last_twist_.twist.angular.z, -1.0, 0.001);
 }
+
+// ---------------------------------------------------------------------------
+// Curvature regulation: both output branches receive regulated values
+// (ADR-0012, #292). A constant capability envelope of 1.0 rad/s with a
+// commanded (2.0, 2.0) regulates to (1.0, 1.0): same curvature (radius 1 m),
+// half the speed. The plan-review must-fix locked in by these tests: the
+// regulation applies at update() entry, ahead of the output-type branch.
+// ---------------------------------------------------------------------------
+
+class CurvatureRegulationNodeTest : public ::testing::Test
+{
+protected:
+  void setUpWithOutputType(const std::string & output_type)
+  {
+    rclcpp::init(0, nullptr);
+
+    rclcpp::NodeOptions options;
+    options.parameter_overrides({
+      rclcpp::Parameter("output_type", output_type),
+      rclcpp::Parameter("max_speed", 2.0),
+      rclcpp::Parameter("max_yaw_speed", 2.0),
+      rclcpp::Parameter("capability_curve_enabled", true),
+      rclcpp::Parameter("capability_curve_v_omega_max",
+        std::vector<double>{0.0, 1.0, 2.0, 1.0}),
+      rclcpp::Parameter("capability_curve_margin", 1.0),
+      rclcpp::Parameter("capability_curve_pivot_speed", 0.05)
+    });
+    node_ = std::make_shared<helm_manager::HelmManager>("test_curv_node", options);
+    helper_ = std::make_shared<rclcpp::Node>("test_curv_helper");
+
+    mode_pub_ = helper_->create_publisher<std_msgs::msg::String>(
+      "/piloting_mode", 1);
+    manual_twist_pub_ = helper_->create_publisher<geometry_msgs::msg::TwistStamped>(
+      "/piloting_mode/manual/cmd_vel", 10);
+
+    twist_sub_ = helper_->create_subscription<geometry_msgs::msg::TwistStamped>(
+      "/out/cmd_vel", 1,
+      [this](const geometry_msgs::msg::TwistStamped::SharedPtr msg) {
+        last_twist_ = *msg;
+        twist_received_ = true;
+      });
+    helm_sub_ = helper_->create_subscription<marine_interfaces::msg::Helm>(
+      "/out/helm", 1,
+      [this](const marine_interfaces::msg::Helm::SharedPtr msg) {
+        last_helm_ = *msg;
+        helm_received_ = true;
+      });
+
+    auto state = node_->configure();
+    ASSERT_EQ(state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+    state = node_->activate();
+    ASSERT_EQ(state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+    std_msgs::msg::String mode;
+    mode.data = "manual";
+    mode_pub_->publish(mode);
+    spinBoth(100ms);
+  }
+
+  void TearDown() override
+  {
+    mode_pub_.reset();
+    manual_twist_pub_.reset();
+    twist_sub_.reset();
+    helm_sub_.reset();
+    helper_.reset();
+    node_.reset();
+    rclcpp::shutdown();
+  }
+
+  void spinBoth(std::chrono::milliseconds duration)
+  {
+    auto start = std::chrono::steady_clock::now();
+    while (std::chrono::steady_clock::now() - start < duration) {
+      rclcpp::spin_some(node_->get_node_base_interface());
+      rclcpp::spin_some(helper_);
+      std::this_thread::sleep_for(1ms);
+    }
+  }
+
+  template<typename Predicate>
+  bool spinUntil(Predicate pred, std::chrono::milliseconds timeout = 2000ms)
+  {
+    auto start = std::chrono::steady_clock::now();
+    while (std::chrono::steady_clock::now() - start < timeout) {
+      rclcpp::spin_some(node_->get_node_base_interface());
+      rclcpp::spin_some(helper_);
+      if (pred()) {
+        return true;
+      }
+      std::this_thread::sleep_for(1ms);
+    }
+    return false;
+  }
+
+  std::shared_ptr<helm_manager::HelmManager> node_;
+  std::shared_ptr<rclcpp::Node> helper_;
+  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr mode_pub_;
+  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr manual_twist_pub_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr twist_sub_;
+  rclcpp::Subscription<marine_interfaces::msg::Helm>::SharedPtr helm_sub_;
+
+  geometry_msgs::msg::TwistStamped last_twist_;
+  marine_interfaces::msg::Helm last_helm_;
+  bool twist_received_ = false;
+  bool helm_received_ = false;
+};
+
+TEST_F(CurvatureRegulationNodeTest, RegulationAppliesToTwistOutputBranch)
+{
+  setUpWithOutputType("twist");
+
+  geometry_msgs::msg::TwistStamped twist;
+  twist.twist.linear.x = 2.0;
+  twist.twist.angular.z = 2.0;  // envelope allows 1.0 -> regulate to (1, 1)
+  manual_twist_pub_->publish(twist);
+  spinUntil([this] {return twist_received_;});
+
+  ASSERT_TRUE(twist_received_);
+  EXPECT_NEAR(last_twist_.twist.linear.x, 1.0, 1e-6);
+  EXPECT_NEAR(last_twist_.twist.angular.z, 1.0, 1e-6);
+}
+
+TEST_F(CurvatureRegulationNodeTest, RegulationAppliesToHelmConversionBranch)
+{
+  setUpWithOutputType("helm");
+
+  geometry_msgs::msg::TwistStamped twist;
+  twist.twist.linear.x = 2.0;
+  twist.twist.angular.z = 2.0;  // regulated to (1, 1) before conversion
+  manual_twist_pub_->publish(twist);
+  spinUntil([this] {return helm_received_;});
+
+  ASSERT_TRUE(helm_received_);
+  // throttle = 1.0 / max_speed(2.0); rudder = -1.0 / max_yaw_speed(2.0)
+  EXPECT_NEAR(last_helm_.throttle, 0.5, 1e-6);
+  EXPECT_NEAR(last_helm_.rudder, -0.5, 1e-6);
+}

--- a/helm_manager/test/test_curvature_regulation.cpp
+++ b/helm_manager/test/test_curvature_regulation.cpp
@@ -236,4 +236,9 @@ TEST(CurvatureRegulationConfigTest, InvalidCurvesRejected)
   auto bad_pivot = bizzyLikeConfig();
   bad_pivot.pivot_speed = -0.1;
   EXPECT_FALSE(validateCurvatureConfig(bad_pivot, error));
+
+  auto no_rest = bizzyLikeConfig();
+  no_rest.curve = {0.5, 0.4, 1.3, 0.4};  // first breakpoint above v=0:
+  EXPECT_FALSE(validateCurvatureConfig(no_rest, error))
+    << "rest capability must be explicit, not clamp-extended";
 }

--- a/helm_manager/test/test_curvature_regulation.cpp
+++ b/helm_manager/test/test_curvature_regulation.cpp
@@ -1,0 +1,239 @@
+// Copyright 2026 University of New Hampshire
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the University of New Hampshire nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/// Pure-logic tests for curvature-preserving speed regulation (ADR-0012,
+/// #292). No ROS spin — the algorithm is exercised directly through the
+/// header the HelmManager node calls.
+
+#include <gtest/gtest.h>
+#include <cmath>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "../src/curvature_regulation.h"
+
+using helm_manager::CurvatureRegulationConfig;
+using helm_manager::applyCurvatureRegulation;
+using helm_manager::curvatureCapabilityAt;
+using helm_manager::validateCurvatureConfig;
+
+namespace
+{
+
+// A non-monotonic envelope shaped like BizzyBoat's measured differential
+// curve: weaker at rest, peak at mid-speed, degrading at high speed.
+// margin 1.0 so expected values read directly off the table.
+CurvatureRegulationConfig bizzyLikeConfig()
+{
+  CurvatureRegulationConfig config;
+  config.enabled = true;
+  config.curve = {0.0, 0.26, 0.5, 0.40, 1.3, 0.40, 1.8, 0.20, 2.5, 0.20};
+  config.margin = 1.0;
+  config.pivot_speed = 0.05;
+  return config;
+}
+
+}  // namespace
+
+TEST(CurvatureRegulation, DisabledByDefault)
+{
+  CurvatureRegulationConfig config;  // defaults: enabled=false, empty curve
+  auto [v, w] = applyCurvatureRegulation(2.0, 5.0, config);
+  EXPECT_DOUBLE_EQ(v, 2.0);
+  EXPECT_DOUBLE_EQ(w, 5.0);
+}
+
+TEST(CurvatureRegulation, EmptyCurvePassthrough)
+{
+  CurvatureRegulationConfig config;
+  config.enabled = true;  // enabled but no curve: nothing to regulate with
+  auto [v, w] = applyCurvatureRegulation(2.0, 5.0, config);
+  EXPECT_DOUBLE_EQ(v, 2.0);
+  EXPECT_DOUBLE_EQ(w, 5.0);
+}
+
+TEST(CurvatureRegulation, WithinEnvelopePassthrough)
+{
+  auto config = bizzyLikeConfig();
+  auto [v, w] = applyCurvatureRegulation(1.0, 0.3, config);  // λ(1.0) = 0.40
+  EXPECT_DOUBLE_EQ(v, 1.0);
+  EXPECT_DOUBLE_EQ(w, 0.3);
+}
+
+TEST(CurvatureRegulation, ZeroYawPassthrough)
+{
+  auto config = bizzyLikeConfig();
+  auto [v, w] = applyCurvatureRegulation(3.0, 0.0, config);
+  EXPECT_DOUBLE_EQ(v, 3.0);
+  EXPECT_DOUBLE_EQ(w, 0.0);
+}
+
+TEST(CurvatureRegulation, ScalesBothPreservingCurvature)
+{
+  auto config = bizzyLikeConfig();
+  // Commanded radius v/w = 2.0/0.5 = 4 m; λ(2.0) = 0.20 < 0.5 → regulate.
+  const double v_cmd = 2.0, w_cmd = 0.5;
+  auto [v, w] = applyCurvatureRegulation(v_cmd, w_cmd, config);
+  ASSERT_GT(v, 0.0);
+  ASSERT_GT(w, 0.0);
+  EXPECT_LT(v, v_cmd);
+  EXPECT_LT(w, w_cmd);
+  // Curvature preserved exactly.
+  EXPECT_NEAR(v / w, v_cmd / w_cmd, 1e-9);
+  // Result is feasible under the envelope.
+  EXPECT_LE(w, curvatureCapabilityAt(config, v) + 1e-9);
+  // Same scale factor on both.
+  EXPECT_NEAR(v / v_cmd, w / w_cmd, 1e-9);
+}
+
+TEST(CurvatureRegulation, NonMonotonicLookupFindsGlobalMax)
+{
+  auto config = bizzyLikeConfig();
+  // k = w/v = 0.35/2.0 = 0.175 per unit. At the high band λ = 0.20:
+  // f(2.0) = 0.20 - 0.35 < 0, infeasible at commanded speed. Walking down,
+  // the crossing is where λ(x) = 0.175·x. In the 1.3→1.8 segment λ falls
+  // 0.40→0.20 (slope -0.4): 0.40 - 0.4(x - 1.3) = 0.175x → x = 0.92/0.575
+  // = 1.6 — well above what a monotonic assumption stopping at the first
+  // low-band failure would give.
+  auto [v, w] = applyCurvatureRegulation(2.0, 0.35, config);
+  EXPECT_NEAR(v, 1.6, 1e-9);
+  EXPECT_NEAR(w, 0.35 * v / 2.0, 1e-9);  // curvature preserved
+  EXPECT_LE(w, curvatureCapabilityAt(config, v) + 1e-9);
+}
+
+TEST(CurvatureRegulation, FloorBehaviorNeverStops)
+{
+  auto config = bizzyLikeConfig();
+  // Absurd yaw demand: infeasible at any speed above a crawl.
+  auto [v, w] = applyCurvatureRegulation(1.5, 50.0, config);
+  EXPECT_DOUBLE_EQ(v, config.pivot_speed);  // floor speed, not zero
+  EXPECT_GT(w, 0.0);                        // maximum achievable yaw there
+  EXPECT_NEAR(w, curvatureCapabilityAt(config, config.pivot_speed), 1e-9);
+}
+
+TEST(CurvatureRegulation, PivotCommandClampsYawAtRestCapability)
+{
+  auto config = bizzyLikeConfig();
+  auto [v, w] = applyCurvatureRegulation(0.0, 1.0, config);
+  EXPECT_DOUBLE_EQ(v, 0.0);            // pivot stays a pivot
+  EXPECT_DOUBLE_EQ(w, 0.26);           // λ(0) with margin 1.0
+  // Within rest capability: untouched.
+  auto [v2, w2] = applyCurvatureRegulation(0.0, 0.2, config);
+  EXPECT_DOUBLE_EQ(v2, 0.0);
+  EXPECT_DOUBLE_EQ(w2, 0.2);
+}
+
+TEST(CurvatureRegulation, NeverSpeedsUp)
+{
+  auto config = bizzyLikeConfig();
+  // At 0.2 m/s the interpolated λ ≈ 0.316; demand 0.35 rad/s. The peak band
+  // (0.5-1.3 m/s, λ = 0.40) could satisfy it — but regulation must never
+  // exceed the commanded speed.
+  auto [v, w] = applyCurvatureRegulation(0.2, 0.35, config);
+  EXPECT_LE(std::abs(v), 0.2 + 1e-12);
+  EXPECT_LE(std::abs(w), 0.35 + 1e-12);
+  EXPECT_LE(w, curvatureCapabilityAt(config, v) + 1e-9);
+}
+
+TEST(CurvatureRegulation, MarginApplied)
+{
+  auto config = bizzyLikeConfig();
+  config.margin = 0.5;
+  // λ(1.0) = 0.40 * 0.5 = 0.20; a command inside the unmargined envelope
+  // but outside the margined one must be regulated.
+  auto [v, w] = applyCurvatureRegulation(1.0, 0.3, config);
+  EXPECT_LT(v, 1.0);
+  EXPECT_NEAR(v / w, 1.0 / 0.3, 1e-9);
+  EXPECT_LE(w, curvatureCapabilityAt(config, v) + 1e-9);
+}
+
+TEST(CurvatureRegulation, PreservesDirection)
+{
+  auto config = bizzyLikeConfig();
+  for(const double sv : {1.0, -1.0}) {
+    for(const double sw : {1.0, -1.0}) {
+      auto [v, w] = applyCurvatureRegulation(sv * 2.0, sw * 0.5, config);
+      EXPECT_GT(v * sv, 0.0) << "sv=" << sv << " sw=" << sw;
+      EXPECT_GT(w * sw, 0.0) << "sv=" << sv << " sw=" << sw;
+      EXPECT_NEAR(std::abs(v / w), 4.0, 1e-9);  // |radius| preserved
+    }
+  }
+}
+
+TEST(CurvatureRegulation, NonFiniteInputPassthrough)
+{
+  auto config = bizzyLikeConfig();
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  auto [v, w] = applyCurvatureRegulation(nan, 0.5, config);
+  EXPECT_TRUE(std::isnan(v));
+  EXPECT_DOUBLE_EQ(w, 0.5);
+}
+
+TEST(CurvatureRegulationConfigTest, ValidConfigAccepted)
+{
+  auto config = bizzyLikeConfig();
+  std::string error;
+  EXPECT_TRUE(validateCurvatureConfig(config, error)) << error;
+}
+
+TEST(CurvatureRegulationConfigTest, DisabledAlwaysValid)
+{
+  CurvatureRegulationConfig config;  // empty curve but disabled
+  std::string error;
+  EXPECT_TRUE(validateCurvatureConfig(config, error));
+}
+
+TEST(CurvatureRegulationConfigTest, InvalidCurvesRejected)
+{
+  std::string error;
+
+  auto odd = bizzyLikeConfig();
+  odd.curve = {0.0, 0.26, 0.5};  // odd length
+  EXPECT_FALSE(validateCurvatureConfig(odd, error));
+
+  auto unsorted = bizzyLikeConfig();
+  unsorted.curve = {0.5, 0.4, 0.5, 0.3};  // speeds not strictly ascending
+  EXPECT_FALSE(validateCurvatureConfig(unsorted, error));
+
+  auto negative = bizzyLikeConfig();
+  negative.curve = {0.0, -0.26, 0.5, 0.4};  // negative capability
+  EXPECT_FALSE(validateCurvatureConfig(negative, error));
+
+  auto empty_enabled = bizzyLikeConfig();
+  empty_enabled.curve.clear();  // enabled with no curve
+  EXPECT_FALSE(validateCurvatureConfig(empty_enabled, error));
+
+  auto bad_margin = bizzyLikeConfig();
+  bad_margin.margin = 1.5;
+  EXPECT_FALSE(validateCurvatureConfig(bad_margin, error));
+
+  auto bad_pivot = bizzyLikeConfig();
+  bad_pivot.pivot_speed = -0.1;
+  EXPECT_FALSE(validateCurvatureConfig(bad_pivot, error));
+}


### PR DESCRIPTION
Curvature-preserving speed regulation in `helm_manager` (ADR-0012). Closes #292.

When a commanded `(v, ω)` exceeds the platform's capability envelope, both components are scaled by the same factor `s ∈ (0, 1]` so the yaw rate becomes achievable while the commanded curvature `v/ω` — the turn radius — is preserved exactly. Motivated by BizzyBoat's differential-drive conversion (rolker/unh_echoboats_project11#411): the planner can promise a tight radius and the helm makes it true by slowing through turns, instead of the old independent yaw clamp silently widening them.

## Design (ADR-0012, in this PR)

- **Proportional scaling, never clip yaw alone** — clipping ω widens the turn; reducing v alone tightens it; both leave the planned arc.
- **Per-platform envelope as parameters** — flat `[v, ω_max, …]` table, linear interpolation, clamp-constant ends, **no monotonicity assumption** (measured envelopes peak mid-speed); top-down feasibility scan with closed-form per-segment crossing.
- **Never speeds up**; floor at `capability_curve_pivot_speed` (keep moving, cap yaw) instead of stopping mid-line; true pivot stays a pivot with yaw clamped at rest capability.
- **Fail-safe**: param-gated default-off; invalid tables disable regulation with an error log; `max_speed`/`max_yaw_speed` clamps remain as backstop.
- **Regulated once at `update(TwistStamped)` entry** so both the twist output and the twist→helm conversion carry regulated values (plan-review must-fix, locked by node-level tests). `Helm` (throttle/rudder) operator input is deliberately not modulated.

## Contents

- `docs/decisions/0012-curvature-preserving-speed-regulation.md`
- `helm_manager/src/curvature_regulation.h` — pure logic (validation, capability lookup, regulation), no ROS deps
- `helm_manager` node: four `capability_curve_*` params (configure + hot-reload), regulation wiring
- 13 pure-logic tests + 2 node-level both-branches tests; README section

## Review

Pre-push /review-code: **approved, Ship: recommended** (deep mode, Round 1, 0 must-fix). One suggestion deferred: ParameterDescriptor descriptions for the new params (existing params lack them too — repo-wide pass later). Plan + reviews in `.agent/work-plans/issue-292/`.

## Test plan

`colcon test --packages-select helm_manager`: 135 tests, 0 failures (15 new curvature tests, 2 new node-level tests). Follow-ups (not this PR): `unh_marine_simulation` coverage (issue filed, non-gating); BizzyBoat provisional curve + planner radius in unh_echoboats_project11 (supersedes rolker/unh_echoboats_project11#412's interim envelope); IzzyBoat envelope rides rolker/unh_echoboats_project11#120.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
