### PR TITLE
Field import: unh_marine_autonomy (2026-08-20)

### DIFF
--- a/marine_autonomy/launch/operator_ui_launch.py
+++ b/marine_autonomy/launch/operator_ui_launch.py
@@ -116,7 +116,7 @@ def generate_launch_description():
         executable='CCOMAutonomousMissionPlanner',
         name='camp2',
         arguments=[
-           PathJoinSubstitution([ FindPackageShare('camp'), '/workspace/'])],
+           PathJoinSubstitution([ FindPackageShare('camp'), 'workspace/'])],
         namespace=namespace,
         parameters=[{'robot_namespace': robot_namespace}],
         condition=IfCondition(dual_camp),

--- a/marine_autonomy/launch/operator_ui_launch.py
+++ b/marine_autonomy/launch/operator_ui_launch.py
@@ -37,7 +37,6 @@ from launch.substitutions import LaunchConfiguration
 def generate_launch_description():
     namespace = LaunchConfiguration('namespace')
     robot_namespace = LaunchConfiguration('robot_namespace')
-    background_chart = LaunchConfiguration('background_chart')
     rqt = LaunchConfiguration('rqt')
     rqt_perspective = LaunchConfiguration('rqt_perspective')
     rviz = LaunchConfiguration('rviz')
@@ -49,13 +48,6 @@ def generate_launch_description():
     )
     robot_namespace_arg = DeclareLaunchArgument(
         "robot_namespace", default_value="ben"
-    )
-    background_chart_arg = DeclareLaunchArgument(
-        "background_chart",
-         default_value=PathJoinSubstitution([
-              FindPackageShare('camp'),
-               'workspace/13283/13283_2.KAP'
-         ])
     )
     rqt_arg = DeclareLaunchArgument(
         "rqt", default_value="false"
@@ -106,9 +98,12 @@ def generate_launch_description():
         package='camp',
         executable='CCOMAutonomousMissionPlanner',
         name='camp',
+        # Workspace directory only. CAMP no longer needs a background raster
+        # supplied at launch: it carries an OpenStreetMap backdrop, and charts
+        # are app state it persists and restores itself. The 13283 raster this
+        # used to force is obsolete.
         arguments=[
-           PathJoinSubstitution([ FindPackageShare('camp'), 'workspace/']),
-           background_chart],
+           PathJoinSubstitution([ FindPackageShare('camp'), 'workspace/'])],
         namespace=namespace,
         parameters=[{'robot_namespace': robot_namespace}],
         respawn=True,
@@ -121,8 +116,7 @@ def generate_launch_description():
         executable='CCOMAutonomousMissionPlanner',
         name='camp2',
         arguments=[
-           PathJoinSubstitution([ FindPackageShare('camp'), '/workspace/']),
-           background_chart],
+           PathJoinSubstitution([ FindPackageShare('camp'), '/workspace/'])],
         namespace=namespace,
         parameters=[{'robot_namespace': robot_namespace}],
         condition=IfCondition(dual_camp),
@@ -132,7 +126,6 @@ def generate_launch_description():
     return LaunchDescription([
         namespace_arg,
         robot_namespace_arg,
-        background_chart_arg,
         rqt_arg,
         rqt_perspective_arg,
         rviz_arg,


### PR DESCRIPTION
Closes #317.

Field import from gitcloud: operator_ui launch no longer forces the obsolete 13283 background raster on CAMP (argument removed outright). Pre-review clean — see #317. Pairs with rolker/camp#192's launch commit.

**Diverged branch note**: cut from `gitcloud/jazzy`; jazzy has 120 newer local commits (recent uma arcs incl. today's ADR-0010 D3 amendment). This PR's merge reconciles; field SHAs preserved.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
