### PR TITLE
ADR-0010 D7: withdraw footprint clipping — it deletes the LOD ancestors (#337)

### DIFF
--- a/docs/decisions/0010-geospatial-world-model.md
+++ b/docs/decisions/0010-geospatial-world-model.md
@@ -319,11 +319,46 @@ Export rules (`s57_to_geotiff`, new tool in `s57_tools`, feeding the existing
 - **Scale → GGGS level**: each ENC cell exports at the level matching its
   compilation scale (≈0.5 mm-at-scale resolvable ground distance, mapped to
   the nearest GGGS level). The store is already multi-level (ADR-0002 D2/#151).
-- **Largest scale governs**: each chart's raster footprint is clipped by all
+- ~~**Largest scale governs**: each chart's raster footprint is clipped by all
   finer-scale charts' footprints, so coarse cells are never generated where
   finer coverage exists — standard chart practice, and it prevents the
   shallowest-reliable walk from letting a coarse band's midpoint shadow a
-  confident harbor-chart depth.
+  confident harbor-chart depth.~~
+
+  **Amended 2026-08-22
+  ([#337](https://github.com/rolker/unh_marine_autonomy/issues/337),
+  [s57_tools#49](https://github.com/rolker/s57_tools/issues/49)):
+  footprint-clipping is withdrawn. Every chart is exported entire, at its own
+  level.** Clipping by a finer cell's *declared* `M_COVR` deleted the coarser
+  levels the rest of this family of documents runs on:
+  [ADR-0013](0013-bounded-lod-navigation.md) D5 makes *"every level always has a
+  renderable answer, by upsampling from a resident ancestor"* an invariant, and
+  D3's corollary fills coverage gaps from coarser levels and marks them (S-52
+  3.1.7 overscale). Both need the coarse material to still exist.
+
+  It also falsified **D9 below, in this same ADR**. D9 exempts `chart` from
+  pyramid generation because "the scale ladder is a cartographer-curated
+  pyramid" — true of the ENC corpus, and false of what we stored, because
+  footprint-clipping turns a nested ladder into a region-disjoint patchwork with
+  no ancestors. This clause was what broke that premise; removing it makes D9
+  correct as written.
+
+  Measured over the Isles of Shoals survey box: charted coverage **34.6% →
+  99.2%** (level 6 alone, 19.2% → 99.1%), recovering 64.6% of the survey area
+  from charts already on disk. The corpus also exports 13 of 13 cells instead of
+  12 — one approach cell was being clipped to nothing, which had looked like a
+  conversion failure.
+
+  **The safety rationale is preserved, not discarded** — it is a *precedence*
+  concern, and precedence does not require deletion. The display draws finer
+  over coarser (`camp#194` composites every level at or below the selection and
+  discards no-data pixels, so finer covers coarser where it exists and coarse
+  shows through the gaps). `shallowestReliable` takes the shallowest reliable
+  value across all layers and levels, so a coarse band's midpoint can only win
+  where it is **shallower** — conservative — and its large CATZOC σ routes it to
+  go-slow rather than keepout under the #276 cost model. Scale precedence now
+  lives in the consumers, where a coarse value can be *ranked* without being
+  *destroyed*.
 
 **Chart ingestion is gated on the cost-model rework** — a precondition, not a
 parallel track, and satisfied by


### PR DESCRIPTION
Closes #337. Pairs with [s57_tools#50](https://github.com/rolker/s57_tools/pull/50), the code change.

Docs-only.

## What changed

`ADR-0010` D7's **"Largest scale governs"** clause is struck through and replaced
with a dated amendment: footprint-clipping is withdrawn, every chart is exported
entire at its own level.

Struck rather than deleted, so a reader sees what was decided and why it changed.

## Why

Clipping by a finer cell's *declared* `M_COVR` deleted the coarser levels the
rest of this family of documents runs on — `ADR-0013` D5's *"every level always
has a renderable answer, by upsampling from a resident ancestor"* invariant, and
D3's corollary filling coverage gaps from coarser levels and marking them
overscale (S-52 3.1.7).

**It also falsified D9 in this same ADR.** D9 exempts `chart` from pyramid
generation because the ENC scale ladder is already a cartographer-curated
pyramid — true of the corpus, false of what we stored, because footprint-clipping
turns a nested ladder into a region-disjoint patchwork with no ancestors.
Withdrawing this clause makes **D9 correct as written** rather than requiring D9
to change too.

## Measured

| Isles of Shoals survey box | clipped | unclipped |
|---|---|---|
| level 6 | 19.2% | **99.1%** |
| **any level** | **34.6%** | **99.2%** |
| no charted depth | 65.4% | **0.8%** |

64.6% of the survey area recovered from charts already on disk. Found because
CAMP renders blank over the survey area when zoomed out, reported three days
before a survey.

## The safety clause is kept

D7's second rationale — stopping a coarse band's midpoint shadowing a confident
harbour depth in the shallowest-reliable walk — is a **precedence** concern, and
precedence does not require deletion. The amendment records where precedence now
lives: the display draws finer over coarser (`camp#194`), and
`shallowestReliable` takes the shallowest reliable value across all levels, so a
coarse midpoint can only win where it is *shallower* — conservative — with its
large CATZOC σ routing it to go-slow rather than keepout under #276.

## Governance note for the reviewer

`ADR-0010` is **Accepted**, and the workspace's
[ADR-0012](https://github.com/rolker/ros2_agent_workspace/blob/main/docs/decisions/0012-permit-cross-reference-addendums-in-adrs.md)
permits only *navigational* addendums to accepted ADRs — substantive changes are
meant to supersede. This is substantive.

I followed **this repo's own precedent** instead: `ADR-0002` carries inline
`**Amended <date> (#issue):**` blocks including a partial supersession
("Amendment A2's collapse to a single `survey` layer is partially superseded on
new evidence"). Flagging the tension rather than resolving it silently — if you
would rather this be a superseding `uma-ADR-0014`, say so and I will rewrite it
that way.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 5 (1M context)`
