### PR TITLE
import_geotiff: vdatum-aware vertical conversion for reference imports (MLLW → ellipsoid)

### DIFF
--- a/.agent/work-plans/issue-315/progress.md
+++ b/.agent/work-plans/issue-315/progress.md
@@ -1,0 +1,28 @@
+---
+issue: 315
+---
+
+# Issue #315 — import_geotiff: vdatum-aware vertical conversion for reference imports (MLLW → ellipsoid)
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-08-20 17:10 -04:00
+**By**: Claude Code Agent (Claude Fable 5)
+**Verdict**: approved
+
+**Branch**: feature/issue-315 at `f1766b4`
+**Mode**: pre-push
+**Depth**: Standard (reason: new conversion behavior feeding the nav costmap, ~400 lines / 11 files, C++)
+**Must-fix**: 2 | **Suggestions**: 2
+**Round**: 1 | **Ship**: recommended — all findings fixed in-session, 336 tests green across marine_bathymetry_store + marine_vertical_datum
+
+Static analysis: covered by the packages' ament lint colcon tests (green). Plan drift: no work plan (direct implementation per operator direction). Copilot: off (default). Local model: skipped per operator guidance (--no-local while workspace#590 pends). Governance: README doc consequence carried; ADR-0010 D4 datum-at-import satisfied; Reference read-only gate untouched.
+
+### Findings
+- [x] (must-fix, cross-confirmed: Lens A + Lens B) --source-datum whole-record-replaced registry.json, blanking prior platform/sensor/survey/date (and conversely a later single-flag run erased the datum stamp) — field-wise merge — `marine_bathymetry_store/src/import_geotiff_main.cpp`
+- [x] (must-fix, cross-confirmed: Lens A suggestion + Lens B must-fix) no-coverage hard error escaped main uncaught (std::terminate) — try/catch print + exit 1 on the normal-mode import/save — `marine_bathymetry_store/src/import_geotiff_main.cpp`
+- [x] (suggestion, Lens B) vertical_datum_fn serial-invocation contract undocumented at the importer boundary — doc block added — `marine_bathymetry_store/include/marine_bathymetry_store/geotiff_import.hpp`
+- [x] (suggestion, Lens B) per-pixel MHHW proj_trans discarded — VDatumConfig.want_mhhw MLLW-only mode, CLI opts in — `marine_vertical_datum`
+
+### False positives
+- (none)

