### PR TITLE
Repoint path literals to the world root: ~/data/stores → ~/data/world (ADR-0010 D3)

### DIFF
--- a/.agent/work-plans/issue-310/plan.md
+++ b/.agent/work-plans/issue-310/plan.md
@@ -1,0 +1,212 @@
+# Plan: ~/data/stores → ~/data/world: store root migration (ADR-0010 D3)
+
+## Issue
+
+https://github.com/rolker/unh_marine_autonomy/issues/310
+
+## Context
+
+ADR-0010 D3 moves the store root from `~/data/stores/` to `~/data/world/`,
+with a theme mapping (`bathymetry` → `depths`, `sidescan`/`backscatter` →
+`imagery`, contacts → `features`, ENC corpus → `charts`). D3 states "path
+changes are config migration" — this issue is that migration for the
+`unh_marine_autonomy` repo's config/docs/test surface, plus the on-disk data
+move on the dev host (salmon/gabby repoint separately, see Consequences).
+`#308` (D8 re-split, folding `survey/` into `processed/`) is closed, so the
+"land after #308" sequencing note is satisfied and `survey/` migrates to
+`processed/` exactly once, per D3's migration note.
+
+Repo sweep (`grep -rn '~/data/stores\|data/stores'`, excluding build/install/
+log and other issues' `.agent/work-plans/`) confirms four touchpoints in this
+repo, matching both the issue body's non-exhaustive list and the Issue
+Review's additions — no further literals found in `config/`,
+`marine_autonomy/`, or `marine_autonomy_integration_tests/`:
+
+1. `bathymetry_layer/src/bathymetry_layer.cpp:33` — doc comment example for
+   `store_path` (the parameter itself defaults to `""`, no code literal to
+   change).
+2. `bathymetry_layer/README.md:92` — same example in the parameter table.
+3. `bathymetry_layer/test/test_bathymetry_layer.cpp:96-102` — `~`-expansion
+   unit test uses `~/data/stores/bathymetry` / `/home/field/data/stores/
+   bathymetry` as example literals (path-expansion logic, not the new root,
+   is under test).
+4. `marine_sidescan_mosaic/launch/sidescan_mosaic.launch.py:36-41` — the live
+   node's default `output_dir` argument and its description.
+5. `marine_sidescan_mosaic/README.md:108-109,257` — example CLI invocations
+   (`sidescan_tier2_processed`, `build_sidescan_overviews`, `--bathy-store`).
+6. `docs/sonar_reference.md:68-69` — "Data of record" table (tiled stores +
+   survey index canonical paths).
+
+**Operator decisions (checkpoint 1, 2026-08-20 — binding, not reopened here):**
+
+- **Clean cut, no compat symlink**, on all three hosts (dev, salmon, gabby).
+  Nothing keeps `~/data/stores` alive as an alias; any reader still pointed
+  at the old root fails loudly (missing-directory / empty-store behavior
+  already exists in `bathymetry_layer` — `store_path` empty or unreadable
+  logs and contributes no cost, it does not silently serve stale data) so a
+  missed repoint surfaces immediately instead of degrading quietly.
+- Dev-host data migrates as part of this issue's execution (not deferred):
+  - `~/data/stores/bathymetry/` → `~/data/world/depths/`, with `survey/`
+    folded into `processed/` (created fresh — D3's migration note: the
+    fused pre-D8 `survey/` layer carries no per-cell live-vs-re-run
+    provenance, so it is re-classified wholesale, not split) and `chart/`,
+    `reference/`, `registry.json`, `_archive/` carried over as-is.
+  - `~/data/stores/sidescan/` + `~/data/stores/backscatter/` →
+    `~/data/world/imagery/sidescan/` and `~/data/world/imagery/backscatter/`
+    respectively (imagery keeps its own tiering per D3 — `processed`/`tier1`
+    for sidescan, `survey`/`_archive`/`registry.json` for backscatter carry
+    over unchanged, no re-classification).
+  - contacts store → `~/data/world/features/` (no contacts DB found at a
+    known path on this dev host during planning — verify at implementation
+    time; if absent, this sub-step is a no-op, not skipped-and-forgotten).
+  - `~/data/world/store/` — the ENC eval store created 2026-08-20 (contains
+    only `chart/` with GeoTIFF tiles + `editions.json`, no `survey`/
+    `reference`/`processed`) — **reconciles into `~/data/world/depths/`**:
+    diff its `chart/` against the migrated `~/data/stores/bathymetry/
+    chart/` before merging (both are chart-theme D7 output; if they cover
+    disjoint tile sets, union them; if they overlap, the eval store is the
+    newer/throwaway one — prefer the `~/data/stores/bathymetry/chart/`
+    tiles and treat `world/store/chart/` as superseded, since it was an
+    eval artifact, not the daily-survey store). After reconciliation,
+    remove the now-empty `~/data/world/store/` directory.
+  - `~/data/stores/s102_cache/` and `s102_shoals/` are **out of scope**
+    here — already reassigned to `~/data/world/s100/s102/` under #288.
+  - `survey_index.db` (+ `.v1.db.bak`) → `~/data/world/` top level (no
+    existing top-level home defined by D3 for this file; it is dev-tooling
+    metadata, not a themed store — place at `~/data/world/survey_index.db`
+    and record the choice in `docs/sonar_reference.md`, since D3 doesn't
+    enumerate it and this issue is the first to give it a canonical home).
+- salmon and gabby repoint their own store trees on the same clean-cut
+  contract, sequenced with a field-rebuild day (per the issue body) —
+  **not performed by this PR**; tracked as a follow-up (Consequences).
+- `unh_echoboats_project11` config repoints (`nav2_overlay.yaml:136,215`
+  `store_path`, `bizzyboat.yaml:88` `draft_dir`) are a **separate PR in that
+  repo** — named here as a follow-up, not implemented in this issue.
+
+## Approach
+
+1. **Update `bathymetry_layer` doc/comment examples.** Change the
+   `store_path` example in `bathymetry_layer/src/bathymetry_layer.cpp:33`'s
+   comment and `bathymetry_layer/README.md:92`'s parameter-table example
+   from `~/data/stores/bathymetry` to `~/data/world/depths`. No code
+   behavior changes — `store_path_` still defaults to `""` and is set by
+   config, not a compiled-in literal.
+
+2. **Decide and update the `test_bathymetry_layer.cpp` literals.** The test
+   (`ExpandUserPathHandlesTilde`, lines 96-102) exercises the `~`-expansion
+   *mechanism*, not the canonical root — but leaving `~/data/stores/...`
+   literals in a test that sits beside a just-updated README/comment reads
+   as a stale example to the next reader. Update both literals
+   (`~/data/stores/bathymetry` → `~/data/world/depths`, and the
+   already-expanded `/home/field/data/stores/bathymetry` →
+   `/home/field/data/world/depths`) to keep the test's example path
+   consistent with the new canonical root; the expansion logic under test
+   is path-content-agnostic, so this is a safe, purely-cosmetic literal
+   swap with no behavioral risk.
+
+3. **Update `marine_sidescan_mosaic` launch default.** In
+   `sidescan_mosaic.launch.py:36-41`, change `default_output_dir` from
+   `os.path.expanduser('~/data/stores/sidescan/draft')` to
+   `os.path.expanduser('~/data/world/imagery/sidescan/draft')`, and update
+   the accompanying comment (`~/data/stores/<modality>/<maturity>/` →
+   `~/data/world/imagery/<modality>/<maturity>/`) and the
+   `DeclareLaunchArgument` description string to match.
+
+4. **Update `marine_sidescan_mosaic/README.md` example invocations.**
+   Lines 108-109 (`sidescan_tier2_processed ... --bathy-store`) and line 257
+   (`build_sidescan_overviews`): replace `~/data/stores/sidescan/...` with
+   `~/data/world/imagery/sidescan/...` and `~/data/stores/bathymetry` with
+   `~/data/world/depths`.
+
+5. **Update `docs/sonar_reference.md`'s "Data of record" table.** Replace
+   the `Tiled stores` row's path (`~/data/stores/{bathymetry,backscatter,
+   sidescan}/`) with the themed layout (`~/data/world/{depths,imagery}/` —
+   note `backscatter` and `sidescan` both fold under `imagery/` per D3, so
+   the row's brace-list collapses to two entries, not three) and the
+   `Survey index` row's path from `~/data/stores/survey_index.db` to
+   `~/data/world/survey_index.db`, keeping the existing v1-backup note.
+
+6. **Migrate the dev host's on-disk store content** (see decisions above
+   for the full per-theme mapping and the eval-store reconciliation). This
+   is an operational step against `~/data/`, not a repo-tracked change —
+   perform it as a plain filesystem move (`mv`, not delete-and-recreate) so
+   content is preserved, verify tile counts before/after per theme, then
+   remove the emptied `~/data/stores/` and `~/data/world/store/`
+   directories. Do **not** leave a compat symlink (operator decision).
+
+7. **Verify no other repo-tracked references were missed.** Re-run the
+   sweep grep (`grep -rn '~/data/stores\|data/stores'` across tracked
+   files, excluding `.agent/work-plans/issue-*/` history for *other*
+   issues, which is a historical record and out of scope to edit) after
+   steps 1-5 land, to confirm only the six touchpoints above remain
+   addressed and nothing new was introduced by the edits themselves.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `bathymetry_layer/src/bathymetry_layer.cpp` | `store_path` doc-comment example path (line 33) |
+| `bathymetry_layer/README.md` | `store_path` parameter-table example path (line 92) |
+| `bathymetry_layer/test/test_bathymetry_layer.cpp` | `ExpandUserPathHandlesTilde` example literals (lines 96-102) |
+| `marine_sidescan_mosaic/launch/sidescan_mosaic.launch.py` | `default_output_dir`, comment, and arg description (lines 36-41) |
+| `marine_sidescan_mosaic/README.md` | Example CLI invocations (lines 108-109, 257) |
+| `docs/sonar_reference.md` | "Data of record" table: tiled-stores + survey-index rows (lines 68-69) |
+| `~/data/world/` (dev host, not repo-tracked) | Move `~/data/stores/{bathymetry,sidescan,backscatter}` + contacts store content into themed `world/` subtrees; fold `bathymetry/survey/` into `depths/processed/`; reconcile `~/data/world/store/chart/` into `depths/chart/`; relocate `survey_index.db` (+ backup); remove emptied `~/data/stores/` and `~/data/world/store/` |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| A change includes its consequences | The doc/code/test/launch-default sweep from both the issue body and the Issue Review is folded in fully (Approach steps 1-5); the dev-host data move is scoped explicitly rather than left as an unstated assumption (step 6). |
+| Only what's needed | No store-content restructuring beyond what D3 already specifies (theme remap + one-time `survey/`→`processed/` reclassification); no D6/D7 library/exporter work; s100/datum territory stays with #288. |
+| Improve incrementally | Single bounded PR in this repo; salmon/gabby repoints and the `unh_echoboats_project11` config PR are named as separate follow-ups, not bundled in. |
+| Human control and transparency | Clean-cut-vs-symlink and the eval-store reconciliation were operator decisions at checkpoint 1 (2026-08-20) and are recorded verbatim in Context, not re-derived; the data-move step states its verification method (tile-count check) rather than asserting success. |
+| Capture decisions, not just implementations | This plan records the `survey_index.db` new-home decision (not specified by D3 itself) and the eval-store-supersedes-vs-union call explicitly, so a future reader doesn't have to re-derive them from a `mv` history. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0010 (D3) | Yes | Direct implementation: theme mapping, one-time `survey/`→`processed/` reclassification, "path changes are config migration" consequence. |
+| 0002 (as amended) | Indirect | `store_path` semantics and layer taxonomy inside `bathymetry_layer` are unchanged — only the path literal moves. |
+| 0006/0007 | Indirect | Imagery-theme stores (sidescan, backscatter) keep their own internal tiering/layer names per D3; only their parent root moves under `imagery/`. |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `bathymetry_layer`'s `store_path` example | `unh_echoboats_project11`'s `nav2_overlay.yaml:136,215` (`store_path`) and `bizzyboat.yaml:88` (`draft_dir`) | No — separate PR in that repo (named as follow-up, per issue body's explicit scope split) |
+| dev-host store root | salmon (operator station) and gabby (boat) store roots | No — three-host sequencing needs a field-rebuild day; follow-up, tracked but not implemented here |
+| `~/data/world/store/` (eval store) reconciled away | Anything else pointed at `~/data/world/store/chart/` as a path (none found in this repo's tracked config) | Yes — reconciliation performed; no other repo-tracked consumer found |
+| `s102_cache`/`s102_shoals` under `~/data/stores/` | `~/data/world/s100/s102/` relocation | No — already #288's scope, explicitly excluded here |
+| `survey_index.db`'s new canonical path | `s57_tools#278`'s `--cache` required-explicit-until-migration note | No — cross-referenced only; that repo's own follow-up |
+
+## Documentation & Instruction Impact
+
+- **Stale docs** (must land in this PR): `bathymetry_layer/README.md`,
+  `marine_sidescan_mosaic/README.md`, and `docs/sonar_reference.md` all
+  contain `~/data/stores` example paths that become inaccurate the moment
+  the default changes — all three are in Files to Change above.
+- **Agent-instruction candidates**: None — this is a scoped path migration
+  with no new recurring pattern or pitfall to encode; the clean-cut decision
+  and per-theme mapping are already durably recorded in ADR-0010 D3 and this
+  plan/progress.md, which is the appropriate home for a one-time migration
+  record (not `.agent/knowledge/`).
+
+## Open Questions
+
+- None blocking — the operator settled clean-cut-vs-symlink and the
+  eval-store reconciliation direction at checkpoint 1. The only residual
+  judgment call (eval store `chart/` superseded vs. unioned with the
+  migrated `bathymetry/chart/`) is resolved by the decision rule in Context
+  (prefer the daily-survey store's tiles) and should be executed, not
+  re-asked, unless implementation finds the two chart sets are unexpectedly
+  identical or contradictory in a way this plan didn't anticipate.
+
+## Estimated Scope
+
+Single PR in `unh_marine_autonomy` (config/docs/test literal sweep) plus an
+operator-run, non-repo-tracked dev-host data migration performed alongside
+it. Two follow-ups explicitly named, not bundled: the
+`unh_echoboats_project11` config PR, and salmon/gabby repoint + field-rebuild
+day.

--- a/.agent/work-plans/issue-310/progress.md
+++ b/.agent/work-plans/issue-310/progress.md
@@ -98,3 +98,16 @@ overlap. No other open blockers identified.
 - [ ] Update `docs/sonar_reference.md:68-69` (tiled-stores table + survey-index path).
 - [ ] Decide and record the transitional-symlink-vs-clean-cut question explicitly during plan-task.
 - [ ] Cross-reference (don't implement here) the `unh_echoboats_project11` config PR need and the potential `s102_import --cache` default follow-up once this migration lands.
+
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-08-20 18:29 -04:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Plan**: `.agent/work-plans/issue-310/plan.md` at `9762c14`
+**Branch**: feature/issue-310 at `9762c14`
+**Phases**: single
+
+### Open questions
+- [ ] No open questions — plan is review-plan-ready (clean-cut-vs-symlink and eval-store reconciliation were settled at checkpoint 1 and encoded in the plan).

--- a/.agent/work-plans/issue-310/progress.md
+++ b/.agent/work-plans/issue-310/progress.md
@@ -136,3 +136,24 @@ overlap. No other open blockers identified.
 - Deliberate deviation from plan step 6, per the operator's 2026-08-20 cleanup directive: _archive snapshots + survey_index.v1.db.bak are DELETED by the migration script, not carried over (all regenerable). The dropped v1-backup mention in sonar_reference.md is therefore correct, not a lost fact.
 - Dev-host data migration (plan step 6): scripted with pre/post tile-count verification (scratchpad migrate_world_310.sh); execution is the operator's keystroke (host permission classifier correctly blocks agent-run destructive ~/data ops). Pending at entry time.
 - Tests: bathymetry_layer + marine_sidescan_mosaic suites — my one new failure (E501 from the wrapped launch description) fixed; the 9 remaining failures are a pre-existing jazzy lint regression from the DEM-drape arc, filed as uma#323, out of scope here.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-08-20 18:52 -04:00
+**By**: Claude Code Agent (Claude Fable 5)
+**Verdict**: approved
+
+**Branch**: feature/issue-310 at `07c5641`
+**Mode**: pre-push
+**Depth**: Light (reason: doc/literal sweep, ~30 lines, no behavior change beyond a launch default)
+**Must-fix**: 1 | **Suggestions**: 1
+**Round**: 1 | **Ship**: recommended — the one must-fix (stale ecosystem-map status) fixed in-session; suggestion resolved as no-change-needed
+
+Static analysis: ament lint via colcon (my E501 caught + fixed; remaining failures = pre-existing uma#323). Adversarial: 1 pass (Lens A) — verified theme mapping vs ADR-0010 D3, test-literal consistency, launch py_compile, exhaustive-grep.
+
+### Findings
+- [x] (must-fix, Claude Adversarial/Lens A) docs/sonar_ecosystem.md still declared #310 "unstarted" with ~/data/stores literals — self-contradiction on merge — fixed
+- [x] (suggestion, Claude Adversarial/Lens A) sonar_reference.md dropped the v1-backup mention — no-change-needed: the migration deletes survey_index.v1.db.bak per the operator's cleanup directive, so the omission is accurate
+
+### False positives
+- (none)

--- a/.agent/work-plans/issue-310/progress.md
+++ b/.agent/work-plans/issue-310/progress.md
@@ -111,3 +111,15 @@ overlap. No other open blockers identified.
 
 ### Open questions
 - [ ] No open questions — plan is review-plan-ready (clean-cut-vs-symlink and eval-store reconciliation were settled at checkpoint 1 and encoded in the plan).
+
+## Plan Review
+**Status**: complete
+**When**: 2026-08-20 18:31 -04:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Plan**: `.agent/work-plans/issue-310/plan.md` at `9762c14`
+**PR**: PR-less
+**Verdict**: approve
+
+### Findings
+- [ ] Plan looks solid. Ready for implementation.

--- a/.agent/work-plans/issue-310/progress.md
+++ b/.agent/work-plans/issue-310/progress.md
@@ -1,0 +1,100 @@
+---
+issue: 310
+---
+
+# Issue #310 — ~/data/stores → ~/data/world: store root migration (ADR-0010 D3)
+
+## Issue Review
+**Status**: complete
+**When**: 2026-08-20 18:22 -04:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Issue**: #310
+**Comment**: (best-effort post follows this entry; not recorded inline)
+**Scope verdict**: well-scoped
+
+### Scope Assessment
+
+**Well-scoped?** Yes. This is a config-migration issue with a clear, bounded
+deliverable: repoint on-disk store-root defaults from `~/data/stores/` to
+`~/data/world/` per ADR-0010 D3. ADR-0010 itself calls out "path changes are
+config migration" as the residual work after the layer re-split — this issue
+is exactly that residual. Scope boundaries against sibling issues are
+explicitly settled (see #288's plan checkpoint, `.agent/work-plans/issue-288/plan.md:27-32`):
+`#288` owns `datum/`/`s100/` and their consumers; `uma#310` owns the store-root
+relocation (`store_path`, CAMP paths, survey-index path); `uma#311` owns the
+`docs/sonar_ecosystem.md` reframe. No overlap found.
+
+**Right repo?** Yes for the `unh_marine_autonomy` portion (bathymetry_layer's
+`store_path`, `marine_sidescan_mosaic`'s default output dir, docs). The issue
+correctly identifies that the `unh_echoboats_project11` touchpoints
+(`bizzyboat_project11/config/nav2_overlay.yaml`, `bizzyboat.yaml`) need their
+own config PR in that repo rather than being folded into this one — that's
+the right split per workspace-vs-project separation (config lives with the
+consuming platform repo).
+
+**Dependencies**: `#308` (D8 re-split) is already **CLOSED/merged** — the
+issue's "sequencing: no hard dependency on #308, but landing after it avoids
+migrating survey/ twice" note is now moot/satisfied; no blocking dependency
+remains. `#288` is open but explicitly "coordinates with (does not depend
+on)" per the issue body, and the scope-boundary note above confirms no
+overlap. No other open blockers identified.
+
+### Principle Alignment
+
+| Principle | Status | Notes |
+|---|---|---|
+| A change includes its consequences | Watch | The issue's "Known config touchpoints" list is explicitly non-exhaustive. A repo sweep (`grep -rn '~/data/stores'`) in this worktree turns up additional hits the plan should sweep: `docs/sonar_reference.md:68-69` (tiled-stores table + survey-index path — already flagged as uma#310 territory in `#288`'s progress.md), `bathymetry_layer/README.md:92` + `bathymetry_layer.cpp:33` (doc comment for `store_path` default), `bathymetry_layer/test/test_bathymetry_layer.cpp:96-102` (path-expansion unit test literals), `marine_sidescan_mosaic/README.md:108-109,257` (example invocations). None of these change behavior, but stale examples/docs left post-migration would mislead operators. |
+| Only what's needed | OK | Migration only; no scope creep into the D6/D7 library/exporter work, which correctly stays out of this issue. |
+| Improve incrementally | OK | Small, bounded, single-purpose PR consistent with ADR-0010's "each lands as its own issue/PR" consequence note. |
+| Human control and transparency | Watch | The issue leaves the transitional-symlink-vs-clean-cut decision explicitly open ("plan-phase decision") and correctly defers three-host sequencing (dev/salmon/gabby) rather than deciding it here — appropriate to flag for the plan phase, not a gap in the issue itself. |
+| Capture decisions, not just implementations | OK | This issue is itself the config-migration execution of an already-recorded ADR-0010 D3 decision; no new undocumented decision being made, aside from the symlink-vs-clean-cut call which is correctly deferred to plan-task. |
+
+### ADR Applicability
+
+| ADR | Triggered | Notes |
+|---|---|---|
+| 0010 — Geospatial world model | Yes | This issue directly implements D3's on-disk root migration; the theme mapping (`bathymetry`→`depths`, `sidescan`/`backscatter`→`imagery`, contacts→`features`) matches D3 exactly. |
+| 0002 — Bathymetric data store (as amended) | Indirect | `store_path` default lives in `bathymetry_layer`, governed by ADR-0002/ADR-0010's layer taxonomy; the migration doesn't touch layer semantics, only path. |
+| 0006/0007 — Backscatter stores | Indirect | `marine_sidescan_mosaic`'s default output dir falls under D3's `imagery/` mapping; sibling-store tiering is unaffected by the path move. |
+
+### Consequences
+
+- Update `bathymetry_layer/README.md:92` and the matching source comment in
+  `bathymetry_layer.cpp:33` alongside the `store_path` default change (doc +
+  code default must move together).
+- Update `bathymetry_layer/test/test_bathymetry_layer.cpp:96-102` if the
+  literal example paths are meant to reflect the new canonical root (or leave
+  as generic path-expansion test fixtures — plan should decide explicitly
+  rather than leave ambiguous).
+- Update `marine_sidescan_mosaic/README.md` example invocations
+  (lines 108-109, 257) and `sidescan_mosaic.launch.py:36-41` together.
+- Update `docs/sonar_reference.md:68-69` (tiled-stores table, survey-index
+  path) — already anticipated as uma#310 territory by `#288`'s review.
+- Cross-repo: `unh_echoboats_project11` config PR for
+  `bizzyboat_project11/config/nav2_overlay.yaml:136,215` and
+  `bizzyboat.yaml:88` — correctly out of this repo's scope but should be
+  tracked so it isn't dropped (issue body already names both touchpoints).
+- Possible knock-on: `s57_tools#278`'s progress.md records "`--cache` stays
+  required-explicit until ~/data/stores→~/data/world migration lands
+  (confirmed, Roland 2026-07-24)" — once this migration lands, revisit
+  whether `s102_import` should gain a default `--cache` path under
+  `~/data/world/s100/s102/`. Not this issue's scope (different repo/tool),
+  but worth a cross-reference note so it isn't lost.
+
+### Recommendations
+
+- During plan-task, decide and record the transitional-symlink-vs-clean-cut
+  question explicitly (the issue leaves it open by design) — this affects
+  whether the three-host rollout (dev/salmon/gabby) can be staggered or must
+  be synchronized.
+- Confirm the repo sweep for `~/data/stores` literals (this review's list
+  above, plus the issue's own non-exhaustive list) is captured as explicit
+  plan work items, not left implicit.
+
+### Actions
+- [ ] Sweep and update `bathymetry_layer/README.md:92`, `bathymetry_layer.cpp:33`, and (decide explicitly) `bathymetry_layer/test/test_bathymetry_layer.cpp:96-102` alongside the `store_path` default change.
+- [ ] Sweep and update `marine_sidescan_mosaic/README.md:108-109,257` and `sidescan_mosaic.launch.py:36-41` together.
+- [ ] Update `docs/sonar_reference.md:68-69` (tiled-stores table + survey-index path).
+- [ ] Decide and record the transitional-symlink-vs-clean-cut question explicitly during plan-task.
+- [ ] Cross-reference (don't implement here) the `unh_echoboats_project11` config PR need and the potential `s102_import --cache` default follow-up once this migration lands.

--- a/.agent/work-plans/issue-310/progress.md
+++ b/.agent/work-plans/issue-310/progress.md
@@ -157,3 +157,13 @@ Static analysis: ament lint via colcon (my E501 caught + fixed; remaining failur
 
 ### False positives
 - (none)
+
+## Implementation
+**Status**: complete
+**When**: 2026-08-20 19:02 -04:00
+**By**: Claude Code Agent (Claude Fable 5)
+
+**Scope**: dev-host data migration executed (operator-run script, plan step 6) + verified.
+
+- Executed by the operator 2026-08-20 evening; verification against disk: depths = chart 54 (16 Lewes-era + 38 Shoals eval unioned, 0 collisions) + reference 47 + processed 37 (= pre-D8 survey/ folded once) = 138 ✓; imagery/sidescan 1576 ✓ unchanged; imagery/backscatter 37 ✓ (delta = deleted _archive per operator cleanup directive); survey_index.db at world root ✓; eval store dir removed ✓; residual ~/data/stores = s102_cache + s102_shoals only (#288 scope) ✓.
+- Noted seam (tracked, uma#316): merged chart editions.json registers only the 13 Shoals cells — the 16 pre-registry Lewes chart tiles will drop on the next Shoals-region wholesale regen (regenerable; acceptable).

--- a/.agent/work-plans/issue-310/progress.md
+++ b/.agent/work-plans/issue-310/progress.md
@@ -123,3 +123,16 @@ overlap. No other open blockers identified.
 
 ### Findings
 - [ ] Plan looks solid. Ready for implementation.
+
+## Implementation
+**Status**: complete
+**When**: 2026-08-20 18:52 -04:00
+**By**: Claude Code Agent (Claude Fable 5)
+
+**Branch**: feature/issue-310 at `07c5641` (rebased onto current jazzy — 15 same-day merges picked up)
+
+- Repo half per plan steps 1-5+7: six path-literal touchpoints repointed to the world root (bathymetry_layer doc/README/test → world/depths; sidescan launch default + README → world/imagery/sidescan; sonar_reference data-of-record table + survey_index.db world-root home). Sweep re-verified clean (ADR-0010 decision text intentionally untouched).
+- Review finding folded in: docs/sonar_ecosystem.md status text updated — it still called #310 "unstarted" with stores literals (self-contradiction on merge).
+- Deliberate deviation from plan step 6, per the operator's 2026-08-20 cleanup directive: _archive snapshots + survey_index.v1.db.bak are DELETED by the migration script, not carried over (all regenerable). The dropped v1-backup mention in sonar_reference.md is therefore correct, not a lost fact.
+- Dev-host data migration (plan step 6): scripted with pre/post tile-count verification (scratchpad migrate_world_310.sh); execution is the operator's keystroke (host permission classifier correctly blocks agent-run destructive ~/data ops). Pending at entry time.
+- Tests: bathymetry_layer + marine_sidescan_mosaic suites — my one new failure (E501 from the wrapped launch description) fixed; the 9 remaining failures are a pre-existing jazzy lint regression from the DEM-drape arc, filed as uma#323, out of scope here.

--- a/bathymetry_layer/README.md
+++ b/bathymetry_layer/README.md
@@ -89,7 +89,7 @@ it as unsurveyed would be a safety regression), and no longer wholesale keepout
 | Parameter | Type | Default | Meaning |
 |---|---|---|---|
 | `enabled` | bool | `true` | Enable the layer. |
-| `store_path` | string | `""` | Path to the on-disk store directory. Empty = contributes no cost. A leading `~`/`~/` is expanded to `$HOME`, so one portable value (`~/data/stores/bathymetry`) resolves on both the boat (`field` user) and a dev/sim host. |
+| `store_path` | string | `""` | Path to the on-disk store directory. Empty = contributes no cost. A leading `~`/`~/` is expanded to `$HOME`, so one portable value (`~/data/world/depths`) resolves on both the boat (`field` user) and a dev/sim host. |
 | `minimum_depth` | double | `1.0` | Clearance (m) below which a cell is `LETHAL_OBSTACLE`. |
 | `maximum_caution_depth` | double | `2.5` | Clearance (m) at/above which a cell is `FREE_SPACE`; between `minimum_depth` and this the cost ramps. |
 | `confidence_gate` | double | `0.5` | 1-sigma vertical-uncertainty **trust threshold** (m). A sample with `σ ≤ confidence_gate` is *trusted* and may drive a cell to `LETHAL_OBSTACLE` when its worst-case clearance (`clearance − σ`) is below `minimum_depth`. A sample with larger σ is *costed as caution* (never LETHAL on uncertainty alone); only `σ = ∞ / NaN` (unknown quality) stays conservatively LETHAL. **Renamed from `max_uncertainty` (#276) — see the migration note below; this is NOT the old reject-filter.** |

--- a/bathymetry_layer/src/bathymetry_layer.cpp
+++ b/bathymetry_layer/src/bathymetry_layer.cpp
@@ -30,7 +30,7 @@ using marine_bathymetry_store::DepthSample;
 using marine_bathymetry_store::reliableSamples;
 
 // Expand a leading "~" or "~/" in a path to $HOME so one portable store_path
-// value (e.g. "~/data/stores/bathymetry") resolves on both the boat (field user)
+// value (e.g. "~/data/world/depths") resolves on both the boat (field user)
 // and a dev/sim host with a different home. std::filesystem does no such
 // expansion. A bare absolute/relative path, an empty string, or the unsupported
 // "~user" form is returned unchanged (the latter would need getpwnam).

--- a/bathymetry_layer/test/test_bathymetry_layer.cpp
+++ b/bathymetry_layer/test/test_bathymetry_layer.cpp
@@ -93,13 +93,13 @@ TEST(BathymetryLayer, ExpandUserPathHandlesTilde)
   ::setenv("HOME", "/home/tester", 1);
 
   EXPECT_EQ(
-    BathymetryLayerForTest::expandUserPath("~/data/stores/bathymetry"),
-    "/home/tester/data/stores/bathymetry");
+    BathymetryLayerForTest::expandUserPath("~/data/world/depths"),
+    "/home/tester/data/world/depths");
   EXPECT_EQ(BathymetryLayerForTest::expandUserPath("~"), "/home/tester");
   // Absolute, relative, and empty paths are returned unchanged.
   EXPECT_EQ(
-    BathymetryLayerForTest::expandUserPath("/home/field/data/stores/bathymetry"),
-    "/home/field/data/stores/bathymetry");
+    BathymetryLayerForTest::expandUserPath("/home/field/data/world/depths"),
+    "/home/field/data/world/depths");
   EXPECT_EQ(BathymetryLayerForTest::expandUserPath("relative/path"), "relative/path");
   EXPECT_EQ(BathymetryLayerForTest::expandUserPath(""), "");
   // The unsupported "~user" form is left untouched (not expanded).

--- a/docs/sonar_ecosystem.md
+++ b/docs/sonar_ecosystem.md
@@ -74,11 +74,14 @@ ADR-0010 D4 defers the real reference-vs-chart arbitration:
 | `draft` | Live on-boat CUBE output | Streaming append; known-gappy; disposable, regenerable from bags (D8) |
 | `processed` | Off-boat deterministic `import_bag` re-run | Authoritative; distributed back; clears overlapped draft cell-wise (D8) |
 
-**Adopted target, partially materialized.** `~/data/world/` is the adopted root,
-but today it exists only on the dev host as an **eval store** (uma#314: 13 ENC
-cells). The full migration off the legacy `~/data/stores/` root — nav2
-`store_path`s, launch files, CAMP/operator-station paths, and dev tooling such as
-`~/data/stores/survey_index.db` — is **uma#310 (unstarted)**.
+**Adopted target, materialized on the dev host.** `~/data/world/` is the
+canonical root: this repo's path literals (launch defaults, doc examples,
+`~/data/world/survey_index.db`) were repointed and the dev host's store
+content migrated under it in **uma#310** (clean cut, no compat symlink —
+stale readers fail loudly). Still pending from #310's follow-ups: the
+`unh_echoboats_project11` nav2 `store_path`/`draft_dir` config repoints
+(separate PR in that repo) and the salmon/gabby store-root moves,
+sequenced with a field-rebuild day.
 
 ## Arc 1 — Coverage
 
@@ -244,9 +247,10 @@ best-source in the store (not costmap override hacks), and a fully
 GNSS-ellipsoidal runtime (no `chart_datum` frame). The load-bearing pieces are
 merged — D6 datum library, D3/D7 chart layer + regeneration, D8 draft/processed
 split, D9 depths pyramid, D10 `s57_layer` split. **Remaining frontier is
-operational, not design:** (1) the store-root migration off `~/data/stores/`
-(uma#310, unstarted) — until it lands `~/data/world/` is a 13-cell dev-host eval
-store (uma#314); (2) the chart-updater's cron-cycle operational validation (the
+operational, not design:** (1) the store-root migration's cross-host tail
+(uma#310 landed the dev host + this repo's literals; the echoboats config PR
+and the salmon/gabby moves ride the field-rebuild day); (2) the
+chart-updater's cron-cycle operational validation (the
 updater shipped in s57_tools#28 / [PR#33](https://github.com/rolker/s57_tools/pull/33); the nav-liveness-gated regeneration loop
 still needs a real cron cycle exercised); (3) field datum-grid provisioning
 (uma#288 — geoid/VDatum download + user-polygon materialization).

--- a/docs/sonar_reference.md
+++ b/docs/sonar_reference.md
@@ -65,8 +65,8 @@ noted):
 
 | What | Where | Notes |
 |---|---|---|
-| Tiled stores | `~/data/stores/{bathymetry,backscatter,sidescan}/` | Regenerable caches over the bags |
-| Survey index | `~/data/stores/survey_index.db` | v2 (134 Massabesic bags); v1 backup `survey_index.v1.db.bak` |
+| Tiled stores | `~/data/world/{depths,imagery}/` (bathymetry → `depths/`; backscatter + sidescan → `imagery/`) | Regenerable caches over the bags |
+| Survey index | `~/data/world/survey_index.db` | v2 (134 Massabesic bags); dev-tooling metadata, so it sits at the world root rather than in a themed store (#310) |
 | Retrofitted-bag originals | `salmon:~/data/retrofit_backups_2026-07-02/` | 10 `.orig` files — the pre-retrofit **data of record** |
 | Surface sound speed | `~/surface_sound_speed/` | 1 Hz deliverable; gap-filled freshwater Marczak (1997), global offset ≈ +1.07 m/s |
 

--- a/marine_sidescan_mosaic/README.md
+++ b/marine_sidescan_mosaic/README.md
@@ -105,8 +105,8 @@ value tiles directly (ADR-0006 D9 — a file-level dependency, no
 
 ```bash
 ros2 run marine_sidescan_mosaic sidescan_tier2_processed \
-    ~/data/stores/sidescan/tier1/2026-06-19.sst1 /tmp/tier2_dem \
-    --bathy-store ~/data/stores/bathymetry \
+    ~/data/world/imagery/sidescan/tier1/2026-06-19.sst1 /tmp/tier2_dem \
+    --bathy-store ~/data/world/depths \
     [--bathy-layers processed,draft,reference] [--min-dem-coverage 0.5] \
     [--datum-check-warn-m 1.0] [--bathy-cache-tiles 8] [--allow-mixed-projection]
 ```
@@ -254,7 +254,7 @@ regenerable, so a rebuild is idempotent and safe to re-run.
 
 ```bash
 ros2 run marine_sidescan_mosaic build_sidescan_overviews \
-    ~/data/stores/sidescan/processed [--fine-level 13] [--min-level 0] [--dry-run]
+    ~/data/world/imagery/sidescan/processed [--fine-level 13] [--min-level 0] [--dry-run]
 ```
 
 Each level is folded from the one below it, down to `--min-level` (0 = apex). The

--- a/marine_sidescan_mosaic/launch/sidescan_mosaic.launch.py
+++ b/marine_sidescan_mosaic/launch/sidescan_mosaic.launch.py
@@ -33,12 +33,14 @@ from launch_ros.actions import Node
 def generate_launch_description():
     # The live node writes the operator `draft` layer (splat=newest) of the
     # sidescan store; default to the canonical split-store layout
-    # ~/data/stores/<modality>/<maturity>/ (ADR-0006). Override per platform.
-    default_output_dir = os.path.expanduser('~/data/stores/sidescan/draft')
+    # ~/data/world/imagery/<modality>/<maturity>/ (ADR-0006, root per ADR-0010 D3).
+    # Override per platform.
+    default_output_dir = os.path.expanduser('~/data/world/imagery/sidescan/draft')
     args = [
         DeclareLaunchArgument('output_dir', default_value=default_output_dir,
                               description='GGGS GeoTIFF tile dir; default = the sidescan '
-                                          'store draft layer (~/data/stores/sidescan/draft)'),
+                                          'store draft layer '
+                                          '(~/data/world/imagery/sidescan/draft)'),
         DeclareLaunchArgument('gggs_level', default_value='13',
                               description='GGGS level (13 ~= 0.11 m cells)'),
         DeclareLaunchArgument('splat', default_value='newest',


### PR DESCRIPTION
Implements the repo half of **ADR-0010 D3's store-root migration**: every tracked `~/data/stores` path literal repoints to the themed `~/data/world/` layout, per the committed plan (`.agent/work-plans/issue-310/plan.md`) and the operator's checkpoint decisions (2026-08-20): **clean cut, no compat symlink** — stale readers fail loudly.

## What changed

- **bathymetry_layer**: `store_path` doc-comment + README example → `~/data/world/depths`; tilde-expansion test literals updated to match (the expansion mechanism under test is path-content-agnostic).
- **marine_sidescan_mosaic**: launch default `output_dir` → `~/data/world/imagery/sidescan/draft` (+ comment/description); README example invocations repointed.
- **docs/sonar_reference.md**: data-of-record table → `~/data/world/{depths,imagery}/`; `survey_index.db` gets its first canonical home at the world root (dev-tooling metadata, not a themed store — a decision D3 left open, recorded here).
- **docs/sonar_ecosystem.md**: status text updated from "#310 unstarted" to landed-with-cross-host-tail (pre-push review finding — the START-HERE map would otherwise contradict the repo on merge).

Sweep verified exhaustive by fresh grep; ADR-0010's own decision text intentionally untouched (immutable record). The **dev-host data move** (bathymetry→depths with `survey/`→`processed/` folded once, sidescan+backscatter→imagery/, ENC eval store reconciled into depths/chart/, survey_index.db to the world root, `_archive`/`.bak` dropped per the operator's cleanup directive) runs as an operator-executed script alongside this PR.

## Follow-ups (named, not implemented here)

- `unh_echoboats_project11` config repoints (`nav2_overlay.yaml` `store_path`, `bizzyboat.yaml` `draft_dir`) — separate PR in that repo.
- salmon + gabby store-root moves — sequenced with the field-rebuild day.
- Pre-existing jazzy lint regression in marine_sidescan_mosaic — #323 (unrelated, filed during this work).

## Test plan

- [x] `colcon test` bathymetry_layer + marine_sidescan_mosaic — the one new failure my edit introduced (E501) fixed; remaining failures are the pre-existing #323 set, bit-identical on an unmodified checkout
- [x] Launch file `py_compile` after the string wrap
- [ ] Dev-host migration script run with pre/post tile-count verification (operator keystroke; gate for merge)

Part of the world-model arc (#86 / ADR-0010).
Closes #310

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
