### PR TITLE
import_geotiff: merge into staged tiles instead of replacing them (#339)

### DIFF
--- a/.agent/work-plans/issue-339/progress.md
+++ b/.agent/work-plans/issue-339/progress.md
@@ -86,3 +86,49 @@ convention).
 operator at the checkpoint (`loadWindow` over alternatives), and verifying it
 required running the real ENC corpus and comparing coverage against the previous
 run — host state a fresh-context sub-agent did not have.
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-08-22 17:15 -04:00
+**By**: Claude Code Agent (Claude Opus 5 (1M context))
+
+**PR**: #344 at `bdf5279` (round 2)
+**Sources**: 1 (Copilot @ `bdf5279`, current)
+**Cross-source confirmations**: 0
+**CI**: all pass (`build` success, first-try this round)
+
+Round 1's two findings are resolved (see the `## Implementation` above). Two new
+ones, both valid; the second is the more interesting.
+
+### Findings
+- [ ] (valid, Copilot) `sourceGeoBounds()` does not enforce the guards
+      `importGeoTiff` applies — geographic CRS and an unrotated geotransform. A
+      projected (metres) or rotated source yields bounds that are wildly wrong,
+      so `loadWindow` adopts far too many staged tiles — **reintroducing the
+      O(total tiles) load this round was meant to remove** — before the import
+      then fails on its own guard. Fail fast instead: apply the same checks in
+      `sourceGeoBounds` and throw before any adoption —
+      `marine_bathymetry_store/src/import_geotiff_main.cpp:214`
+- [ ] (valid, latent, Copilot — previously missed) With
+      `merge_into_resident` set, the local `tiles` map is seeded from the
+      resident layer, so it holds cells **outside the current import's
+      footprint**. `importGeoTiff` then passes that map to
+      `store.clearOverlappedDraft(tiles)` when the layer is `Processed`
+      (`geotiff_import.cpp:262`) — which would clear Draft under
+      *previously imported* Processed data, well beyond what this import touched.
+      ADR-0010 D8's anti-clobber destroys data, so this is the serious end of the
+      finding —
+      `marine_bathymetry_store/src/geotiff_import.cpp:200`
+
+      **Not reachable today** (verified): `merge_into_resident` is set in exactly
+      one place, the `--stage` path (`import_geotiff_main.cpp:453`), and
+      `--stage` is chart-only — a non-chart `--stage` is rejected at
+      `:484`. But the flag is public API on `GeoTiffImportOptions`, so the
+      footgun is one future caller away, and it fails silently and destructively.
+
+### False positives
+- None this round.
+
+### Notes (not findings)
+- Round 2 of the address-findings loop. Both remedies are small and concrete
+  (guard + guard); no design question outstanding.

--- a/.agent/work-plans/issue-339/progress.md
+++ b/.agent/work-plans/issue-339/progress.md
@@ -1,0 +1,55 @@
+---
+issue: 339
+---
+
+# Issue #339 — import_geotiff --stage overwrites shared GGGS tiles instead of merging — chart cells clobber at every seam
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-08-22 16:49 -04:00
+**By**: Claude Code Agent (Claude Opus 5 (1M context))
+
+**PR**: #344 at `1f61e4cb`
+**Sources**: 1 (Copilot @ `1f61e4cb`, current). No human reviews, no
+conversation comments. **No prior local timeline** — this issue was driven by
+hand, so this entry creates `progress.md` mid-lifecycle.
+**Cross-source confirmations**: 0
+**CI**: green **after a re-run** — see the flake note below.
+
+Both comments verified against the code; both valid. The first is significant
+and blocks the Boston->Shoals rebuild this work exists to enable.
+
+### Findings
+- [ ] (valid, **significant**, Copilot) `--stage` calls `load(store, stage_dir)`
+      on every invocation, which scans each layer dir and GDAL-loads **every**
+      `.tif` it finds. Staging N sources is then O(N x T) tile opens, each a
+      960x960x2 float64 read (~14 MB). For the 13-cell Shoals corpus that is
+      tolerable; for the 80-cell Boston->Shoals region over ~18x the area it is
+      hundreds of gigabytes of I/O and would not finish in useful time.
+      **Remedy available in-tree**: `loadWindow(store, dir, min_pt, max_pt)`
+      gates each tile on its **filename-derived** bounding box before paying any
+      GDAL cost, and skips already-resident tiles — so adopting only the tiles
+      the incoming GeoTIFF actually touches makes the pass linear. Compute the
+      source's extent from its geotransform and window the adoption —
+      `marine_bathymetry_store/src/import_geotiff_main.cpp:392`
+- [ ] (valid, minor, Copilot) The contention warning relies on adjacent
+      string-literal concatenation across continuation lines rather than explicit
+      `<<` insertions. Compiles and is correct, but is easy to break silently in
+      a later edit —
+      `marine_bathymetry_store/src/import_geotiff_main.cpp:417`
+
+### False positives
+- None this round.
+
+### Notes (not findings)
+- **CI flake, unrelated to this change.** The first run of
+  `docker-jazzy-ros-core` failed on
+  `marine_autonomy_integration_tests.TestMissionCommandFlow
+  test_command_bridge_routes_to_mission_manager`
+  (`Expected "clear_tasks" on marine/mission_manager/command, got: []`) — a
+  launch/pub-sub timing assertion. That package has **no dependency on
+  `marine_bathymetry_store`** (its deps are `command_bridge`,
+  `mission_manager`, `marine_nav_interfaces`, `marine_interfaces`), so this
+  change cannot reach it; `jazzy` is green 8-for-8 and every other branch today
+  passed. A re-run of the failed job passed. Worth its own issue if it recurs —
+  a flaky integration test silently costs a merge cycle each time.

