### PR TITLE
docs: world/ datum + s100 siblings — ADR-0010 D3 amendment + consumer repoints

### DIFF
--- a/.agent/work-plans/issue-288/plan.md
+++ b/.agent/work-plans/issue-288/plan.md
@@ -48,8 +48,13 @@ ADR amendment (1) should merge before or alongside the consumer repoints (3–4)
    File: `docs/decisions/0010-geospatial-world-model.md`.
 
 2. **Verify updater covers `datum/`** — s57_tools#28 shipped but was scoped to ENC
-   download. Confirm whether it was extended to `datum/` (projsync + VDatum bundle),
-   or file a follow-on in `s57_tools` if not. No code change in this repo.
+   download. **Verified 2026-08-20 (host, against enc_updater source)**: the updater
+   *consumes* grids for the D7 export (`geoid`/`vdatum_dir` region config) but has
+   **no download/provisioning step** for them (no projsync / VDatum-bundle fetch in
+   `downloader.py` or elsewhere). → A follow-on s57_tools issue is required
+   ("provision world/datum/ grids: projsync geoid + VDatum bundle fetch");
+   **filing queued for the publish checkpoint** (local-first). No code change in
+   this repo.
 
 3. **Repoint `unh_marine_autonomy` consumers**:
    - `marine_vertical_datum/README.md` grid-provisioning section: update canonical
@@ -144,7 +149,7 @@ ADR amendment (1) should merge before or alongside the consumer repoints (3–4)
 
 ## Open Questions
 
-- [ ] Confirm whether s57_tools#28 (shipped/closed) was extended to download `datum/` grids, or whether a follow-on issue in s57_tools is needed for the projsync + VDatum bundle step (item 2).
+- [x] ~~Confirm whether s57_tools#28 was extended to download `datum/` grids~~ — **resolved 2026-08-20**: it was not (consumes but does not provision); follow-on s57_tools issue required, filing queued for the publish checkpoint (item 2).
 - [x] ~~Confirm the S-102 cache path~~ — **settled at the 2026-08-20 plan checkpoint**: separate `world/s100/` top-level sibling; S-102 cache at `~/data/world/s100/s102/`. Recorded in the ADR amendment (item 1).
 
 ## Estimated Scope