--- a/marine_bathymetry_store/CMakeLists.txt
+++ b/marine_bathymetry_store/CMakeLists.txt
@@ -82,7 +82,8 @@ install(TARGETS ${PROJECT_NAME}
 
 # The `import_geotiff` CLI: import a GeoTIFF into a store layer's fused surface.
 add_executable(import_geotiff src/import_geotiff_main.cpp)
-target_link_libraries(import_geotiff ${PROJECT_NAME})
+target_link_libraries(import_geotiff ${PROJECT_NAME}
+  marine_vertical_datum::marine_vertical_datum)
 
 # S-102 importer core (#278): discover/fetch/convert/run stages as an internal
 # static library so the pipeline is testable without spawning the CLI. Its

--- a/marine_bathymetry_store/README.md
+++ b/marine_bathymetry_store/README.md
@@ -164,6 +164,19 @@ import_geotiff --commit /path/to/staged /path/to/store
 `import_geotiff <store_dir> <layer> <geotiff>`; `chart` is stage/commit only (a
 chart layer is never written into a live store incrementally).
 
+**Tidal-datum-referenced sources**
+([#315](https://github.com/rolker/unh_marine_autonomy/issues/315)): a grid
+referenced to MLLW imports with
+`--source-datum mllw --geoid <grid> --vdatum-dir <dir>` — each pixel's
+vertical offset is the MLLW ellipsoidal height *at that point* from the
+VDatum grids (the same `world/datum/` grids the `enc_updater` provisions),
+never a hand-computed constant. Pixels default to positive-down depths below
+the datum (`h_ellip = mllw_z − depth`); pass `--source-up` for up-positive
+datum-relative heights. Mutually exclusive with
+`--depth-scale`/`--depth-offset`; a point outside the grids' coverage is a
+hard error (a partially converted surface never imports); the source datum
+is recorded in `registry.json` provenance (`datum` field).
+
 Sequence — everything that can refuse does so **before** the live layer is
 touched, so a rejected regeneration leaves the old layer standing (D7):
 

--- a/marine_bathymetry_store/include/marine_bathymetry_store/geotiff_import.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/geotiff_import.hpp
@@ -24,6 +24,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <limits>
 #include <optional>
 #include <string>
@@ -66,6 +67,21 @@ struct GeoTiffImportOptions
   /// ellipsoidal height.
   double depth_scale = 1.0;
   double depth_offset = 0.0;
+  /// Per-point vertical-datum resolver (#315): when set, the source datum's
+  /// ellipsoidal height at each pixel's (lat, lon) replaces the constant
+  /// `depth_offset` — `height = depth_scale * pixel + fn(lat, lon)`. This is
+  /// how a tidal-datum-referenced grid (e.g. depths below MLLW) imports
+  /// without a hand-computed constant: the offset varies across the extent
+  /// and comes from the VDatum grids (the CLI builds this from
+  /// marine_vertical_datum::make_vdatum_query, keeping this library
+  /// PROJ-free). Returning std::nullopt means the datum grids have no
+  /// coverage at that point — a HARD ERROR (`std::runtime_error`), never a
+  /// silent skip or a fall-back to `depth_offset`: importing an
+  /// unconverted (or partially converted) surface would corrupt the layer.
+  /// Mutually exclusive with a non-zero `depth_offset`
+  /// (`std::invalid_argument`); `depth_scale` still applies (a
+  /// positive-down depth-below-datum product uses `depth_scale = -1`).
+  std::function<std::optional<double>(double lat, double lon)> vertical_datum_fn;
   /// GGGS level to import at. The store is multi-level (ADR-0002 §D2): a coarse
   /// chart prior imports at a coarse level, a fine survey grid at a fine level,
   /// and both can share the store. `std::nullopt` (the default) uses the

--- a/marine_bathymetry_store/include/marine_bathymetry_store/geotiff_import.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/geotiff_import.hpp
@@ -81,6 +81,12 @@ struct GeoTiffImportOptions
   /// Mutually exclusive with a non-zero `depth_offset`
   /// (`std::invalid_argument`); `depth_scale` still applies (a
   /// positive-down depth-below-datum product uses `depth_scale = -1`).
+  /// Threading contract: the importer invokes this SERIALLY from the one
+  /// calling thread, so a single-threaded-only callable (e.g. a
+  /// marine_vertical_datum query, whose copies share one PROJ context) is
+  /// safe to supply. A future parallel pixel loop must not share one
+  /// callable across threads — build one query per thread instead (see
+  /// vdatum_query.hpp).
   std::function<std::optional<double>(double lat, double lon)> vertical_datum_fn;
   /// GGGS level to import at. The store is multi-level (ADR-0002 §D2): a coarse
   /// chart prior imports at a coarse level, a fine survey grid at a fine level,

--- a/marine_bathymetry_store/include/marine_bathymetry_store/registry.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/registry.hpp
@@ -50,11 +50,19 @@ struct StoreMetadata
   std::string sensor;    ///< Contributing sensor (e.g. "m3").
   std::string survey;    ///< Survey / campaign id (e.g. "massabesic-2026").
   std::string date;      ///< Acquisition date (ISO-8601, e.g. "2026-06-30").
+  /// Source vertical datum the import converted FROM (e.g. "mllw", #315).
+  /// Stored values are always ellipsoidal; this records what the source was
+  /// referenced to before conversion. Empty when the source was already
+  /// ellipsoidal (or converted by constant scale/offset). Absent from
+  /// pre-#315 registries, which load with it empty — an additive field, no
+  /// schema-version bump.
+  std::string datum;
 
   /// @brief True if every field is empty (nothing worth persisting).
   bool empty() const noexcept
   {
-    return platform.empty() && sensor.empty() && survey.empty() && date.empty();
+    return platform.empty() && sensor.empty() && survey.empty() &&
+           date.empty() && datum.empty();
   }
 
   /// @brief Write `registry.json` under @p store_root_dir atomically.

--- a/marine_bathymetry_store/src/geotiff_import.cpp
+++ b/marine_bathymetry_store/src/geotiff_import.cpp
@@ -58,6 +58,11 @@ ProcessedImportResult importGeoTiff(
   if (options.uncertainty_band < 0) {
     throw std::invalid_argument("importGeoTiff: uncertainty_band must be >= 0 (0 = none)");
   }
+  if (options.vertical_datum_fn && options.depth_offset != 0.0) {
+    throw std::invalid_argument(
+      "importGeoTiff: vertical_datum_fn and a non-zero depth_offset are "
+      "mutually exclusive (the datum query IS the per-point offset)");
+  }
 
   // Target import level: a caller-specified level (multi-level, ADR-0002 §D2) or
   // the store's default level.
@@ -135,8 +140,24 @@ ProcessedImportResult importGeoTiff(
       if (!std::isfinite(depth_row[x]) || (has_nodata && depth_row[x] == nodata)) {
         continue;   // no-data pixel
       }
+      const double longitude = gt[0] + (x + 0.5) * gt[1];
       // Vertical conversion at import (§D4): pixel value -> ellipsoidal height.
-      const double depth = options.depth_scale * depth_row[x] + options.depth_offset;
+      // With a per-point datum resolver (#315) the offset is the source
+      // datum's ellipsoidal height at this pixel; no coverage there is a
+      // hard error — a partially converted surface must never import.
+      double offset = options.depth_offset;
+      if (options.vertical_datum_fn) {
+        const std::optional<double> datum_z =
+          options.vertical_datum_fn(latitude, longitude);
+        if (!datum_z.has_value()) {
+          throw std::runtime_error(
+            "importGeoTiff: vertical-datum grids have no coverage at (" +
+            std::to_string(latitude) + ", " + std::to_string(longitude) +
+            ") — refusing a partial datum conversion for " + path);
+        }
+        offset = *datum_z;
+      }
+      const double depth = options.depth_scale * depth_row[x] + offset;
       // A non-finite OR non-positive uncertainty is *missing*, not perfect:
       // zero would pass every reliability gate and carry infinite weight in
       // 1/sigma^2 fusion. Such cells get default_uncertainty (NaN by default
@@ -148,7 +169,6 @@ ProcessedImportResult importGeoTiff(
       {
         uncertainty = uncertainty_row[x];
       }
-      const double longitude = gt[0] + (x + 0.5) * gt[1];
       // Fill the pixel's full FOOTPRINT of store cells, not just the cell
       // under its centre — a coarser-than-store source (e.g. a 5 m contour
       // prior into a 0.5 m store) must produce coverage, not isolated dots.

--- a/marine_bathymetry_store/src/import_geotiff_main.cpp
+++ b/marine_bathymetry_store/src/import_geotiff_main.cpp
@@ -53,9 +53,12 @@
 #include <string>
 #include <system_error>
 
+#include <optional>
+
 #include "marine_bathymetry_store/bathymetry_store.hpp"
 #include "marine_bathymetry_store/geotiff_import.hpp"
 #include "marine_bathymetry_store/registry.hpp"
+#include "marine_vertical_datum/vdatum_query.hpp"
 #include "marine_bathymetry_store/tile_io.hpp"
 
 namespace
@@ -71,6 +74,7 @@ void usage()
     "       import_geotiff --commit <staged_dir> <store_dir>      (atomic chart swap)\n"
     "                      [--cell-size m] [--level N]\n"
     "                      [--uncertainty m] [--depth-scale s] [--depth-offset m]\n"
+    "                      [--source-datum mllw --geoid G --vdatum-dir D [--source-up]]\n"
     "                      [--platform P] [--sensor S] [--survey K] [--date D]\n"
     "  layer:      draft | processed | reference | chart\n"
     "              ('survey' is a deprecated alias for 'processed'; ADR-0010 D8)\n"
@@ -104,6 +108,20 @@ void usage()
     "               height = scale*pixel + offset (defaults 1, 0). A\n"
     "               positive-down depths-below-lake-surface product imports\n"
     "               with scale -1 and offset = lake surface ellipsoidal height\n"
+    "  --source-datum mllw --geoid <grid> --vdatum-dir <dir> (#315):\n"
+    "               per-cell vertical-datum conversion for a tidal-datum-\n"
+    "               referenced grid: each pixel's offset is the MLLW\n"
+    "               ellipsoidal height at its (lat, lon) from the VDatum\n"
+    "               grids (the same grids the enc_updater provisions under\n"
+    "               world/datum/), never a hand-computed constant. Pixels\n"
+    "               are assumed POSITIVE-DOWN depths below the datum (the\n"
+    "               hydrographic norm); pass --source-up for up-positive\n"
+    "               heights relative to the datum. Mutually exclusive with\n"
+    "               --depth-scale/--depth-offset; a point outside the grids'\n"
+    "               coverage is a HARD ERROR (never a partial conversion).\n"
+    "               Draft/processed/reference imports only (the chart path\n"
+    "               converts in s57_to_geotiff). Records the source datum in\n"
+    "               registry.json provenance.\n"
     "  --platform/--sensor/--survey/--date: coarse store-level provenance\n"
     "               (StoreMetadata) written to registry.json (ADR-0005 #248)\n";
   exit(1);
@@ -171,6 +189,12 @@ int main(int argc, char * argv[])
   double constant_uncertainty = -1.0;   // sentinel: use the file's band
   double depth_scale = 1.0;
   double depth_offset = 0.0;
+  bool depth_scale_set = false;         // for the --source-datum exclusion
+  bool depth_offset_set = false;
+  const char * source_datum = nullptr;  // --source-datum (only "mllw" today)
+  const char * geoid_grid = nullptr;    // --geoid (with --source-datum)
+  const char * vdatum_dir = nullptr;    // --vdatum-dir (with --source-datum)
+  bool source_up = false;               // --source-up: datum-relative heights
   marine_bathymetry_store::StoreMetadata metadata;
 
   const auto need_arg = [&](int & i) -> const char * {
@@ -236,8 +260,18 @@ int main(int argc, char * argv[])
       constant_uncertainty = parse_finite("--uncertainty", need_arg(i));
     } else if (std::strcmp(argv[i], "--depth-scale") == 0) {
       depth_scale = parse_finite("--depth-scale", need_arg(i));
+      depth_scale_set = true;
     } else if (std::strcmp(argv[i], "--depth-offset") == 0) {
       depth_offset = parse_finite("--depth-offset", need_arg(i));
+      depth_offset_set = true;
+    } else if (std::strcmp(argv[i], "--source-datum") == 0) {
+      source_datum = need_arg(i);
+    } else if (std::strcmp(argv[i], "--geoid") == 0) {
+      geoid_grid = need_arg(i);
+    } else if (std::strcmp(argv[i], "--vdatum-dir") == 0) {
+      vdatum_dir = need_arg(i);
+    } else if (std::strcmp(argv[i], "--source-up") == 0) {
+      source_up = true;
     } else if (std::strcmp(argv[i], "--platform") == 0) {
       metadata.platform = need_arg(i);
     } else if (std::strcmp(argv[i], "--sensor") == 0) {
@@ -257,6 +291,35 @@ int main(int argc, char * argv[])
   // a normal survey/reference import.
   if (stage_dir != nullptr && commit_dir != nullptr) {
     std::cerr << "--stage and --commit are mutually exclusive\n";
+    usage();
+  }
+
+  // --source-datum validation (#315). Every mis-combination is a loud usage
+  // error — a datum flag silently ignored is exactly how a wrong-datum
+  // surface would reach the store.
+  if (source_datum != nullptr) {
+    if (std::strcmp(source_datum, "mllw") != 0) {
+      std::cerr << "--source-datum '" << source_datum
+                << "' unsupported (only 'mllw' today)\n";
+      usage();
+    }
+    if (stage_dir != nullptr || commit_dir != nullptr) {
+      std::cerr << "--source-datum applies to survey/reference imports only; "
+                << "the chart path converts datums in s57_to_geotiff\n";
+      usage();
+    }
+    if (depth_scale_set || depth_offset_set) {
+      std::cerr << "--source-datum and --depth-scale/--depth-offset are "
+                << "mutually exclusive (the datum query IS the conversion; "
+                << "use --source-up for up-positive datum-relative heights)\n";
+      usage();
+    }
+    if (geoid_grid == nullptr || vdatum_dir == nullptr) {
+      std::cerr << "--source-datum requires both --geoid and --vdatum-dir\n";
+      usage();
+    }
+  } else if (geoid_grid != nullptr || vdatum_dir != nullptr || source_up) {
+    std::cerr << "--geoid/--vdatum-dir/--source-up require --source-datum\n";
     usage();
   }
 
@@ -376,6 +439,38 @@ int main(int argc, char * argv[])
   if (constant_uncertainty >= 0.0) {
     options.uncertainty_band = 0;
     options.default_uncertainty = constant_uncertainty;
+  }
+  if (source_datum != nullptr) {
+    // Per-cell MLLW -> ellipsoid conversion (#315). Build the query ONCE
+    // (it owns the PROJ context; per-point work is a single proj_trans) and
+    // pass it in as the per-point offset resolver. Setup failure — missing
+    // or unreadable grids — is a hard error here, before any pixel is read.
+    marine_vertical_datum::VDatumConfig vconfig;
+    vconfig.geoid_grid = geoid_grid;
+    vconfig.vdatum_grid_dir = vdatum_dir;
+    const marine_vertical_datum::VDatumQueryFn vquery =
+      marine_vertical_datum::make_vdatum_query(
+      vconfig, [](const std::string & msg) {
+        std::cerr << "vdatum: " << msg << "\n";
+      });
+    if (!vquery) {
+      std::cerr << "--source-datum mllw: vdatum query setup failed "
+                << "(see vdatum messages above; check --geoid/--vdatum-dir)\n";
+      return 1;
+    }
+    options.vertical_datum_fn =
+      [vquery](double lat, double lon) -> std::optional<double> {
+        const auto result = vquery(lat, lon);
+        if (!result.has_value()) {
+          return std::nullopt;
+        }
+        return result->mllw_z;
+      };
+    // Positive-down depths below the datum by default (hydrographic norm):
+    // h_ellip = mllw_z - depth. --source-up keeps +1 for up-positive
+    // heights relative to the datum: h_ellip = mllw_z + height.
+    options.depth_scale = source_up ? 1.0 : -1.0;
+    metadata.datum = source_datum;
   }
   const marine_bathymetry_store::ProcessedImportResult import_result =
     marine_bathymetry_store::importGeoTiff(store, layer, geotiff, options);

--- a/marine_bathymetry_store/src/import_geotiff_main.cpp
+++ b/marine_bathymetry_store/src/import_geotiff_main.cpp
@@ -448,6 +448,9 @@ int main(int argc, char * argv[])
     marine_vertical_datum::VDatumConfig vconfig;
     vconfig.geoid_grid = geoid_grid;
     vconfig.vdatum_grid_dir = vdatum_dir;
+    // Only mllw_z is consumed: skip the MHHW pipeline so a million-pixel
+    // import doesn't pay a second, discarded proj_trans per pixel.
+    vconfig.want_mhhw = false;
     const marine_vertical_datum::VDatumQueryFn vquery =
       marine_vertical_datum::make_vdatum_query(
       vconfig, [](const std::string & msg) {
@@ -472,8 +475,20 @@ int main(int argc, char * argv[])
     options.depth_scale = source_up ? 1.0 : -1.0;
     metadata.datum = source_datum;
   }
-  const marine_bathymetry_store::ProcessedImportResult import_result =
-    marine_bathymetry_store::importGeoTiff(store, layer, geotiff, options);
+  // Clean failure for runtime errors (#315 review): a vdatum-coverage gap a
+  // few pixels past the grids' edge is a routine operational condition of
+  // --source-datum, not misuse — it must print and exit 1, never abort via
+  // std::terminate (matching the --commit path's catch). Nothing partial can
+  // land either way: tiles accumulate in memory and the store save runs
+  // after a successful import.
+  marine_bathymetry_store::ProcessedImportResult import_result;
+  try {
+    import_result =
+      marine_bathymetry_store::importGeoTiff(store, layer, geotiff, options);
+  } catch (const std::exception & e) {
+    std::cerr << "import failed: " << e.what() << "\n";
+    return 1;
+  }
   std::cout << "imported " << import_result.cells_imported << " cell(s) into "
             << positional[1] << "\n";
   // ADR-0010 D8 anti-clobber: a processed import supersedes overlapped live draft
@@ -487,12 +502,27 @@ int main(int argc, char * argv[])
               << import_result.draft_tiles_touched.size() << " draft tile(s)\n";
   }
 
-  // Write the coarse StoreMetadata only if any field was supplied; otherwise
-  // preserve whatever registry.json already held (loaded above).
+  // Field-wise provenance merge (#315 review): CLI-supplied fields update
+  // the registry, everything else carries forward from what was loaded. A
+  // whole-record replace here would let a pure conversion run
+  // (--source-datum with no provenance flags) blank previously recorded
+  // platform/sensor/survey/date — or a later single-flag run erase the
+  // datum stamp while the converted cells remain in the store.
+  marine_bathymetry_store::StoreMetadata merged = existing_metadata;
+  if (!metadata.platform.empty()) {merged.platform = metadata.platform;}
+  if (!metadata.sensor.empty()) {merged.sensor = metadata.sensor;}
+  if (!metadata.survey.empty()) {merged.survey = metadata.survey;}
+  if (!metadata.date.empty()) {merged.date = metadata.date;}
+  if (!metadata.datum.empty()) {merged.datum = metadata.datum;}
   const marine_bathymetry_store::StoreMetadata * to_write =
-    metadata.empty() ? (existing_metadata.empty() ? nullptr : &existing_metadata) :
-    &metadata;
-  const std::size_t saved = marine_bathymetry_store::save(store, store_dir, to_write);
+    merged.empty() ? nullptr : &merged;
+  std::size_t saved = 0;
+  try {
+    saved = marine_bathymetry_store::save(store, store_dir, to_write);
+  } catch (const std::exception & e) {
+    std::cerr << "save failed: " << e.what() << "\n";
+    return 1;
+  }
   std::cout << "saved " << saved << " tile(s) under " << store_dir << "\n";
   return 0;
 }

--- a/marine_bathymetry_store/src/registry.cpp
+++ b/marine_bathymetry_store/src/registry.cpp
@@ -65,6 +65,7 @@ void StoreMetadata::save(const std::string & store_root_dir) const
     {"sensor", sensor},
     {"survey", survey},
     {"date", date},
+    {"datum", datum},
   };
 
   const fs::path tmp = fs::path(store_root_dir) / kRegistryTmpFile;
@@ -130,6 +131,7 @@ void StoreMetadata::load(const std::string & store_root_dir)
   sensor = jsonStr(doc, "sensor");
   survey = jsonStr(doc, "survey");
   date = jsonStr(doc, "date");
+  datum = jsonStr(doc, "datum");   // absent in pre-#315 registries -> empty
 }
 
 }  // namespace marine_bathymetry_store

--- a/marine_bathymetry_store/test/test_geotiff_import.cpp
+++ b/marine_bathymetry_store/test/test_geotiff_import.cpp
@@ -543,3 +543,75 @@ TEST_F(GeoTiffImportTest, DraftImportDoesNotClearAnything)
   EXPECT_EQ(result.draft_cells_cleared, 0u);
   EXPECT_TRUE(result.draft_tiles_touched.empty());
 }
+
+// --- Per-point vertical-datum conversion (#315) ---
+
+TEST_F(GeoTiffImportTest, VerticalDatumFnAppliesPerPointOffset)
+{
+  // An MLLW-referenced grid: each pixel's offset is the datum's ellipsoidal
+  // height AT THAT POINT, not one constant — inject a longitude-dependent
+  // resolver and check two same-row cells convert with different offsets.
+  BathymetryStore store(11, /*reference_writable=*/true);
+  const std::vector<float> depth{10.0f, 10.0f};   // equal depths below datum
+  const std::vector<float> unc{0.5f, 0.5f};
+  const auto tif = writeTestTiff(dir_ / "mllw.tif", store.level(), 2, 1, depth, unc);
+
+  GeoTiffImportOptions options;
+  options.depth_scale = -1.0;   // positive-down depths below the datum
+  const gggs::GridIndex grid = store.level().gridIndex(43.0, -70.5);
+  const double cell_x = grid.longitudinalSpan() / gggs::cell_rows_per_grid;
+  const double split = grid.westLongitude() + cell_x;   // between the 2 pixels
+  options.vertical_datum_fn =
+    [split](double, double lon) -> std::optional<double> {
+      return lon < split ? -28.0 : -29.0;   // western vs eastern mllw_z
+    };
+  const auto imported =
+    importGeoTiff(store, SourceLayer::Reference, tif, options).cells_imported;
+  EXPECT_EQ(imported, 2u);
+
+  const auto west = store.get(SourceLayer::Reference, nwCell(store, store.level()));
+  ASSERT_TRUE(west.has_value());
+  EXPECT_DOUBLE_EQ(west->depth, -38.0);    // -1 * 10 + (-28)
+  const auto east = store.get(
+    SourceLayer::Reference,
+    store.cellIndex(
+      grid.northLatitude() - 0.5 * grid.latitudinalSpan() / gggs::cell_rows_per_grid,
+      grid.westLongitude() + 1.5 * cell_x));
+  ASSERT_TRUE(east.has_value());
+  EXPECT_DOUBLE_EQ(east->depth, -39.0);    // -1 * 10 + (-29)
+}
+
+TEST_F(GeoTiffImportTest, VerticalDatumFnNoCoverageIsHardError)
+{
+  // A point outside the datum grids must abort the import — a partially
+  // converted surface must never land in the store.
+  BathymetryStore store(11, /*reference_writable=*/true);
+  const std::vector<float> depth{10.0f};
+  const std::vector<float> unc{0.5f};
+  const auto tif = writeTestTiff(dir_ / "gap.tif", store.level(), 1, 1, depth, unc);
+
+  GeoTiffImportOptions options;
+  options.depth_scale = -1.0;
+  options.vertical_datum_fn =
+    [](double, double) -> std::optional<double> {return std::nullopt;};
+  EXPECT_THROW(
+    importGeoTiff(store, SourceLayer::Reference, tif, options), std::runtime_error);
+  EXPECT_TRUE(store.tiles(SourceLayer::Reference).empty());
+}
+
+TEST_F(GeoTiffImportTest, VerticalDatumFnExcludesConstantOffset)
+{
+  // The datum query IS the offset; combining it with a constant one is a
+  // caller bug and must fail loudly, not silently sum.
+  BathymetryStore store(11, /*reference_writable=*/true);
+  const std::vector<float> depth{10.0f};
+  const std::vector<float> unc{0.5f};
+  const auto tif = writeTestTiff(dir_ / "both.tif", store.level(), 1, 1, depth, unc);
+
+  GeoTiffImportOptions options;
+  options.depth_offset = -20.0;
+  options.vertical_datum_fn =
+    [](double, double) -> std::optional<double> {return -28.0;};
+  EXPECT_THROW(
+    importGeoTiff(store, SourceLayer::Reference, tif, options), std::invalid_argument);
+}

--- a/marine_bathymetry_store/test/test_import_geotiff_cli.cpp
+++ b/marine_bathymetry_store/test/test_import_geotiff_cli.cpp
@@ -212,3 +212,58 @@ TEST_F(ImportGeotiffCliTest, CommitWithoutStoreDirIsUsageError)
   const fs::path staged = dir_ / "staged";
   EXPECT_EQ(run("--commit \"" + staged.string() + "\""), 1);
 }
+
+// --- --source-datum flag validation (#315) ---
+// The vdatum grids themselves aren't exercised here (no PROJ fixtures in this
+// suite); these pin the loud-usage-error contract: a datum flag silently
+// ignored is exactly how a wrong-datum surface would reach the store.
+
+TEST_F(ImportGeotiffCliTest, SourceDatumExcludesDepthScaleOffset)
+{
+  const fs::path store = dir_ / "store";
+  EXPECT_EQ(
+    run(
+      store.string() + " reference " + tif_.string() +
+      " --source-datum mllw --geoid g.tif --vdatum-dir v --depth-offset -20"),
+    1);
+  EXPECT_EQ(
+    run(
+      store.string() + " reference " + tif_.string() +
+      " --source-datum mllw --geoid g.tif --vdatum-dir v --depth-scale -1"),
+    1);
+}
+
+TEST_F(ImportGeotiffCliTest, SourceDatumRequiresBothGridFlags)
+{
+  const fs::path store = dir_ / "store";
+  EXPECT_EQ(
+    run(store.string() + " reference " + tif_.string() + " --source-datum mllw"), 1);
+  EXPECT_EQ(
+    run(
+      store.string() + " reference " + tif_.string() +
+      " --source-datum mllw --geoid g.tif"),
+    1);
+}
+
+TEST_F(ImportGeotiffCliTest, DatumGridFlagsRequireSourceDatum)
+{
+  const fs::path store = dir_ / "store";
+  EXPECT_EQ(
+    run(store.string() + " reference " + tif_.string() + " --geoid g.tif"), 1);
+  EXPECT_EQ(
+    run(store.string() + " reference " + tif_.string() + " --source-up"), 1);
+}
+
+TEST_F(ImportGeotiffCliTest, SourceDatumRejectsUnknownDatumAndStageMode)
+{
+  EXPECT_EQ(
+    run(
+      (dir_ / "store").string() + " reference " + tif_.string() +
+      " --source-datum navd88 --geoid g.tif --vdatum-dir v"),
+    1);
+  EXPECT_EQ(
+    run(
+      "--stage " + (dir_ / "staged").string() + " chart " + tif_.string() +
+      " --source-datum mllw --geoid g.tif --vdatum-dir v"),
+    1);
+}

--- a/marine_bathymetry_store/test/test_import_geotiff_cli.cpp
+++ b/marine_bathymetry_store/test/test_import_geotiff_cli.cpp
@@ -267,3 +267,30 @@ TEST_F(ImportGeotiffCliTest, SourceDatumRejectsUnknownDatumAndStageMode)
       " --source-datum mllw --geoid g.tif --vdatum-dir v"),
     1);
 }