--- a/.agent/work-plans/issue-339/progress.md
+++ b/.agent/work-plans/issue-339/progress.md
@@ -194,3 +194,18 @@ Round 2's two guards are resolved. One new finding.
 
 ### False positives
 - None this round.
+
+## Implementation
+**Status**: complete
+**When**: 2026-08-22 17:45 -04:00
+**By**: Claude Code Agent (Claude Opus 5 (1M context))
+
+**Branch**: feature/issue-339 (PR #344, round 3 — final)
+
+- [x] `--stage` now wraps adoption/import/save in `try/catch`, mirroring the
+      normal import path's contract: print a diagnosis, return 1, never
+      terminate. **Verified end to end** with a UTM-reprojected source —
+      `stage failed: not a geographic WGS84 raster: ...`, exit code 1.
+
+334 tests, 0 failures. Operator elected to close the loop here (Ship:
+recommended at round 3); no round 4.

--- a/.agent/work-plans/issue-339/progress.md
+++ b/.agent/work-plans/issue-339/progress.md
@@ -132,3 +132,30 @@ ones, both valid; the second is the more interesting.
 ### Notes (not findings)
 - Round 2 of the address-findings loop. Both remedies are small and concrete
   (guard + guard); no design question outstanding.
+
+## Implementation
+**Status**: complete
+**When**: 2026-08-22 17:27 -04:00
+**By**: Claude Code Agent (Claude Opus 5 (1M context))
+
+**Branch**: feature/issue-339 at `0135f41` (PR #344, round 2)
+
+Works both findings from the round-2 `## Integrated Review` above.
+
+- [x] **`sourceGeoBounds` missing CRS / rotation guards** — now enforces the
+      same conditions `importGeoTiff` does (geographic WGS84, unrotated
+      geotransform) **before** any adoption, so a projected or rotated source
+      fails fast with the same diagnosis instead of first dragging in far too
+      many staged tiles.
+- [x] **`merge_into_resident` + Processed = Draft cleared beyond the footprint**
+      — now refused with `std::invalid_argument`. Not reachable today (flag set
+      only on the chart-only `--stage` path), so the guard pins it against a
+      future caller of what is public API on `GeoTiffImportOptions`.
+
+**Regression cover**: `MergeIntoResidentIsRefusedForProcessed` asserts both
+halves — Processed throws, Chart still imports. **Mutation-verified**: stubbing
+the guard to `if (false)` makes the test FAIL. 334 tests, 0 failures.
+
+**Deviation, recorded**: applied host-inline rather than via a dispatched
+`address-findings`, same reasoning as round 1 — the remedy was an operator
+decision taken at the checkpoint.

--- a/.agent/work-plans/issue-339/progress.md
+++ b/.agent/work-plans/issue-339/progress.md
@@ -159,3 +159,38 @@ the guard to `if (false)` makes the test FAIL. 334 tests, 0 failures.
 **Deviation, recorded**: applied host-inline rather than via a dispatched
 `address-findings`, same reasoning as round 1 — the remedy was an operator
 decision taken at the checkpoint.
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-08-22 17:37 -04:00
+**By**: Claude Code Agent (Claude Opus 5 (1M context))
+
+**PR**: #344 at `0c68b36` (round 3)
+**Sources**: 1 (Copilot @ `0c68b36`, current)
+**Cross-source confirmations**: 0
+**CI**: all pass (`build` success)
+**Round**: 3 | **Ship**: recommended — one finding, small and mechanical, with an
+existing pattern to copy 100 lines away. Returns are diminishing; this is the
+point the convergence guidance says to surface rather than loop.
+
+Round 2's two guards are resolved. One new finding.
+
+### Findings
+- [ ] (valid, Copilot) `--stage` does not wrap its import/save in
+      `try/catch`, so an exception terminates the process instead of printing a
+      clean message and returning 1. The **normal** import path already does
+      exactly this (`import_geotiff_main.cpp:574-579`, `:608-613`); `--stage`
+      is the odd one out —
+      `marine_bathymetry_store/src/import_geotiff_main.cpp:457`
+
+      **Pre-existing, not introduced here** (verified against `origin/jazzy`:
+      the stage block called `importGeoTiff` and `save` bare there too). But
+      this PR **adds four throw sites** to that path — the two
+      `sourceGeoBounds` guards plus `loadWindow` — so it goes from rarely
+      reachable to routinely reachable. It matters concretely for the pending
+      Boston->Shoals regeneration: one unreadable or non-geographic cell out of
+      ~80 would abort the whole run via `std::terminate` rather than skipping
+      or failing cleanly.
+
+### False positives
+- None this round.

--- a/.agent/work-plans/issue-339/progress.md
+++ b/.agent/work-plans/issue-339/progress.md
@@ -53,3 +53,36 @@ and blocks the Boston->Shoals rebuild this work exists to enable.
   change cannot reach it; `jazzy` is green 8-for-8 and every other branch today
   passed. A re-run of the failed job passed. Worth its own issue if it recurs —
   a flaky integration test silently costs a merge cycle each time.
+
+## Implementation
+**Status**: complete
+**When**: 2026-08-22 17:06 -04:00
+**By**: Claude Code Agent (Claude Opus 5 (1M context))
+
+**Branch**: feature/issue-339 at `fb5ef85` (PR #344)
+
+Works both findings from the `## Integrated Review` above.
+
+- [x] **Wholesale `load()` on every `--stage` call** — replaced with
+      `loadWindow` over the incoming source's own extent (new `sourceGeoBounds`
+      helper reads its geotransform). Each source now pays only for the tiles it
+      touches, so the pass is linear rather than O(N x total tiles).
+      **Measured on the real 13-cell corpus**: 53 tile-loads total, 44 s wall,
+      output byte-identical in tile set and coverage (L6 99.1% / L7 80.0% /
+      any-level 99.2%). GDAL wired into the `import_geotiff` CMake target, since
+      the CLI now reads a geotransform itself.
+- [x] **Adjacent string-literal concatenation in the contention warning** — now
+      explicit `<<` insertions per segment.
+
+**Regression cover**: `StagingASecondSourceMergesIntoTheSharedTile` covers the
+windowing without a new test — its two sources share a GGGS tile, so a window too
+narrow to adopt it would make the second source replace the first and fail the
+assertion. 333 tests, 0 failures (cpplint / uncrustify / cppcheck included; an
+include-order violation introduced by the new GDAL header was fixed to the house
+convention).
+
+**Deviation, recorded**: applied host-inline rather than via a dispatched
+`address-findings`. The remedy for the significant finding was chosen by the
+operator at the checkpoint (`loadWindow` over alternatives), and verifying it
+required running the real ENC corpus and comparing coverage against the previous
+run — host state a fresh-context sub-agent did not have.

--- a/marine_bathymetry_store/CMakeLists.txt
+++ b/marine_bathymetry_store/CMakeLists.txt
@@ -83,8 +83,12 @@ install(TARGETS ${PROJECT_NAME}
 
 # The `import_geotiff` CLI: import a GeoTIFF into a store layer's fused surface.
 add_executable(import_geotiff src/import_geotiff_main.cpp)
+# GDAL directly: the CLI reads the source raster's geotransform to window the
+# staged-tile adoption (#339), so it needs the headers itself rather than only
+# through ${PROJECT_NAME}.
 target_link_libraries(import_geotiff ${PROJECT_NAME}
-  marine_vertical_datum::marine_vertical_datum)
+  marine_vertical_datum::marine_vertical_datum ${GDAL_LIBRARIES})
+target_include_directories(import_geotiff PRIVATE ${GDAL_INCLUDE_DIRS})
 
 # The `build_depth_overviews` CLI (ADR-0010 D9 / ADR-0011): offline batch builder
 # of the shallowest-preserving depth overview pyramid for a draft/processed layer.

--- a/marine_bathymetry_store/include/marine_bathymetry_store/geotiff_import.hpp
+++ b/marine_bathymetry_store/include/marine_bathymetry_store/geotiff_import.hpp
@@ -94,6 +94,21 @@ struct GeoTiffImportOptions
   /// store's default level (`store.level()`), preserving the single-level
   /// caller's behaviour; pass a level to match the source resolution.
   std::optional<uint8_t> level = std::nullopt;
+  /// Merge into the layer's resident tiles instead of replacing them per tile.
+  ///
+  /// `importTiles` inserts whole tiles, so by default a second source touching a
+  /// tile another source already wrote **discards that source's cells**. That is
+  /// intended for a re-import that supersedes (a shrinking survey must drop the
+  /// cells it no longer covers), and wrong for a layer assembled from many
+  /// disjoint sources — a chart layer built cell-by-cell from ENC cells, where
+  /// two neighbouring cells legitimately share a GGGS tile at their seam
+  /// (#339).
+  ///
+  /// With this set, each touched tile is seeded from the resident tile first, so
+  /// the import fills gaps and the existing lowest-uncertainty contention rule
+  /// arbitrates any cell both sources claim. Contentions against resident data
+  /// are counted in `ProcessedImportResult::resident_contentions`.
+  bool merge_into_resident = false;
 };
 
 /// @brief Result of a GeoTIFF import, including the anti-clobber side effect.
@@ -118,6 +133,23 @@ struct ProcessedImportResult
   /// `Draft` tiles with ≥1 cleared cell (each appears once). Cache-invalidation
   /// seam for camp#171/#172; these tiles are touched (dirtied), not removed.
   std::vector<gggs::GridIndex> draft_tiles_touched;
+  /// Contention **events** against data already resident in the layer, when
+  /// `GeoTiffImportOptions::merge_into_resident` is set (always 0 otherwise).
+  ///
+  /// An event is a source pixel landing on a cell the resident tile already
+  /// holds a *different* value for. It counts events, not distinct cells: when
+  /// the source is finer than the store level, several pixels fall in one cell
+  /// and each is counted. That is deliberate — this is an alarm, not an
+  /// accounting.
+  ///
+  /// **Expected to be zero for sources that do not overlap.** ENC cells
+  /// partition their usage band, so a chart regeneration reporting a non-zero
+  /// count means two sources disagree about the same ground: either NOAA has
+  /// rescheme-overlapped, or the tool has been pointed at genuinely overlapping
+  /// products (S-102 — see
+  /// [#316](https://github.com/rolker/unh_marine_autonomy/issues/316), where the
+  /// arbitration rule is still an open decision).
+  std::size_t resident_contentions = 0;
 };
 
 /// @brief Import @p path into @p layer's single fused surface.

