### PR TITLE
docs: implementable design for the persistent launch/lifecycle manager

### DIFF
--- a/.agent/work-plans/issue-327/progress.md
+++ b/.agent/work-plans/issue-327/progress.md
@@ -1,0 +1,67 @@
+---
+issue: 327
+---
+
+# Issue #327 — Research + design: persistent launch/lifecycle manager for boat and operator station
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-08-22 19:31 -04:00
+**By**: Claude Code Agent (Claude Opus)
+
+**PR**: #340 at `74dbb1d`
+**Sources**: 1 (Copilot review 5000840166 @ `74dbb1d`, + CI rollup). No prior local
+review timeline exists for this issue — research and design were driven by hand, so
+this file starts here and cross-source confirmation was not available.
+**Cross-source confirmations**: 0
+**CI**: all-pass (build: success; copilot-pull-request-reviewer: success)
+
+Copilot delivered 5 inline comments plus 1 suppressed duplicate (line 516 repeats the
+line 509 finding). All 5 land on the single added file, `docs/launch_manager.md`.
+The authority for what the doc must say is the settled-design comment on issue #327
+(comment 5375366186); each finding below was checked against it.
+
+### Findings
+- [ ] (must-fix, Copilot) Readiness `timeout` scope is self-contradictory. The schema and
+  every example put `timeout` as a sibling key inside the `ready` map
+  (`ready: {tcp_port: 7447, timeout: 15.0}`), but line 486 reads "Every predicate takes
+  `timeout`" while line 473 allows `ready` to name more than one predicate. An
+  implementer cannot tell whether the budget is per-predicate or shared. Fix: state that
+  `timeout` is a `ready`-level key bounding the conjunction of all its predicates, and
+  reword line 486 accordingly — `docs/launch_manager.md`
+- [ ] (must-fix, Copilot) The escalation ladder's "respawn budget" (line 328) names no
+  config key. The schema defines only `start_attempts`, `retry_limit`, `retry_window`,
+  `backoff`. The settled design's two-budget split (`start_attempts` = never became
+  ready; `retry_limit`/`retry_window` = was ready then died) plus the `respawns_in_window`
+  status field (line 426) make the intent unambiguous — respawns consume `retry_limit`
+  within `retry_window` — but the doc never says so. Fix: name the keys inline at line 328
+  — `docs/launch_manager.md`
+- [ ] (should-fix, Copilot) Declared arguments are typed and value-constrained (lines
+  258-266: `type: bool`, `pattern:`), but `~/command` carries them as
+  `diagnostic_msgs/KeyValue[]` (line 439), which is string-to-string only. The doc never
+  says how a typed value crosses the wire. Fix: one sentence stating values travel as
+  string scalars and are parsed and coerced against the declared type on receipt, with a
+  failed parse rejected the same way an out-of-range value is — `docs/launch_manager.md`
+- [ ] (minor, Copilot) Cross-repo and workspace-layer paths are unresolvable to a reader
+  on GitHub: the tmux scripts at line 24 (`bizzyboat_project11/scripts/...`) name a ROS
+  package, not the repo that owns it, and lines 509/516 use workspace layer paths
+  (`layers/main/underlay_ws/src/...`). All four paths were verified to exist on this host,
+  so the doc is accurate — the gap is attribution, not correctness. Fix: name the owning
+  repos once (`unh_echoboats_project11`, `ros2launch_session`, `ros2launch_gui`) and note
+  that the layer paths are workspace-relative. Do **not** adopt Copilot's suggested
+  remedies — see false positives — `docs/launch_manager.md`
+
+### False positives
+- (Copilot, line 509/516) "Point to the actual underlay repo URL, or the pinned entry in
+  `config/repos/underlay.repos`." Both remedies are unavailable. `ros2launch_session` and
+  `ros2launch_gui` have exactly one remote each, `git@gitcloud:field/...` — they are
+  field-mode repos with no GitHub URL to link, and AGENTS.md forbids constructing GitHub
+  URLs that were not looked up. `config/repos/underlay.repos` does not exist in this repo
+  or in the workspace; the path is invented. The residual attribution concern is kept as
+  the minor finding above.
+- (Copilot, line 24) "Consider referencing them generically so the doc stays correct when
+  scripts move/rename." Generic references would make the claim unverifiable, which the
+  workspace Documentation Accuracy rule specifically forbids — every documented claim must
+  be checkable against source. All three script paths were confirmed present at
+  `platforms_ws/src/unh_echoboats_project11/bizzyboat_project11/scripts/`. Keeping the
+  concrete paths and adding the owning repo name is the correct resolution.

--- a/.agent/work-plans/issue-327/progress.md
+++ b/.agent/work-plans/issue-327/progress.md
@@ -22,27 +22,27 @@ The authority for what the doc must say is the settled-design comment on issue #
 (comment 5375366186); each finding below was checked against it.
 
 ### Findings
-- [ ] (must-fix, Copilot) Readiness `timeout` scope is self-contradictory. The schema and
+- [x] (must-fix, Copilot) Readiness `timeout` scope is self-contradictory. The schema and
   every example put `timeout` as a sibling key inside the `ready` map
   (`ready: {tcp_port: 7447, timeout: 15.0}`), but line 486 reads "Every predicate takes
   `timeout`" while line 473 allows `ready` to name more than one predicate. An
   implementer cannot tell whether the budget is per-predicate or shared. Fix: state that
   `timeout` is a `ready`-level key bounding the conjunction of all its predicates, and
   reword line 486 accordingly — `docs/launch_manager.md`
-- [ ] (must-fix, Copilot) The escalation ladder's "respawn budget" (line 328) names no
+- [x] (must-fix, Copilot) The escalation ladder's "respawn budget" (line 328) names no
   config key. The schema defines only `start_attempts`, `retry_limit`, `retry_window`,
   `backoff`. The settled design's two-budget split (`start_attempts` = never became
   ready; `retry_limit`/`retry_window` = was ready then died) plus the `respawns_in_window`
   status field (line 426) make the intent unambiguous — respawns consume `retry_limit`
   within `retry_window` — but the doc never says so. Fix: name the keys inline at line 328
   — `docs/launch_manager.md`