+
+TEST_F(ImportGeotiffCliTest, ProvenanceMergesFieldWiseAcrossImports)
+{
+  // #315 review: a later import passing only some provenance flags must
+  // carry the registry's other fields forward, never whole-record-replace
+  // them with empties (same merge path protects the datum stamp).
+  const fs::path store = dir_ / "store";
+  ASSERT_EQ(
+    run(store.string() + " reference " + tif_.string() + " --platform bizzy"), 0);
+  ASSERT_EQ(
+    run(store.string() + " reference " + tif_.string() + " --survey appledore"), 0);
+  std::ifstream reg(store / "registry.json");
+  ASSERT_TRUE(reg.good());
+  const std::string content(
+    (std::istreambuf_iterator<char>(reg)), std::istreambuf_iterator<char>());
+  EXPECT_NE(content.find("\"platform\": \"bizzy\""), std::string::npos) << content;
+  EXPECT_NE(content.find("\"survey\": \"appledore\""), std::string::npos) << content;
+}
+
+TEST_F(ImportGeotiffCliTest, RuntimeImportFailureExitsOneCleanly)
+{
+  // #315 review: a runtime import failure (here: a missing GeoTIFF; the
+  // vdatum-coverage gap takes the same path) must print + exit 1, never
+  // abort via std::terminate. run() returns -1 on an abnormal exit.
+  EXPECT_EQ(
+    run((dir_ / "store").string() + " reference " + (dir_ / "missing.tif").string()), 1);
+}