--- a/marine_bathymetry_store/src/geotiff_import.cpp
+++ b/marine_bathymetry_store/src/geotiff_import.cpp
@@ -55,6 +55,22 @@ ProcessedImportResult importGeoTiff(
   if (options.depth_band < 1) {
     throw std::invalid_argument("importGeoTiff: depth_band must be >= 1");
   }
+  if (options.merge_into_resident && layer == SourceLayer::Processed) {
+    // Seeding from the resident layer puts cells OUTSIDE this import's footprint
+    // into `tiles`, and a Processed import hands that same map to
+    // clearOverlappedDraft (ADR-0010 D8) — which would then clear Draft under
+    // previously-imported Processed data, well beyond what this import touched.
+    // Anti-clobber destroys data, so refuse rather than trust the caller.
+    //
+    // The flag is for assembling a layer from many disjoint sources (a chart
+    // layer built cell-by-cell from ENC cells). A Processed re-import is meant
+    // to supersede per tile — a shrinking survey must drop the cells it no
+    // longer covers — so merging is the wrong semantics there anyway.
+    throw std::invalid_argument(
+      "importGeoTiff: merge_into_resident is not supported for the Processed "
+      "layer — seeded cells outside the import footprint would drive "
+      "clearOverlappedDraft to clear Draft data this import never covered");
+  }
   if (options.uncertainty_band < 0) {
     throw std::invalid_argument("importGeoTiff: uncertainty_band must be >= 0 (0 = none)");
   }

--- a/marine_bathymetry_store/src/geotiff_import.cpp
+++ b/marine_bathymetry_store/src/geotiff_import.cpp
@@ -118,6 +118,7 @@ ProcessedImportResult importGeoTiff(
 
   std::map<gggs::GridIndex, BathymetryTile> tiles;
   std::size_t imported = 0;
+  std::size_t resident_contentions = 0;
 
   std::vector<double> depth_row(width);
   std::vector<double> uncertainty_row(width);
@@ -184,6 +185,19 @@ ProcessedImportResult importGeoTiff(
         level.gridIndex(box_max.latitude, box_max.longitude));
       for (; grid_it.valid(); grid_it.next()) {
         auto tile_it = tiles.find(*grid_it);
+        // [#339] The tile this grid may already hold in the LAYER (not in this
+        // import's working set). importTiles inserts whole tiles, so without
+        // seeding from it a second source touching this grid would discard the
+        // first source's cells — which is what two adjacent ENC cells sharing a
+        // GGGS tile at their seam do on every chart regeneration.
+        const BathymetryTile * resident = nullptr;
+        if (options.merge_into_resident) {
+          const auto & resident_map = store.tiles(layer);
+          const auto found = resident_map.find(*grid_it);
+          if (found != resident_map.end()) {
+            resident = &found->second;
+          }
+        }
         for (gggs::CellAreaIterator cell_it(*grid_it, box_min, box_max);
           cell_it.valid(); cell_it.next())
         {
@@ -192,7 +206,20 @@ ProcessedImportResult importGeoTiff(
             continue;   // outside GGGS's usable envelope
           }
           if (tile_it == tiles.end()) {
-            tile_it = tiles.emplace(cell.grid(), BathymetryTile(cell.grid())).first;
+            tile_it = tiles.emplace(
+              cell.grid(),
+              resident != nullptr ? *resident : BathymetryTile(cell.grid())).first;
+          }
+          if (resident != nullptr) {
+            // Alarm, not accounting: a source pixel landing where the layer
+            // already holds a DIFFERENT value means two sources disagree about
+            // the same ground. Zero for sources that do not overlap.
+            const BathyCell res = resident->get(cell.row(), cell.column());
+            const bool same_sigma = res.uncertainty == uncertainty ||
+              (std::isnan(res.uncertainty) && std::isnan(uncertainty));
+            if (res.hasData() && !(res.depth == depth && same_sigma)) {
+              ++resident_contentions;
+            }
           }
           // Several input pixels can land in one cell when the input is finer
           // than the store level: keep the lowest-uncertainty value (a finite
@@ -223,6 +250,7 @@ ProcessedImportResult importGeoTiff(
 
   ProcessedImportResult result;
   result.cells_imported = imported;
+  result.resident_contentions = resident_contentions;
 
   // Anti-clobber (ADR-0010 D8): a Processed import supersedes overlapped live
   // Draft cells. Delegate to the store's public `clearOverlappedDraft` (the store

--- a/marine_bathymetry_store/src/import_geotiff_main.cpp
+++ b/marine_bathymetry_store/src/import_geotiff_main.cpp
@@ -380,6 +380,17 @@ int main(int argc, char * argv[])
       /*chart_staging_writable=*/true);
     std::cout << "store default level: " << static_cast<int>(store.level().level()) << "\n";
 
+    // [#339] Adopt whatever is already staged so this cell MERGES into it.
+    // Without this the store starts empty and importTiles replaces whole tiles,
+    // so a cell sharing a GGGS tile with a previously staged neighbour discarded
+    // that neighbour's cells — silently, and depending on staging order. Loaded
+    // tiles are clean, so `save` below still writes only the tiles this import
+    // actually touched.
+    const std::size_t adopted = marine_bathymetry_store::load(store, stage_dir);
+    if (adopted > 0) {
+      std::cout << "adopted " << adopted << " already-staged tile(s) to merge into\n";
+    }
+
     marine_bathymetry_store::GeoTiffImportOptions options;
     options.depth_scale = depth_scale;
     options.depth_offset = depth_offset;
@@ -390,9 +401,21 @@ int main(int argc, char * argv[])
       options.uncertainty_band = 0;
       options.default_uncertainty = constant_uncertainty;
     }
-    const std::size_t imported = marine_bathymetry_store::importGeoTiff(
-      store, layer, geotiff, options).cells_imported;
-    std::cout << "imported " << imported << " cell(s) into chart\n";
+    options.merge_into_resident = true;
+    const auto staged = marine_bathymetry_store::importGeoTiff(
+      store, layer, geotiff, options);
+    std::cout << "imported " << staged.cells_imported << " cell(s) into chart\n";
+    if (staged.resident_contentions > 0) {
+      // Expected zero: ENC cells partition their usage band, so no two of them
+      // should claim the same cell. A non-zero count means two sources disagree
+      // about the same ground (a rescheme overlap, or genuinely overlapping
+      // products such as S-102 — see #316, where the arbitration rule is still
+      // an open decision). The lowest-uncertainty rule resolved them; say so.
+      std::cout << "warning: " << staged.resident_contentions
+                << " contention(s) with already-staged data — two sources "
+        "disagree about the same cell; kept the lower-uncertainty "
+        "value\n";
+    }
 
     // Provenance flags are rejected above, so the staged store never carries a
     // registry.json (it would be dropped by the chart-only --commit anyway).

--- a/marine_bathymetry_store/src/import_geotiff_main.cpp
+++ b/marine_bathymetry_store/src/import_geotiff_main.cpp
@@ -45,21 +45,27 @@
 /// provenance (StoreMetadata) may be set with the --platform/--sensor/--survey/
 /// --date flags and is written to <store_dir>/registry.json.
 
+#include <gdal_priv.h>
+
+#include <algorithm>
 #include <cmath>
 #include <cstring>
 #include <filesystem>
 #include <iostream>
+#include <memory>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <system_error>
+#include <utility>
 
-#include <optional>
+#include <geographic_msgs/msg/geo_point.hpp>
 
 #include "marine_bathymetry_store/bathymetry_store.hpp"
 #include "marine_bathymetry_store/geotiff_import.hpp"
 #include "marine_bathymetry_store/registry.hpp"
-#include "marine_vertical_datum/vdatum_query.hpp"
 #include "marine_bathymetry_store/tile_io.hpp"
+#include "marine_vertical_datum/vdatum_query.hpp"
 
 namespace
 {
@@ -173,6 +179,39 @@ std::size_t countStagedChartTiles(const std::string & staged_dir)
     }
   }
   return tiles;
+}
+
+/// Geographic bounding box of @p path, from its geotransform alone.
+///
+/// Used to window the staged-tile adoption (#339): only tiles this source can
+/// possibly touch need loading. Opening the dataset here is one extra open of a
+/// file the importer opens anyway — negligible against the whole-staged-set
+/// `load()` it replaces.
+std::pair<geographic_msgs::msg::GeoPoint, geographic_msgs::msg::GeoPoint>
+sourceGeoBounds(const std::string & path)
+{
+  GDALAllRegister();
+  std::unique_ptr<GDALDataset, void (*)(GDALDataset *)> ds(
+    static_cast<GDALDataset *>(GDALOpen(path.c_str(), GA_ReadOnly)),
+    [](GDALDataset * d) {if (d) {GDALClose(d);}});
+  if (!ds) {
+    throw std::runtime_error("could not open " + path);
+  }
+  double gt[6] = {0, 1, 0, 0, 0, 1};
+  if (ds->GetGeoTransform(gt) != CE_None) {
+    throw std::runtime_error("missing geotransform in " + path);
+  }
+  const double x0 = gt[0];
+  const double y0 = gt[3];
+  const double x1 = x0 + gt[1] * ds->GetRasterXSize();
+  const double y1 = y0 + gt[5] * ds->GetRasterYSize();
+  geographic_msgs::msg::GeoPoint min_pt;
+  geographic_msgs::msg::GeoPoint max_pt;
+  min_pt.longitude = std::min(x0, x1);
+  min_pt.latitude = std::min(y0, y1);
+  max_pt.longitude = std::max(x0, x1);
+  max_pt.latitude = std::max(y0, y1);
+  return {min_pt, max_pt};
 }
 
 }  // namespace