--- a/.agent/work-plans/issue-288/plan.md
+++ b/.agent/work-plans/issue-288/plan.md
@@ -1,0 +1,138 @@
+# Plan: Canonical home for geospatial support data under ~/data/world/
+
+## Issue
+
+https://github.com/rolker/unh_marine_autonomy/issues/288
+
+## Context
+
+ADR-0010 D3 establishes `~/data/world/` as the root for the geospatial world model
+but does not include a `datum/` subtree. Grids (geoid + VDatum regional `.gtx`) are
+currently downloaded at CMake build time by `mru_transform` into `~/.cache/mru_transform/`
+and symlink-installed into its package share; `chart_datum_launch.py` defaults point
+there. ENC data lives in hand-maintained `~/data/ENC_ROOT`; `s102_import` has no
+default cache path. User datum polygons are authored in project repos but have no
+canonical deploy-side location. The updater (s57_tools#28, **shipped/closed**)
+manages `~/data/world/charts/` but does not yet extend to `datum/`.
+
+This issue closes the gap: `datum/` joins `charts/` as a top-level sibling under
+`world/`, consumers are repointed, and the CMake build-time download is deleted once
+field hosts are provisioned.
+
+## Approach
+
+Six work items; items 1–6 are each their own sub-PR. Items 1–3 land in
+`unh_marine_autonomy`; items 4–6 land in their respective repos (noted below).
+ADR amendment (1) should merge before or alongside the consumer repoints (3–4).
+
+1. **Amend ADR-0010 D3** — add `datum/` subtree to the `~/data/world/` tree; add the
+   user-polygon materialization note (authored in project repos, copied to
+   `world/datum/user/` by the deploy/updater step, never updater-authored).
+   File: `docs/decisions/0010-geospatial-world-model.md`.
+
+2. **Verify updater covers `datum/`** — s57_tools#28 shipped but was scoped to ENC
+   download. Confirm whether it was extended to `datum/` (projsync + VDatum bundle),
+   or file a follow-on in `s57_tools` if not. No code change in this repo.
+
+3. **Repoint `unh_marine_autonomy` consumers**:
+   - `marine_vertical_datum/README.md` grid-provisioning section: update canonical
+     grid path from `~/.cache/mru_transform/...` to `~/data/world/datum/geoid/` and
+     `~/data/world/datum/vdatum/`.
+   - `marine_bathymetry_store` s102_import docs and `src/s102_import_main.cpp` help
+     text: note canonical cache path `~/data/world/charts/s102`.
+   - `docs/sonar_ecosystem.md`: reframe to mention the world model (ADR-0010 D1
+     consequence, already listed in ADR Consequences; last verified 2026-06-29, stale).
+   - Survey index path: `survey_index_bag`/`survey_index_query` use a relative
+     `survey_index.db` default — **no absolute path exists to update in code**.
+     Update `marine_survey_index/README.md` to note the canonical path becomes
+     `~/data/world/survey_index.db` and that the `--db` flag should be passed
+     explicitly with that path.
+
+4. **Repoint cross-repo consumers** (separate PRs in their own repos):
+   - `mru_transform` `launch/chart_datum_launch.py`: change `geoid_grid` default from
+     `$(_SHARE)/data/geoid/...` to `~/data/world/datum/geoid/us_noaa_g2018u0.tif`;
+     change `vdatum_grid_dir` default to `~/data/world/datum/vdatum`.
+   - `unh_echoboats_project11` izzyboat/gabby scripts: change
+     `ROS_S57_ENC_ROOT=/home/field/data/ENC_ROOT` →
+     `ROS_S57_ENC_ROOT=/home/field/data/world/charts`.
+
+5. **User polygon materialization step** (in `bizzyboat_project11` deploy config):
+   Add a deploy-step that copies the git-reviewed
+   `massabesic_datum_polygons.yaml` into `~/data/world/datum/user/` on the
+   target host. Git remains source of truth; `world/` is the discovery surface.
+
+6. **Delete `mru_transform` CMake download block** (GATED — in `mru_transform`):
+   Remove the `projsync` + VDatum zip download block entirely (no disabled fallback).
+   **Gate**: the PR may not merge until deploy-log entries from **both gabby and
+   salmon** confirm `~/data/world/datum/` is populated. The required evidence is the
+   output of:
+   ```
+   ls ~/data/world/datum/geoid/us_noaa_g2018u0.tif
+   ls ~/data/world/datum/vdatum/*_mllw.gtx 2>/dev/null | wc -l
+   ```
+   from each host (≥1 mllw file required), recorded in the deployment log.
+   This is satisfied by running the s57_tools updater (or a provisioning script) once
+   on each host before the deletion PR merges. Add a comment in the PR body citing the
+   specific log entries — `bizzyboat_deployment_log.md` timestamp lines are the
+   designated evidence location.
+
+## Files to Change
+
+| File | Repo | Change |
+|------|------|--------|
+| `docs/decisions/0010-geospatial-world-model.md` | unh_marine_autonomy | Amend D3 tree: add `datum/`; add user-polygon materialization note |
+| `marine_vertical_datum/README.md` | unh_marine_autonomy | Grid-provisioning section: canonical path → `~/data/world/datum/` |
+| `marine_bathymetry_store/src/s102_import_main.cpp` | unh_marine_autonomy | Help text: canonical cache → `~/data/world/charts/s102` |
+| `marine_bathymetry_store/README.md` | unh_marine_autonomy | s102_import invocation docs: update `--cache` example |
+| `docs/sonar_ecosystem.md` | unh_marine_autonomy | Reframe to reference world model (ADR-0010 D1) |
+| `marine_survey_index/README.md` | unh_marine_autonomy | Note canonical path `~/data/world/survey_index.db` for `--db` |
+| `mru_transform/launch/chart_datum_launch.py` | mru_transform | Default geoid/vdatum paths → `~/data/world/datum/` |
+| `mru_transform/CMakeLists.txt` | mru_transform | Delete download block (GATED, item 6) |
+| `izzyboat_project11/scripts/start_tmux_*.bash` | unh_echoboats_project11 | `ROS_S57_ENC_ROOT` → `world/charts` |
+| Deploy config | bizzyboat_project11 | Add polygon materialization step |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Human control and transparency | User polygons stay in git (PR review on safety-relevant files); `world/` is discovery-only |
+| Enforcement over documentation | CMake deletion gate is a verifiable deploy-log check, not an honor system |
+| A change includes its consequences | sonar_ecosystem.md reframe + survey index path included; cross-repo items scoped to explicit sub-PRs |
+| Only what's needed | No structural store changes; `world/` root already established by D3 |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| unh_marine_autonomy ADR-0010 | Yes | D3 amendment adds `datum/`; D7 updater scope confirmed/extended via s57_tools |
+| workspace ADR-0001 | Yes | Design amendment recorded in ADR text before code changes |
+
+## Consequences
+
+| If we change... | Also update... | Included? |
+|---|---|---|
+| `chart_datum_launch.py` defaults | Field deployment docs (bizzyboat_deployment_log bootstrap notes) | Yes — deploy log evidence is part of the gate (item 6) |
+| `ROS_S57_ENC_ROOT` scripts | On-host symlink or data migration step | Yes — part of item 4/5 sub-PRs |
+| Survey index default path | `marine_survey_index/README.md` | Yes — item 3 |
+| mru_transform CMake block deleted | CI build on a fresh `$HOME` must pass without grids | Yes — gate in item 6 ensures hosts are provisioned first |
+
+## Documentation & Instruction Impact
+
+- **Stale docs**: `marine_vertical_datum/README.md` (grid-provisioning section cites
+  `~/.cache/mru_transform/` implicitly; update to `~/data/world/datum/`).
+  `docs/sonar_ecosystem.md` (last updated 2026-06-29, predates world-model naming).
+  `marine_survey_index/README.md` (no canonical path for `--db`).
+  `marine_bathymetry_store/README.md` s102_import `--cache` example.
+- **Agent-instruction candidates**: None — the world-layout convention is already
+  captured in ADR-0010 and the `.agent/knowledge/` provisioning docs cover grid paths.
+
+## Open Questions
+
+- [ ] Confirm whether s57_tools#28 (shipped/closed) was extended to download `datum/` grids, or whether a follow-on issue in s57_tools is needed for the projsync + VDatum bundle step (item 2).
+- [ ] Confirm the S-102 cache path: `world/charts/s102` (charts sibling) or a separate `world/s100/` sibling — the issue says "updater's call"; record the chosen path in the ADR amendment or the s57_tools updater PR.
+
+## Estimated Scope
+
+Multiple PRs: item 1+3 (unh_marine_autonomy — this branch), items 4–6 in their
+respective repos. Items 4 and 5 can parallel-develop against item 1. Item 6 is last
+and gated.

--- a/.agent/work-plans/issue-288/plan.md
+++ b/.agent/work-plans/issue-288/plan.md
@@ -83,11 +83,11 @@ ADR amendment (1) should merge before or alongside the consumer repoints (3–4)
    deferred** (not covered by this item's boat-host deploy-step); noted here so the
    deferral is explicit.
 
-6. **Delete `mru_transform` CMake download block** (GATED — in `mru_transform`;
-   **explicitly blocked on item 2's outcome** — the updater (or a follow-on
-   provisioning script) must actually cover `datum/` before hosts can be provisioned.
-   s57_tools#28 status host-verified 2026-08-20: filed and CLOSED/shipped):
+6. **Delete `mru_transform` CMake download block** (GATED — in `mru_transform`):
    Remove the `projsync` + VDatum zip download block entirely (no disabled fallback).
+   **Blocked on item 2's outcome**: the updater (or a follow-on provisioning script)
+   must actually cover `datum/` before hosts can be provisioned. s57_tools#28 status
+   host-verified 2026-08-20: filed and CLOSED/shipped.
    **Gate**: the PR may not merge until deploy-log entries from **both gabby and
    salmon** confirm `~/data/world/datum/` is populated. The required evidence is the
    output of:

--- a/.agent/work-plans/issue-288/plan.md
+++ b/.agent/work-plans/issue-288/plan.md
@@ -25,9 +25,26 @@ Six work items; items 1–6 are each their own sub-PR. Items 1–3 land in
 `unh_marine_autonomy`; items 4–6 land in their respective repos (noted below).
 ADR amendment (1) should merge before or alongside the consumer repoints (3–4).
 
-1. **Amend ADR-0010 D3** — add `datum/` subtree to the `~/data/world/` tree; add the
-   user-polygon materialization note (authored in project repos, copied to
-   `world/datum/user/` by the deploy/updater step, never updater-authored).
+**Scope boundary vs. sibling issues** (settled at the 2026-08-20 plan checkpoint):
+
+- **#288 owns**: the `datum/` subtree (+ new `s100/` sibling), and datum/S-102/ENC
+  consumer repoints.
+- **uma#310 owns**: the `~/data/stores` → `~/data/world` store-root relocation and
+  its consequences (nav2 `store_path`, CAMP store paths, **survey-index path** —
+  all out of #288's scope).
+- **uma#311 owns**: the `docs/sonar_ecosystem.md` reframe (deliberately dropped
+  from #288 to avoid double-tracking).
+
+1. **Amend ADR-0010 D3** — add `datum/` and `s100/` subtrees to the `~/data/world/`
+   tree; add the user-polygon materialization note (authored in project repos, copied
+   to `world/datum/user/` by the deploy/updater step, never updater-authored).
+   The amendment must **justify `datum/`'s top-level placement** (support data, not a
+   store/feature/registry per D1) and the **git-authored `world/datum/user/` exception**
+   to D1's regenerable-from-source invariant (source of truth is the project repo;
+   the copy in `world/` is regenerable from git).
+   S-102 path decision (operator, 2026-08-20): S-100 family products get a top-level
+   `world/s100/` sibling (room for future S-100 products beyond S-102); the S-102
+   import cache lives at `~/data/world/s100/s102/`.
    File: `docs/decisions/0010-geospatial-world-model.md`.
 
 2. **Verify updater covers `datum/`** — s57_tools#28 shipped but was scoped to ENC
@@ -39,14 +56,10 @@ ADR amendment (1) should merge before or alongside the consumer repoints (3–4)
      grid path from `~/.cache/mru_transform/...` to `~/data/world/datum/geoid/` and
      `~/data/world/datum/vdatum/`.
    - `marine_bathymetry_store` s102_import docs and `src/s102_import_main.cpp` help
-     text: note canonical cache path `~/data/world/charts/s102`.
-   - `docs/sonar_ecosystem.md`: reframe to mention the world model (ADR-0010 D1
-     consequence, already listed in ADR Consequences; last verified 2026-06-29, stale).
-   - Survey index path: `survey_index_bag`/`survey_index_query` use a relative
-     `survey_index.db` default — **no absolute path exists to update in code**.
-     Update `marine_survey_index/README.md` to note the canonical path becomes
-     `~/data/world/survey_index.db` and that the `--db` flag should be passed
-     explicitly with that path.
+     text: note canonical cache path `~/data/world/s100/s102` (path settled at the
+     plan checkpoint — see item 1).
+   - (Dropped) `docs/sonar_ecosystem.md` reframe — owned by uma#311.
+   - (Dropped) survey-index path note — store-root territory, owned by uma#310.
 
 4. **Repoint cross-repo consumers** (separate PRs in their own repos):
    - `mru_transform` `launch/chart_datum_launch.py`: change `geoid_grid` default from
@@ -60,8 +73,15 @@ ADR amendment (1) should merge before or alongside the consumer repoints (3–4)
    Add a deploy-step that copies the git-reviewed
    `massabesic_datum_polygons.yaml` into `~/data/world/datum/user/` on the
    target host. Git remains source of truth; `world/` is the discovery surface.
+   Note: ADR-0010 D6 also lists CAMP (operator-side) as a datum-library consumer
+   needing grids on the operator station — **operator-station provisioning is
+   deferred** (not covered by this item's boat-host deploy-step); noted here so the
+   deferral is explicit.
 
-6. **Delete `mru_transform` CMake download block** (GATED — in `mru_transform`):
+6. **Delete `mru_transform` CMake download block** (GATED — in `mru_transform`;
+   **explicitly blocked on item 2's outcome** — the updater (or a follow-on
+   provisioning script) must actually cover `datum/` before hosts can be provisioned.
+   s57_tools#28 status host-verified 2026-08-20: filed and CLOSED/shipped):
    Remove the `projsync` + VDatum zip download block entirely (no disabled fallback).
    **Gate**: the PR may not merge until deploy-log entries from **both gabby and
    salmon** confirm `~/data/world/datum/` is populated. The required evidence is the
@@ -80,12 +100,10 @@ ADR amendment (1) should merge before or alongside the consumer repoints (3–4)
 
 | File | Repo | Change |
 |------|------|--------|
-| `docs/decisions/0010-geospatial-world-model.md` | unh_marine_autonomy | Amend D3 tree: add `datum/`; add user-polygon materialization note |
+| `docs/decisions/0010-geospatial-world-model.md` | unh_marine_autonomy | Amend D3 tree: add `datum/` + `s100/`; justify top-level placement + `user/` git exception; user-polygon materialization note |
 | `marine_vertical_datum/README.md` | unh_marine_autonomy | Grid-provisioning section: canonical path → `~/data/world/datum/` |
-| `marine_bathymetry_store/src/s102_import_main.cpp` | unh_marine_autonomy | Help text: canonical cache → `~/data/world/charts/s102` |
+| `marine_bathymetry_store/src/s102_import_main.cpp` | unh_marine_autonomy | Help text: canonical cache → `~/data/world/s100/s102` |
 | `marine_bathymetry_store/README.md` | unh_marine_autonomy | s102_import invocation docs: update `--cache` example |
-| `docs/sonar_ecosystem.md` | unh_marine_autonomy | Reframe to reference world model (ADR-0010 D1) |
-| `marine_survey_index/README.md` | unh_marine_autonomy | Note canonical path `~/data/world/survey_index.db` for `--db` |
 | `mru_transform/launch/chart_datum_launch.py` | mru_transform | Default geoid/vdatum paths → `~/data/world/datum/` |
 | `mru_transform/CMakeLists.txt` | mru_transform | Delete download block (GATED, item 6) |
 | `izzyboat_project11/scripts/start_tmux_*.bash` | unh_echoboats_project11 | `ROS_S57_ENC_ROOT` → `world/charts` |
@@ -97,7 +115,7 @@ ADR amendment (1) should merge before or alongside the consumer repoints (3–4)
 |---|---|
 | Human control and transparency | User polygons stay in git (PR review on safety-relevant files); `world/` is discovery-only |
 | Enforcement over documentation | CMake deletion gate is a verifiable deploy-log check, not an honor system |
-| A change includes its consequences | sonar_ecosystem.md reframe + survey index path included; cross-repo items scoped to explicit sub-PRs |
+| A change includes its consequences | Cross-repo items scoped to explicit sub-PRs; adjacent consequences explicitly routed to owners (sonar_ecosystem.md → uma#311, survey-index path → uma#310) |
 | Only what's needed | No structural store changes; `world/` root already established by D3 |
 
 ## ADR Compliance
@@ -113,23 +131,21 @@ ADR amendment (1) should merge before or alongside the consumer repoints (3–4)
 |---|---|---|
 | `chart_datum_launch.py` defaults | Field deployment docs (bizzyboat_deployment_log bootstrap notes) | Yes — deploy log evidence is part of the gate (item 6) |
 | `ROS_S57_ENC_ROOT` scripts | On-host symlink or data migration step | Yes — part of item 4/5 sub-PRs |
-| Survey index default path | `marine_survey_index/README.md` | Yes — item 3 |
 | mru_transform CMake block deleted | CI build on a fresh `$HOME` must pass without grids | Yes — gate in item 6 ensures hosts are provisioned first |
 
 ## Documentation & Instruction Impact
 
 - **Stale docs**: `marine_vertical_datum/README.md` (grid-provisioning section cites
   `~/.cache/mru_transform/` implicitly; update to `~/data/world/datum/`).
-  `docs/sonar_ecosystem.md` (last updated 2026-06-29, predates world-model naming).
-  `marine_survey_index/README.md` (no canonical path for `--db`).
   `marine_bathymetry_store/README.md` s102_import `--cache` example.
+  (`docs/sonar_ecosystem.md` → uma#311; `marine_survey_index/README.md` → uma#310.)
 - **Agent-instruction candidates**: None — the world-layout convention is already
   captured in ADR-0010 and the `.agent/knowledge/` provisioning docs cover grid paths.
 
 ## Open Questions
 
 - [ ] Confirm whether s57_tools#28 (shipped/closed) was extended to download `datum/` grids, or whether a follow-on issue in s57_tools is needed for the projsync + VDatum bundle step (item 2).
-- [ ] Confirm the S-102 cache path: `world/charts/s102` (charts sibling) or a separate `world/s100/` sibling — the issue says "updater's call"; record the chosen path in the ADR amendment or the s57_tools updater PR.
+- [x] ~~Confirm the S-102 cache path~~ — **settled at the 2026-08-20 plan checkpoint**: separate `world/s100/` top-level sibling; S-102 cache at `~/data/world/s100/s102/`. Recorded in the ADR amendment (item 1).
 
 ## Estimated Scope
 

--- a/.agent/work-plans/issue-288/progress.md
+++ b/.agent/work-plans/issue-288/progress.md
@@ -1,0 +1,70 @@
+---
+issue: 288
+---
+
+# Issue #288 — Canonical home for geospatial support data under ~/data/world/
+
+## Issue Review
+**Status**: complete
+**When**: 2026-08-20 12:46 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Issue**: #288
+**Comment**: (best-effort post follows this entry; not recorded inline)
+**Scope verdict**: well-scoped
+
+### Summary
+
+The issue proposes amending ADR-0010 D3 to add a `datum/` subtree under `~/data/world/`, giving VDatum grids, geoid files, and user override polygons a canonical, updater-managed location. It also relocates the S-102 fetch cache under `world/charts/`, repoints consumers, adds a materialization step for user datum polygons (from project repos into `world/datum/user/`), and gates the `mru_transform` CMake download block deletion on field-host provisioning.
+
+This matches the established umbrella-tracker pattern for ADR-0010 follow-on work (uma#86, uma#272); each work item will become its own sub-issue/PR.
+
+### Scope Assessment
+
+**Well-scoped?** Yes as a design/tracking issue — six concrete, bounded work items; each will land as its own sub-issue or PR. The issue correctly calls out its parent (#86, ADR-0010) and the decision it settles (design settled with Roland 2026-07-31).
+
+**Right repo?** Yes — unh_marine_autonomy owns ADR-0010 and the world model definition. s57_tools and mru_transform work items are correctly placed in their respective repos (s57_tools#28 referenced, mru_transform CMake deletion is a separate downstream task).
+
+**Dependencies?**
+- Requires s57_tools#28 (extend updater scope) — may not yet exist as an issue; should be created before the ADR amendment lands.
+- The `mru_transform` CMake block deletion (item 6) is gated on field-host (gabby/salmon) provisioning via the `world/` sync or a deployment provisioning step.
+- ADR-0010 amendment (item 1) should land first or alongside item 2 to avoid divergence between the ADR text and the implemented tree.
+
+### Principle Alignment
+
+| Principle | Status | Notes |
+|---|---|---|
+| Human control and transparency | OK | User polygon materialization from git preserves PR review for safety-relevant hand-authored files; design rationale fully documented. |
+| Enforcement over documentation | Watch | The CMake block deletion gate ("gated on field-host provisioning") has no named enforcement mechanism — easy to defer indefinitely. The work plan should define what "provisioned" means concretely (a provisioning script output, a deploy-step assertion, or a CI check). |
+| Capture decisions, not just implementations | OK | This issue is precisely recording a design amendment to ADR-0010; the 2026-07-31 design discussion is attributed. |
+| A change includes its consequences | Watch | `docs/sonar_ecosystem.md` reframe is listed in ADR-0010's Consequences section but not in this issue's work items. The survey index path (`~/data/stores/survey_index.db` → `~/data/world/`) is another known migration not explicitly called out in item 4. |
+| Only what's needed | OK | `world/` layout is well-bounded; evictable caches explicitly excluded; non-goals section is crisp. |
+| Improve incrementally | OK | Umbrella-tracker pattern is appropriate; each item lands separately. CMake deletion is correctly deferred until safety precondition is met. |
+| Safety First (project principle) | OK | CMake deletion gated on field-host readiness; user polygons stay in git for PR review; updater nav-liveness check (ADR-0010 D7) retained. |
+| Standards Compliance (project principle) | OK | No ROS 2 convention changes; library extraction (D6) follows established patterns. |
+
+### ADR Applicability
+
+| ADR | Triggered | Notes |
+|---|---|---|
+| unh_marine_autonomy ADR-0010 (D3 amendment) | Yes | The issue IS the amendment request; item 1 commits it. The amendment must clarify the user-polygon materialization model (authored in git, not updater-managed) alongside the tree layout. |
+| workspace ADR-0001 (adopt ADRs) | Yes | A design decision is being recorded. Amending ADR-0010 in the same PR as the code it documents is the correct pattern. |
+| workspace ADR-0003 (project-agnostic workspace) | No | All content stays in project repos. |
+| workspace ADR-0013 (progress.md vocabulary) | No | No new skill or entry type introduced. |
+
+### Consequences
+
+From ADR-0010's own Consequences section — items not explicitly listed in the issue's work items:
+- `docs/sonar_ecosystem.md` reframe (ADR-0010 Consequences paragraph) — not in issue work items. Should be a named sub-task or explicitly deferred.
+- Survey index path migration (`~/data/stores/survey_index.db`) — not called out in item 4; should be verified when repointing consumers.
+
+Recommendations:
+- Item 6 (delete CMake block) needs a named concrete gate: e.g., "deployment provisioning script runs `projsync`/VDatum download before field build; verified via a deploy-step output or a CI readiness check on the target host." Without this, the deletion may silently break the next fresh field build.
+- The S-102 cache relocation path (`world/charts/` vs `s100/` sibling) is deferred to the updater — acceptable, but the sub-issue for item 3 should capture that the path must be recorded in the edition registry once chosen.
+- Confirm s57_tools#28 is filed (or will be filed as part of this work) before the ADR amendment merges, so the referenced issue exists and is cross-linked.
+
+### Actions
+- [ ] Define a concrete, verifiable gate for the `mru_transform` CMake block deletion (item 6) — e.g., a provisioning script, deploy-step assertion, or field-host CI check — so "gated on field-host provisioning" cannot silently slip.
+- [ ] Add `docs/sonar_ecosystem.md` reframe to the work item list (or explicitly defer it with a reason); it is listed in ADR-0010's own Consequences and is omitted here.
+- [ ] Verify `~/data/stores/survey_index.db` path migration is captured in item 4 (repoint consumers).
+- [ ] Confirm s57_tools#28 is filed before or alongside item 1 (ADR-0010 amendment).

--- a/.agent/work-plans/issue-288/progress.md
+++ b/.agent/work-plans/issue-288/progress.md
@@ -99,3 +99,19 @@ Recommendations:
 - [ ] (suggestion) ADR amendment (item 1) must justify `datum/`'s top-level placement (support data, not a store/feature/registry per D1) and the git-authored `world/datum/user/` exception to D1's regenerable-from-source invariant. — `plan.md:28`
 - [ ] (suggestion) D6 lists CAMP (operator-side) as a datum-library consumer needing grids on the operator station; item 5 provisions only boat hosts — note or defer operator-station provisioning. — `plan.md:59`
 - [ ] (suggestion) Make item 6 explicitly blocked on item 2's outcome (updater datum/ coverage); confirm s57_tools#28 status (plan asserts shipped/closed; review-issue was unsure). — `plan.md:64`
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-08-20 13:26 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-288 at `040c945`
+**Mode**: pre-push
+**Depth**: Deep (reason: substantive ADR-0010 amendment [Deep trigger]; 307 changed lines ≥200)
+**Must-fix**: 1 | **Suggestions**: 1
+**Round**: 1 | **Ship**: continue — one mechanical wording contradiction (grids labeled "updater-managed" vs. this PR's verified "not yet provisioned"); design itself sound, expect fast convergence
+
+### Findings
+- [ ] (must-fix) ADR-0010 D3 + marine_vertical_datum README present datum grids as "updater-managed"/"populated by the updater", contradicting item-2's verified fact that the updater does not provision grids (provisioning is a queued follow-on); reword to intended/future or state provisioning is currently manual [cross-pass confirmed: Lens A + Lens B] — `docs/decisions/0010-geospatial-world-model.md:120,159`, `marine_vertical_datum/README.md:61`
+- [ ] (suggestion) `s100/` is also tagged "(updater-managed)" but the S-102 cache is populated by the operator-run `s102_import` CLI, not the cron updater — attribute to import tooling — `docs/decisions/0010-geospatial-world-model.md:118`

--- a/.agent/work-plans/issue-288/progress.md
+++ b/.agent/work-plans/issue-288/progress.md
@@ -168,8 +168,8 @@ Out-of-scope (not findings for this PR): stale `~/data/stores/` paths in `docs/s
 **CI**: failures-noted — `marine_autonomy_integration_tests` `test_command_bridge_routes_to_mission_manager` (launch_testing timing flake: "Expected clear_tasks ... got []" + KeyboardInterrupt teardown; both reported failures are the same test double-counted across Test.xml/xunit). Diff is docs-only + one help-text string — cannot affect command_bridge/mission_manager. jazzy branch green at 08-18. Failed-job re-run triggered 2026-08-20 to confirm flake.
 
 ### Findings
-- [ ] (trivial, Copilot) plan.md item-6 lead-in sentence hard to parse (flagged as unmatched paren; parens balance but the 4-line parenthetical is unreadable) — reword — `.agent/work-plans/issue-288/plan.md:85-88`
-- [ ] (trivial, Copilot) "(expanded)" wording ambiguous: `vdatum_query.cpp` does NOT expand `~`/env vars (verified — no wordexp/getenv), so state that literal absolute paths must be passed; also nest the `VDatumConfig` line under its parent bullet for correct Markdown structure — `marine_vertical_datum/README.md:72-75`
+- [x] (trivial, Copilot) plan.md item-6 lead-in sentence hard to parse (flagged as unmatched paren; parens balance but the 4-line parenthetical is unreadable) — reword — `.agent/work-plans/issue-288/plan.md:85-88`
+- [x] (trivial, Copilot) "(expanded)" wording ambiguous: `vdatum_query.cpp` does NOT expand `~`/env vars (verified — no wordexp/getenv), so state that literal absolute paths must be passed; also nest the `VDatumConfig` line under its parent bullet for correct Markdown structure — `marine_vertical_datum/README.md:72-75`
 
 ### False positives
 - (none)
@@ -177,3 +177,22 @@ Out-of-scope (not findings for this PR): stale `~/data/stores/` paths in `docs/s
 **Local-timeline reconciliation**: pre-push rounds 1–2 findings (provenance
 wording, datum/user symmetry caveat) all resolved before publish; Copilot raised
 neither, and raised nothing overlapping — no cross-source confirmations.
+
+## Implementation
+**Status**: complete
+**When**: 2026-08-20 14:10 +00:00
+**By**: Claude Code Agent (Claude Opus)
+
+**PR**: #312 at `0d8e93c`
+**Addressed**: Integrated Review (2026-08-20 10:07 -04:00, PR #312 at `d439d7d`)
+**Commits**: `a7de8ae`, `0d8e93c`
+
+### Actions
+- [x] (trivial, Copilot) Reworded plan.md item-6: pulled the "explicitly blocked on item 2 / s57_tools#28 status" clause out of the header's parenthetical into its own **Blocked on item 2's outcome** sentence, so the lead-in reads as a clean `(GATED — in mru_transform)` header — `.agent/work-plans/issue-288/plan.md:86-90`
+- [x] (trivial, Copilot) Replaced the ambiguous "(expanded)" annotation on the `VDatumConfig` example: verified `vdatum_query.cpp` has no `wordexp`/`getenv`/`expanduser` (grep clean across `src/` + `include/`), so the README now states literal absolute paths must be passed (`~`/env vars are used as-is and will not resolve) and shows a `/home/<user>/…` canonical example instead of the misleading tilde form; continuation lines stay indented under the parent bullet — `marine_vertical_datum/README.md:72-76`
+
+### Next step
+Lifecycle: **Implementation** → **review-code** (re-review the fixes). Hand off to a
+fresh-context sub-agent:
+
+    .agent/scripts/dispatch_subagent.sh --mode in-process --issue 288 --skill review-code

--- a/.agent/work-plans/issue-288/progress.md
+++ b/.agent/work-plans/issue-288/progress.md
@@ -156,3 +156,24 @@ fresh-context sub-agent:
 
 Local Adversarial skipped: Ollama server unreachable (localhost:11434 down; ollama not on PATH).
 Out-of-scope (not findings for this PR): stale `~/data/stores/` paths in `docs/sonar_reference.md:68-69` are store-root-relocation territory (uma#310); `docs/sonar_ecosystem.md` reframe is uma#311 — both correctly untouched per the plan's scope boundary.
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-08-20 10:07 -04:00
+**By**: Claude Code Agent (Claude Fable 5)
+
+**PR**: #312 at `d439d7d`
+**Sources**: 3 (Copilot R1 @ `d439d7d`, Local Review (Pre-Push) R1–R2 @ prior SHAs, CI rollup)
+**Cross-source confirmations**: 0
+**CI**: failures-noted — `marine_autonomy_integration_tests` `test_command_bridge_routes_to_mission_manager` (launch_testing timing flake: "Expected clear_tasks ... got []" + KeyboardInterrupt teardown; both reported failures are the same test double-counted across Test.xml/xunit). Diff is docs-only + one help-text string — cannot affect command_bridge/mission_manager. jazzy branch green at 08-18. Failed-job re-run triggered 2026-08-20 to confirm flake.
+
+### Findings
+- [ ] (trivial, Copilot) plan.md item-6 lead-in sentence hard to parse (flagged as unmatched paren; parens balance but the 4-line parenthetical is unreadable) — reword — `.agent/work-plans/issue-288/plan.md:85-88`
+- [ ] (trivial, Copilot) "(expanded)" wording ambiguous: `vdatum_query.cpp` does NOT expand `~`/env vars (verified — no wordexp/getenv), so state that literal absolute paths must be passed; also nest the `VDatumConfig` line under its parent bullet for correct Markdown structure — `marine_vertical_datum/README.md:72-75`
+
+### False positives
+- (none)
+
+**Local-timeline reconciliation**: pre-push rounds 1–2 findings (provenance
+wording, datum/user symmetry caveat) all resolved before publish; Copilot raised
+neither, and raised nothing overlapping — no cross-source confirmations.

--- a/.agent/work-plans/issue-288/progress.md
+++ b/.agent/work-plans/issue-288/progress.md
@@ -138,3 +138,21 @@ Lifecycle: **Implementation** → **review-code** (re-review the fixes). Hand of
 fresh-context sub-agent:
 
     .agent/scripts/dispatch_subagent.sh --mode in-process --issue 288 --skill review-code
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-08-20 13:36 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-288 at `4773469`
+**Mode**: pre-push
+**Depth**: Deep (reason: substantive ADR-0010 amendment [Deep trigger])
+**Must-fix**: 0 | **Suggestions**: 1
+**Round**: 2 | **Ship**: recommended — no must-fix; round-1 must-fix (grids "updater-managed" mislabel) + suggestion (s100 cache attribution) both verified addressed; only a low-priority symmetry suggestion remains
+
+### Findings
+- [ ] (suggestion) `datum/user/` materialization described present-tense without the "queued follow-on / not yet implemented" caveat the grids get; add for symmetry (deploy step = plan item 5, bizzyboat_project11) — `docs/decisions/0010-geospatial-world-model.md:170`
+
+Local Adversarial skipped: Ollama server unreachable (localhost:11434 down; ollama not on PATH).
+Out-of-scope (not findings for this PR): stale `~/data/stores/` paths in `docs/sonar_reference.md:68-69` are store-root-relocation territory (uma#310); `docs/sonar_ecosystem.md` reframe is uma#311 — both correctly untouched per the plan's scope boundary.

--- a/.agent/work-plans/issue-288/progress.md
+++ b/.agent/work-plans/issue-288/progress.md
@@ -196,3 +196,25 @@ Lifecycle: **Implementation** → **review-code** (re-review the fixes). Hand of
 fresh-context sub-agent:
 
     .agent/scripts/dispatch_subagent.sh --mode in-process --issue 288 --skill review-code
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-08-20 14:17 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-288 at `10a0e17`
+**Mode**: pre-push
+**Depth**: Deep (reason: substantive ADR-0010 D3 rewrite [Deep trigger])
+**Must-fix**: 1 | **Suggestions**: 0
+**Round**: 3 | **Ship**: continue — one NEW must-fix (must-fix rose 0→1 vs. round-2 approve): the ADR names a phantom S-102 cache origin path; single-line factual correction in a decision record, fast convergence expected
+
+### Findings
+- [ ] (must-fix) ADR amendment states the S-102 cache "moves from `~/data/stores/s102_cache`" — a phantom path found nowhere else in the repo; the real prior location (README on origin/jazzy, and what this PR itself edits) was `~/data/world/charts/s102`, and the plan Context says s102_import had no default cache path at all. Change the "from" to `~/data/world/charts/s102` (or drop the phantom origin). [cross-pass confirmed: Lens A + Lens B] — `docs/decisions/0010-geospatial-world-model.md:179`
+
+### Notes
+- Verified load-bearing claim: `marine_vertical_datum/README.md`'s assertion that the datum library does not expand `~`/env vars is code-accurate — `vdatum_query.cpp` passes `geoid_grid`/`vdatum_grid_dir` verbatim into the filesystem scan + PROJ pipeline (no wordexp/getenv/expanduser/HOME).
+- S-102 cache path (`s100/s102`) consistent across all four changed files; Lens B grep confirms no stale `charts/s102` stragglers in any consumer.
+- Round-2 residual suggestion (datum/user/ "queued follow-on" symmetry caveat) resolved in the amendment prose — not re-raised.
+- Local Adversarial skipped: Ollama unreachable (localhost:11434 down; ollama not on PATH). Copilot Adversarial off (default; --copilot not passed).
+- Plan drift: none — diff matches plan items 1+3 (this-branch scope); items 4–6 are separate cross-repo PRs.

--- a/.agent/work-plans/issue-288/progress.md
+++ b/.agent/work-plans/issue-288/progress.md
@@ -68,3 +68,16 @@ Recommendations:
 - [ ] Add `docs/sonar_ecosystem.md` reframe to the work item list (or explicitly defer it with a reason); it is listed in ADR-0010's own Consequences and is omitted here.
 - [ ] Verify `~/data/stores/survey_index.db` path migration is captured in item 4 (repoint consumers).
 - [ ] Confirm s57_tools#28 is filed before or alongside item 1 (ADR-0010 amendment).
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-08-20 14:10 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Plan**: `.agent/work-plans/issue-288/plan.md` at `d10e736`
+**Branch**: feature/issue-288 at `d10e736`
+**Phases**: multiple (6 work items; items 1+3 land on this branch, items 4–6 in cross-repo sub-PRs)
+
+### Open questions
+- [ ] Confirm whether s57_tools#28 (shipped/closed) was extended to `datum/` grids, or if a follow-on s57_tools issue is needed.
+- [ ] Confirm S-102 cache path choice: `world/charts/s102` vs `world/s100/` — record in ADR amendment or updater PR.

--- a/.agent/work-plans/issue-288/progress.md
+++ b/.agent/work-plans/issue-288/progress.md
@@ -81,3 +81,21 @@ Recommendations:
 ### Open questions
 - [ ] Confirm whether s57_tools#28 (shipped/closed) was extended to `datum/` grids, or if a follow-on s57_tools issue is needed.
 - [ ] Confirm S-102 cache path choice: `world/charts/s102` vs `world/s100/` — record in ADR amendment or updater PR.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-08-20 13:09 +00:00
+**By**: Claude Code Agent (Claude Opus)
+<!-- Independent: plan authored by Claude Sonnet in a prior context; this review is a fresh-context Opus sub-agent, not the author, so no self-review annotation. -->
+
+**Plan**: `.agent/work-plans/issue-288/plan.md` at `d10e736`
+**PR**: PR-less (`--issue` / host-dispatch mode)
+**Verdict**: changes-requested
+
+### Findings
+- [ ] (must-fix) Scope boundary vs **uma#310** (store-root migration) not declared; item 3 relocates `survey_index.db` — #310's territory — while other root-migration consequences (nav2 `store_path`, CAMP paths) are uncovered. State the boundary: #288 = `datum/` subtree + datum/S-102/ENC consumer repoints; #310 = store-root relocation. — `plan.md:46`
+- [ ] (must-fix) `docs/sonar_ecosystem.md` reframe double-tracked with **uma#311** (ecosystem-doc housekeeping); assign a single owner (leans #311) and remove from the other plan. — `plan.md:44`
+- [ ] (must-fix) Item 3 edits `s102_import_main.cpp` help text to cite `~/data/world/charts/s102`, a path the plan itself flags as unsettled (Open Q2); resolve the path and reconcile with ADR-0010 D11 (S-102 = gridded depth → raster convention) before touching the .cpp. — `plan.md:41`
+- [ ] (suggestion) ADR amendment (item 1) must justify `datum/`'s top-level placement (support data, not a store/feature/registry per D1) and the git-authored `world/datum/user/` exception to D1's regenerable-from-source invariant. — `plan.md:28`
+- [ ] (suggestion) D6 lists CAMP (operator-side) as a datum-library consumer needing grids on the operator station; item 5 provisions only boat hosts — note or defer operator-station provisioning. — `plan.md:59`
+- [ ] (suggestion) Make item 6 explicitly blocked on item 2's outcome (updater datum/ coverage); confirm s57_tools#28 status (plan asserts shipped/closed; review-issue was unsure). — `plan.md:64`

--- a/.agent/work-plans/issue-288/progress.md
+++ b/.agent/work-plans/issue-288/progress.md
@@ -113,5 +113,28 @@ Recommendations:
 **Round**: 1 | **Ship**: continue — one mechanical wording contradiction (grids labeled "updater-managed" vs. this PR's verified "not yet provisioned"); design itself sound, expect fast convergence
 
 ### Findings
-- [ ] (must-fix) ADR-0010 D3 + marine_vertical_datum README present datum grids as "updater-managed"/"populated by the updater", contradicting item-2's verified fact that the updater does not provision grids (provisioning is a queued follow-on); reword to intended/future or state provisioning is currently manual [cross-pass confirmed: Lens A + Lens B] — `docs/decisions/0010-geospatial-world-model.md:120,159`, `marine_vertical_datum/README.md:61`
-- [ ] (suggestion) `s100/` is also tagged "(updater-managed)" but the S-102 cache is populated by the operator-run `s102_import` CLI, not the cron updater — attribute to import tooling — `docs/decisions/0010-geospatial-world-model.md:118`
+- [x] (must-fix) ADR-0010 D3 + marine_vertical_datum README present datum grids as "updater-managed"/"populated by the updater", contradicting item-2's verified fact that the updater does not provision grids (provisioning is a queued follow-on); reword to intended/future or state provisioning is currently manual [cross-pass confirmed: Lens A + Lens B] — `docs/decisions/0010-geospatial-world-model.md:120,159`, `marine_vertical_datum/README.md:61`
+- [x] (suggestion) `s100/` is also tagged "(updater-managed)" but the S-102 cache is populated by the operator-run `s102_import` CLI, not the cron updater — attribute to import tooling — `docs/decisions/0010-geospatial-world-model.md:118`
+
+## Implementation
+**Status**: complete
+**When**: 2026-08-20 13:30 +00:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Branch**: feature/issue-288 at `e0812f8`
+**Addressed**: Local Review (Pre-Push) (2026-08-20 13:26 +00:00, branch feature/issue-288 at `040c945`)
+**Commits**: `e0812f8`
+
+### Actions
+- [x] (must-fix) Reworded datum grids from "updater-managed"/"populated by the updater" to "intended to be updater-managed"; state the updater does not yet provision grids (projsync geoid + VDatum bundle is a queued s57_tools follow-on) and they are currently placed manually — `docs/decisions/0010-geospatial-world-model.md:119-121,162-165`, `marine_vertical_datum/README.md:61-63`
+- [x] (suggestion) Re-attributed the `s100/` S-102 import cache from "(updater-managed)" to the operator-run `s102_import` CLI, not the cron updater — `docs/decisions/0010-geospatial-world-model.md:117-119`
+
+Both findings corrected the same "updater-managed" provenance mislabel and fell
+within one contiguous ADR diff hunk (the D3 tree diagram), so they landed in a
+single commit rather than split.
+
+### Next step
+Lifecycle: **Implementation** → **review-code** (re-review the fixes). Hand off to a
+fresh-context sub-agent:
+
+    .agent/scripts/dispatch_subagent.sh --mode in-process --issue 288 --skill review-code

--- a/docs/decisions/0010-geospatial-world-model.md
+++ b/docs/decisions/0010-geospatial-world-model.md
@@ -176,8 +176,11 @@ regenerable, never hand-edited in place, and never updater-authored.
 **`s100/`** hosts S-100 family products as their own top-level sibling
 (decided at the #288 plan checkpoint): the family will span both raster
 (S-102) and feature (S-101) products, so it does not belong under `charts/`.
-The S-102 import cache moves from `~/data/stores/s102_cache` to
-`~/data/world/s100/s102/`.
+The S-102 import cache's canonical location is `~/data/world/s100/s102/` —
+superseding both the `~/data/world/charts/s102` example previously documented
+in the `marine_bathymetry_store` README (#278; `s102_import` itself has no
+default `--cache` path) and ad-hoc pre-world locations in use on existing
+hosts (e.g. `~/data/stores/s102_cache`).
 
 ### D4 — Layers encode process; σ encodes trust
 

--- a/docs/decisions/0010-geospatial-world-model.md
+++ b/docs/decisions/0010-geospatial-world-model.md
@@ -168,9 +168,10 @@ follow-on. Until it lands, grids are placed manually.
 regenerable-from-source posture: override polygons (e.g.
 `massabesic_datum_polygons.yaml`) are safety-relevant and stay PR-reviewed in
 their project repo, which remains the source of truth; a deploy step
-**materializes** a copy into `world/datum/user/` for discovery. The invariant
-holds with git as the source — the copy is regenerable, never hand-edited in
-place, and never updater-authored.
+**materializes** a copy into `world/datum/user/` for discovery (the deploy
+step is a queued follow-on in `bizzyboat_project11` — #288 plan item 5 — not
+yet implemented). The invariant holds with git as the source — the copy is
+regenerable, never hand-edited in place, and never updater-authored.
 
 **`s100/`** hosts S-100 family products as their own top-level sibling
 (decided at the #288 plan checkpoint): the family will span both raster

--- a/docs/decisions/0010-geospatial-world-model.md
+++ b/docs/decisions/0010-geospatial-world-model.md
@@ -115,10 +115,13 @@ load-bearing: an operator authorized to work inside a restricted area waives
 ├── features/     contacts (ADR-0004); chart features thin — see D11
 ├── charts/       the ENC corpus itself + edition registry (cron-managed, D7)
 ├── s100/         S-100 family products; S-102 import cache at s100/s102/
-│                 (updater-managed; amended 2026-08-20, #288)
+│                 (populated by the operator-run s102_import CLI, not the
+│                 cron updater; amended 2026-08-20, #288)
 └── datum/        vertical-datum support data: geoid/ + vdatum/ grids
-                  (updater-managed) + user/ override polygons materialized
-                  from git (amended 2026-08-20, #288 — see amendment below)
+                  (updater-managed target — provisioning is a queued
+                  s57_tools follow-on, currently manual) + user/ override
+                  polygons materialized from git
+                  (amended 2026-08-20, #288 — see amendment below)
 ```
 
 Provenance layers for the depth theme, replacing ADR-0002 A2's
@@ -156,8 +159,10 @@ plus user override polygons, consumed across themes (S-102 depth imports, the
 D6 datum library and its CAMP/operator use, `chart_datum_node`). Because no
 single store owns it and it is neither a feature set nor a registry (D1), it
 sits as a **top-level sibling** rather than inside `charts/` or `depths/`.
-Grids (`datum/geoid/`, `datum/vdatum/`) are **updater-managed** like the ENC
-corpus (D7).
+Grids (`datum/geoid/`, `datum/vdatum/`) are **intended to be updater-managed**
+like the ENC corpus (D7), but the updater does not yet provision them: that
+download step (projsync geoid + VDatum bundle) is a queued `s57_tools`
+follow-on. Until it lands, grids are placed manually.
 
 **`datum/user/` is the one git-authored exception** to the
 regenerable-from-source posture: override polygons (e.g.

--- a/docs/decisions/0010-geospatial-world-model.md
+++ b/docs/decisions/0010-geospatial-world-model.md
@@ -113,7 +113,12 @@ load-bearing: an operator authorized to work inside a restricted area waives
 ├── imagery/      sidescan store (two-tier, ADR-0006) +
 │                 MBES backscatter store (CUBE-coupled, ADR-0007)
 ├── features/     contacts (ADR-0004); chart features thin — see D11
-└── charts/       the ENC corpus itself + edition registry (cron-managed, D7)
+├── charts/       the ENC corpus itself + edition registry (cron-managed, D7)
+├── s100/         S-100 family products; S-102 import cache at s100/s102/
+│                 (updater-managed; amended 2026-08-20, #288)
+└── datum/        vertical-datum support data: geoid/ + vdatum/ grids
+                  (updater-managed) + user/ override polygons materialized
+                  from git (amended 2026-08-20, #288 — see amendment below)
 ```
 
 Provenance layers for the depth theme, replacing ADR-0002 A2's
@@ -143,6 +148,30 @@ split — it is **re-classified wholesale to `processed/`**, which is accurate:
 the current Massabesic stores were regenerated via `import_bag` (the
 authoritative path). `draft/` starts empty. Beyond that, path changes are
 config migration.
+
+#### D3 amendment (2026-08-20, #288) — `datum/` and `s100/` siblings
+
+**`datum/` is support data, not a store** — geoid and VDatum regional grids
+plus user override polygons, consumed across themes (S-102 depth imports, the
+D6 datum library and its CAMP/operator use, `chart_datum_node`). Because no
+single store owns it and it is neither a feature set nor a registry (D1), it
+sits as a **top-level sibling** rather than inside `charts/` or `depths/`.
+Grids (`datum/geoid/`, `datum/vdatum/`) are **updater-managed** like the ENC
+corpus (D7).
+
+**`datum/user/` is the one git-authored exception** to the
+regenerable-from-source posture: override polygons (e.g.
+`massabesic_datum_polygons.yaml`) are safety-relevant and stay PR-reviewed in
+their project repo, which remains the source of truth; a deploy step
+**materializes** a copy into `world/datum/user/` for discovery. The invariant
+holds with git as the source — the copy is regenerable, never hand-edited in
+place, and never updater-authored.
+
+**`s100/`** hosts S-100 family products as their own top-level sibling
+(decided at the #288 plan checkpoint): the family will span both raster
+(S-102) and feature (S-101) products, so it does not belong under `charts/`.
+The S-102 import cache moves from `~/data/stores/s102_cache` to
+`~/data/world/s100/s102/`.
 
 ### D4 — Layers encode process; σ encodes trust
 

--- a/marine_bathymetry_store/README.md
+++ b/marine_bathymetry_store/README.md
@@ -217,7 +217,7 @@ ed3.0.0) for a geographic area and imports it into a store layer:
 ```bash
 ros2 run marine_bathymetry_store s102_import \
   --area -70.75,42.90,-70.55,43.05 \
-  --store /path/to/scratch_store --cache ~/data/world/charts/s102 \
+  --store /path/to/scratch_store --cache ~/data/world/s100/s102 \
   --datum vdatum --geoid <geoid.tif> --vdatum-grids <gtx_dir>
 ```
 

--- a/marine_bathymetry_store/src/s102_import_main.cpp
+++ b/marine_bathymetry_store/src/s102_import_main.cpp
@@ -56,6 +56,7 @@ void usage()
     "                   [--offline] [--force]\n"
     "\n"
     "Fetches NOAA S-102 ed3.0.0 tiles intersecting --area into --cache\n"
+    "(canonical: ~/data/world/s100/s102 — ADR-0010 D3 as amended by #288)\n"
     "(SHA256-verified, idempotent), converts them to store convention\n"
     "(geographic WGS84, per-cell MLLW->ellipsoid via --datum), and imports\n"
     "each at the GGGS level matching its native resolution.\n"

--- a/marine_vertical_datum/README.md
+++ b/marine_vertical_datum/README.md
@@ -55,6 +55,12 @@ matching the bathymetry store's convention.
 Grids live **wherever imports run** — dev machines and the boat as offline
 tooling — never on the navigation runtime (ADR-0010 D6/D7).
 
+The **canonical on-host location** is the world tree (ADR-0010 D3, amended
+by [#288](https://github.com/rolker/unh_marine_autonomy/issues/288)):
+`~/data/world/datum/geoid/` for the geoid file and `~/data/world/datum/vdatum/`
+for the regional `.gtx` directory, populated by the updater/provisioning step
+rather than hand-managed.
+
 - **Geoid** (ellipsoid → NAVD88): e.g. `us_noaa_g2018u0.tif`, via
   `projsync --file us_noaa_g2018u0.tif` or from
   <https://cdn.proj.org/>.
@@ -62,9 +68,10 @@ tooling — never on the navigation runtime (ADR-0010 D6/D7).
   VDatum grid bundles from NOAA (<https://vdatum.noaa.gov/>) and extract the
   `*.gtx` files into one directory; the query scans it recursively for
   `*_mllw*.gtx` / `*_mhhw*.gtx`.
-- Point `VDatumConfig` at both. PROJ networking is disabled in this library,
-  so nothing is fetched at query time — missing grids fail setup loudly via
-  `DiagFn`.
+- Point `VDatumConfig` at both — canonically
+  `{"~/data/world/datum/geoid/us_noaa_g2018u0.tif", "~/data/world/datum/vdatum"}`
+  (expanded). PROJ networking is disabled in this library, so nothing is
+  fetched at query time — missing grids fail setup loudly via `DiagFn`.
 
 Where VDatum has no coverage (inland lakes), use the polygon config /
 lake-datum override instead — that is the precedence chain's job.

--- a/marine_vertical_datum/README.md
+++ b/marine_vertical_datum/README.md
@@ -69,10 +69,12 @@ it lands, populate them manually as below.
   VDatum grid bundles from NOAA (<https://vdatum.noaa.gov/>) and extract the
   `*.gtx` files into one directory; the query scans it recursively for
   `*_mllw*.gtx` / `*_mhhw*.gtx`.
-- Point `VDatumConfig` at both — canonically
-  `{"~/data/world/datum/geoid/us_noaa_g2018u0.tif", "~/data/world/datum/vdatum"}`
-  (expanded). PROJ networking is disabled in this library, so nothing is
-  fetched at query time — missing grids fail setup loudly via `DiagFn`.
+- Point `VDatumConfig` at both — pass **literal absolute paths**; the library
+  does not expand `~` or environment variables, so a tilde form is used as-is
+  and will not resolve. Canonically
+  `{"/home/<user>/data/world/datum/geoid/us_noaa_g2018u0.tif", "/home/<user>/data/world/datum/vdatum"}`.
+  PROJ networking is disabled in this library, so nothing is fetched at query
+  time — missing grids fail setup loudly via `DiagFn`.
 
 Where VDatum has no coverage (inland lakes), use the polygon config /
 lake-datum override instead — that is the precedence chain's job.

--- a/marine_vertical_datum/README.md
+++ b/marine_vertical_datum/README.md
@@ -58,8 +58,9 @@ tooling — never on the navigation runtime (ADR-0010 D6/D7).
 The **canonical on-host location** is the world tree (ADR-0010 D3, amended
 by [#288](https://github.com/rolker/unh_marine_autonomy/issues/288)):
 `~/data/world/datum/geoid/` for the geoid file and `~/data/world/datum/vdatum/`
-for the regional `.gtx` directory, populated by the updater/provisioning step
-rather than hand-managed.
+for the regional `.gtx` directory. Provisioning these grids into the world tree
+is an intended updater/provisioning step (a queued `s57_tools` follow-on); until
+it lands, populate them manually as below.
 
 - **Geoid** (ellipsoid → NAVD88): e.g. `us_noaa_g2018u0.tif`, via
   `projsync --file us_noaa_g2018u0.tif` or from


### PR DESCRIPTION
Part of #288 — delivers work items 1–3 (the `unh_marine_autonomy` scope of the umbrella). Items 4–6 (mru_transform launch defaults, echoboats `ROS_S57_ENC_ROOT`, bizzyboat polygon deploy-step, gated CMake deletion) follow as sub-PRs in their own repos.

## What's here

- **ADR-0010 D3 amendment**: `datum/` and `s100/` join the `~/data/world/` tree as top-level siblings, with the placement justification (cross-theme support data, not a store/feature/registry per D1), the git-authored `world/datum/user/` exception (project repo stays source of truth; a deploy step — queued, plan item 5 — materializes the copy), and the settled S-102 cache path `~/data/world/s100/s102/`.
- **Consumer repoints**: `marine_vertical_datum/README.md` gains the canonical `world/datum/` grid locations; `s102_import` help text + `marine_bathymetry_store/README.md` example move the cache to `world/s100/s102`.
- **Item-2 verification recorded**: the `enc_updater` consumes datum grids (`geoid`/`vdatum_dir` region config) but has **no provisioning step** — follow-on filed in `s57_tools`. Provenance wording in the ADR/README reflects this (intended updater target, currently manual).

## Scope boundary (settled at the plan checkpoint)

- **uma#310** owns the store-root migration (incl. survey-index path) — out of scope here.
- **uma#311** owns the `docs/sonar_ecosystem.md` reframe — deliberately dropped from this PR.

## Review trail

Plan review (3 must-fixes, all resolved at the plan checkpoint) → two local pre-push review rounds → round 2: no must-fix, **Ship: recommended**; final symmetry suggestion applied. Full timeline in `.agent/work-plans/issue-288/progress.md`.

Docs-only PR — no Test plan section.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