-- [ ] (should-fix, Copilot) Declared arguments are typed and value-constrained (lines
+- [x] (should-fix, Copilot) Declared arguments are typed and value-constrained (lines
   258-266: `type: bool`, `pattern:`), but `~/command` carries them as
   `diagnostic_msgs/KeyValue[]` (line 439), which is string-to-string only. The doc never
   says how a typed value crosses the wire. Fix: one sentence stating values travel as
   string scalars and are parsed and coerced against the declared type on receipt, with a
   failed parse rejected the same way an out-of-range value is — `docs/launch_manager.md`
-- [ ] (minor, Copilot) Cross-repo and workspace-layer paths are unresolvable to a reader
+- [x] (minor, Copilot) Cross-repo and workspace-layer paths are unresolvable to a reader
   on GitHub: the tmux scripts at line 24 (`bizzyboat_project11/scripts/...`) name a ROS
   package, not the repo that owns it, and lines 509/516 use workspace layer paths
   (`layers/main/underlay_ws/src/...`). All four paths were verified to exist on this host,
@@ -65,3 +65,58 @@ The authority for what the doc must say is the settled-design comment on issue #
   be checkable against source. All three script paths were confirmed present at
   `platforms_ws/src/unh_echoboats_project11/bizzyboat_project11/scripts/`. Keeping the
   concrete paths and adding the owning repo name is the correct resolution.
+
+## Implementation
+**Status**: complete
+**When**: 2026-08-22 19:34 -04:00
+**By**: Claude Code Agent (Claude Opus)
+
+**PR**: #340 at `5b57cf7`
+**Addressed**: `## Integrated Review` (2026-08-22 19:31 -04:00, PR #340 at `74dbb1d`) — all
+4 open actions, 0 deferred.
+**Commits**: `96ad0bc`, `fbe594b`, `6c2f85b`, `5b57cf7`
+
+All four were doc-only edits to `docs/launch_manager.md`. Every fix states intent already
+settled in issue #327 comment 5375366186; no new design decision was made. Every path named
+in the attribution fix was verified on this host before it was written.
+
+### Actions
+- [x] (must-fix) Readiness `timeout` scoped to the `ready` map, not each predicate —
+  `docs/launch_manager.md:487,500` (plus the `ready` schema row at `:171`). The intro now
+  names `timeout` a reserved key alongside the predicates, and the following paragraph
+  states it is a single budget bounding the **conjunction** of every predicate, with a
+  two-predicate example spelling out "30 s together, not 30 s each". Matches the settled
+  design's example config, where `timeout` is a sibling of the predicate keys inside
+  `ready`. — `96ad0bc`
+- [x] (must-fix) Escalation ladder now names the config keys behind "respawn budget" —
+  `docs/launch_manager.md:339`. Step 3 reads "the respawn budget is `retry_limit` respawns
+  within `retry_window`", ties it to the `respawns_in_window` status field, and step 4 says
+  which budget `FAILED` follows: `retry_limit`/`retry_window` for a group that reached
+  `READY`, `start_attempts` for one that never did. This is the settled design's two-budget
+  split (never-became-ready vs. was-ready-then-died) said out loud. — `fbe594b`
+- [x] (should-fix) Typed declared arguments crossing the `diagnostic_msgs/KeyValue[]` wire
+  — `docs/launch_manager.md:272`. New paragraph in **Declared arguments**: values travel as
+  string scalars, are parsed and coerced against the declared `type` on receipt (before the
+  range check), and a value that fails to parse is rejected exactly as an out-of-range one
+  is. The rejection sentence that follows was extended to list the parse failure alongside
+  the undeclared-argument and failed-constraint cases. — `6c2f85b`
+- [x] (minor) Attribution for cross-repo and workspace-layer paths —
+  `docs/launch_manager.md:25,525`. The Purpose section now says `bizzyboat_project11` is a
+  package in the **`unh_echoboats_project11`** repository and gives its workspace checkout
+  path; **Implementation substrate** now says `ros2launch_session` and `ros2launch_gui` are
+  repositories of the same name in the underlay layer and that the paths quoted are
+  workspace-relative checkout locations, not upstream URLs. Copilot's own remedies were not
+  adopted, per the triage: no `config/repos/underlay.repos` link (the file does not exist)
+  and the concrete tmux script paths were kept rather than made generic (Documentation
+  Accuracy requires a checkable claim). Verified present before writing:
+  `layers/main/platforms_ws/src/unh_echoboats_project11/bizzyboat_project11/scripts/{start_tmux_project11,start_tmux_operator_project11,stop_tmux_project11}.bash`,
+  `layers/main/underlay_ws/src/ros2launch_session`, `layers/main/underlay_ws/src/ros2launch_gui`
+  and the three `ros2launch_gui` widget files cited at `:485`. — `5b57cf7`
+
+### Checks
+Pre-commit hooks ran clean on all four commits (never `--no-verify`). No code changed, so
+no package tests apply. Not pushed — the host performs pushes.
+
+### Next step
+Re-review the fixes with a fresh-context sub-agent:
+`.agent/scripts/dispatch_subagent.sh --mode in-process --issue 327 --skill review-code`

--- a/.agent/work-plans/issue-327/progress.md
+++ b/.agent/work-plans/issue-327/progress.md
@@ -152,33 +152,33 @@ the three tmux scripts, `ros2launch_session` (`LaunchSession`, `from_service`,
 `core_launch.py` including udp_bridge, and all eight intra-document anchors.
 
 ### Findings
-- [ ] (must-fix) Example `default_profile: awareness` contradicts the doc's three "comms-only default profile" claims; keep the settled example, reword the prose — `docs/launch_manager.md:205,17,578-579,588`
-- [ ] (must-fix) `retry_limit`/`retry_window` is bound to both ladder step 3 (group restart) and step 4 (`FAILED`); the respawn budget triggering step 3 is a third, unnamed budget (`launch`'s own `respawn_max_retries`) — regression from the round-1 fix — `docs/launch_manager.md:339-344`
-- [ ] (must-fix) `launch.events.process.process_matchers` ships three matchers, not "`matches_pid` and `matches_name` only"; `launch.events.matchers.matches_action` also exists and is a non-racy handle that narrows the spike — `docs/launch_manager.md:555-556`
-- [ ] (must-fix) `from_service()` is a `@contextlib.contextmanager` whose `finally` calls `session.shutdown()` when processes remain (`launch_session.py:277-282`) — one `with` per group tears down the whole stack; belongs in the section that already warns `shutdown()` stops everything — `docs/launch_manager.md:532-534,546-549`
-- [ ] (must-fix) `bool force` is declared on the wire and defined nowhere; safety-relevant (plausibly bypasses `FAILED` stickiness or the `RELOAD_CONFIG` running-group guard) — define or delete — `docs/launch_manager.md:453`
-- [ ] (must-fix) Single `last_request_id` ack slot vs. three mandated concurrent front ends: a `REJECTED` result and its reason are transient, and a client's "re-send until acknowledged" loop can never terminate — `docs/launch_manager.md:411-413,426-428,456-458`
-- [ ] (must-fix) Idempotency by `request_id` addresses duplication, not reordering, yet the doc claims it makes the topic safe over a link that "duplicates and reorders"; a held `STOP helm` delivered after a later `START helm` is re-executed — `docs/launch_manager.md:456-458`
-- [ ] (must-fix) Output has no channel in the control surface, while the doc promises per-process output tabs on the same topics across the link and sets tmux-scrollback parity as a regression criterion — `docs/launch_manager.md:350-358,479-483` vs `:400-454`
-- [ ] (must-fix) `zenoh` and `comms` are ordinary groups with ordinary budgets, but `FAILED` is sticky until a `CLEAR_FAILURE` that must arrive over the transport those groups provide — reintroduces "no remote control surface"; the accepted consequence covers only a manager crash — `docs/launch_manager.md:218-226,297-299,510-516`
-- [ ] (must-fix) "Convergence means the two cannot race" is not established: `autostart=True` unconditionally drives to `active` (`lifecycle_node.py:127-129`) while `target` may be `inactive`, and transient startup states are not excluded from convergence — `docs/launch_manager.md:389-392,381`
-- [ ] (suggestion) The doc's central safety claim is half-established: a lifecycle-repaired `helm_manager` is `active` with no `piloting_mode` (volatile, event-driven, created in `on_configure`) and still publishes nothing, yet reports `READY`/OK; and the open-hazard interval grades `DEGRADED`→WARN, same as `STARTING` — `docs/launch_manager.md:288-289,330-332,473-475`
-- [ ] (suggestion) Neither budget has a stated reset condition, and `CLEAR_FAILURE` leaves desired `RUNNING` so convergence restarts immediately — the acknowledgement is either ceremony or an instant re-entry to the crash loop — `docs/launch_manager.md:153-156,297-299,438-439`
-- [ ] (suggestion) A clean exit with desired `RUNNING` (and `restart: never`) has no representable state: prose says `READY`→`STOPPED` but the table defines `STOPPED` as "desired `STOPPED`" — and the ladder never references the `restart` enum — `docs/launch_manager.md:175,189-192,285`
-- [ ] (suggestion) State diagram omits `STARTING`→`FAILED` (ready-timeout exhausting `start_attempts`) and the retry/backoff self-loop — `docs/launch_manager.md:301-319`
-- [ ] (suggestion) Dependents of a group leaving `READY`: `BLOCKED` and `DEGRADED` definitions collide, and `blocked_by` is populated only when `BLOCKED`, so the named cause has nowhere to go — `docs/launch_manager.md:285-295,346-348,436`
-- [ ] (suggestion) `SUPERSEDED` appears once, in an enum comment, and is defined nowhere — `docs/launch_manager.md:427`
-- [ ] (suggestion) `lifecycle: {delegate: ...}` is not exempted from the escalation ladder; Nav2's own manager deliberately deactivates nodes, which reads as drift and would fight the delegate. `READY`'s "lifecycle at target" is also undefined when there is no `target` — `docs/launch_manager.md:377-382` vs `:288,328-348`
-- [ ] (suggestion) `START [helm]` with `core` stopped has no stated behavior (pull in dependencies / reject / block forever); the load-time `requires` rule has no runtime counterpart — `docs/launch_manager.md:198,445-451`
-- [ ] (suggestion) `SET_LIFECYCLE`/`lifecycle_target` appear only in the message sketch; unstated whether they mutate the configured target or are a one-shot the convergence loop immediately undoes — `docs/launch_manager.md:448-451`
-- [ ] (suggestion) Declared-argument keys (`type`, `pattern`, `default`) never appear in a schema table, and the rule demands "a range or set" while the example shows a regex and an unconstrained bool — `docs/launch_manager.md:258-269`
-- [ ] (suggestion) `exec:`, `environment:`, and `log_dir` are unconstrained and re-read by `RELOAD_CONFIG`; one sentence naming the config file as the trust boundary and `~/command` as unauthenticated-by-acceptance turns a silent hole into a knowing one — `docs/launch_manager.md:258-262,460-462`
-- [ ] (suggestion) `output_ring_bytes` per-group vs. two retained buffers (first + latest) — per buffer or total? Relationship to `log_dir` (memory / disk / both) unstated — `docs/launch_manager.md:146,350-354`
-- [ ] (suggestion) `ros2launch_manager_msgs` is said to depend on `std_msgs`, which nothing in either message sketch uses — `docs/launch_manager.md:415-416`
-- [ ] (suggestion) The example config's `file:` values are post-refactor names that do not exist yet; a pointer to §Assumed launch-file refactor would stop a reader treating it as runnable — `docs/launch_manager.md:216-256`
-- [ ] (suggestion) `LaunchService.run()` defaults to `shutdown_when_idle=True`; an all-`STOPPED` manager's shared service would exit — worth one line pinning it False — `docs/launch_manager.md:528-534`
-- [ ] (suggestion) Diagnostics mapping omits `STOPPED` and `STOPPING`; since `STOPPED` is "the resting state, not a failure" it should be stated OK rather than guessed — `docs/launch_manager.md:474-475`
-- [ ] (suggestion) The non-default-`restart` justification rule is demonstrated nowhere: every example group sets the default `on-failure`, four with redundant justification comments — `docs/launch_manager.md:184-188,220-250`
+- [x] (must-fix) Example `default_profile: awareness` contradicts the doc's three "comms-only default profile" claims; keep the settled example, reword the prose — `docs/launch_manager.md:205,17,578-579,588`
+- [x] (must-fix) `retry_limit`/`retry_window` is bound to both ladder step 3 (group restart) and step 4 (`FAILED`); the respawn budget triggering step 3 is a third, unnamed budget (`launch`'s own `respawn_max_retries`) — regression from the round-1 fix — `docs/launch_manager.md:339-344`
+- [x] (must-fix) `launch.events.process.process_matchers` ships three matchers, not "`matches_pid` and `matches_name` only"; `launch.events.matchers.matches_action` also exists and is a non-racy handle that narrows the spike — `docs/launch_manager.md:555-556`
+- [x] (must-fix) `from_service()` is a `@contextlib.contextmanager` whose `finally` calls `session.shutdown()` when processes remain (`launch_session.py:277-282`) — one `with` per group tears down the whole stack; belongs in the section that already warns `shutdown()` stops everything — `docs/launch_manager.md:532-534,546-549`
+- [x] (must-fix) `bool force` is declared on the wire and defined nowhere; safety-relevant (plausibly bypasses `FAILED` stickiness or the `RELOAD_CONFIG` running-group guard) — define or delete — `docs/launch_manager.md:453`
+- [x] (must-fix) Single `last_request_id` ack slot vs. three mandated concurrent front ends: a `REJECTED` result and its reason are transient, and a client's "re-send until acknowledged" loop can never terminate — `docs/launch_manager.md:411-413,426-428,456-458`
+- [x] (must-fix) Idempotency by `request_id` addresses duplication, not reordering, yet the doc claims it makes the topic safe over a link that "duplicates and reorders"; a held `STOP helm` delivered after a later `START helm` is re-executed — `docs/launch_manager.md:456-458`
+- [x] (must-fix) Output has no channel in the control surface, while the doc promises per-process output tabs on the same topics across the link and sets tmux-scrollback parity as a regression criterion — `docs/launch_manager.md:350-358,479-483` vs `:400-454`
+- [x] (must-fix) `zenoh` and `comms` are ordinary groups with ordinary budgets, but `FAILED` is sticky until a `CLEAR_FAILURE` that must arrive over the transport those groups provide — reintroduces "no remote control surface"; the accepted consequence covers only a manager crash — `docs/launch_manager.md:218-226,297-299,510-516`
+- [x] (must-fix) "Convergence means the two cannot race" is not established: `autostart=True` unconditionally drives to `active` (`lifecycle_node.py:127-129`) while `target` may be `inactive`, and transient startup states are not excluded from convergence — `docs/launch_manager.md:389-392,381`
+- [x] (suggestion) The doc's central safety claim is half-established: a lifecycle-repaired `helm_manager` is `active` with no `piloting_mode` (volatile, event-driven, created in `on_configure`) and still publishes nothing, yet reports `READY`/OK; and the open-hazard interval grades `DEGRADED`→WARN, same as `STARTING` — `docs/launch_manager.md:288-289,330-332,473-475`
+- [x] (suggestion) Neither budget has a stated reset condition, and `CLEAR_FAILURE` leaves desired `RUNNING` so convergence restarts immediately — the acknowledgement is either ceremony or an instant re-entry to the crash loop — `docs/launch_manager.md:153-156,297-299,438-439`
+- [x] (suggestion) A clean exit with desired `RUNNING` (and `restart: never`) has no representable state: prose says `READY`→`STOPPED` but the table defines `STOPPED` as "desired `STOPPED`" — and the ladder never references the `restart` enum — `docs/launch_manager.md:175,189-192,285`
+- [x] (suggestion) State diagram omits `STARTING`→`FAILED` (ready-timeout exhausting `start_attempts`) and the retry/backoff self-loop — `docs/launch_manager.md:301-319`
+- [x] (suggestion) Dependents of a group leaving `READY`: `BLOCKED` and `DEGRADED` definitions collide, and `blocked_by` is populated only when `BLOCKED`, so the named cause has nowhere to go — `docs/launch_manager.md:285-295,346-348,436`
+- [x] (suggestion) `SUPERSEDED` appears once, in an enum comment, and is defined nowhere — `docs/launch_manager.md:427`
+- [x] (suggestion) `lifecycle: {delegate: ...}` is not exempted from the escalation ladder; Nav2's own manager deliberately deactivates nodes, which reads as drift and would fight the delegate. `READY`'s "lifecycle at target" is also undefined when there is no `target` — `docs/launch_manager.md:377-382` vs `:288,328-348`
+- [x] (suggestion) `START [helm]` with `core` stopped has no stated behavior (pull in dependencies / reject / block forever); the load-time `requires` rule has no runtime counterpart — `docs/launch_manager.md:198,445-451`
+- [x] (suggestion) `SET_LIFECYCLE`/`lifecycle_target` appear only in the message sketch; unstated whether they mutate the configured target or are a one-shot the convergence loop immediately undoes — `docs/launch_manager.md:448-451`
+- [x] (suggestion) Declared-argument keys (`type`, `pattern`, `default`) never appear in a schema table, and the rule demands "a range or set" while the example shows a regex and an unconstrained bool — `docs/launch_manager.md:258-269` (deferred: a schema table plus a re-statement of the constraint rule is doc scope the operator ruled out for this pass)
+- [x] (suggestion) `exec:`, `environment:`, and `log_dir` are unconstrained and re-read by `RELOAD_CONFIG`; one sentence naming the config file as the trust boundary and `~/command` as unauthenticated-by-acceptance turns a silent hole into a knowing one — `docs/launch_manager.md:258-262,460-462`
+- [x] (suggestion) `output_ring_bytes` per-group vs. two retained buffers (first + latest) — per buffer or total? Relationship to `log_dir` (memory / disk / both) unstated — `docs/launch_manager.md:146,350-354` (deferred: per-buffer-or-total is an unmade design decision, not a wording fix)
+- [x] (suggestion) `ros2launch_manager_msgs` is said to depend on `std_msgs`, which nothing in either message sketch uses — `docs/launch_manager.md:415-416`
+- [x] (suggestion) The example config's `file:` values are post-refactor names that do not exist yet; a pointer to §Assumed launch-file refactor would stop a reader treating it as runnable — `docs/launch_manager.md:216-256`
+- [x] (suggestion) `LaunchService.run()` defaults to `shutdown_when_idle=True`; an all-`STOPPED` manager's shared service would exit — worth one line pinning it False — `docs/launch_manager.md:528-534`
+- [x] (suggestion) Diagnostics mapping omits `STOPPED` and `STOPPING`; since `STOPPED` is "the resting state, not a failure" it should be stated OK rather than guessed — `docs/launch_manager.md:474-475`
+- [x] (suggestion) The non-default-`restart` justification rule is demonstrated nowhere: every example group sets the default `on-failure`, four with redundant justification comments — `docs/launch_manager.md:184-188,220-250` (deferred: would mean changing the settled example config, which this pass must not do)
 
 ### Governance
 Principles — Safety First: **Concern** (must-fix 8, 9, 10 and the helm-authority suggestion are
@@ -199,3 +199,93 @@ the doc drops nothing settled there, and the example config is reproduced faithf
 must-fixes exist precisely *because* the doc's prose drifted from that example (must-fix 1) or
 over-committed beyond it (must-fix 2, introduced by the round-1 fix `fbe594b`) — both should be
 resolved by changing the prose, not the settled example.
+
+## Implementation
+**Status**: complete
+**When**: 2026-08-22 22:42 -04:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Branch**: feature/issue-327 at `2f3061c`
+**Addressed**: `## Local Review (Pre-Push)` (2026-08-22 22:29 -04:00, branch at `adc6a0d`) — 10 must-fix, 17 suggestions
+**Commits**: eaf6b5c, a608167, 3a0e664, 462c534, b7fd9ff, 862f68a, 3f942ea, 37367e8, 70e73b6, 26e229f, e2b90fb, 96d9eba, c06873d, 2f3061c
+
+All edits are to `docs/launch_manager.md`. Operator scope for this pass: fix all 10
+must-fixes; take cheap, clearly-correct suggestions; record the zenoh/comms sticky-`FAILED`
+hazard as an Open item rather than solving it; do not invent design decisions, and do not
+change the example config reproduced from settled-design comment 5375366186 — where prose
+and example disagreed, the prose changed.
+
+### Actions
+- [x] MF1 default-profile contradiction — prose now says the default profile is per host and
+  must include the link; the example's `awareness` stands `docs/launch_manager.md` §Purpose,
+  §Deployment, §Assumed launch-file refactor (eaf6b5c)
+- [x] MF2 budget conflation — ladder now names three budgets at three levels; step 2 is
+  `launch`'s per-process `respawn_max_retries` (verified `launch/actions/execute_local.py:100`,
+  enforced `:606-608`, default `-1`), step 3/4 keep `retry_limit`/`retry_window` and
+  `start_attempts` (a608167)
+- [x] MF3 matcher inventory — corrected to three (`matches_pid`, `matches_name`,
+  `matches_executable`, all reading `process_details`, `None` before start) plus
+  `launch.events.matchers.matches_action` (identity match, `launch/events/matchers.py:22`);
+  spike narrowed to whether a per-process sweep tears down as cleanly as a scoped shutdown,
+  since naming a process is no longer the open part (3a0e664)
+- [x] MF4 `from_service()` context manager — recorded that its `finally` calls
+  `session.shutdown()` while processes remain (`ros2launch_session/launch_session.py:279-282`),
+  so a per-group `with` is not an available shape (462c534)
+- [x] MF5 undefined `force` — kept the settled field, marked `# UNDEFINED` in the sketch with
+  the two safety-relevant readings named, and added an Open item: define or delete (b7fd9ff)
+- [x] MF6 single ack slot — limitation written up under §`~/status` (a REJECTED result is what
+  gets overwritten; re-send-until-acknowledged never terminates) + Open item (862f68a)
+- [x] MF7 duplication vs reordering — claim split; a delayed `STOP` after a later `START` is
+  executed on arrival, desired state bounds but does not prevent it + Open item (3f942ea)
+- [x] MF8 output has no channel — §Front ends now states the gap; tmux-scrollback parity holds
+  on the manager's host only + Open item constrained by best-effort UDP (37367e8)
+- [x] MF9 sticky `FAILED` on link-carrying groups — written up honestly under §Process
+  ownership as a second hazard the accepted consequence does not cover (`CLEAR_FAILURE` must
+  travel over the link those groups provide), explicitly left open because every remedy
+  changes the escalation ladder; cross-referenced from the stickiness paragraph (70e73b6)
+- [x] MF10 no-race claim — narrowed to "where the two agree on the destination"; autostart's
+  transition is unconditional (`launch_ros/actions/lifecycle_node.py:122-130`), so a
+  non-`active` `target` genuinely fights it, and transient `configuring`/`activating` must be
+  excluded from drift; both listed as Open items (26e229f)
+- [x] Suggestion (operator-requested) helm authority — lifecycle repair restores the node, not
+  the mode: `piloting_mode` is a plain depth-1, non-latched subscription created in
+  `on_configure` (`helm_manager.cpp:60`) and `piloting_mode_` comes back empty
+  (`test_helm_manager.cpp:791-806`, `HeartbeatWithEmptyModeBeforeAnySwitch`); convergence
+  makes the gap bounded and reported rather than silent (e2b90fb, citation refined 2f3061c)
+- [x] Suggestions applied as verified facts: dropped the unused `std_msgs` dependency; noted
+  the example config's post-refactor `file:` names do not exist yet (only `core_launch.py`
+  and `perception_launch.py` do); diagnostics mapping now covers `STOPPED`/`STOPPING` → OK;
+  shared `LaunchService` must run `shutdown_when_idle=False` (default `True`,
+  `launch/launch_service.py:259,364`); state-diagram note for `STARTING`→`FAILED` and the
+  retry self-loop; config file named as the trust boundary; **Status** now says an ADR is
+  still owed (96d9eba)
+- [x] Suggestions converted to one honest Open item rather than decided: budget reset /
+  `CLEAR_FAILURE` re-entry, clean exit with desired `RUNNING`, `restart: never` in the ladder,
+  `delegate` exemption and `READY` without a `target`, `START` with an unmet dependency at
+  runtime, `SET_LIFECYCLE` persistence, `BLOCKED` vs `DEGRADED` for dependents, undefined
+  `SUPERSEDED` (c06873d)
+- [x] Declared-argument schema table — `docs/launch_manager.md:258-269` (deferred: adding a key
+  table and re-stating the constraint rule is scope the operator ruled out for this pass)
+- [x] `output_ring_bytes` per buffer or total — `docs/launch_manager.md:146` (deferred:
+  unmade design decision, not a wording fix)
+- [x] Non-default `restart` rule demonstrated nowhere — `docs/launch_manager.md:184-188`
+  (deferred: the only demonstration would be changing the settled example config, which this
+  pass must not do)
+
+### Verification
+- Documentation Accuracy: every API claim touched was re-read on this host —
+  `process_matchers` (three functions) and `launch.events.matchers.matches_action`,
+  `execute_local.py` respawn retry enforcement, `launch_service.py` `shutdown_when_idle`
+  defaults, `lifecycle_node.py` autostart transition, `launch_session.py` `from_service`
+  contextmanager `finally`, `helm_manager.cpp:60` and the helm heartbeat test, and the
+  `bizzyboat_project11/launch/` file inventory.
+- All 13 intra-document anchors resolve against the doc's own headings (checked by script).
+- No trailing whitespace; the only >100-char lines are pre-existing table rows and the
+  pre-existing `guarded` bullet. This repo has no `.pre-commit-config.yaml`, so the commit
+  hooks that ran are the repo-local git hooks; no linter profile applies to `.md` here.
+- No code touched, so no build or test is implicated.
+
+### Next step
+Re-review: `.agent/scripts/dispatch_subagent.sh --mode in-process --issue 327 --skill review-code`.
+Per the operator's scoping, no further review round is planned — the doc merges as a draft
+design — so the host may proceed straight to the PR/merge gate instead.

--- a/.agent/work-plans/issue-327/progress.md
+++ b/.agent/work-plans/issue-327/progress.md
@@ -120,3 +120,82 @@ no package tests apply. Not pushed — the host performs pushes.
 ### Next step
 Re-review the fixes with a fresh-context sub-agent:
 `.agent/scripts/dispatch_subagent.sh --mode in-process --issue 327 --skill review-code`
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-08-22 22:29 -04:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-327 at `adc6a0d`
+**Mode**: pre-push
+**Depth**: Deep (reason: 626 added lines in the single new doc; 200+ lines is a Deep trigger)
+**Must-fix**: 10 | **Suggestions**: 17
+**Round**: 1 | **Ship**: recommended — second review round overall (an `## Integrated Review`
+preceded it); every must-fix is a doc-internal contradiction, a false API claim, or a stated
+property the doc does not establish. All are single-location edits whose remedy is to say
+something already settled or to name an Open item. None is a new design decision, so one fix
+pass should close them — a further full review round is not warranted for a draft design doc.
+
+**Specialists**: Static Analysis (no linter profile for `.md` — content review only);
+Governance; Plan Drift (skipped, no `plan.md` for #327); Claude Adversarial ×2 (Lens A + Lens B);
+Copilot off (default); Local Adversarial skipped (Ollama at localhost:11434 unreachable, curl 52).
+**Context**: no `.agents/review-context.yaml` in this repo — review used `.agents/README.md` only.
+
+**Documentation Accuracy sweep**: every cited path, line number, and API claim was
+re-verified on this host. All correct except the matcher inventory (must-fix 3):
+`helm_manager.cpp:45`, the four launch files' respawn/`LifecycleTransition` line pairs
+(46/50, 51/56, 45/49, 56), `lifecycle_node.py:121-131`, `launch_service.py:269-272`,
+`mission_manager.py:75` `done_hover`, the `camp_interface.py` best-effort-UDP comment,
+the three tmux scripts, `ros2launch_session` (`LaunchSession`, `from_service`,
+`wait_for_*`, `shutdown`), the three `ros2launch_gui` widget files, `docs/autonomy_modes.md`,
+`core_launch.py` including udp_bridge, and all eight intra-document anchors.
+
+### Findings
+- [ ] (must-fix) Example `default_profile: awareness` contradicts the doc's three "comms-only default profile" claims; keep the settled example, reword the prose — `docs/launch_manager.md:205,17,578-579,588`
+- [ ] (must-fix) `retry_limit`/`retry_window` is bound to both ladder step 3 (group restart) and step 4 (`FAILED`); the respawn budget triggering step 3 is a third, unnamed budget (`launch`'s own `respawn_max_retries`) — regression from the round-1 fix — `docs/launch_manager.md:339-344`
+- [ ] (must-fix) `launch.events.process.process_matchers` ships three matchers, not "`matches_pid` and `matches_name` only"; `launch.events.matchers.matches_action` also exists and is a non-racy handle that narrows the spike — `docs/launch_manager.md:555-556`
+- [ ] (must-fix) `from_service()` is a `@contextlib.contextmanager` whose `finally` calls `session.shutdown()` when processes remain (`launch_session.py:277-282`) — one `with` per group tears down the whole stack; belongs in the section that already warns `shutdown()` stops everything — `docs/launch_manager.md:532-534,546-549`
+- [ ] (must-fix) `bool force` is declared on the wire and defined nowhere; safety-relevant (plausibly bypasses `FAILED` stickiness or the `RELOAD_CONFIG` running-group guard) — define or delete — `docs/launch_manager.md:453`
+- [ ] (must-fix) Single `last_request_id` ack slot vs. three mandated concurrent front ends: a `REJECTED` result and its reason are transient, and a client's "re-send until acknowledged" loop can never terminate — `docs/launch_manager.md:411-413,426-428,456-458`
+- [ ] (must-fix) Idempotency by `request_id` addresses duplication, not reordering, yet the doc claims it makes the topic safe over a link that "duplicates and reorders"; a held `STOP helm` delivered after a later `START helm` is re-executed — `docs/launch_manager.md:456-458`
+- [ ] (must-fix) Output has no channel in the control surface, while the doc promises per-process output tabs on the same topics across the link and sets tmux-scrollback parity as a regression criterion — `docs/launch_manager.md:350-358,479-483` vs `:400-454`
+- [ ] (must-fix) `zenoh` and `comms` are ordinary groups with ordinary budgets, but `FAILED` is sticky until a `CLEAR_FAILURE` that must arrive over the transport those groups provide — reintroduces "no remote control surface"; the accepted consequence covers only a manager crash — `docs/launch_manager.md:218-226,297-299,510-516`
+- [ ] (must-fix) "Convergence means the two cannot race" is not established: `autostart=True` unconditionally drives to `active` (`lifecycle_node.py:127-129`) while `target` may be `inactive`, and transient startup states are not excluded from convergence — `docs/launch_manager.md:389-392,381`
+- [ ] (suggestion) The doc's central safety claim is half-established: a lifecycle-repaired `helm_manager` is `active` with no `piloting_mode` (volatile, event-driven, created in `on_configure`) and still publishes nothing, yet reports `READY`/OK; and the open-hazard interval grades `DEGRADED`→WARN, same as `STARTING` — `docs/launch_manager.md:288-289,330-332,473-475`
+- [ ] (suggestion) Neither budget has a stated reset condition, and `CLEAR_FAILURE` leaves desired `RUNNING` so convergence restarts immediately — the acknowledgement is either ceremony or an instant re-entry to the crash loop — `docs/launch_manager.md:153-156,297-299,438-439`
+- [ ] (suggestion) A clean exit with desired `RUNNING` (and `restart: never`) has no representable state: prose says `READY`→`STOPPED` but the table defines `STOPPED` as "desired `STOPPED`" — and the ladder never references the `restart` enum — `docs/launch_manager.md:175,189-192,285`
+- [ ] (suggestion) State diagram omits `STARTING`→`FAILED` (ready-timeout exhausting `start_attempts`) and the retry/backoff self-loop — `docs/launch_manager.md:301-319`
+- [ ] (suggestion) Dependents of a group leaving `READY`: `BLOCKED` and `DEGRADED` definitions collide, and `blocked_by` is populated only when `BLOCKED`, so the named cause has nowhere to go — `docs/launch_manager.md:285-295,346-348,436`
+- [ ] (suggestion) `SUPERSEDED` appears once, in an enum comment, and is defined nowhere — `docs/launch_manager.md:427`
+- [ ] (suggestion) `lifecycle: {delegate: ...}` is not exempted from the escalation ladder; Nav2's own manager deliberately deactivates nodes, which reads as drift and would fight the delegate. `READY`'s "lifecycle at target" is also undefined when there is no `target` — `docs/launch_manager.md:377-382` vs `:288,328-348`
+- [ ] (suggestion) `START [helm]` with `core` stopped has no stated behavior (pull in dependencies / reject / block forever); the load-time `requires` rule has no runtime counterpart — `docs/launch_manager.md:198,445-451`
+- [ ] (suggestion) `SET_LIFECYCLE`/`lifecycle_target` appear only in the message sketch; unstated whether they mutate the configured target or are a one-shot the convergence loop immediately undoes — `docs/launch_manager.md:448-451`
+- [ ] (suggestion) Declared-argument keys (`type`, `pattern`, `default`) never appear in a schema table, and the rule demands "a range or set" while the example shows a regex and an unconstrained bool — `docs/launch_manager.md:258-269`
+- [ ] (suggestion) `exec:`, `environment:`, and `log_dir` are unconstrained and re-read by `RELOAD_CONFIG`; one sentence naming the config file as the trust boundary and `~/command` as unauthenticated-by-acceptance turns a silent hole into a knowing one — `docs/launch_manager.md:258-262,460-462`
+- [ ] (suggestion) `output_ring_bytes` per-group vs. two retained buffers (first + latest) — per buffer or total? Relationship to `log_dir` (memory / disk / both) unstated — `docs/launch_manager.md:146,350-354`
+- [ ] (suggestion) `ros2launch_manager_msgs` is said to depend on `std_msgs`, which nothing in either message sketch uses — `docs/launch_manager.md:415-416`
+- [ ] (suggestion) The example config's `file:` values are post-refactor names that do not exist yet; a pointer to §Assumed launch-file refactor would stop a reader treating it as runnable — `docs/launch_manager.md:216-256`
+- [ ] (suggestion) `LaunchService.run()` defaults to `shutdown_when_idle=True`; an all-`STOPPED` manager's shared service would exit — worth one line pinning it False — `docs/launch_manager.md:528-534`
+- [ ] (suggestion) Diagnostics mapping omits `STOPPED` and `STOPPING`; since `STOPPED` is "the resting state, not a failure" it should be stated OK rather than guessed — `docs/launch_manager.md:474-475`
+- [ ] (suggestion) The non-default-`restart` justification rule is demonstrated nowhere: every example group sets the default `on-failure`, four with redundant justification comments — `docs/launch_manager.md:184-188,220-250`
+
+### Governance
+Principles — Safety First: **Concern** (must-fix 8, 9, 10 and the helm-authority suggestion are
+all safety-property claims the doc does not establish). Modularity/Decoupling: **Pass** (underlay
+placement, own interfaces package, no `marine_interfaces` dependency). Hardware Agnosticism:
+**Pass** (nothing marine in the schema). Simulation-First: **N/A** (no behavior).
+ADRs — none triggered; this is a design doc, not an ADR, and the settled-design comment records
+that an ADR is still owed. Worth one line in the doc saying so, so a reader does not read
+"Proposed" as the decision record.
+Consequences — `.agents/README.md`'s `docs/` tree listing does not include this file, but it is
+already stale for four other docs (`sonar_ecosystem.md`, `sonar_reference.md`,
+`survey_index_schema.md`, `decisions/`). Pre-existing; fixing it here would make the PR
+non-atomic. Flagged as a **Watch**, not a required update.
+
+### Settled-design fidelity
+No finding proposes a different design decision. Checked against issue #327 comment 5375366186:
+the doc drops nothing settled there, and the example config is reproduced faithfully. Two
+must-fixes exist precisely *because* the doc's prose drifted from that example (must-fix 1) or
+over-committed beyond it (must-fix 2, introduced by the round-1 fix `fbe594b`) — both should be
+resolved by changing the prose, not the settled example.

--- a/docs/launch_manager.md
+++ b/docs/launch_manager.md
@@ -1,6 +1,7 @@
 # ros2launch_manager — Design
 
-**Status**: Proposed (2026-08-22). Tracked by
+**Status**: Proposed (2026-08-22) — a draft design, not a decision record. An ADR is still
+owed and this document does not substitute for one. Tracked by
 [rolker/unh_marine_autonomy#327](https://github.com/rolker/unh_marine_autonomy/issues/327).
 Prior-art survey in `.agents/workspace-context/research_digest.md`
 ([PR #328](https://github.com/rolker/unh_marine_autonomy/pull/328)).
@@ -268,6 +269,11 @@ profiles:
   survey:    [zenoh, comms, core, perception, logging, helm, autonomy]
 ```
 
+This is an illustration, not a runnable file: `comms_launch.py`, `logging_launch.py`,
+`helm_launch.py`, and `autonomy_launch.py` are the post-split names from
+[Assumed launch-file refactor](#assumed-launch-file-refactor) and do not exist yet. Only
+`core_launch.py` and `perception_launch.py` are present in `bizzyboat_project11` today.
+
 ### Declared arguments
 
 Launch arguments reachable from a command must be **declared in configuration with a type
@@ -332,6 +338,11 @@ the link itself — see [Process ownership](#process-ownership).
       │ desired=STOPPED                              │ all processes exited
    any state ────────────────► STOPPING ─────────────┘
 ```
+
+Two transitions are left out of the drawing to keep it readable: `STARTING` → `FAILED`,
+when the readiness timeout exhausts `start_attempts` without the group ever becoming
+`READY`; and the retry/backoff self-loop on `DEGRADED`, which is where the ladder below
+spends most of its time.
 
 ## Convergence and the escalation ladder
 
@@ -455,8 +466,8 @@ non-negotiable:
   in the snapshot, or an ack slot per client) but choosing one is a decision this document
   does not make.
 
-Sketch (in `ros2launch_manager_msgs`, which depends only on `builtin_interfaces`,
-`std_msgs`, and `diagnostic_msgs`):
+Sketch (in `ros2launch_manager_msgs`, which depends only on `builtin_interfaces` and
+`diagnostic_msgs`):
 
 ```
 # ManagerStatus.msg
@@ -520,6 +531,15 @@ older than the last one applied from that client) is an [open item](#open-items)
 affecting a running group are reported, not applied — restarting a running survey because
 someone fixed a typo is not a decision the manager gets to make.
 
+**The config file is the trust boundary.** `exec:`, `environment:`, and `log_dir` are
+unconstrained by design — that is what makes the manager generic — so anyone who can write
+the config can run anything as the manager's user, and `RELOAD_CONFIG` makes that reachable
+without a restart. What the declared-argument rules protect is the *link*: nothing arriving
+over the radio can introduce a command or a path, only select among values the file already
+allows. Write access to the config, and to whatever mechanism edits it, is therefore
+equivalent to write access to the boat, and is accepted as such rather than mitigated
+here.
+
 ### Services
 
 The same verbs as services, **local only** — not bridged across the link. This is what
@@ -530,8 +550,10 @@ round-trip is both available and convenient.
 ### Diagnostics
 
 One `diagnostic_updater` task per group, so existing operator dashboards pick the manager
-up for free with no work on their side. `READY` → OK; `STARTING`/`DEGRADED`/`BLOCKED` →
-WARN; `FAILED` → ERROR; clean exit of a `RUNNING` group → WARN.
+up for free with no work on their side. `READY` → OK; `STOPPED` → OK (it is the resting
+state, not a failure); `STOPPING` → OK (an operator asked for it);
+`STARTING`/`DEGRADED`/`BLOCKED` → WARN; `FAILED` → ERROR; clean exit of a `RUNNING` group
+→ WARN.
 
 ### Front ends
 
@@ -629,6 +651,11 @@ URLs.
 (`launch/launch_service.py`, lines 269-272). One process therefore hosts exactly one
 running `LaunchService`. Per-group `LaunchService`s on background threads are not an
 available design.
+
+That shared service must be started with `shutdown_when_idle=False`; the parameter defaults
+to `True` on both `run()` and `run_async()` (`launch/launch_service.py:259,364`). A manager
+whose groups are all `STOPPED` — the boat sitting at the dock on a `link` profile — is
+precisely the idle case, and the default would have the service exit out from under it.
 
 The consequence is specific and must be handled in implementation: **`LaunchSession.
 shutdown()` calls `LaunchService.shutdown()`, which stops everything** — every group

--- a/docs/launch_manager.md
+++ b/docs/launch_manager.md
@@ -168,7 +168,7 @@ Exactly one of `launch` or `exec` is required.
 | `exec` | string[] | — | A bare command vector, for things with no launch file. |
 | `arguments` | map | `{}` | Launch arguments. **Declared**, typed, and value-constrained — see [Declared arguments](#declared-arguments). |
 | `requires` | string[] | `[]` | Groups that must be `READY` before this one starts. Must be acyclic. |
-| `ready` | map | `{}` | Readiness predicate — see [Readiness predicates](#readiness-predicates). Empty means ready when all processes have started. |
+| `ready` | map | `{}` | Readiness predicates plus a `ready`-level `timeout` — see [Readiness predicates](#readiness-predicates). Empty means ready when all processes have started. |
 | `lifecycle` | map | — | Lifecycle target — see [Lifecycle handling](#lifecycle-handling). |
 | `restart` | enum | `on-failure` | `never` \| `on-failure` \| `always`. systemd's vocabulary, deliberately. |
 | `start_attempts` | int | inherited | Override. |
@@ -471,8 +471,9 @@ output tabs (`ros2launch_gui/qt/process_output_widget.py`,
 
 ## Readiness predicates
 
-`ready` names one or more predicates, all of which must hold. Predicate types are a
-registry, not a fixed enum — a downstream user adds one without patching the manager.
+`ready` names one or more predicates, all of which must hold, plus the reserved key
+`timeout`. Predicate types are a registry, not a fixed enum — a downstream user adds one
+without patching the manager.
 
 | Predicate | Config | Satisfied when |
 |---|---|---|
@@ -483,8 +484,11 @@ registry, not a fixed enum — a downstream user adds one without patching the m
 | `tcp_port` | `{tcp_port: <port>}` | A TCP connect to the port succeeds. |
 | `output` | `{output: {pattern: <re>, stream: stderr}}` | Process output matches. |
 
-Every predicate takes `timeout` (float, seconds); exceeding it moves the group toward the
-`start_attempts` budget rather than sitting in `STARTING` forever. `topics` with
+`timeout` (float, seconds) is a `ready`-level key, not a per-predicate one: it is a single
+budget bounding the **conjunction** of every predicate in the map. `ready: {nodes: [/a],
+topics: [{name: /t, min_rate: 1.0}], timeout: 30.0}` gives both predicates 30 s to hold
+together, not 30 s each. Exceeding it moves the group toward the `start_attempts` budget
+rather than sitting in `STARTING` forever. `topics` with
 `min_rate` is the strongest of these and should be preferred where a rate is meaningful —
 node presence proves a process ran, not that it works.
 

--- a/docs/launch_manager.md
+++ b/docs/launch_manager.md
@@ -749,6 +749,24 @@ on its own terms, and it makes the manager's job smaller.
   mission hovers at current position (`mission_manager.py:75` in the `mission_manager` package constructs `done_hover` fresh
   with no pose), so the flag applied to nothing. But a profile change that stops autonomy under way is still worth a confirmation
   dialog, and the UI is where that belongs.
+- **Semantics still to pin down before implementation.** Each is a small decision the doc
+  does not currently make: whether and when the `start_attempts` and
+  `retry_limit`/`retry_window` counters reset — as written, `CLEAR_FAILURE` leaves desired
+  state at `RUNNING`, so convergence restarts the group immediately and can walk straight
+  back into the crash loop it just acknowledged; what state a group is in after a *clean*
+  exit while desired is still `RUNNING` (the table defines `STOPPED` as desired
+  `STOPPED`, so the prose's `READY` → `STOPPED` has nowhere to land), and where
+  `restart: never` sits in the escalation ladder, which never mentions the enum; whether a
+  `lifecycle: {delegate: ...}` group is exempt from lifecycle repair — Nav2's manager
+  deactivates nodes deliberately, which this ladder would read as drift and fight — and
+  what `READY`'s "lifecycle at target" means when there is no `target`; what `START` on a
+  group whose `requires` are `STOPPED` does, given that the `requires` rule quoted above is
+  a *load-time* check with no runtime counterpart; whether `SET_LIFECYCLE` changes the
+  configured target or is a one-shot the convergence loop immediately undoes; how the
+  `DEGRADED` reported for dependents of a group that left `READY` is told apart from
+  `BLOCKED`, and where their cause is carried, since `blocked_by` is populated only when
+  `BLOCKED`; and what `SUPERSEDED` means, since it appears once, in a comment on the result
+  enum, and is defined nowhere.
 - **`autostart` versus a non-`active` target.** `autostart=True` always drives to
   `active`, so a group configured with `target: inactive` or `unconfigured` and an
   autostarting launch file has two writers pulling opposite ways (see

--- a/docs/launch_manager.md
+++ b/docs/launch_manager.md
@@ -478,9 +478,18 @@ running-group guard below — remove a safety property that was put there delibe
 therefore listed as an [open item](#open-items): define it or delete the field before
 implementation, and until then a manager must ignore it rather than guess.
 
-Idempotency by `request_id` is what makes a topic safe as a command channel over a link
-that duplicates and reorders: a client re-sends until it sees its `request_id` acknowledged
-in `~/status`, and re-sends cost nothing.
+Idempotency by `request_id` is what makes a topic safe against **duplication**: a client
+re-sends until it sees its `request_id` acknowledged in `~/status`, re-sends cost nothing,
+and a copy arriving after the original was applied is a no-op.
+
+It does nothing about **reordering**, and the link reorders as well as duplicates. A
+`STOP helm` held up and delivered after a later `START helm` carries a `request_id` the
+manager has never seen, so it is executed on arrival and stops a group the operator has
+just started. Desired state bounds the damage — the outcome is a wrong desired state
+rather than a corrupted one, visible in the next snapshot and corrected by the next command
+— but the manager as specified will act on a stale command. A defence (a per-client
+monotonic sequence number, a send timestamp with a staleness horizon, or refusing a command
+older than the last one applied from that client) is an [open item](#open-items).
 
 `RELOAD_CONFIG` re-reads the file and applies it to groups that are `STOPPED`. Changes
 affecting a running group are reported, not applied — restarting a running survey because
@@ -663,6 +672,9 @@ on its own terms, and it makes the manager's job smaller.
   mission hovers at current position (`mission_manager.py:75` in the `mission_manager` package constructs `done_hover` fresh
   with no pose), so the flag applied to nothing. But a profile change that stops autonomy under way is still worth a confirmation
   dialog, and the UI is where that belongs.
+- **Stale commands after reordering.** `request_id` idempotency covers duplication only
+  (see [`~/command`](#command-subscribed)). Nothing yet rejects a delayed command that the
+  operator has already superseded.
 - **Acknowledging concurrent clients.** `last_request_id` is a single slot shared by every
   front end (see [`~/status`](#status-published)). Until it is widened, a rejection can be
   lost before the client that caused it observes it, and "re-send until acknowledged" is

--- a/docs/launch_manager.md
+++ b/docs/launch_manager.md
@@ -458,8 +458,15 @@ string   profile               # SET_PROFILE
 string[] groups                # START | STOP | RESTART | SET_LIFECYCLE | CLEAR_FAILURE
 string   lifecycle_target      # SET_LIFECYCLE
 diagnostic_msgs/KeyValue[] arguments   # declared arguments only
-bool     force
+bool     force                 # UNDEFINED - see Open items
 ```
+
+`force` is part of the settled command set but **nothing defines what it overrides**, and
+it is a field a front end could plausibly set by default. Both readings that suggest
+themselves — bypassing `FAILED` stickiness, and overriding the `RELOAD_CONFIG`
+running-group guard below — remove a safety property that was put there deliberately. It is
+therefore listed as an [open item](#open-items): define it or delete the field before
+implementation, and until then a manager must ignore it rather than guess.
 
 Idempotency by `request_id` is what makes a topic safe as a command channel over a link
 that duplicates and reorders: a client re-sends until it sees its `request_id` acknowledged
@@ -646,6 +653,10 @@ on its own terms, and it makes the manager's job smaller.
   mission hovers at current position (`mission_manager.py:75` in the `mission_manager` package constructs `done_hover` fresh
   with no pose), so the flag applied to nothing. But a profile change that stops autonomy under way is still worth a confirmation
   dialog, and the UI is where that belongs.
+- **`force` is undefined.** The command message carries `bool force`, settled as part of
+  the command set, with no stated semantics. Define exactly what it overrides — and
+  confirm that whatever that is may be overridden by a single bool arriving over the radio
+  link — or delete the field.
 - **Repo layout**: three sibling repos (`ros2launch_session`, `ros2launch_gui`,
   `ros2launch_manager`, matching what exists) versus one `ros2launch_tools` repo with three
   packages (easier to release and discover). **Start separate, revisit at release time.**

--- a/docs/launch_manager.md
+++ b/docs/launch_manager.md
@@ -53,6 +53,18 @@ Three problems, in increasing order of severity.
    created. A respawned-but-unconfigured `helm_manager` is a live process with a live node
    name, zero control authority — manual *or* autonomous — and no indication of it.
 
+   Driving it back to `active` is necessary but not sufficient, which is worth being
+   precise about, because it bounds what this manager can claim. `piloting_mode` is a plain
+   depth-1 subscription created in `on_configure` (`helm_manager.cpp:60`) — default
+   durability, so not latched — and the mode is published when an operator selects one.
+   A `helm_manager` that has just been repaired therefore comes back with an empty
+   `piloting_mode_` (asserted as the default in
+   `helm_manager/test/test_helm_manager.cpp:795`) and publishes nothing until a mode is
+   selected again. What convergence changes is that this interval is **bounded and
+   reported** — `DEGRADED` with a named cause — instead of silent and indefinite. Closing
+   it completely means the mode being re-asserted after a repair, which is the helm's
+   business rather than the manager's and is out of scope here.
+
    `LifecycleNode(autostart=True)` does **not** fix this. It is one-shot by construction:
    `launch_ros/actions/lifecycle_node.py` emits a single `LifecycleTransition`
    (configure, then activate) at `execute()` time (lines 121-131) and never re-applies it.

--- a/docs/launch_manager.md
+++ b/docs/launch_manager.md
@@ -158,7 +158,7 @@ One YAML file per manager instance. All durations are seconds (float); all sizes
 | `log_dir` | path | *required* | Root for per-group output capture. |
 | `environment` | map<string,string> | `{}` | Environment applied to every group; group-level `environment` overrides per key. |
 | `status_period` | float | `1.0` | Periodic `~/status` publish interval. On-change publishes are additional, not a replacement. |
-| `output_ring_bytes` | int | `1048576` | Per-group output ring buffer size. See [Output retention](#output-retention). |
+| `output_ring_bytes` | int | `1048576` | Size of **one** retained output buffer. A group retains two (first failure, most recent), so its worst-case cost is twice this. See [Output retention](#output-retention). |
 | `restart_defaults` | map | see below | Defaults for every group's restart policy. |
 
 ### `manager.restart_defaults` (and per-group overrides)
@@ -169,8 +169,9 @@ One YAML file per manager instance. All durations are seconds (float); all sizes
 | `retry_limit` | int | `5` | Restarts allowed for a group that **was ready and then died**, within `retry_window`. |
 | `retry_window` | float | `300.0` | Sliding window for `retry_limit`. |
 | `backoff` | float[] | `[1, 2, 5, 10, 30]` | Delay before each successive attempt; the last value repeats. |
+| `respawn_max_retries` | int | `3` | Respawns allowed for a **single process** inside a group before the group escalates. Passed through to each `ExecuteProcess` action; `launch`'s own default is `-1` (unbounded), which the manager must not inherit. |
 
-The two budgets are separate because the failure cases differ. Never-became-ready is
+The three budgets are separate because the failure cases differ. Never-became-ready is
 usually a configuration error — a missing device, a bad path — and burning ten attempts on
 it wastes the window in which an operator could still fix it. Was-ready-then-died is more
 likely transient, and deserves a larger budget.
@@ -192,6 +193,7 @@ Exactly one of `launch` or `exec` is required.
 | `retry_limit` | int | inherited | Override. |
 | `retry_window` | float | inherited | Override. |
 | `backoff` | float[] | inherited | Override. |
+| `respawn_max_retries` | int | inherited | Override. |
 | `shutdown` | map | `{signal: SIGINT, timeout: 10.0}` | Stop discipline — see [Stopping a group](#stopping-a-group). |
 | `environment` | map<string,string> | `{}` | Merged over `manager.environment`. |
 | `description` | string | `""` | One line, shown in the UIs. |
@@ -361,11 +363,12 @@ When a `READY` group drifts, the manager escalates cheapest-first:
    manager observes the restart and re-drives lifecycle. Respawn is **not** a blind spot,
    because the manager holds the `LaunchService` itself rather than shelling out to
    `ros2 launch` — it sees per-process start and exit events and can count and report them
-   (`respawns_in_window`). This step has a budget of its own, and it is **not** one of the
-   two in `restart_defaults`: it is `launch`'s per-process `respawn_max_retries` on the
-   `ExecuteProcess` action (`launch/actions/execute_local.py:100`, enforced at
-   `:606-608`), which defaults to `-1` — unbounded. A process that respawns forever never
-   escalates, so the manager must set it rather than inherit the default.
+   (`respawns_in_window`). This step has a budget of its own, at a different level from the
+   other two: `respawn_max_retries`, which the manager passes through to `launch`'s
+   per-process `respawn_max_retries` on the `ExecuteProcess` action
+   (`launch/actions/execute_local.py:100`, enforced at `:606-608`). `launch`'s own default
+   is `-1` — unbounded — and a process that respawns forever never escalates, so the
+   manager always sets this rather than inheriting it.
 3. **Group restart.** Triggered when a process exhausts its respawn allowance, an essential
    process exits, or the launch description terminates. Full stop-then-start of the group,
    respecting `shutdown` discipline.
@@ -390,6 +393,14 @@ and keeping only the tenth is how a crash loop erases its own explanation.
 The output ring buffer **must survive the process that produced it**, and **must not be
 wiped by a restart**. That is precisely what tmux scrollback provides today, and losing it
 would make the manager a regression on the axis operators actually use.
+
+Concretely: a group retains **two** buffers of `output_ring_bytes` each — first failure and
+most recent — so the manager's worst-case output cost is `2 × output_ring_bytes × groups`.
+Both are held **in memory** for serving, and both are also written under `log_dir` so they
+survive a manager restart, which in-memory retention alone would not. Buffers are byte
+rings, not line rings: an oversized buffer drops from the front, and the retained window is
+therefore the *tail* of the first failure, not its head. Whether that is the right end to
+keep for a first failure is an [open item](#open-items).
 
 ### Stopping a group
 
@@ -751,7 +762,9 @@ on its own terms, and it makes the manager's job smaller.
   with no pose), so the flag applied to nothing. But a profile change that stops autonomy under way is still worth a confirmation
   dialog, and the UI is where that belongs.
 - **Semantics still to pin down before implementation.** Each is a small decision the doc
-  does not currently make: whether and when the `start_attempts` and
+  does not currently make: which end of an oversized first-failure buffer to keep — a byte
+  ring drops from the front, so the retained window is the failure's *tail*, while the root
+  cause is often in its head; whether and when the `start_attempts` and
   `retry_limit`/`retry_window` counters reset — as written, `CLEAR_FAILURE` leaves desired
   state at `RUNNING`, so convergence restarts the group immediately and can walk straight
   back into the crash loop it just acknowledged; what state a group is in after a *clean*

--- a/docs/launch_manager.md
+++ b/docs/launch_manager.md
@@ -539,7 +539,10 @@ URLs.
   matching (`wait_for_output`), startup/shutdown waits (`wait_for_startup`,
   `wait_for_shutdown`), and — critically — `from_service()`, which **injects a launch
   description into an already-running `LaunchService`** via `emit_event()`. That injection
-  is what makes "start a group at 11:40, having started at boot" possible at all.
+  is what makes "start a group at 11:40, having started at boot" possible at all. Its
+  shape matters, and is picked up below: `from_service()` is a
+  `@contextlib.contextmanager` (`launch_session.py:252-253`), and leaving its `with` block
+  shuts the *shared* service down.
 - **`ros2launch_gui`** (`layers/main/underlay_ws/src/ros2launch_gui`) provides the qt / tk
   / tui front ends, per-process output widgets, and the `QueryUserInterface` round-trip for
   pushing UI actions into a running launch system.
@@ -555,6 +558,15 @@ The consequence is specific and must be handled in implementation: **`LaunchSess
 shutdown()` calls `LaunchService.shutdown()`, which stops everything** — every group
 sharing the service, not just the caller's. It cannot be the mechanism for stopping one
 group.
+
+This reaches further than an explicit `shutdown()` call, because `from_service()` is a
+context manager: its `finally` calls `session.shutdown()` whenever any process is still
+running at context exit (`ros2launch_session/launch_session.py:279-282`). The natural
+reading — one `with LaunchSession.from_service(...)` per group — therefore tears down the
+whole stack the moment the first group's block exits. The manager either holds each
+injected session's context open for as long as that group runs and unwinds them only at
+manager shutdown, or the scoped-shutdown API of option 2 below owns group teardown
+instead. A per-group `with` block is not an available shape.
 
 The available mechanism is per-process shutdown events:
 `launch.events.process.ShutdownProcess`, which `ExecuteProcess` handles with its own

--- a/docs/launch_manager.md
+++ b/docs/launch_manager.md
@@ -420,6 +420,16 @@ non-negotiable:
   confirms its command landed by seeing it reflected in the next snapshot. This matches the
   existing mission heartbeat-as-ack pattern rather than inventing a second one.
 
+  **One ack slot is not enough for three front ends.** The design mandates an rqt plugin, a
+  TUI, and a CLI, all live at once, against a single `last_request_id` that the next
+  command overwrites. Between two `status_period` ticks that is easy to do — and the loser
+  is the client whose command was `REJECTED`, since the rejection *and* its reason are what
+  get overwritten, while an `ACCEPTED` command at least leaves its effect visible in the
+  group states. A client that re-sends until acknowledged then never terminates. Recorded
+  as an [open item](#open-items); the fix is small (a short ring of recent request results
+  in the snapshot, or an ack slot per client) but choosing one is a decision this document
+  does not make.
+
 Sketch (in `ros2launch_manager_msgs`, which depends only on `builtin_interfaces`,
 `std_msgs`, and `diagnostic_msgs`):
 
@@ -653,6 +663,10 @@ on its own terms, and it makes the manager's job smaller.
   mission hovers at current position (`mission_manager.py:75` in the `mission_manager` package constructs `done_hover` fresh
   with no pose), so the flag applied to nothing. But a profile change that stops autonomy under way is still worth a confirmation
   dialog, and the UI is where that belongs.
+- **Acknowledging concurrent clients.** `last_request_id` is a single slot shared by every
+  front end (see [`~/status`](#status-published)). Until it is widened, a rejection can be
+  lost before the client that caused it observes it, and "re-send until acknowledged" is
+  not a terminating loop.
 - **`force` is undefined.** The command message carries `bool force`, settled as part of
   the command set, with no stated semantics. Define exactly what it overrides — and
   confirm that whatever that is may be overridden by a single bool arriving over the radio

--- a/docs/launch_manager.md
+++ b/docs/launch_manager.md
@@ -1,0 +1,607 @@
+# ros2launch_manager — Design
+
+**Status**: Proposed (2026-08-22). Tracked by
+[rolker/unh_marine_autonomy#327](https://github.com/rolker/unh_marine_autonomy/issues/327).
+Prior-art survey in `.agents/workspace-context/research_digest.md`
+([PR #328](https://github.com/rolker/unh_marine_autonomy/pull/328)).
+
+**Home of this document**: the manager itself will live in a new `ros2launch_manager`
+repository in the **underlay**, which does not exist yet. This document lives here until
+that repository is created, then moves into it with a pointer left behind. Nothing in the
+design may depend on a marine package (see [Scope](#scope-and-non-goals)); it is written
+here for review convenience, not because it belongs to the marine stack.
+
+## Purpose
+
+A persistent launch and lifecycle manager: a node that starts at boot, autostarts a
+comms-only subset of the stack, and brings the rest up (and down) on command, driving
+lifecycle transitions and reporting state over ROS so that rqt, TUI, and CLI front ends
+all work from the operator station across the radio link.
+
+It replaces the tmux bringup scripts used on the boat and the operator station today —
+`bizzyboat_project11/scripts/start_tmux_project11.bash`,
+`start_tmux_operator_project11.bash`, and `stop_tmux_project11.bash` — which drive
+`tmux send-keys` into named windows with `sleep` for ordering.
+
+### What is actually broken today
+
+Three problems, in increasing order of severity.
+
+1. **Ordering is by `sleep`.** There is no readiness condition anywhere in the bringup, so
+   a slow sensor or a slow chart load is indistinguishable from a working start.
+
+2. **There is no remote control surface.** Bringing a subsystem back up means an SSH
+   session into a tmux window on the boat. Over the radio link, at the time you most want
+   it, that is the least available thing on the boat.
+
+3. **A respawned lifecycle node has no control authority and nothing reports it.**
+   `LifecycleTransition` fires once when the launch description executes, while
+   `respawn=True` brings the process back afterwards — so a respawned lifecycle node sits
+   in `unconfigured` forever. This affects `helm_manager/launch/helm_manager_launch.py`
+   (`respawn=True` at line 46, `LifecycleTransition` at line 50),
+   `mission_manager/mission_manager/launch/mission_manager_launch.py` (lines 51 and 56),
+   and `joy_to_helm/launch/joy_to_helm_launch.py` (lines 45 and 49).
+   `marine_autonomy/launch/platform_sender_launch.py` has the transition without respawn
+   (line 56), so it fails visibly instead.
+
+   For `helm_manager` this is severe: `HelmManager::on_configure`
+   (`helm_manager/src/helm_manager.cpp:45`) is where the heartbeat publisher, the
+   `piloting_mode` subscription, and the `out/helm` / `out/cmd_vel` publishers are all
+   created. A respawned-but-unconfigured `helm_manager` is a live process with a live node
+   name, zero control authority — manual *or* autonomous — and no indication of it.
+
+   `LifecycleNode(autostart=True)` does **not** fix this. It is one-shot by construction:
+   `launch_ros/actions/lifecycle_node.py` emits a single `LifecycleTransition`
+   (configure, then activate) at `execute()` time (lines 121-131) and never re-applies it.
+   **Convergence** — repeatedly comparing observed lifecycle state against target — is
+   what fixes it, and that requires a live manager.
+
+This third point is the one that turns the manager from a convenience into a safety
+argument. It was a known limitation when the launch files were written; it is recorded
+here as motivation, not as a defect report.
+
+## Scope and non-goals
+
+The eventual ambition is that `ros2launch_manager` is usable outside this workspace. That
+imposes hard constraints:
+
+- **Underlay placement is structural.** The underlay builds before every marine package,
+  so the manager *cannot* depend on one. The layering enforces the boundary rather than
+  relying on discipline.
+- **Its own interfaces package**, with **no `marine_interfaces` dependency**. The live
+  temptation is reusing `Heartbeat`; don't.
+- **Nothing marine in the schema.** Platform specifics live in config, in the platform
+  repositories.
+- **Generic mechanisms, not special cases**: `lifecycle: {delegate: ...}` rather than a
+  Nav2 branch; named readiness predicates rather than a fixed enum.
+
+**Guardrail**: *design* for adoption, do not *build* for adoption. If genericness delays
+getting the boat launched, the boat wins.
+
+**Non-goals**: replacing `launch` (this manages launch descriptions, it does not reinvent
+them); configuration management or parameter distribution; cross-host orchestration (each
+host runs its own manager); anything resembling a container runtime.
+
+### "Mode" is not an available word
+
+`docs/autonomy_modes.md` defines the helm's piloting modes — standby, manual, autonomous —
+and that vocabulary is load-bearing for operators. The manager's named presets are
+therefore **profiles**, and the word "mode" does not appear in its schema, topics, or UI.
+
+## Core model
+
+Three concepts, and the relationship between them is the whole design.
+
+### Group
+
+A **group** is the unit of start and stop: one launch file (or one bare executable).
+Per-launch-file granularity is deliberate — the launch files are being refactored anyway
+(see [Assumed launch-file refactor](#assumed-launch-file-refactor)), so the split can be
+made to match the operational units rather than the other way round.
+
+### Desired state
+
+**Per-group desired state is the single source of truth.** Each group has a desired state
+of `RUNNING` or `STOPPED`, and the manager runs a convergence loop against it. Everything
+else — profiles, restarts, lifecycle — is expressed in terms of writing or converging to
+that.
+
+### Profile
+
+A **profile** is a named preset that bulk-writes desired state **once**. It is not a state
+the manager holds.
+
+The manager reports `profile_actual`, which is *derived*: the name of the profile whose
+group set exactly matches current desired state, or `custom` when none does. This is what
+dissolves the "we are in survey profile but navigation is stopped" contradiction — that
+situation is simply `custom`, and there is no second source of truth to reconcile.
+
+### No persistence across manager restarts
+
+The manager does **not** persist desired state. Every start converges to
+`default_profile`.
+
+Rationale: the boat comes up adrift by design, and a full-stack crash is not a
+carry-on-as-normal situation. Refusing to persist deletes a state file, a staleness
+window, and the need to define clean-versus-dirty shutdown. The cost — an operator
+re-selects a profile after a manager restart — is paid in a situation where they should be
+looking at the boat anyway.
+
+## Configuration schema
+
+One YAML file per manager instance. All durations are seconds (float); all sizes are bytes
+(integer).
+
+### `manager`
+
+| Key | Type | Default | Meaning |
+|---|---|---|---|
+| `name` | string | *required* | Manager instance name; also the ROS node name. Must be unique per DDS domain. |
+| `default_profile` | string | *required* | Profile converged to on every manager start. Must exist in `profiles`. |
+| `log_dir` | path | *required* | Root for per-group output capture. |
+| `environment` | map<string,string> | `{}` | Environment applied to every group; group-level `environment` overrides per key. |
+| `status_period` | float | `1.0` | Periodic `~/status` publish interval. On-change publishes are additional, not a replacement. |
+| `output_ring_bytes` | int | `1048576` | Per-group output ring buffer size. See [Output retention](#output-retention). |
+| `restart_defaults` | map | see below | Defaults for every group's restart policy. |
+
+### `manager.restart_defaults` (and per-group overrides)
+
+| Key | Type | Default | Meaning |
+|---|---|---|---|
+| `start_attempts` | int | `3` | Attempts allowed for a group that has **never become ready**. |
+| `retry_limit` | int | `5` | Restarts allowed for a group that **was ready and then died**, within `retry_window`. |
+| `retry_window` | float | `300.0` | Sliding window for `retry_limit`. |
+| `backoff` | float[] | `[1, 2, 5, 10, 30]` | Delay before each successive attempt; the last value repeats. |
+
+The two budgets are separate because the failure cases differ. Never-became-ready is
+usually a configuration error — a missing device, a bad path — and burning ten attempts on
+it wastes the window in which an operator could still fix it. Was-ready-then-died is more
+likely transient, and deserves a larger budget.
+
+### `groups.<name>`
+
+Exactly one of `launch` or `exec` is required.
+
+| Key | Type | Default | Meaning |
+|---|---|---|---|
+| `launch` | map | — | `{package: <str>, file: <str>}` — a launch file to include. |
+| `exec` | string[] | — | A bare command vector, for things with no launch file. |
+| `arguments` | map | `{}` | Launch arguments. **Declared**, typed, and value-constrained — see [Declared arguments](#declared-arguments). |
+| `requires` | string[] | `[]` | Groups that must be `READY` before this one starts. Must be acyclic. |
+| `ready` | map | `{}` | Readiness predicate — see [Readiness predicates](#readiness-predicates). Empty means ready when all processes have started. |
+| `lifecycle` | map | — | Lifecycle target — see [Lifecycle handling](#lifecycle-handling). |
+| `restart` | enum | `on-failure` | `never` \| `on-failure` \| `always`. systemd's vocabulary, deliberately. |
+| `start_attempts` | int | inherited | Override. |
+| `retry_limit` | int | inherited | Override. |
+| `retry_window` | float | inherited | Override. |
+| `backoff` | float[] | inherited | Override. |
+| `shutdown` | map | `{signal: SIGINT, timeout: 10.0}` | Stop discipline — see [Stopping a group](#stopping-a-group). |
+| `environment` | map<string,string> | `{}` | Merged over `manager.environment`. |
+| `description` | string | `""` | One line, shown in the UIs. |
+
+**A non-default `restart` value must carry a one-line justification referencing actual
+startup behavior** — as a YAML comment on the line, and reviewed as such. "It comes up
+with no active piloting mode and publishes nothing" is a justification; "it should
+restart" is not. The point is that whoever changes it later can see what was known.
+
+A **clean exit is also suspicious** for a long-lived group. Under `restart: on-failure` a
+zero-exit is not restarted, but it is reported at least as `WARN` in diagnostics and shown
+in the UI — silently going from `READY` to `STOPPED` is exactly the failure that tmux
+hides today.
+
+### `profiles.<name>`
+
+A list of group names whose desired state is set to `RUNNING`; every group not listed is
+set to `STOPPED`. Profiles are flat by design — no inheritance, no composition. A profile
+that names a group with unsatisfied `requires` is a configuration error, rejected at load.
+
+### Example
+
+```yaml
+manager:
+  name: gabby
+  default_profile: awareness
+  log_dir: /home/field/data/logs/bizzyboat
+  environment:
+    RMW_IMPLEMENTATION: rmw_zenoh_cpp
+    ROS_S57_ENC_ROOT: /home/field/data/ENC_ROOT
+  restart_defaults:
+    start_attempts: 3
+    retry_limit: 5
+    retry_window: 300.0
+    backoff: [1, 2, 5, 10, 30]
+
+groups:
+  zenoh:
+    exec: [ros2, run, rmw_zenoh_cpp, rmw_zenohd]
+    ready: {tcp_port: 7447, timeout: 15.0}
+    restart: on-failure       # router; everything else is unreachable without it
+    start_attempts: 10
+  comms:
+    launch: {package: bizzyboat_project11, file: comms_launch.py}
+    requires: [zenoh]
+    ready: {nodes: [/udp_bridge], timeout: 20.0}
+    restart: on-failure       # the operator link; nothing else is observable without it
+  core:
+    launch: {package: bizzyboat_project11, file: core_launch.py}
+    requires: [zenoh]
+    ready: {topics: [{name: /mavros/state, min_rate: 0.5}], timeout: 60.0}
+    restart: on-failure
+  perception:
+    launch: {package: bizzyboat_project11, file: perception_launch.py}
+    requires: [core]
+    restart: on-failure
+  logging:
+    launch: {package: bizzyboat_project11, file: logging_launch.py}
+    requires: [core]
+    shutdown: {signal: SIGINT, timeout: 30.0}   # rosbag2 must close its files
+    restart: on-failure
+  helm:
+    launch: {package: bizzyboat_project11, file: helm_launch.py}
+    requires: [core]
+    lifecycle: {nodes: [/helm_manager], target: active}
+    ready: {lifecycle_active: [/helm_manager], timeout: 20.0}
+    restart: on-failure       # comes up with no active piloting mode; publishes nothing
+  autonomy:
+    launch: {package: bizzyboat_project11, file: autonomy_launch.py}
+    requires: [helm]
+    restart: on-failure       # with no mission, hovers at current position
+
+profiles:
+  link:      [zenoh, comms]
+  awareness: [zenoh, comms, core, perception]
+  survey:    [zenoh, comms, core, perception, logging, helm, autonomy]
+```
+
+### Declared arguments
+
+Launch arguments reachable from a command must be **declared in configuration with a type
+and an allowed range or set**. Free-form launch arguments arriving over a radio link are an
+injection surface, and a manager that accepts them is a remote-execution service.
+
+```yaml
+  logging:
+    arguments:
+      bag_prefix: {type: string, pattern: '^[A-Za-z0-9_-]{1,64}$', default: survey}
+      compress:   {type: bool, default: false}
+```
+
+A command carrying an undeclared argument, or a value failing its constraint, is
+**rejected** — the request is acknowledged with a rejection reason, and nothing starts.
+
+## Group state machine
+
+| State | Meaning |
+|---|---|
+| `STOPPED` | Desired `STOPPED`, nothing running. The resting state, not a failure. |
+| `BLOCKED` | Desired `RUNNING`, but a `requires` dependency is not `READY`. |
+| `STARTING` | Processes launched, readiness predicate not yet satisfied. |
+| `READY` | Readiness predicate satisfied and (if configured) lifecycle at target. |
+| `DEGRADED` | Was `READY`; a process respawned or lifecycle drifted, repair in progress. |
+| `FAILED` | Budget exhausted or an unrecoverable error. **Sticky.** |
+| `STOPPING` | Shutdown signalled, processes not yet all exited. |
+
+`BLOCKED` is deliberately distinct from `FAILED`. When `core` fails, `helm` and `autonomy`
+should point at `core` rather than presenting three independent failures for an operator to
+triage under way — that is the difference between one diagnosis and three.
+
+`FAILED` is **sticky**: it persists until an explicit `CLEAR_FAILURE`, even if the
+underlying cause resolves. This is what makes `CLEAR_FAILURE` a real command rather than
+ceremony — an operator's acknowledgement that they have looked.
+
+```
+                 desired=RUNNING, deps unmet
+   STOPPED ───────────────────────────────────► BLOCKED
+      │                                            │ deps READY
+      │ desired=RUNNING, deps met                  ▼
+      └──────────────────────────────────────► STARTING
+                                                   │ ready predicate satisfied
+                                                   ▼
+                        repair ok             ┌── READY ──┐
+                    ┌───────────────────────► │           │ process died / lifecycle drift
+                    │                         └───────────┘
+                 DEGRADED ◄──────────────────────────┘
+                    │ budget exhausted
+                    ▼
+                 FAILED  ──── CLEAR_FAILURE ────► STOPPED
+      ▲                                              ▲
+      │ desired=STOPPED                              │ all processes exited
+   any state ────────────────► STOPPING ─────────────┘
+```
+
+## Convergence and the escalation ladder
+
+**There is no "restart" primitive.** There is desired state, a convergence loop, and a
+give-up threshold. This is the single most consequential decision in the design: it means a
+manual stop can never be mistaken for a failure, because desired state *became* `STOPPED`.
+`RESTART` as a command is sugar — write `STOPPED`, wait for exit, write `RUNNING`.
+
+When a `READY` group drifts, the manager escalates cheapest-first:
+
+1. **Lifecycle repair.** The node is alive but off-target. Re-drive transitions only. No
+   process is touched — this is the common case for the respawn gap described above, and
+   it costs nothing.
+2. **Node respawn.** `launch`'s own `respawn` brings the process back inside the group; the
+   manager observes the restart and re-drives lifecycle. Respawn is **not** a blind spot,
+   because the manager holds the `LaunchService` itself rather than shelling out to
+   `ros2 launch` — it sees per-process start and exit events and can count and report them.
+3. **Group restart.** Triggered when the respawn budget is exhausted, an essential process
+   exits, or the launch description terminates. Full stop-then-start of the group,
+   respecting `shutdown` discipline.
+4. **`FAILED`.** Budget exhausted. Sticky until `CLEAR_FAILURE`.
+
+Dependents of a group leaving `READY` are **not** torn down automatically. They are
+reported as `DEGRADED` with the cause named. Cascading teardown of a running autonomy stack
+because a sensor group blinked is a worse failure than the blink.
+
+### Output retention
+
+In a crash loop the manager retains the output of the **first** failure as well as the most
+recent. The first usually holds the root cause; the tenth is usually a downstream symptom,
+and keeping only the tenth is how a crash loop erases its own explanation.
+
+The output ring buffer **must survive the process that produced it**, and **must not be
+wiped by a restart**. That is precisely what tmux scrollback provides today, and losing it
+would make the manager a regression on the axis operators actually use.
+
+### Stopping a group
+
+`shutdown: {signal: <SIGINT|SIGTERM>, timeout: <float>}`. The manager signals, waits up to
+`timeout` for every process in the group to exit, then escalates through `launch`'s own
+SIGINT → SIGTERM → SIGKILL sequence.
+
+The `logging` group is the motivating case: `rosbag2` must receive SIGINT and be given time
+to close its files, or the recording is damaged. A default 10 s timeout is not enough for a
+large bag; the example config gives it 30 s.
+
+## Lifecycle handling
+
+**Non-Nav2 lifecycle is the primary case, not the exception.** `helm_manager`,
+`mission_manager`, `joy_to_helm`, and `platform_sender` are all `LifecycleNode`s. Nav2 is
+the one group we would *delegate* to its own lifecycle manager.
+
+```yaml
+    lifecycle: {nodes: [/helm_manager], target: active}    # manager drives
+    lifecycle: {delegate: /lifecycle_manager_navigation}   # someone else drives
+```
+
+`target` is one of `unconfigured`, `inactive`, `active`. `delegate` names a node that owns
+the transitions; the manager then only observes.
+
+Two rules make this safe:
+
+- **Converge, do not command.** Read current state, transition only when off-target. The
+  manager never emits a transition blindly, which is what allows it to run continuously
+  without fighting anything else.
+- **Keep `LifecycleNode(autostart=True)` in the launch files.** It preserves standalone
+  `ros2 launch` usability on the bench — an important property, since most development
+  happens without the manager — and convergence means the two cannot race: `autostart`
+  reaches the target, the manager observes the target, nothing further happens.
+
+`autostart=True` has a second benefit: because the action resolves its own fully-qualified
+node name, it removes the `PythonExpression` namespace concatenation currently needed to
+name the node in each of the four launch files cited above.
+
+## Control surface
+
+### `~/status` (published)
+
+A **full snapshot**, at `status_period` plus on-change. Three properties are
+non-negotiable:
+
+- **Never deltas.** Deltas are unrecoverable over a lossy link — one dropped message and
+  every subsequent state is wrong with no way to notice.
+- **Not transient-local across the link.** `mission_manager`'s `camp_interface.py` already
+  documents why, in the comment on its `task_feedback_publisher`: the udp_bridge to shore
+  is best-effort UDP and does not tunnel DDS durability, so **periodic re-publish is what
+  survives the link**. The same reasoning applies here without modification.
+- **The ack is the state.** Status carries `last_request_id` and its result, so a client
+  confirms its command landed by seeing it reflected in the next snapshot. This matches the
+  existing mission heartbeat-as-ack pattern rather than inventing a second one.
+
+Sketch (in `ros2launch_manager_msgs`, which depends only on `builtin_interfaces`,
+`std_msgs`, and `diagnostic_msgs`):
+
+```
+# ManagerStatus.msg
+builtin_interfaces/Time stamp
+string   manager_name
+string   config_path
+string   profile_actual        # or "custom"
+string[] profiles_available
+GroupStatus[] groups
+string   last_request_id
+uint8    last_request_result   # ACCEPTED | REJECTED | SUPERSEDED
+string   last_request_detail   # rejection reason, human-readable
+
+# GroupStatus.msg
+string   name
+uint8    desired_state         # STOPPED | RUNNING
+uint8    state                 # STOPPED|BLOCKED|STARTING|READY|DEGRADED|FAILED|STOPPING
+string   detail
+builtin_interfaces/Time state_since
+string[] blocked_by            # group names, when state == BLOCKED
+string   lifecycle_state       # "" when the group has no lifecycle config
+uint32   start_attempts_used
+uint32   respawns_in_window
+```
+
+### `~/command` (subscribed)
+
+```
+# Command.msg
+string   request_id            # client-generated; repeating one is an idempotent no-op
+uint8    type                  # SET_PROFILE | START | STOP | RESTART
+                               # | SET_LIFECYCLE | CLEAR_FAILURE | RELOAD_CONFIG
+string   profile               # SET_PROFILE
+string[] groups                # START | STOP | RESTART | SET_LIFECYCLE | CLEAR_FAILURE
+string   lifecycle_target      # SET_LIFECYCLE
+diagnostic_msgs/KeyValue[] arguments   # declared arguments only
+bool     force
+```
+
+Idempotency by `request_id` is what makes a topic safe as a command channel over a link
+that duplicates and reorders: a client re-sends until it sees its `request_id` acknowledged
+in `~/status`, and re-sends cost nothing.
+
+`RELOAD_CONFIG` re-reads the file and applies it to groups that are `STOPPED`. Changes
+affecting a running group are reported, not applied — restarting a running survey because
+someone fixed a typo is not a decision the manager gets to make.
+
+### Services
+
+The same verbs as services, **local only** — not bridged across the link. This is what
+makes udp_bridge service support a genuine side-quest rather than a blocker for this work.
+Services are for scripts and for the CLI on the same host, where a request/response
+round-trip is both available and convenient.
+
+### Diagnostics
+
+One `diagnostic_updater` task per group, so existing operator dashboards pick the manager
+up for free with no work on their side. `READY` → OK; `STARTING`/`DEGRADED`/`BLOCKED` →
+WARN; `FAILED` → ERROR; clean exit of a `RUNNING` group → WARN.
+
+### Front ends
+
+An rqt plugin, a TUI, and a CLI (a `ros2 launch`-adjacent verb extension) are all **the
+same client on the same topics**, so all three work from the operator station over the
+link. `ros2launch_gui` already provides qt, tk, and tui user interfaces with per-process
+output tabs (`ros2launch_gui/qt/process_output_widget.py`,
+`ros2launch_gui/tk/process_manager.py`, `ros2launch_gui/tui/output_view.py`) to build on.
+
+## Readiness predicates
+
+`ready` names one or more predicates, all of which must hold. Predicate types are a
+registry, not a fixed enum — a downstream user adds one without patching the manager.
+
+| Predicate | Config | Satisfied when |
+|---|---|---|
+| *(none)* | `{}` | Every process in the group has started. |
+| `nodes` | `{nodes: [/name, ...]}` | All named nodes are visible in the graph. |
+| `topics` | `{topics: [{name: /t, min_rate: <hz>}]}` | Each topic is publishing at ≥ `min_rate`. |
+| `lifecycle_active` | `{lifecycle_active: [/name, ...]}` | All named nodes are in `active`. |
+| `tcp_port` | `{tcp_port: <port>}` | A TCP connect to the port succeeds. |
+| `output` | `{output: {pattern: <re>, stream: stderr}}` | Process output matches. |
+
+Every predicate takes `timeout` (float, seconds); exceeding it moves the group toward the
+`start_attempts` budget rather than sitting in `STARTING` forever. `topics` with
+`min_rate` is the strongest of these and should be preferred where a rate is meaningful —
+node presence proves a process ran, not that it works.
+
+## Process ownership
+
+**The manager owns the whole process tree, including the DDS router (`zenoh`) and the
+`comms` group.**
+
+**Accepted consequence**: a manager crash briefly blacks out the operator link. This was
+chosen over a detached-supervisor model, which would have kept the link up across a manager
+crash at the cost of giving up `ros2launch_session`'s teardown guarantee — and a stack that
+cannot be reliably torn down is a worse problem on a boat than a link that blinks.
+
+Mitigation is twofold: keep the manager small enough that crashing is a bug rather than a
+scenario, and run it under systemd with `Restart=always`.
+
+## Implementation substrate
+
+The workspace already owns the two hardest pieces, which is why this is a thin manager
+rather than another launch replacement.
+
+- **`ros2launch_session`** (`layers/main/underlay_ws/src/ros2launch_session`) provides
+  `LaunchSession`: a long-lived `LaunchService` wrapper with guaranteed shutdown via
+  `LaunchService`'s SIGINT → SIGTERM → SIGKILL escalation, output capture and pattern
+  matching (`wait_for_output`), startup/shutdown waits (`wait_for_startup`,
+  `wait_for_shutdown`), and — critically — `from_service()`, which **injects a launch
+  description into an already-running `LaunchService`** via `emit_event()`. That injection
+  is what makes "start a group at 11:40, having started at boot" possible at all.
+- **`ros2launch_gui`** (`layers/main/underlay_ws/src/ros2launch_gui`) provides the qt / tk
+  / tui front ends, per-process output widgets, and the `QueryUserInterface` round-trip for
+  pushing UI actions into a running launch system.
+
+### One `LaunchService` per process — a constraint, not a choice
+
+`LaunchService.run_async` **asserts it is running on the main thread** and raises otherwise
+(`launch/launch_service.py`, lines 269-272). One process therefore hosts exactly one
+running `LaunchService`. Per-group `LaunchService`s on background threads are not an
+available design.
+
+The consequence is specific and must be handled in implementation: **`LaunchSession.
+shutdown()` calls `LaunchService.shutdown()`, which stops everything** — every group
+sharing the service, not just the caller's. It cannot be the mechanism for stopping one
+group.
+
+The available mechanism is per-process shutdown events:
+`launch.events.process.ShutdownProcess`, which `ExecuteProcess` handles with its own
+SIGINT → SIGTERM → SIGKILL escalation (`sigterm_timeout` / `sigkill_timeout`). The
+matchers shipped in `launch.events.process.process_matchers` are `matches_pid` and
+`matches_name` only — there is no notion of a group — so **the manager must maintain the
+group-to-process attribution itself**, from the `process_started` events observed while
+that group's description is being injected.
+
+This is the one place where the design meets an API that was not built for it, and it is
+called out here rather than discovered later. Two candidate resolutions, to be settled by a
+spike before implementation commits:
+
+1. The manager tracks attribution locally and emits `ShutdownProcess` per process.
+2. `ros2launch_session` grows a scoped-shutdown API (a session that shuts down only its own
+   injected description) and the manager uses it. This is the better home for the logic,
+   and `ros2launch_session` is ours to extend.
+
+Option 2 is preferred; option 1 is the fallback if scoped shutdown proves to need more from
+`launch` than is available.
+
+## Deployment
+
+Each host runs its own manager under a distinct `manager.name` — one on the boat, one on
+the operator station. There is no cross-host orchestration and no manager-of-managers; the
+two are peers that happen to be connected. UIs **discover managers by scanning for status
+topics**, so an operator station UI shows both without being configured with either.
+
+Both run under systemd with `Restart=always`. The boat's `default_profile` is a
+comms-only subset, so a boat that boots is reachable and reports its state; nothing else
+starts until someone asks for it.
+
+## Assumed launch-file refactor
+
+This design assumes `bizzyboat_project11`'s launch files are split so that groups match
+operational units. **This is a dependency, and it is not yet filed as an issue.**
+
+- **`comms`** — udp_bridge, currently inside `core_launch.py`, becomes its own launch file.
+  Without this the link cannot be a group of its own, and the comms-only default profile is
+  not expressible.
+- **`logging`** — its own group, so the boat can be up without accumulating bags. Needs the
+  SIGINT-and-wait stop discipline described above so `rosbag2` closes cleanly.
+- **`nav_launch.py`** splits into `helm` / `autonomy` / `charts`.
+
+Swapping `LifecycleTransition` + `PythonExpression` for `autostart=True` in the four
+lifecycle launch files is worth doing **regardless of this issue** — it is a simplification
+on its own terms, and it makes the manager's job smaller.
+
+## Open items
+
+- **Scoped group shutdown** (see [above](#one-launchservice-per-process--a-constraint-not-a-choice)) —
+  needs a spike before implementation. The only identified gap between this design and the
+  available APIs.
+- **`system_modes`-style parameter-and-lifecycle "modes" are deferred.** Parameters-as-modes
+  fights live tuning: tune a gain on the water, then a profile change silently reverts it.
+  This needs a conflict story before it is safe to build.
+- **Confirmation for destructive profile changes belongs in the UI layer, not in config.**
+  An earlier `guarded` flag was proposed and dropped — a restarted autonomy stack with no
+  mission hovers at current position (`mission_manager.py:75` in the `mission_manager` package constructs `done_hover` fresh
+  with no pose), so the flag applied to nothing. But a profile change that stops autonomy under way is still worth a confirmation
+  dialog, and the UI is where that belongs.
+- **Repo layout**: three sibling repos (`ros2launch_session`, `ros2launch_gui`,
+  `ros2launch_manager`, matching what exists) versus one `ros2launch_tools` repo with three
+  packages (easier to release and discover). **Start separate, revisit at release time.**
+- **Unverified footnote**: whether `mission_manager` re-sends a mission to a restarted
+  navigator. Made non-load-bearing by the hover behavior above, but it should be checked
+  before anyone relies on it.
+
+## References
+
+- [rolker/unh_marine_autonomy#327](https://github.com/rolker/unh_marine_autonomy/issues/327)
+  — tracking issue; the settled-design discussion is recorded in its comments.
+- `.agents/workspace-context/research_digest.md` — prior-art survey (rosmon,
+  `better_launch`, `system_modes`, Nav2 `lifecycle_manager`, ROS 1 `capabilities`) and the
+  upstream-direction check.
+- [`autonomy_modes.md`](autonomy_modes.md) — the helm piloting modes that own the word
+  "mode".

--- a/docs/launch_manager.md
+++ b/docs/launch_manager.md
@@ -21,7 +21,9 @@ all work from the operator station across the radio link.
 It replaces the tmux bringup scripts used on the boat and the operator station today —
 `bizzyboat_project11/scripts/start_tmux_project11.bash`,
 `start_tmux_operator_project11.bash`, and `stop_tmux_project11.bash` — which drive
-`tmux send-keys` into named windows with `sleep` for ordering.
+`tmux send-keys` into named windows with `sleep` for ordering. `bizzyboat_project11` is a
+package in the **`unh_echoboats_project11`** repository (checked out at
+`layers/main/platforms_ws/src/unh_echoboats_project11/` in this workspace).
 
 ### What is actually broken today
 
@@ -519,7 +521,9 @@ scenario, and run it under systemd with `Restart=always`.
 ## Implementation substrate
 
 The workspace already owns the two hardest pieces, which is why this is a thin manager
-rather than another launch replacement.
+rather than another launch replacement. Both are repositories of the same name in the
+underlay layer; the paths below are workspace-relative checkout locations, not upstream
+URLs.
 
 - **`ros2launch_session`** (`layers/main/underlay_ws/src/ros2launch_session`) provides
   `LaunchSession`: a long-lived `LaunchService` wrapper with guaranteed shutdown via

--- a/docs/launch_manager.md
+++ b/docs/launch_manager.md
@@ -297,7 +297,9 @@ triage under way — that is the difference between one diagnosis and three.
 
 `FAILED` is **sticky**: it persists until an explicit `CLEAR_FAILURE`, even if the
 underlying cause resolves. This is what makes `CLEAR_FAILURE` a real command rather than
-ceremony — an operator's acknowledgement that they have looked.
+ceremony — an operator's acknowledgement that they have looked. Stickiness assumes the
+operator can reach the manager to acknowledge, which is not true of the groups that carry
+the link itself — see [Process ownership](#process-ownership).
 
 ```
                  desired=RUNNING, deps unmet
@@ -562,6 +564,21 @@ cannot be reliably torn down is a worse problem on a boat than a link that blink
 Mitigation is twofold: keep the manager small enough that crashing is a bug rather than a
 scenario, and run it under systemd with `Restart=always`.
 
+**A second hazard, which that accepted consequence does not cover.** In the example config
+`zenoh` and `comms` are ordinary groups with ordinary budgets, and `FAILED` is sticky. A
+link group that crash-loops past its budget therefore lands in `FAILED` and stays there
+until a `CLEAR_FAILURE` — a command that can only arrive over the transport those very
+groups provide. The manager is alive, the boat is unreachable, and nothing will retry: "no
+remote control surface", the third problem this design exists to fix, reappearing at the
+moment it matters most. It is not the manager-crash case above, which systemd resolves in
+seconds without operator action.
+
+This is **deliberately left open**, because every way out of it changes the escalation
+ladder for link-carrying groups — exempting them from stickiness, self-clearing `FAILED`
+after a timer, giving them an unbounded budget, or marking a group as link-carrying and
+treating it differently — and that is a design decision, not a wording fix. See
+[Open items](#open-items).
+
 ## Implementation substrate
 
 The workspace already owns the two hardest pieces, which is why this is a thin manager
@@ -682,6 +699,10 @@ on its own terms, and it makes the manager's job smaller.
   mission hovers at current position (`mission_manager.py:75` in the `mission_manager` package constructs `done_hover` fresh
   with no pose), so the flag applied to nothing. But a profile change that stops autonomy under way is still worth a confirmation
   dialog, and the UI is where that belongs.
+- **Sticky `FAILED` on the groups that carry the link.** A `zenoh` or `comms` group that
+  exhausts its budget cannot be revived, because `CLEAR_FAILURE` has to travel over the
+  link it just lost (see [Process ownership](#process-ownership)). Needs a decision about
+  how link-carrying groups escalate; recorded here rather than solved.
 - **No output channel.** Retained per-group output has no defined transport to a remote
   front end (see [Front ends](#front-ends)). Until one exists, the promise of per-process
   output tabs over the link, and parity with tmux scrollback, are met on the manager's host

--- a/docs/launch_manager.md
+++ b/docs/launch_manager.md
@@ -558,23 +558,38 @@ group.
 
 The available mechanism is per-process shutdown events:
 `launch.events.process.ShutdownProcess`, which `ExecuteProcess` handles with its own
-SIGINT → SIGTERM → SIGKILL escalation (`sigterm_timeout` / `sigkill_timeout`). The
-matchers shipped in `launch.events.process.process_matchers` are `matches_pid` and
-`matches_name` only — there is no notion of a group — so **the manager must maintain the
-group-to-process attribution itself**, from the `process_started` events observed while
-that group's description is being injected.
+SIGINT → SIGTERM → SIGKILL escalation (`sigterm_timeout` / `sigkill_timeout`). Every such
+event carries a `process_matcher` predicate over `ExecuteProcess` actions
+(`launch/events/process/process_targeted_event.py:31-51`); none of the shipped matchers
+knows about groups, so **the manager must maintain the group-to-process attribution
+itself**.
+
+`launch.events.process.process_matchers` ships three — `matches_pid`, `matches_name`, and
+`matches_executable` — and all three read `action.process_details`, which is `None` until
+the process has started. A fourth, `launch.events.matchers.matches_action`, matches an
+action object by identity (`launch/events/matchers.py:22-24`) and is the useful one here:
+the manager builds the launch description it injects, so it already holds every
+`ExecuteProcess` object in a group. Attribution is then by construction rather than
+recovered after the fact from a pid or a name — and the attribution is not racy, because it
+does not wait for `process_details` to be populated. `process_started` events remain the
+way to observe *when* an attributed process is up.
 
 This is the one place where the design meets an API that was not built for it, and it is
 called out here rather than discovered later. Two candidate resolutions, to be settled by a
 spike before implementation commits:
 
-1. The manager tracks attribution locally and emits `ShutdownProcess` per process.
+1. The manager tracks attribution locally and emits one `ShutdownProcess` per process,
+   matched with `matches_action` against the actions it injected.
 2. `ros2launch_session` grows a scoped-shutdown API (a session that shuts down only its own
    injected description) and the manager uses it. This is the better home for the logic,
    and `ros2launch_session` is ours to extend.
 
 Option 2 is preferred; option 1 is the fallback if scoped shutdown proves to need more from
-`launch` than is available.
+`launch` than is available. `matches_action` narrows what the spike has to establish: the
+open question is not *how to name a process to shut down* but whether a per-process
+shutdown sweep tears a group down as cleanly as a description-scoped one — ordering,
+`OnProcessExit` handlers, and whatever `launch` does with a description whose processes
+have all exited.
 
 ## Deployment
 

--- a/docs/launch_manager.md
+++ b/docs/launch_manager.md
@@ -59,9 +59,10 @@ Three problems, in increasing order of severity.
    depth-1 subscription created in `on_configure` (`helm_manager.cpp:60`) — default
    durability, so not latched — and the mode is published when an operator selects one.
    A `helm_manager` that has just been repaired therefore comes back with an empty
-   `piloting_mode_` (asserted as the default in
-   `helm_manager/test/test_helm_manager.cpp:795`) and publishes nothing until a mode is
-   selected again. What convergence changes is that this interval is **bounded and
+   `piloting_mode_` — asserted for a freshly configured-and-activated node by
+   `HelmManagerHeartbeatTest.HeartbeatWithEmptyModeBeforeAnySwitch`
+   (`helm_manager/test/test_helm_manager.cpp:791-806`) — and publishes nothing until a mode
+   is selected again. What convergence changes is that this interval is **bounded and
    reported** — `DEGRADED` with a named cause — instead of silent and indefinite. Closing
    it completely means the mode being re-asserted after a repair, which is the helm's
    business rather than the manager's and is out of scope here.

--- a/docs/launch_manager.md
+++ b/docs/launch_manager.md
@@ -13,8 +13,9 @@ here for review convenience, not because it belongs to the marine stack.
 
 ## Purpose
 
-A persistent launch and lifecycle manager: a node that starts at boot, autostarts a
-comms-only subset of the stack, and brings the rest up (and down) on command, driving
+A persistent launch and lifecycle manager: a node that starts at boot, autostarts the
+subset of the stack named by its configured `default_profile`, and brings the rest up (and
+down) on command, driving
 lifecycle transitions and reporting state over ROS so that rqt, TUI, and CLI front ends
 all work from the operator station across the radio link.
 
@@ -575,9 +576,12 @@ the operator station. There is no cross-host orchestration and no manager-of-man
 two are peers that happen to be connected. UIs **discover managers by scanning for status
 topics**, so an operator station UI shows both without being configured with either.
 
-Both run under systemd with `Restart=always`. The boat's `default_profile` is a
-comms-only subset, so a boat that boots is reachable and reports its state; nothing else
-starts until someone asks for it.
+Both run under systemd with `Restart=always`. Each host's `default_profile` is chosen for
+that host; what it must always include is the link — `zenoh` and `comms` — so a host that
+boots is reachable and reports its state. The example config picks `awareness` for the
+boat (link plus `core` and `perception`); the `link` profile is there for a boot that
+should bring up nothing but the link. Whatever the default profile does not name stays
+`STOPPED` until someone asks for it.
 
 ## Assumed launch-file refactor
 
@@ -585,8 +589,8 @@ This design assumes `bizzyboat_project11`'s launch files are split so that group
 operational units. **This is a dependency, and it is not yet filed as an issue.**
 
 - **`comms`** — udp_bridge, currently inside `core_launch.py`, becomes its own launch file.
-  Without this the link cannot be a group of its own, and the comms-only default profile is
-  not expressible.
+  Without this the link cannot be a group of its own, and no profile — `link` least of all —
+  can select the operator link without dragging the rest of `core` up with it.
 - **`logging`** — its own group, so the boat can be up without accumulating bags. Needs the
   SIGINT-and-wait stop discipline described above so `rosbag2` closes cleanly.
 - **`nav_launch.py`** splits into `helm` / `autonomy` / `charts`.

--- a/docs/launch_manager.md
+++ b/docs/launch_manager.md
@@ -327,8 +327,12 @@ When a `READY` group drifts, the manager escalates cheapest-first:
    `ros2 launch` — it sees per-process start and exit events and can count and report them.
 3. **Group restart.** Triggered when the respawn budget is exhausted, an essential process
    exits, or the launch description terminates. Full stop-then-start of the group,
-   respecting `shutdown` discipline.
-4. **`FAILED`.** Budget exhausted. Sticky until `CLEAR_FAILURE`.
+   respecting `shutdown` discipline. The respawn budget is `retry_limit` respawns within
+   `retry_window` — a group that was `READY` and then died is on the retry budget, and each
+   respawn is counted in `respawns_in_window`.
+4. **`FAILED`.** The applicable budget is exhausted — `retry_limit`/`retry_window` for a
+   group that had reached `READY`, `start_attempts` for one that never did. Sticky until
+   `CLEAR_FAILURE`.
 
 Dependents of a group leaving `READY` are **not** torn down automatically. They are
 reported as `DEGRADED` with the cause named. Cascading teardown of a running autonomy stack

--- a/docs/launch_manager.md
+++ b/docs/launch_manager.md
@@ -266,8 +266,15 @@ injection surface, and a manager that accepts them is a remote-execution service
       compress:   {type: bool, default: false}
 ```
 
-A command carrying an undeclared argument, or a value failing its constraint, is
-**rejected** — the request is acknowledged with a rejection reason, and nothing starts.
+On the wire, `~/command` carries arguments as `diagnostic_msgs/KeyValue[]`, which is
+string-to-string. Values therefore travel as **string scalars** and are parsed and coerced
+against the declared `type` on receipt — `compress: "true"` becomes a bool before it is
+range-checked. A value that fails to parse as its declared type is rejected exactly as an
+out-of-range value is.
+
+A command carrying an undeclared argument, a value that fails to parse as its declared
+type, or a value failing its constraint, is **rejected** — the request is acknowledged with
+a rejection reason, and nothing starts.
 
 ## Group state machine
 

--- a/docs/launch_manager.md
+++ b/docs/launch_manager.md
@@ -334,15 +334,22 @@ When a `READY` group drifts, the manager escalates cheapest-first:
 2. **Node respawn.** `launch`'s own `respawn` brings the process back inside the group; the
    manager observes the restart and re-drives lifecycle. Respawn is **not** a blind spot,
    because the manager holds the `LaunchService` itself rather than shelling out to
-   `ros2 launch` — it sees per-process start and exit events and can count and report them.
-3. **Group restart.** Triggered when the respawn budget is exhausted, an essential process
-   exits, or the launch description terminates. Full stop-then-start of the group,
-   respecting `shutdown` discipline. The respawn budget is `retry_limit` respawns within
-   `retry_window` — a group that was `READY` and then died is on the retry budget, and each
-   respawn is counted in `respawns_in_window`.
-4. **`FAILED`.** The applicable budget is exhausted — `retry_limit`/`retry_window` for a
-   group that had reached `READY`, `start_attempts` for one that never did. Sticky until
-   `CLEAR_FAILURE`.
+   `ros2 launch` — it sees per-process start and exit events and can count and report them
+   (`respawns_in_window`). This step has a budget of its own, and it is **not** one of the
+   two in `restart_defaults`: it is `launch`'s per-process `respawn_max_retries` on the
+   `ExecuteProcess` action (`launch/actions/execute_local.py:100`, enforced at
+   `:606-608`), which defaults to `-1` — unbounded. A process that respawns forever never
+   escalates, so the manager must set it rather than inherit the default.
+3. **Group restart.** Triggered when a process exhausts its respawn allowance, an essential
+   process exits, or the launch description terminates. Full stop-then-start of the group,
+   respecting `shutdown` discipline.
+4. **`FAILED`.** The budget on *step 3* is exhausted — `retry_limit` group restarts within
+   `retry_window` for a group that had reached `READY`, `start_attempts` for one that never
+   did. Sticky until `CLEAR_FAILURE`.
+
+So three budgets, at three levels: `respawn_max_retries` bounds respawns of one process,
+`retry_limit`/`retry_window` bounds restarts of a group that had been `READY`, and
+`start_attempts` bounds attempts at a group that never got there.
 
 Dependents of a group leaving `READY` are **not** torn down automatically. They are
 reported as `DEGRADED` with the cause named. Cascading teardown of a running autonomy stack

--- a/docs/launch_manager.md
+++ b/docs/launch_manager.md
@@ -398,8 +398,19 @@ Two rules make this safe:
   without fighting anything else.
 - **Keep `LifecycleNode(autostart=True)` in the launch files.** It preserves standalone
   `ros2 launch` usability on the bench — an important property, since most development
-  happens without the manager — and convergence means the two cannot race: `autostart`
-  reaches the target, the manager observes the target, nothing further happens.
+  happens without the manager. Where the two agree on the destination they also do not
+  fight: `autostart` emits configure-then-activate once at `execute()` time, the manager
+  observes `active`, finds the group on target, and emits nothing.
+
+  That is narrower than "they cannot race", and the difference is worth stating. The
+  autostart transition is unconditional — `launch_ros/actions/lifecycle_node.py:122-130`
+  appends a `LifecycleTransition` of CONFIGURE then ACTIVATE with no reference to any
+  target — while a group's `target` may be `inactive` or `unconfigured`. With those
+  targets the two genuinely do fight: autostart activates, the manager deactivates. And
+  even with `target: active`, convergence has to treat the states *between* the endpoints
+  (`configuring`, `activating`) as neither on-target nor drift, or it will emit a
+  transition into a transition already in flight. Neither rule is settled here: see
+  [Open items](#open-items).
 
 `autostart=True` has a second benefit: because the action resolves its own fully-qualified
 node name, it removes the `PythonExpression` namespace concatenation currently needed to
@@ -699,6 +710,13 @@ on its own terms, and it makes the manager's job smaller.
   mission hovers at current position (`mission_manager.py:75` in the `mission_manager` package constructs `done_hover` fresh
   with no pose), so the flag applied to nothing. But a profile change that stops autonomy under way is still worth a confirmation
   dialog, and the UI is where that belongs.
+- **`autostart` versus a non-`active` target.** `autostart=True` always drives to
+  `active`, so a group configured with `target: inactive` or `unconfigured` and an
+  autostarting launch file has two writers pulling opposite ways (see
+  [Lifecycle handling](#lifecycle-handling)). Whether that is rejected at config load,
+  handled by dropping `autostart` in those launch files, or left as a documented
+  convention is unsettled — as is how convergence treats the transient
+  `configuring` / `activating` states.
 - **Sticky `FAILED` on the groups that carry the link.** A `zenoh` or `comms` group that
   exhausts its budget cannot be revived, because `CLEAR_FAILURE` has to travel over the
   link it just lost (see [Process ownership](#process-ownership)). Needs a decision about

--- a/docs/launch_manager.md
+++ b/docs/launch_manager.md
@@ -516,6 +516,16 @@ link. `ros2launch_gui` already provides qt, tk, and tui user interfaces with per
 output tabs (`ros2launch_gui/qt/process_output_widget.py`,
 `ros2launch_gui/tk/process_manager.py`, `ros2launch_gui/tui/output_view.py`) to build on.
 
+**Output has no channel yet.** The control surface above is a status topic and a command
+topic; `ManagerStatus` carries no output, and the retained ring buffers of
+[Output retention](#output-retention) have no stated route to a front end. That is a real
+gap, not an oversight of wording: the same-client-on-the-same-topics claim and the
+tmux-scrollback parity criterion are both about output, and as specified they hold only for
+a front end on the manager's own host. The transport is deliberately left open — a
+per-group output topic, a local-only fetch service (like the other services), or a paged
+request/response over the link are all plausible, and they differ in exactly the way that
+matters over a best-effort UDP link. See [Open items](#open-items).
+
 ## Readiness predicates
 
 `ready` names one or more predicates, all of which must hold, plus the reserved key
@@ -672,6 +682,11 @@ on its own terms, and it makes the manager's job smaller.
   mission hovers at current position (`mission_manager.py:75` in the `mission_manager` package constructs `done_hover` fresh
   with no pose), so the flag applied to nothing. But a profile change that stops autonomy under way is still worth a confirmation
   dialog, and the UI is where that belongs.
+- **No output channel.** Retained per-group output has no defined transport to a remote
+  front end (see [Front ends](#front-ends)). Until one exists, the promise of per-process
+  output tabs over the link, and parity with tmux scrollback, are met on the manager's host
+  only. Whatever is chosen has to work over best-effort UDP, which rules out simply
+  publishing every line.
 - **Stale commands after reordering.** `request_id` idempotency covers duplication only
   (see [`~/command`](#command-subscribed)). Nothing yet rejects a delayed command that the
   operator has already superseded.


### PR DESCRIPTION
## Summary

Adds `docs/launch_manager.md` — the design for `ros2launch_manager`, the persistent
launch/lifecycle manager that would replace the `start_tmux_*.bash` bringup on the boat
and the operator station.

Part of #327. This lands the **design document** only; the ADR is a follow-up PR, so the
issue should stay open after this merges.

Written as an implementable spec rather than a narrative: full YAML config schema (every
key, type, default), the group state machine, convergence and the escalation ladder,
lifecycle convergence, the `~/status` / `~/command` control surface with message
sketches, readiness predicates, and the deployment shape.

## What is new relative to the settled-design discussion on #327

One finding, from reading the launch APIs while writing the spec:

`LaunchService.run_async` asserts it is running on the main thread
(`launch/launch_service.py:269-272`), so a process hosts exactly **one** running
`LaunchService` — per-group services on background threads are not an available design.
The consequence is that `LaunchSession.shutdown()` calls `LaunchService.shutdown()` and
therefore stops **every** group, so it cannot be the mechanism for stopping one group.

Per-group stop needs `launch.events.process.ShutdownProcess`, whose only shipped matchers
are `matches_pid` / `matches_name` — no notion of a group — so the manager must maintain
group-to-process attribution itself. The doc records this as the design's one open API
gap, with two candidate resolutions (manager-local attribution, or a scoped-shutdown API
added to `ros2launch_session`; the latter preferred) and flags it as needing a spike
before implementation commits.

## Where the document lives

In this repo for now, moving to the `ros2launch_manager` repo in the underlay once that
exists, with a pointer left behind. The design itself takes no dependency on any marine
package — underlay placement is what enforces that.

## Verification

Every file:line citation in the document was read in source before being written:
the four lifecycle launch files' `respawn=True` / `LifecycleTransition` pairs,
`HelmManager::on_configure`, `mission_manager.py`'s `done_hover`, `camp_interface.py`'s
transient-local comment, `launch_ros`'s one-shot `autostart` handling, and the
`LaunchService` main-thread assertion.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 5 (1M context)`