@@ -380,15 +419,25 @@ int main(int argc, char * argv[])
       /*chart_staging_writable=*/true);
     std::cout << "store default level: " << static_cast<int>(store.level().level()) << "\n";
 
-    // [#339] Adopt whatever is already staged so this cell MERGES into it.
-    // Without this the store starts empty and importTiles replaces whole tiles,
-    // so a cell sharing a GGGS tile with a previously staged neighbour discarded
-    // that neighbour's cells — silently, and depending on staging order. Loaded
-    // tiles are clean, so `save` below still writes only the tiles this import
-    // actually touched.
-    const std::size_t adopted = marine_bathymetry_store::load(store, stage_dir);
+    // [#339] Adopt what is already staged WHERE THIS SOURCE LANDS, so this cell
+    // merges into it. Without any adoption the store starts empty and
+    // importTiles replaces whole tiles, so a cell sharing a GGGS tile with a
+    // previously staged neighbour discarded that neighbour's cells — silently,
+    // and depending on staging order.
+    //
+    // Windowed, not wholesale: `load()` GDAL-opens every staged tile, so
+    // staging N sources would cost O(N x total tiles) full-tile reads and a
+    // real regional corpus (~80 ENC cells) would never finish. `loadWindow`
+    // gates each tile on its FILENAME-derived bounding box before paying any
+    // GDAL cost, and skips tiles already resident, so each source pays only for
+    // the tiles it actually touches. Loaded tiles are clean, so `save` below
+    // still writes only the tiles this import dirtied.
+    const auto source_bounds = sourceGeoBounds(geotiff);
+    const std::size_t adopted = marine_bathymetry_store::loadWindow(
+      store, stage_dir, source_bounds.first, source_bounds.second);
     if (adopted > 0) {
-      std::cout << "adopted " << adopted << " already-staged tile(s) to merge into\n";
+      std::cout << "adopted " << adopted <<
+        " already-staged tile(s) overlapping this source, to merge into\n";
     }
 
     marine_bathymetry_store::GeoTiffImportOptions options;