--- a/marine_bathymetry_store/test/test_tile_io.cpp
+++ b/marine_bathymetry_store/test/test_tile_io.cpp
@@ -1291,3 +1291,27 @@ TEST_F(TileIoTest, ReplaceChartLayerRestoresOrphanedBackupThenSurvivesFailedSwap
   ASSERT_TRUE(got.has_value());   // old orphan data restored and surviving
   EXPECT_DOUBLE_EQ(got->depth, -10.0);
 }
+
+TEST_F(TileIoTest, StoreMetadataDatumFieldRoundTripsAndBackCompat)
+{
+  // #315: the source-datum provenance field persists, and a pre-#315
+  // registry (no "datum" key at all) loads with it empty rather than
+  // erroring — an additive field, no schema-version bump.
+  fs::create_directories(dir_);
+  StoreMetadata md{"bizzy", "colleague-grid", "appledore-2026", "2026-08-20", "mllw"};
+  md.save(dir_.string());
+  StoreMetadata loaded;
+  loaded.load(dir_.string());
+  EXPECT_EQ(loaded.datum, "mllw");
+
+  // Hand-write a pre-#315 registry (current version, no "datum" key).
+  {
+    std::ofstream out(dir_ / "registry.json", std::ios::trunc);
+    out << "{\"version\": 2, \"platform\": \"bizzy\", \"sensor\": \"m3\", "
+        << "\"survey\": \"massabesic-2026\", \"date\": \"2026-06-30\"}\n";
+  }
+  StoreMetadata reloaded;
+  reloaded.load(dir_.string());
+  EXPECT_EQ(reloaded.platform, "bizzy");
+  EXPECT_TRUE(reloaded.datum.empty());
+}

