### PR TITLE
docs: record that no ADR accompanies the launch-manager design

### DIFF
--- a/docs/launch_manager.md
+++ b/docs/launch_manager.md
@@ -1,7 +1,12 @@
 # ros2launch_manager — Design
 
-**Status**: Proposed (2026-08-22) — a draft design, not a decision record. An ADR is still
-owed and this document does not substitute for one. Tracked by
+**Status**: Proposed (2026-08-22) — a draft design, not a decision record, and accepted as
+a draft without a line-by-line read. **No ADR accompanies it, deliberately.** An ADR here
+would restate this document's rationale while governing a tool that has no marine
+dependency and will not live in this repository. The decision that does warrant one — that
+boat and operator-station bringup moves off the `start_tmux_*.bash` scripts onto a managed
+lifecycle, and the platform launch files are refactored to match — belongs with the
+platform code and is not made until implementation starts. Tracked by
 [rolker/unh_marine_autonomy#327](https://github.com/rolker/unh_marine_autonomy/issues/327).
 Prior-art survey in `.agents/workspace-context/research_digest.md`
 ([PR #328](https://github.com/rolker/unh_marine_autonomy/pull/328)).


### PR DESCRIPTION
## Summary

One-line status correction to `docs/launch_manager.md`.

The merged document says "An ADR is still owed and this document does not substitute for
one." That is no longer the plan: on review, an ADR in this repository would restate the
design's own rationale while governing an underlay tool that has no marine dependency and
that the document itself says will move to its own repository.

The decision that *does* warrant an ADR is the platform-side one — boat and
operator-station bringup moving off the `start_tmux_*.bash` scripts onto a managed
lifecycle, with the launch files refactored to match. That has field-procedure
consequences, belongs with the platform code rather than here, and is not actually made
until implementation starts.

Part of #327, which closes once this lands — its research and design-document
deliverables are complete and its third (an ADR "if the design settles") is deliberately
declined with the reasoning recorded in the document.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 5 (1M context)`