@@ -413,8 +462,8 @@ int main(int argc, char * argv[])
       // an open decision). The lowest-uncertainty rule resolved them; say so.
       std::cout << "warning: " << staged.resident_contentions
                 << " contention(s) with already-staged data — two sources "
-        "disagree about the same cell; kept the lower-uncertainty "
-        "value\n";
+                << "disagree about the same cell; kept the lower-uncertainty "
+                << "value\n";
     }
 
     // Provenance flags are rejected above, so the staged store never carries a

--- a/marine_bathymetry_store/src/import_geotiff_main.cpp
+++ b/marine_bathymetry_store/src/import_geotiff_main.cpp
@@ -46,6 +46,7 @@
 /// --date flags and is written to <store_dir>/registry.json.
 
 #include <gdal_priv.h>
+#include <ogr_spatialref.h>
 
 #include <algorithm>
 #include <cmath>
@@ -197,9 +198,24 @@ sourceGeoBounds(const std::string & path)
   if (!ds) {
     throw std::runtime_error("could not open " + path);
   }
+  // Same guards importGeoTiff enforces, applied BEFORE any adoption. Without
+  // them a projected (metres) or rotated source yields a lon/lat box that is
+  // wildly wrong, so loadWindow adopts far too many staged tiles — the very
+  // O(total tiles) cost the windowing exists to avoid — and only then does the
+  // import fail on its own guard. Fail fast instead.
+  const OGRSpatialReference * srs = ds->GetSpatialRef();
+  OGRErr axis_error = OGRERR_NONE;
+  if (srs == nullptr || !srs->IsGeographic() ||
+    std::abs(srs->GetSemiMajor(&axis_error) - 6378137.0) > 1.0 || axis_error != OGRERR_NONE)
+  {
+    throw std::runtime_error("not a geographic WGS84 raster: " + path);
+  }
   double gt[6] = {0, 1, 0, 0, 0, 1};
   if (ds->GetGeoTransform(gt) != CE_None) {
     throw std::runtime_error("missing geotransform in " + path);
+  }
+  if (gt[2] != 0.0 || gt[4] != 0.0) {
+    throw std::runtime_error("rotated geotransform unsupported in " + path);
   }
   const double x0 = gt[0];
   const double y0 = gt[3];