--- a/marine_vertical_datum/include/marine_vertical_datum/vdatum_query.hpp
+++ b/marine_vertical_datum/include/marine_vertical_datum/vdatum_query.hpp
@@ -57,6 +57,13 @@ struct VDatumConfig
 {
   std::string geoid_grid;
   std::string vdatum_grid_dir;
+  // MLLW-only mode (#315): skip building the MHHW pipeline and never run
+  // its per-point proj_trans. For a consumer that only reads mllw_z (the
+  // per-pixel GeoTIFF importer over million-pixel grids), the discarded
+  // MHHW transform would otherwise double the per-point PROJ work. With
+  // false, mhhw_z is always nullopt — semantically identical to "no MHHW
+  // grids found".
+  bool want_mhhw = true;
 };
 
 // The per-point query: (lat, lon) in degrees → VDatumResult, or nullopt

--- a/marine_vertical_datum/src/vdatum_query.cpp
+++ b/marine_vertical_datum/src/vdatum_query.cpp
@@ -190,7 +190,10 @@ VDatumQueryFn make_vdatum_query(const VDatumConfig & config, DiagFn diag)
     return {};   // ProjPipelines dtor releases the context
   }
 
-  if (!mhhw_grids.empty()) {
+  if (!config.want_mhhw) {
+    // MLLW-only consumer (#315): no MHHW pipeline, no per-point second
+    // transform. Deliberately quiet — absence is the requested state.
+  } else if (!mhhw_grids.empty()) {
     pipelines->mhhw =
       create_pipeline(pipelines->context, config.geoid_grid, mhhw_grids, diag);
     if (!pipelines->mhhw) {


### PR DESCRIPTION
Adds **per-cell vertical-datum conversion** to `import_geotiff` for tidal-datum-referenced grids — the importer enhancement decided with the operator 2026-08-20 for the Shoals prior work (#314 step 2): the 1 m Appledore grid is referenced to MLLW, and a hand-computed constant offset is wrong by however much the datum surface varies across the extent.

## What changed

- **Library**: `GeoTiffImportOptions.vertical_datum_fn` — a per-point `(lat, lon) → optional<double>` source-datum ellipsoidal height, applied as each pixel's offset (`height = depth_scale × pixel + fn(lat, lon)`). A point outside the datum grids' coverage is a **hard error** (a partially converted surface never imports — tiles accumulate in memory and land only after the full pixel loop). Mutually exclusive with a constant `depth_offset`. The library stays PROJ-free (`std::function` seam) with the serial-invocation contract documented.
- **CLI**: `--source-datum mllw --geoid <grid> --vdatum-dir <dir> [--source-up]`, using the same `world/datum/` grids the `enc_updater` provisions (s57_tools#37). Positive-down depths below the datum by default (`h_ellip = mllw_z − depth`); `--source-up` for up-positive heights. Every mis-combination is a loud usage error (with `--depth-scale`/`--depth-offset`, with `--stage`/`--commit` — the chart path converts in s57_to_geotiff — partial grid flags, unknown datum names). Runtime import failures print and exit 1.
- **Provenance**: new additive `StoreMetadata.datum` registry field, and the CLI's registry write is now a **field-wise merge** — supplied fields update, everything else carries forward (a pure conversion run can no longer blank prior provenance, nor a later single-flag run erase the datum stamp).
- **marine_vertical_datum**: `VDatumConfig.want_mhhw` MLLW-only mode — skips building/running the MHHW pipeline, halving per-pixel PROJ work for million-pixel imports; the CLI opts in.

## Review

Pre-push review (Standard, two adversarial lenses): 2 cross-confirmed must-fix (provenance wipe; uncaught-throw exit) + 2 suggestions, all fixed in-branch; timeline in `.agent/work-plans/issue-315/progress.md`. Lands on the post-D8 layer taxonomy (draft/processed/reference).

## Test plan

- [x] `colcon test` marine_bathymetry_store + marine_vertical_datum — 336 tests, 0 failures (10 new: per-point offset variation, no-coverage hard error, mutual exclusions, CLI flag matrix, provenance merge, clean exit, registry round-trip + pre-#315 back-compat)
- [ ] Acceptance (post-merge, #314 step 2): import the colleague's 1 m MLLW Appledore GeoTIFF through `--source-datum mllw` against the provisioned `world/datum/` grids

Part of #314.
Closes #315

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