--- a/marine_bathymetry_store/src/import_geotiff_main.cpp
+++ b/marine_bathymetry_store/src/import_geotiff_main.cpp
@@ -448,44 +448,55 @@ int main(int argc, char * argv[])
     // GDAL cost, and skips tiles already resident, so each source pays only for
     // the tiles it actually touches. Loaded tiles are clean, so `save` below
     // still writes only the tiles this import dirtied.
-    const auto source_bounds = sourceGeoBounds(geotiff);
-    const std::size_t adopted = marine_bathymetry_store::loadWindow(
+    // Mirror the normal import path's error contract (see the try/catch around
+    // importGeoTiff/save below): a bad source must print a diagnosis and exit
+    // non-zero, never terminate. This block gained four throw sites with the
+    // windowed adoption (#339) — the two sourceGeoBounds guards and loadWindow
+    // — so on a regional regeneration one unreadable or non-geographic cell out
+    // of dozens would otherwise abort the whole run.
+    try {
+      const auto source_bounds = sourceGeoBounds(geotiff);
+      const std::size_t adopted = marine_bathymetry_store::loadWindow(
       store, stage_dir, source_bounds.first, source_bounds.second);
-    if (adopted > 0) {
-      std::cout << "adopted " << adopted <<
-        " already-staged tile(s) overlapping this source, to merge into\n";
-    }
+      if (adopted > 0) {
+        std::cout << "adopted " << adopted <<
+          " already-staged tile(s) overlapping this source, to merge into\n";
+      }
 
-    marine_bathymetry_store::GeoTiffImportOptions options;
-    options.depth_scale = depth_scale;
-    options.depth_offset = depth_offset;
-    if (level_set) {
-      options.level = static_cast<uint8_t>(level);
-    }
-    if (constant_uncertainty >= 0.0) {
-      options.uncertainty_band = 0;
-      options.default_uncertainty = constant_uncertainty;
-    }
-    options.merge_into_resident = true;
-    const auto staged = marine_bathymetry_store::importGeoTiff(
+      marine_bathymetry_store::GeoTiffImportOptions options;
+      options.depth_scale = depth_scale;
+      options.depth_offset = depth_offset;
+      if (level_set) {
+        options.level = static_cast<uint8_t>(level);
+      }
+      if (constant_uncertainty >= 0.0) {
+        options.uncertainty_band = 0;
+        options.default_uncertainty = constant_uncertainty;
+      }
+      options.merge_into_resident = true;
+      const auto staged = marine_bathymetry_store::importGeoTiff(
       store, layer, geotiff, options);
-    std::cout << "imported " << staged.cells_imported << " cell(s) into chart\n";
-    if (staged.resident_contentions > 0) {
+      std::cout << "imported " << staged.cells_imported << " cell(s) into chart\n";
+      if (staged.resident_contentions > 0) {
       // Expected zero: ENC cells partition their usage band, so no two of them
       // should claim the same cell. A non-zero count means two sources disagree
       // about the same ground (a rescheme overlap, or genuinely overlapping
       // products such as S-102 — see #316, where the arbitration rule is still
       // an open decision). The lowest-uncertainty rule resolved them; say so.
-      std::cout << "warning: " << staged.resident_contentions
-                << " contention(s) with already-staged data — two sources "
-                << "disagree about the same cell; kept the lower-uncertainty "
-                << "value\n";
-    }
+        std::cout << "warning: " << staged.resident_contentions
+                  << " contention(s) with already-staged data — two sources "
+                  << "disagree about the same cell; kept the lower-uncertainty "
+                  << "value\n";
+      }
 
-    // Provenance flags are rejected above, so the staged store never carries a
-    // registry.json (it would be dropped by the chart-only --commit anyway).
-    const std::size_t saved = marine_bathymetry_store::save(store, stage_dir, nullptr);
-    std::cout << "saved " << saved << " tile(s) under " << stage_dir << "\n";
+      // Provenance flags are rejected above, so the staged store never carries a
+      // registry.json (it would be dropped by the chart-only --commit anyway).
+      const std::size_t saved = marine_bathymetry_store::save(store, stage_dir, nullptr);
+      std::cout << "saved " << saved << " tile(s) under " << stage_dir << "\n";
+    } catch (const std::exception & e) {
+      std::cerr << "stage failed: " << e.what() << "\n";
+      return 1;
+    }
     return 0;
   }
 

--- a/marine_bathymetry_store/test/test_geotiff_import.cpp
+++ b/marine_bathymetry_store/test/test_geotiff_import.cpp
@@ -453,6 +453,33 @@ gggs::CellIndex nwCellEast(const BathymetryStore & store, const gggs::Level & le
 }
 }  // namespace
 
+/// [#339] The merge flag must be refused for Processed, not merely unused there.
+///
+/// Seeding from the resident layer puts cells OUTSIDE the import footprint into
+/// the tiles map, and a Processed import hands that same map to
+/// clearOverlappedDraft (ADR-0010 D8) — which would clear Draft under
+/// previously-imported Processed data the import never covered. Unreachable via
+/// the CLI today (the flag is set only on the chart-only --stage path), so this
+/// pins the guard against a future caller rather than a current bug.
+TEST_F(GeoTiffImportTest, MergeIntoResidentIsRefusedForProcessed)
+{
+  BathymetryStore store(11);
+  const std::vector<float> depth{-30.0f, -31.0f, -32.0f, -33.0f};
+  const std::vector<float> unc{0.1f, 0.2f, 0.3f, 0.4f};
+  const auto tif = writeTestTiff(dir_ / "merge_guard.tif", store.level(), 2, 2, depth, unc);
+
+  GeoTiffImportOptions options;
+  options.merge_into_resident = true;
+  EXPECT_THROW(
+    importGeoTiff(store, SourceLayer::Processed, tif, options),
+    std::invalid_argument);
+
+  // Chart is the intended use and must still be accepted.
+  BathymetryStore chart_store =
+    BathymetryStore::fromCellSize(store.level().cellSize(), false, true);
+  EXPECT_NO_THROW(importGeoTiff(chart_store, SourceLayer::Chart, tif, options));
+}
+
 TEST_F(GeoTiffImportTest, AntiClobberCellWiseClearsOnlyCoveredDraftCells)
 {
   // ADR-0010 D8: a Processed import clears overlapped Draft cells CELL-WISE — only

--- a/marine_bathymetry_store/test/test_import_geotiff_cli.cpp
+++ b/marine_bathymetry_store/test/test_import_geotiff_cli.cpp
@@ -37,6 +37,7 @@
 #include <sys/wait.h>
 
 #include <cstdlib>
+#include <cmath>
 #include <filesystem>
 #include <fstream>
 #include <iterator>
@@ -53,7 +54,9 @@ namespace
 
 /// Write a small north-up WGS84 GeoTIFF at the NW corner of the level-@p level
 /// grid containing (43.0, -70.5): band 1 = depth, band 2 = uncertainty.
-void writeFixtureTiff(const fs::path & path, uint8_t level, int width, int height)
+void writeFixtureTiff(
+  const fs::path & path, uint8_t level, int width, int height,
+  int cell_offset_x = 0, int cell_offset_y = 0)
 {
   const gggs::Level lvl(level);
   const gggs::GridIndex grid = lvl.gridIndex(43.0, -70.5);
@@ -77,7 +80,12 @@ void writeFixtureTiff(const fs::path & path, uint8_t level, int width, int heigh
   if (ds == nullptr) {
     throw std::runtime_error("writeFixtureTiff: could not create " + path.string());
   }
-  double gt[6] = {grid.westLongitude(), cell_x, 0.0, grid.northLatitude(), 0.0, -cell_y};
+  // Offsetting by whole cells keeps the patch inside the SAME grid tile while
+  // landing on different cells — which is what two adjacent sources sharing a
+  // GGGS tile at their seam look like (#339).
+  double gt[6] = {
+    grid.westLongitude() + cell_offset_x * cell_x, cell_x, 0.0,
+    grid.northLatitude() - cell_offset_y * cell_y, 0.0, -cell_y};
   ds->SetGeoTransform(gt);
   OGRSpatialReference srs;
   srs.SetWellKnownGeogCS("WGS84");
@@ -134,6 +142,44 @@ protected:
     return WEXITSTATUS(rc);
   }
 
+  /// The single .tif under @p layer_dir (the tests that use it assert count 1).
+  fs::path soleTile(const fs::path & layer_dir)
+  {
+    for (const auto & entry : fs::directory_iterator(layer_dir)) {
+      if (entry.path().extension() == ".tif") {
+        return entry.path();
+      }
+    }
+    throw std::runtime_error("soleTile: no .tif under " + layer_dir.string());
+  }
+
+  /// Cells carrying a finite depth in band 1 of @p tile.
+  std::size_t countFiniteCells(const fs::path & tile)
+  {
+    GDALAllRegister();
+    GDALDataset * ds = static_cast<GDALDataset *>(
+      GDALOpen(tile.string().c_str(), GA_ReadOnly));
+    if (ds == nullptr) {
+      throw std::runtime_error("countFiniteCells: could not open " + tile.string());
+    }
+    const int w = ds->GetRasterXSize();
+    const int h = ds->GetRasterYSize();
+    std::vector<double> band(static_cast<std::size_t>(w) * h);
+    const CPLErr err = ds->GetRasterBand(1)->RasterIO(
+      GF_Read, 0, 0, w, h, band.data(), w, h, GDT_Float64, 0, 0);
+    GDALClose(ds);
+    if (err != CE_None) {
+      throw std::runtime_error("countFiniteCells: read failed for " + tile.string());
+    }
+    std::size_t n = 0;
+    for (const double v : band) {
+      if (std::isfinite(v)) {
+        ++n;
+      }
+    }
+    return n;
+  }
+
   std::size_t countTiles(const fs::path & layer_dir)
   {
     std::size_t n = 0;
@@ -166,6 +212,36 @@ TEST_F(ImportGeotiffCliTest, StageThenCommitChartLandsTiles)
   EXPECT_EQ(
     run("--commit \"" + staged.string() + "\" \"" + store.string() + "\""), 0);
   EXPECT_EQ(countTiles(store / "chart"), 1u);
+}
+
+/// [#339] Two sources sharing one GGGS tile must both survive.
+///
+/// `importTiles` inserts whole tiles, so before this the second `--stage` call
+/// REPLACED the tile the first had written, silently discarding its cells — and
+/// which source survived depended on staging order. A chart layer is assembled
+/// from many ENC cells, and neighbours share a tile at every seam, so this fired
+/// across the whole corpus.
+TEST_F(ImportGeotiffCliTest, StagingASecondSourceMergesIntoTheSharedTile)
+{
+  const fs::path staged = dir_ / "staged";
+  const fs::path second = dir_ / "second.tif";
+  // Same grid tile, disjoint cells: offset well clear of the first patch.
+  writeFixtureTiff(second, 11, 2, 2, /*cell_offset_x=*/20, /*cell_offset_y=*/20);
+
+  ASSERT_EQ(
+    run("--stage \"" + staged.string() + "\" chart \"" + tif_.string() + "\" --level 11"), 0);
+  ASSERT_EQ(countTiles(staged / "chart"), 1u);
+  const std::size_t after_first = countFiniteCells(soleTile(staged / "chart"));
+  ASSERT_GT(after_first, 0u);
+
+  ASSERT_EQ(
+    run("--stage \"" + staged.string() + "\" chart \"" + second.string() + "\" --level 11"), 0);
+  // Still one tile — both sources land in it.
+  ASSERT_EQ(countTiles(staged / "chart"), 1u);
+
+  const std::size_t after_second = countFiniteCells(soleTile(staged / "chart"));
+  EXPECT_GT(after_second, after_first)
+    << "the second source replaced the first instead of merging into its tile";
 }
 
 TEST_F(ImportGeotiffCliTest, StageRejectsNonChartLayer)


### PR DESCRIPTION
Closes #339.

## The bug

`--stage` created an **empty** in-memory store, imported one file, and saved.
`importTiles` inserts whole tiles (`insert_or_assign`), so a second cell landing
on a tile an earlier cell had already written **discarded that cell's data**.
A chart layer is assembled from many ENC cells and neighbours share a GGGS tile
at every seam, so it fired across the whole corpus — and the winner depended on
staging order:

```
stage US5PSMBE            -> tile 7_2224_1750  63.9% filled
then stage US5PSMCE       ->                   16.0% filled
reverse the order         ->                   63.9% filled
```

## The fix, and why it's opt-in

Per-tile replacement is documented in `geotiff_import.hpp` as a footgun, and it
is **right** for a re-import that supersedes — a shrinking survey must drop the
cells it no longer covers. It is wrong for a layer assembled from many disjoint
sources.

So this adds an explicit `GeoTiffImportOptions::merge_into_resident`, set only on
the `--stage` path, rather than changing the default for every caller three days
before a survey. Whether merge should eventually become the default is a separate
question, and a real one given the footgun note.

With it set, `--stage` adopts what is already staged (`load` returns clean tiles,
so `save` still writes only the tiles this import touched), each touched tile is
seeded from its resident tile, and the existing lowest-uncertainty rule
arbitrates any cell both sources claim.

## Contention counting

Contentions against resident data are counted and reported. ENC cells partition
their usage band, so this should be ~zero — it is an **alarm, not an
accounting**, and a non-zero count means two sources disagree about the same
ground: a rescheme overlap, or genuinely overlapping products such as S-102,
where the arbitration rule is still an open decision
([#316](https://github.com/rolker/unh_marine_autonomy/issues/316)).

Across the real 13-cell Portsmouth / Isles of Shoals corpus it reports **exactly
one** contention — a single-cell seam rounding artifact. That the premise holds
this precisely is itself worth having measured rather than assumed.

## Measured

Survey-box coverage across today's two fixes:

| | L6 | L7 | any level |
|---|---|---|---|
| this morning | 19.2% | 15.3% | 34.6% |
| + clip removed ([s57_tools#50](https://github.com/rolker/s57_tools/pull/50)) | **99.1%** | 15.3% | **99.2%** |
| + tile merge (this PR) | 99.1% | **80.0%** | 99.2% |

Total coverage was already restored by the clip removal; this restores the
**harbour-scale** level underneath it. That's the level that resolves rocks, so
it matters for a nearshore survey even though the headline number doesn't move.

## Test plan

`colcon test marine_bathymetry_store`: **333 tests, 0 failures**, 39 skipped
(includes `uncrustify`, `cpplint`, `cppcheck`).

New: `ImportGeotiffCliTest.StagingASecondSourceMergesIntoTheSharedTile` — stages
two sources whose patches fall in the same GGGS tile at different cells, and
asserts the tile's finite-cell count grows rather than being replaced.

**Mutation-verified**: with `merge_into_resident` flipped back to `false` the new
test FAILS; with the fix it passes. It would not have passed before this change.

End-to-end on the real corpus as in the table above.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 5 (1M context)`
